### PR TITLE
Add Codex CLI agent across all clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/aider.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/goose.sh)
 ```
 
+#### Codex CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/codex.sh)
+```
+
 ### Non-Interactive Mode
 
 For automation or CI/CD, set environment variables:
@@ -111,6 +117,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/aider.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/goose.sh)
 ```
 
+#### Codex CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/codex.sh)
+```
+
 ### Non-Interactive Mode
 
 ```bash
@@ -165,6 +177,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/aider.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/goose.sh)
 ```
 
+#### Codex CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/codex.sh)
+```
+
 ### Non-Interactive Mode
 
 ```bash
@@ -217,6 +235,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/aider.sh)
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/goose.sh)
+```
+
+#### Codex CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/codex.sh)
 ```
 
 ### Non-Interactive Mode

--- a/digitalocean/codex.sh
+++ b/digitalocean/codex.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/digitalocean/lib/common.sh)
+fi
+
+log_info "Codex CLI on DigitalOcean"
+echo ""
+
+ensure_do_token
+ensure_ssh_key
+
+DROPLET_NAME=$(get_server_name)
+create_server "$DROPLET_NAME"
+verify_server_connectivity "$DO_SERVER_IP"
+wait_for_cloud_init "$DO_SERVER_IP"
+
+log_warn "Installing Codex CLI..."
+run_server "$DO_SERVER_IP" "npm install -g @openai/codex"
+log_info "Codex CLI installed"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$DO_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$DO_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "DigitalOcean droplet setup completed successfully!"
+log_info "Droplet: $DROPLET_NAME (ID: $DO_DROPLET_ID, IP: $DO_SERVER_IP)"
+echo ""
+
+log_warn "Starting Codex..."
+sleep 1
+clear
+interactive_session "$DO_SERVER_IP" "source ~/.zshrc && codex"

--- a/hetzner/codex.sh
+++ b/hetzner/codex.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hetzner/lib/common.sh)
+fi
+
+log_info "Codex CLI on Hetzner Cloud"
+echo ""
+
+ensure_hcloud_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+verify_server_connectivity "$HETZNER_SERVER_IP"
+wait_for_cloud_init "$HETZNER_SERVER_IP"
+
+log_warn "Installing Codex CLI..."
+run_server "$HETZNER_SERVER_IP" "npm install -g @openai/codex"
+log_info "Codex CLI installed"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$HETZNER_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$HETZNER_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Hetzner server setup completed successfully!"
+log_info "Server: $SERVER_NAME (ID: $HETZNER_SERVER_ID, IP: $HETZNER_SERVER_IP)"
+echo ""
+
+log_warn "Starting Codex..."
+sleep 1
+clear
+interactive_session "$HETZNER_SERVER_IP" "source ~/.zshrc && codex"

--- a/manifest.json
+++ b/manifest.json
@@ -94,6 +94,19 @@
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
       "notes": "Model-agnostic agent by Block (formerly Square), supports OpenRouter as a provider"
+    },
+    "codex": {
+      "name": "Codex CLI",
+      "description": "OpenAI's open-source coding agent",
+      "url": "https://github.com/openai/codex",
+      "install": "npm install -g @openai/codex",
+      "launch": "codex",
+      "env": {
+        "OPENAI_API_KEY": "${OPENROUTER_API_KEY}",
+        "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "notes": "Works with OpenRouter via OPENAI_BASE_URL override pointing to openrouter.ai/api/v1"
     }
   },
   "clouds": {
@@ -173,6 +186,10 @@
     "vultr/openclaw": "implemented",
     "vultr/nanoclaw": "implemented",
     "vultr/aider": "implemented",
-    "vultr/goose": "implemented"
+    "vultr/goose": "implemented",
+    "sprite/codex": "implemented",
+    "hetzner/codex": "implemented",
+    "digitalocean/codex": "implemented",
+    "vultr/codex": "implemented"
   }
 }

--- a/sprite/codex.sh
+++ b/sprite/codex.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sprite/lib/common.sh)
+fi
+
+log_info "Codex CLI on Sprite"
+echo ""
+
+ensure_sprite_installed
+ensure_sprite_authenticated
+
+SPRITE_NAME=$(get_sprite_name)
+ensure_sprite_exists "$SPRITE_NAME" 5
+verify_sprite_connectivity "$SPRITE_NAME"
+
+log_warn "Setting up sprite environment..."
+setup_shell_environment "$SPRITE_NAME"
+
+log_warn "Installing Codex CLI..."
+run_sprite "$SPRITE_NAME" "npm install -g @openai/codex"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+sprite exec -s "$SPRITE_NAME" -file "$ENV_TEMP:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Sprite setup completed successfully!"
+echo ""
+
+log_warn "Starting Codex..."
+sleep 1
+clear
+sprite exec -s "$SPRITE_NAME" -tty -- zsh -c "source ~/.zshrc && codex"

--- a/vultr/codex.sh
+++ b/vultr/codex.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vultr/lib/common.sh)
+fi
+
+log_info "Codex CLI on Vultr"
+echo ""
+
+ensure_vultr_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+verify_server_connectivity "$VULTR_SERVER_IP"
+wait_for_cloud_init "$VULTR_SERVER_IP"
+
+log_warn "Installing Codex CLI..."
+run_server "$VULTR_SERVER_IP" "npm install -g @openai/codex"
+log_info "Codex CLI installed"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$VULTR_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$VULTR_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Vultr instance setup completed successfully!"
+log_info "Server: $SERVER_NAME (ID: $VULTR_SERVER_ID, IP: $VULTR_SERVER_IP)"
+echo ""
+
+log_warn "Starting Codex..."
+sleep 1
+clear
+interactive_session "$VULTR_SERVER_IP" "source ~/.zshrc && codex"


### PR DESCRIPTION
## Summary
- Adds [Codex CLI](https://github.com/openai/codex) (OpenAI's open-source coding agent) as sixth agent
- Works with OpenRouter via `OPENAI_BASE_URL=https://openrouter.ai/api/v1` override
- Implemented on all 4 clouds: sprite, hetzner, digitalocean, vultr
- Matrix now 6 agents x 4 clouds = 24/24 fully implemented

## Test plan
- [ ] Run on any cloud with `OPENROUTER_API_KEY` set
- [ ] Verify `OPENAI_BASE_URL` points to OpenRouter
- [ ] Verify Codex launches and accepts commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)