### PR TITLE
Add Open Interpreter agent across all clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/goose.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/codex.sh)
 ```
 
+#### Open Interpreter
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/interpreter.sh)
+```
+
 ### Non-Interactive Mode
 
 For automation or CI/CD, set environment variables:
@@ -123,6 +129,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/goose.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/codex.sh)
 ```
 
+#### Open Interpreter
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/interpreter.sh)
+```
+
 ### Non-Interactive Mode
 
 ```bash
@@ -181,6 +193,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/goose.sh)
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/codex.sh)
+```
+
+#### Open Interpreter
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/interpreter.sh)
 ```
 
 ### Non-Interactive Mode
@@ -243,6 +261,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/goose.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/codex.sh)
 ```
 
+#### Open Interpreter
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/interpreter.sh)
+```
+
 ### Non-Interactive Mode
 
 ```bash
@@ -301,6 +325,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/goose.sh)
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/codex.sh)
+```
+
+#### Open Interpreter
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/interpreter.sh)
 ```
 
 ### Non-Interactive Mode

--- a/digitalocean/interpreter.sh
+++ b/digitalocean/interpreter.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/digitalocean/lib/common.sh)
+fi
+
+log_info "Open Interpreter on DigitalOcean"
+echo ""
+
+ensure_do_token
+ensure_ssh_key
+
+DROPLET_NAME=$(get_server_name)
+create_server "$DROPLET_NAME"
+verify_server_connectivity "$DO_SERVER_IP"
+wait_for_cloud_init "$DO_SERVER_IP"
+
+log_warn "Installing Open Interpreter..."
+run_server "$DO_SERVER_IP" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$DO_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$DO_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "DigitalOcean droplet setup completed successfully!"
+log_info "Droplet: $DROPLET_NAME (ID: $DO_DROPLET_ID, IP: $DO_SERVER_IP)"
+echo ""
+
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "$DO_SERVER_IP" "source ~/.zshrc && interpreter"

--- a/hetzner/interpreter.sh
+++ b/hetzner/interpreter.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hetzner/lib/common.sh)
+fi
+
+log_info "Open Interpreter on Hetzner Cloud"
+echo ""
+
+ensure_hcloud_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+verify_server_connectivity "$HETZNER_SERVER_IP"
+wait_for_cloud_init "$HETZNER_SERVER_IP"
+
+log_warn "Installing Open Interpreter..."
+run_server "$HETZNER_SERVER_IP" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$HETZNER_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$HETZNER_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Hetzner server setup completed successfully!"
+log_info "Server: $SERVER_NAME (ID: $HETZNER_SERVER_ID, IP: $HETZNER_SERVER_IP)"
+echo ""
+
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "$HETZNER_SERVER_IP" "source ~/.zshrc && interpreter"

--- a/linode/interpreter.sh
+++ b/linode/interpreter.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then source "$SCRIPT_DIR/lib/common.sh"
+else source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/linode/lib/common.sh); fi
+log_info "Open Interpreter on Linode"
+echo ""
+ensure_linode_token
+ensure_ssh_key
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+verify_server_connectivity "$LINODE_SERVER_IP"
+wait_for_cloud_init "$LINODE_SERVER_IP"
+log_warn "Installing Open Interpreter..."
+run_server "$LINODE_SERVER_IP" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$LINODE_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$LINODE_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+echo ""
+log_info "Linode setup completed successfully!"
+echo ""
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "$LINODE_SERVER_IP" "source ~/.zshrc && interpreter"

--- a/manifest.json
+++ b/manifest.json
@@ -107,6 +107,19 @@
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
       "notes": "Works with OpenRouter via OPENAI_BASE_URL override pointing to openrouter.ai/api/v1"
+    },
+    "interpreter": {
+      "name": "Open Interpreter",
+      "description": "Natural language interface for computer control",
+      "url": "https://github.com/OpenInterpreter/open-interpreter",
+      "install": "pip install open-interpreter",
+      "launch": "interpreter",
+      "env": {
+        "OPENAI_API_KEY": "${OPENROUTER_API_KEY}",
+        "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "notes": "Works with OpenRouter via OPENAI_BASE_URL override"
     }
   },
   "clouds": {
@@ -211,6 +224,11 @@
     "linode/nanoclaw": "implemented",
     "linode/aider": "implemented",
     "linode/goose": "implemented",
-    "linode/codex": "implemented"
+    "linode/codex": "implemented",
+    "sprite/interpreter": "implemented",
+    "hetzner/interpreter": "implemented",
+    "digitalocean/interpreter": "implemented",
+    "vultr/interpreter": "implemented",
+    "linode/interpreter": "implemented"
   }
 }

--- a/sprite/interpreter.sh
+++ b/sprite/interpreter.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sprite/lib/common.sh)
+fi
+
+log_info "Open Interpreter on Sprite"
+echo ""
+
+ensure_sprite_installed
+ensure_sprite_authenticated
+
+SPRITE_NAME=$(get_sprite_name)
+ensure_sprite_exists "$SPRITE_NAME" 5
+verify_sprite_connectivity "$SPRITE_NAME"
+
+log_warn "Setting up sprite environment..."
+setup_shell_environment "$SPRITE_NAME"
+
+log_warn "Installing Open Interpreter..."
+run_sprite "$SPRITE_NAME" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+sprite exec -s "$SPRITE_NAME" -file "$ENV_TEMP:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Sprite setup completed successfully!"
+echo ""
+
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+sprite exec -s "$SPRITE_NAME" -tty -- zsh -c "source ~/.zshrc && interpreter"

--- a/vultr/interpreter.sh
+++ b/vultr/interpreter.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vultr/lib/common.sh)
+fi
+
+log_info "Open Interpreter on Vultr"
+echo ""
+
+ensure_vultr_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+verify_server_connectivity "$VULTR_SERVER_IP"
+wait_for_cloud_init "$VULTR_SERVER_IP"
+
+log_warn "Installing Open Interpreter..."
+run_server "$VULTR_SERVER_IP" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$VULTR_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$VULTR_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Vultr instance setup completed successfully!"
+log_info "Server: $SERVER_NAME (ID: $VULTR_SERVER_ID, IP: $VULTR_SERVER_IP)"
+echo ""
+
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "$VULTR_SERVER_IP" "source ~/.zshrc && interpreter"


### PR DESCRIPTION
## Summary
- Adds [Open Interpreter](https://github.com/OpenInterpreter/open-interpreter) as seventh agent
- Natural language interface for computer control, installed via `pip install open-interpreter`
- Works with OpenRouter via `OPENAI_BASE_URL` override
- Implemented on all 5 clouds
- Matrix now **7 agents x 5 clouds = 35/35** implemented

## Test plan
- [ ] Run on any cloud, verify `interpreter` launches
- [ ] Verify OpenRouter API key is injected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)