### PR TITLE
Add Goose agent (Block) across all clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/nanoclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/aider.sh)
 ```
 
+#### Goose
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/goose.sh)
+```
+
 ### Non-Interactive Mode
 
 For automation or CI/CD, set environment variables:
@@ -99,6 +105,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/nanoclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/aider.sh)
 ```
 
+#### Goose
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/goose.sh)
+```
+
 ### Non-Interactive Mode
 
 ```bash
@@ -145,6 +157,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/nanoclaw.sh)
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/aider.sh)
+```
+
+#### Goose
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/goose.sh)
 ```
 
 ### Non-Interactive Mode

--- a/digitalocean/goose.sh
+++ b/digitalocean/goose.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/digitalocean/lib/common.sh)
+fi
+
+log_info "Goose on DigitalOcean"
+echo ""
+
+# 1. Resolve DigitalOcean API token
+ensure_do_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get droplet name and create droplet
+DROPLET_NAME=$(get_server_name)
+create_server "$DROPLET_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$DO_SERVER_IP"
+wait_for_cloud_init "$DO_SERVER_IP"
+
+# 5. Install Goose
+log_warn "Installing Goose..."
+run_server "$DO_SERVER_IP" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+log_info "Goose installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export GOOSE_PROVIDER=openrouter
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+EOF
+
+upload_file "$DO_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$DO_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "DigitalOcean droplet setup completed successfully!"
+log_info "Droplet: $DROPLET_NAME (ID: $DO_DROPLET_ID, IP: $DO_SERVER_IP)"
+echo ""
+
+# 8. Start Goose interactively
+log_warn "Starting Goose..."
+sleep 1
+clear
+interactive_session "$DO_SERVER_IP" "source ~/.zshrc && goose"

--- a/hetzner/goose.sh
+++ b/hetzner/goose.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hetzner/lib/common.sh)
+fi
+
+log_info "Goose on Hetzner Cloud"
+echo ""
+
+# 1. Resolve Hetzner API token
+ensure_hcloud_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$HETZNER_SERVER_IP"
+wait_for_cloud_init "$HETZNER_SERVER_IP"
+
+# 5. Install Goose
+log_warn "Installing Goose..."
+run_server "$HETZNER_SERVER_IP" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+log_info "Goose installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export GOOSE_PROVIDER=openrouter
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+EOF
+
+upload_file "$HETZNER_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$HETZNER_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Hetzner server setup completed successfully!"
+log_info "Server: $SERVER_NAME (ID: $HETZNER_SERVER_ID, IP: $HETZNER_SERVER_IP)"
+echo ""
+
+# 8. Start Goose interactively
+log_warn "Starting Goose..."
+sleep 1
+clear
+interactive_session "$HETZNER_SERVER_IP" "source ~/.zshrc && goose"

--- a/manifest.json
+++ b/manifest.json
@@ -82,6 +82,18 @@
         }
       },
       "notes": "Natively supports OpenRouter via OPENROUTER_API_KEY and --model openrouter/... flag"
+    },
+    "goose": {
+      "name": "Goose",
+      "description": "Block's open-source AI coding agent",
+      "url": "https://github.com/block/goose",
+      "install": "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash",
+      "launch": "goose",
+      "env": {
+        "GOOSE_PROVIDER": "openrouter",
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "notes": "Model-agnostic agent by Block (formerly Square), supports OpenRouter as a provider"
     }
   },
   "clouds": {
@@ -138,6 +150,9 @@
     "digitalocean/nanoclaw": "implemented",
     "sprite/aider": "implemented",
     "hetzner/aider": "implemented",
-    "digitalocean/aider": "implemented"
+    "digitalocean/aider": "implemented",
+    "sprite/goose": "implemented",
+    "hetzner/goose": "implemented",
+    "digitalocean/goose": "implemented"
   }
 }

--- a/sprite/goose.sh
+++ b/sprite/goose.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sprite/lib/common.sh)
+fi
+
+log_info "Goose on Sprite"
+echo ""
+
+# Setup sprite environment
+ensure_sprite_installed
+ensure_sprite_authenticated
+
+SPRITE_NAME=$(get_sprite_name)
+ensure_sprite_exists "$SPRITE_NAME" 5
+verify_sprite_connectivity "$SPRITE_NAME"
+
+log_warn "Setting up sprite environment..."
+
+# Configure shell environment
+setup_shell_environment "$SPRITE_NAME"
+
+# Install Goose
+log_warn "Installing Goose..."
+run_sprite "$SPRITE_NAME" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+
+# Get OpenRouter API key via OAuth
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Inject environment variables
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export GOOSE_PROVIDER=openrouter
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+EOF
+
+sprite exec -s "$SPRITE_NAME" -file "$ENV_TEMP:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Sprite setup completed successfully!"
+echo ""
+
+# Start Goose interactively
+log_warn "Starting Goose..."
+sleep 1
+clear
+sprite exec -s "$SPRITE_NAME" -tty -- zsh -c "source ~/.zshrc && goose"


### PR DESCRIPTION
## Summary
- Adds [Goose](https://github.com/block/goose) as fifth agent (Block's model-agnostic AI coding agent)
- Implemented across all 3 clouds: `sprite/goose.sh`, `hetzner/goose.sh`, `digitalocean/goose.sh`
- Configured with `GOOSE_PROVIDER=openrouter` for OpenRouter integration
- Matrix now 5 agents x 3 clouds = 15/15 implemented

## Test plan
- [ ] Run `sprite/goose.sh` — verify Goose installs and launches
- [ ] Run `hetzner/goose.sh` with `HCLOUD_TOKEN` set
- [ ] Run `digitalocean/goose.sh` with `DO_API_TOKEN` set
- [ ] Verify `GOOSE_PROVIDER=openrouter` is set in shell environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)