### PR TITLE
Add Gemini CLI agent across all clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/codex.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/interpreter.sh)
 ```
 
+#### Gemini CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/gemini.sh)
+```
 ### Non-Interactive Mode
 
 For automation or CI/CD, set environment variables:
@@ -135,6 +140,11 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/codex.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/interpreter.sh)
 ```
 
+#### Gemini CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/gemini.sh)
+```
 ### Non-Interactive Mode
 
 ```bash
@@ -201,6 +211,11 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/codex.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/interpreter.sh)
 ```
 
+#### Gemini CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/gemini.sh)
+```
 ### Non-Interactive Mode
 
 ```bash
@@ -267,6 +282,11 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/codex.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/interpreter.sh)
 ```
 
+#### Gemini CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/gemini.sh)
+```
 ### Non-Interactive Mode
 
 ```bash
@@ -333,6 +353,11 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/codex.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/interpreter.sh)
 ```
 
+#### Gemini CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/gemini.sh)
+```
 ### Non-Interactive Mode
 
 ```bash
@@ -399,6 +424,11 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/codex.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/interpreter.sh)
 ```
 
+#### Gemini CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/gemini.sh)
+```
 ### Non-Interactive Mode
 
 ```bash

--- a/aws-lightsail/gemini.sh
+++ b/aws-lightsail/gemini.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws-lightsail/lib/common.sh)
+fi
+
+log_info "Gemini CLI on AWS Lightsail"
+echo ""
+
+# 1. Ensure AWS CLI is configured
+ensure_aws_cli
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get instance name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$LIGHTSAIL_SERVER_IP"
+wait_for_cloud_init "$LIGHTSAIL_SERVER_IP"
+
+# 5. Install Gemini CLI
+log_warn "Installing Gemini CLI..."
+run_server "$LIGHTSAIL_SERVER_IP" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export GEMINI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+
+upload_file "$LIGHTSAIL_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$LIGHTSAIL_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Lightsail instance setup completed successfully!"
+log_info "Instance: $SERVER_NAME (IP: $LIGHTSAIL_SERVER_IP)"
+echo ""
+
+# 8. Start Gemini interactively
+log_warn "Starting Gemini..."
+sleep 1
+clear
+interactive_session "$LIGHTSAIL_SERVER_IP" "source ~/.zshrc && gemini"

--- a/digitalocean/gemini.sh
+++ b/digitalocean/gemini.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/digitalocean/lib/common.sh)
+fi
+
+log_info "Gemini CLI on DigitalOcean"
+echo ""
+
+ensure_do_token
+ensure_ssh_key
+
+DROPLET_NAME=$(get_server_name)
+create_server "$DROPLET_NAME"
+verify_server_connectivity "$DO_SERVER_IP"
+wait_for_cloud_init "$DO_SERVER_IP"
+
+log_warn "Installing Gemini CLI..."
+run_server "$DO_SERVER_IP" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export GEMINI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$DO_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$DO_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "DigitalOcean droplet setup completed successfully!"
+log_info "Droplet: $DROPLET_NAME (ID: $DO_DROPLET_ID, IP: $DO_SERVER_IP)"
+echo ""
+
+log_warn "Starting Gemini..."
+sleep 1
+clear
+interactive_session "$DO_SERVER_IP" "source ~/.zshrc && gemini"

--- a/hetzner/gemini.sh
+++ b/hetzner/gemini.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hetzner/lib/common.sh)
+fi
+
+log_info "Gemini CLI on Hetzner Cloud"
+echo ""
+
+ensure_hcloud_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+verify_server_connectivity "$HETZNER_SERVER_IP"
+wait_for_cloud_init "$HETZNER_SERVER_IP"
+
+log_warn "Installing Gemini CLI..."
+run_server "$HETZNER_SERVER_IP" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export GEMINI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$HETZNER_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$HETZNER_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Hetzner server setup completed successfully!"
+log_info "Server: $SERVER_NAME (ID: $HETZNER_SERVER_ID, IP: $HETZNER_SERVER_IP)"
+echo ""
+
+log_warn "Starting Gemini..."
+sleep 1
+clear
+interactive_session "$HETZNER_SERVER_IP" "source ~/.zshrc && gemini"

--- a/linode/gemini.sh
+++ b/linode/gemini.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then source "$SCRIPT_DIR/lib/common.sh"
+else source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/linode/lib/common.sh); fi
+log_info "Gemini CLI on Linode"
+echo ""
+ensure_linode_token
+ensure_ssh_key
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+verify_server_connectivity "$LINODE_SERVER_IP"
+wait_for_cloud_init "$LINODE_SERVER_IP"
+log_warn "Installing Gemini CLI..."
+run_server "$LINODE_SERVER_IP" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export GEMINI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$LINODE_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$LINODE_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+echo ""
+log_info "Linode setup completed successfully!"
+echo ""
+log_warn "Starting Gemini..."
+sleep 1
+clear
+interactive_session "$LINODE_SERVER_IP" "source ~/.zshrc && gemini"

--- a/manifest.json
+++ b/manifest.json
@@ -120,6 +120,20 @@
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
       "notes": "Works with OpenRouter via OPENAI_BASE_URL override"
+    },
+    "gemini": {
+      "name": "Gemini CLI",
+      "description": "Google's open-source coding agent",
+      "url": "https://github.com/google-gemini/gemini-cli",
+      "install": "npm install -g @google/gemini-cli",
+      "launch": "gemini",
+      "env": {
+        "GEMINI_API_KEY": "${OPENROUTER_API_KEY}",
+        "OPENAI_API_KEY": "${OPENROUTER_API_KEY}",
+        "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "notes": "Works with OpenRouter via OPENAI_BASE_URL override and GEMINI_API_KEY"
     }
   },
   "clouds": {
@@ -252,6 +266,12 @@
     "aws-lightsail/aider": "implemented",
     "aws-lightsail/goose": "implemented",
     "aws-lightsail/codex": "implemented",
-    "aws-lightsail/interpreter": "implemented"
+    "aws-lightsail/interpreter": "implemented",
+    "sprite/gemini": "implemented",
+    "hetzner/gemini": "implemented",
+    "digitalocean/gemini": "implemented",
+    "vultr/gemini": "implemented",
+    "linode/gemini": "implemented",
+    "aws-lightsail/gemini": "implemented"
   }
 }

--- a/sprite/gemini.sh
+++ b/sprite/gemini.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sprite/lib/common.sh)
+fi
+
+log_info "Gemini CLI on Sprite"
+echo ""
+
+ensure_sprite_installed
+ensure_sprite_authenticated
+
+SPRITE_NAME=$(get_sprite_name)
+ensure_sprite_exists "$SPRITE_NAME" 5
+verify_sprite_connectivity "$SPRITE_NAME"
+
+log_warn "Setting up sprite environment..."
+setup_shell_environment "$SPRITE_NAME"
+
+log_warn "Installing Gemini CLI..."
+run_sprite "$SPRITE_NAME" "npm install -g @google/gemini-cli"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export GEMINI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+sprite exec -s "$SPRITE_NAME" -file "$ENV_TEMP:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Sprite setup completed successfully!"
+echo ""
+
+log_warn "Starting Gemini..."
+sleep 1
+clear
+sprite exec -s "$SPRITE_NAME" -tty -- zsh -c "source ~/.zshrc && gemini"

--- a/vultr/gemini.sh
+++ b/vultr/gemini.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vultr/lib/common.sh)
+fi
+
+log_info "Gemini CLI on Vultr"
+echo ""
+
+ensure_vultr_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+verify_server_connectivity "$VULTR_SERVER_IP"
+wait_for_cloud_init "$VULTR_SERVER_IP"
+
+log_warn "Installing Gemini CLI..."
+run_server "$VULTR_SERVER_IP" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export GEMINI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+upload_file "$VULTR_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$VULTR_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "Vultr instance setup completed successfully!"
+log_info "Server: $SERVER_NAME (ID: $VULTR_SERVER_ID, IP: $VULTR_SERVER_IP)"
+echo ""
+
+log_warn "Starting Gemini..."
+sleep 1
+clear
+interactive_session "$VULTR_SERVER_IP" "source ~/.zshrc && gemini"


### PR DESCRIPTION
## Summary
- Adds [Gemini CLI](https://github.com/google-gemini/gemini-cli) (Google) as eighth agent
- Works with OpenRouter via `OPENAI_BASE_URL` + `GEMINI_API_KEY` env vars
- Implemented on all 6 clouds
- Matrix now **8 agents x 6 clouds = 48/48** fully implemented

## Test plan
- [ ] Run on any cloud, verify `gemini` launches
- [ ] Verify OpenRouter env vars are injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)