### PR TITLE
Add GCP Compute Engine with all 10 agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,3 +584,86 @@ OPENROUTER_API_KEY=sk-or-v1-xxxxx \
 - `OPENROUTER_API_KEY` - Skip OAuth and use this API key directly
 - `LAMBDA_INSTANCE_TYPE` - Instance type (default: `gpu_1x_a10`)
 - `LAMBDA_REGION` - Region (default: `us-east-1`)
+
+---
+
+## GCP Compute Engine
+
+Spawn agents on [Google Cloud Compute Engine](https://cloud.google.com/compute) instances. Requires `gcloud` CLI installed and configured.
+
+### Usage
+
+#### Claude Code
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/claude.sh)
+```
+
+#### OpenClaw
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/openclaw.sh)
+```
+
+#### NanoClaw
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/nanoclaw.sh)
+```
+
+#### Aider
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/aider.sh)
+```
+
+#### Goose
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/goose.sh)
+```
+
+#### Codex CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/codex.sh)
+```
+
+#### Open Interpreter
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/interpreter.sh)
+```
+
+#### Gemini CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/gemini.sh)
+```
+
+#### Amazon Q CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/amazonq.sh)
+```
+
+#### Cline
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/cline.sh)
+```
+
+### Non-Interactive Mode
+
+```bash
+GCP_INSTANCE_NAME=dev-mk1 \
+OPENROUTER_API_KEY=sk-or-v1-xxxxx \
+  bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/claude.sh)
+```
+
+**Environment Variables:**
+- `GCP_INSTANCE_NAME` - Name for the instance (skips prompt)
+- `GCP_PROJECT` - GCP project ID (defaults to gcloud config)
+- `OPENROUTER_API_KEY` - Skip OAuth and use this API key directly
+- `GCP_MACHINE_TYPE` - Machine type (default: `e2-medium`)
+- `GCP_ZONE` - Compute zone (default: `us-central1-a`)

--- a/gcp/aider.sh
+++ b/gcp/aider.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "Aider on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Install Aider
+log_warn "Installing Aider..."
+run_server "$GCP_SERVER_IP" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
+log_info "Aider installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Get model preference
+echo ""
+log_warn "Browse models at: https://openrouter.ai/models"
+log_warn "Which model would you like to use with Aider?"
+MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
+MODEL_ID="${MODEL_ID:-openrouter/auto}"
+
+# 8. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 9. Start Aider interactively
+log_warn "Starting Aider..."
+sleep 1
+clear
+interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/gcp/amazonq.sh
+++ b/gcp/amazonq.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "Amazon Q on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Install Amazon Q CLI
+log_warn "Installing Amazon Q CLI..."
+run_server "$GCP_SERVER_IP" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 8. Start Amazon Q interactively
+log_warn "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && q chat"

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "Claude Code on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Verify Claude Code is installed (fallback to manual install)
+log_warn "Verifying Claude Code installation..."
+if ! run_server "$GCP_SERVER_IP" "command -v claude" >/dev/null 2>&1; then
+    log_warn "Claude Code not found, installing manually..."
+    run_server "$GCP_SERVER_IP" "curl -fsSL https://claude.ai/install.sh | bash"
+fi
+log_info "Claude Code is installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export ANTHROPIC_BASE_URL="https://openrouter.ai/api"
+export ANTHROPIC_AUTH_TOKEN="${OPENROUTER_API_KEY}"
+export ANTHROPIC_API_KEY=""
+export CLAUDE_CODE_SKIP_ONBOARDING="1"
+export CLAUDE_CODE_ENABLE_TELEMETRY="0"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+# 8. Configure Claude Code settings
+log_warn "Configuring Claude Code..."
+
+run_server "$GCP_SERVER_IP" "mkdir -p ~/.claude"
+
+# Upload settings.json
+SETTINGS_TEMP=$(mktemp)
+cat > "$SETTINGS_TEMP" << EOF
+{
+  "theme": "dark",
+  "editor": "vim",
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
+    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
+  },
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "dangerouslySkipPermissions": true
+  }
+}
+EOF
+
+upload_file "$GCP_SERVER_IP" "$SETTINGS_TEMP" "~/.claude/settings.json"
+rm "$SETTINGS_TEMP"
+
+# Upload ~/.claude.json global state
+GLOBAL_STATE_TEMP=$(mktemp)
+cat > "$GLOBAL_STATE_TEMP" << EOF
+{
+  "hasCompletedOnboarding": true,
+  "bypassPermissionsModeAccepted": true
+}
+EOF
+
+upload_file "$GCP_SERVER_IP" "$GLOBAL_STATE_TEMP" "~/.claude.json"
+rm "$GLOBAL_STATE_TEMP"
+
+# Create empty CLAUDE.md
+run_server "$GCP_SERVER_IP" "touch ~/.claude/CLAUDE.md"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 9. Start Claude Code interactively
+log_warn "Starting Claude Code..."
+sleep 1
+clear
+interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && claude"

--- a/gcp/cline.sh
+++ b/gcp/cline.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "Cline on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Install Cline
+log_warn "Installing Cline..."
+run_server "$GCP_SERVER_IP" "npm install -g cline"
+log_info "Cline installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 8. Start Cline interactively
+log_warn "Starting Cline..."
+sleep 1
+clear
+interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && cline"

--- a/gcp/codex.sh
+++ b/gcp/codex.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "Codex CLI on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Install Codex CLI
+log_warn "Installing Codex CLI..."
+run_server "$GCP_SERVER_IP" "npm install -g @openai/codex"
+log_info "Codex CLI installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 8. Start Codex interactively
+log_warn "Starting Codex..."
+sleep 1
+clear
+interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && codex"

--- a/gcp/gemini.sh
+++ b/gcp/gemini.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "Gemini CLI on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Install Gemini CLI
+log_warn "Installing Gemini CLI..."
+run_server "$GCP_SERVER_IP" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export GEMINI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 8. Start Gemini interactively
+log_warn "Starting Gemini..."
+sleep 1
+clear
+interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && gemini"

--- a/gcp/goose.sh
+++ b/gcp/goose.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "Goose on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Install Goose
+log_warn "Installing Goose..."
+run_server "$GCP_SERVER_IP" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+log_info "Goose installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export GOOSE_PROVIDER=openrouter
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 8. Start Goose interactively
+log_warn "Starting Goose..."
+sleep 1
+clear
+interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && goose"

--- a/gcp/interpreter.sh
+++ b/gcp/interpreter.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "Open Interpreter on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Install Open Interpreter
+log_warn "Installing Open Interpreter..."
+run_server "$GCP_SERVER_IP" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 8. Start Open Interpreter interactively
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && interpreter"

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+# Common bash functions for GCP Compute Engine spawn scripts
+# Uses gcloud CLI — requires Google Cloud SDK installed and configured
+
+# ============================================================
+# Provider-agnostic functions
+# ============================================================
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}$1${NC}" >&2; }
+log_warn() { echo -e "${YELLOW}$1${NC}" >&2; }
+log_error() { echo -e "${RED}$1${NC}" >&2; }
+
+safe_read() {
+    local prompt="$1" result=""
+    if [[ -t 0 ]]; then read -p "$prompt" result
+    elif echo -n "" > /dev/tty 2>/dev/null; then read -p "$prompt" result < /dev/tty
+    else log_error "Cannot read input: no TTY available"; return 1; fi
+    echo "$result"
+}
+
+nc_listen() {
+    local port=$1; shift
+    if nc --help 2>&1 | grep -q "BusyBox\|busybox" || nc --help 2>&1 | grep -q "\-p "; then
+        nc -l -p "$port" "$@"
+    else nc -l "$port" "$@"; fi
+}
+
+open_browser() {
+    local url=$1
+    if command -v termux-open-url &>/dev/null; then termux-open-url "$url" </dev/null
+    elif command -v open &>/dev/null; then open "$url" </dev/null
+    elif command -v xdg-open &>/dev/null; then xdg-open "$url" </dev/null
+    else log_warn "Please open: ${url}"; fi
+}
+
+get_openrouter_api_key_manual() {
+    echo ""; log_warn "Manual API Key Entry"
+    echo -e "${YELLOW}Get your API key from: https://openrouter.ai/settings/keys${NC}"; echo ""
+    local api_key=""
+    while [[ -z "$api_key" ]]; do
+        api_key=$(safe_read "Enter your OpenRouter API key: ") || return 1
+        if [[ -z "$api_key" ]]; then log_error "API key cannot be empty"
+        elif [[ ! "$api_key" =~ ^sk-or-v1-[a-f0-9]{64}$ ]]; then
+            log_warn "Warning: API key format doesn't match expected pattern (sk-or-v1-...)"
+            local confirm=$(safe_read "Use this key anyway? (y/N): ") || return 1
+            if [[ "$confirm" =~ ^[Yy]$ ]]; then break; else api_key=""; fi
+        fi
+    done
+    log_info "API key accepted!"; echo "$api_key"
+}
+
+try_oauth_flow() {
+    local callback_port=${1:-5180}
+    log_warn "Attempting OAuth authentication..."
+    if ! command -v nc &>/dev/null; then log_warn "netcat (nc) not found"; return 1; fi
+    local callback_url="http://localhost:${callback_port}/callback"
+    local auth_url="https://openrouter.ai/auth?callback_url=${callback_url}"
+    local oauth_dir=$(mktemp -d) code_file="$oauth_dir/code"
+    log_warn "Starting local OAuth server on port ${callback_port}..."
+    (
+        local success_response='HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nConnection: close\r\n\r\n<html><head><style>body{font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#1a1a2e}.card{text-align:center;color:#fff}h1{color:#00d4aa}p{color:#ffffffcc}</style></head><body><div class="card"><h1>Authentication Successful!</h1><p>You can close this tab</p></div><script>setTimeout(function(){try{window.close()}catch(e){}},3000)</script></body></html>'
+        while true; do
+            local response_file=$(mktemp); echo -e "$success_response" > "$response_file"
+            local request=$(nc_listen "$callback_port" < "$response_file" 2>/dev/null | head -1)
+            local nc_status=$?; rm -f "$response_file"
+            if [[ $nc_status -ne 0 ]]; then break; fi
+            if [[ "$request" == *"/callback?code="* ]]; then
+                echo "$request" | sed -n 's/.*code=\([^ &]*\).*/\1/p' > "$code_file"; break
+            fi
+        done
+    ) </dev/null &
+    local server_pid=$!; sleep 1
+    if ! kill -0 $server_pid 2>/dev/null; then log_warn "Failed to start OAuth server"; rm -rf "$oauth_dir"; return 1; fi
+    log_warn "Opening browser to authenticate with OpenRouter..."; open_browser "$auth_url"
+    local timeout=120 elapsed=0
+    while [[ ! -f "$code_file" ]] && [[ $elapsed -lt $timeout ]]; do sleep 1; ((elapsed++)); done
+    kill $server_pid 2>/dev/null || true; wait $server_pid 2>/dev/null || true
+    if [[ ! -f "$code_file" ]]; then log_warn "OAuth timeout"; rm -rf "$oauth_dir"; return 1; fi
+    local oauth_code=$(cat "$code_file"); rm -rf "$oauth_dir"
+    log_warn "Exchanging OAuth code for API key..."
+    local key_response=$(curl -s -X POST "https://openrouter.ai/api/v1/auth/keys" \
+        -H "Content-Type: application/json" -d "{\"code\": \"$oauth_code\"}")
+    local api_key=$(echo "$key_response" | grep -o '"key":"[^"]*"' | sed 's/"key":"//;s/"$//')
+    if [[ -z "$api_key" ]]; then log_error "Failed to exchange OAuth code: ${key_response}"; return 1; fi
+    log_info "Successfully obtained OpenRouter API key via OAuth!"; echo "$api_key"
+}
+
+get_openrouter_api_key_oauth() {
+    local callback_port=${1:-5180}
+    local api_key=$(try_oauth_flow "$callback_port")
+    if [[ -n "$api_key" ]]; then echo "$api_key"; return 0; fi
+    echo ""; log_warn "OAuth authentication failed or unavailable"
+    log_warn "You can enter your API key manually instead"; echo ""
+    local manual_choice=$(safe_read "Would you like to enter your API key manually? (Y/n): ") || {
+        log_error "Cannot prompt for manual entry in non-interactive mode"
+        log_warn "Set OPENROUTER_API_KEY environment variable for non-interactive usage"; return 1
+    }
+    if [[ ! "$manual_choice" =~ ^[Nn]$ ]]; then
+        api_key=$(get_openrouter_api_key_manual); echo "$api_key"; return 0
+    else log_error "Authentication cancelled by user"; return 1; fi
+}
+
+# ============================================================
+# GCP Compute Engine specific functions
+# ============================================================
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i $HOME/.ssh/id_ed25519"
+
+ensure_gcloud() {
+    if ! command -v gcloud &>/dev/null; then
+        log_error "Google Cloud SDK (gcloud) is required."
+        log_error "Install: https://cloud.google.com/sdk/docs/install"
+        return 1
+    fi
+    # Verify auth
+    if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null | head -1 | grep -q '@'; then
+        log_error "gcloud not authenticated. Run: gcloud auth login"
+        return 1
+    fi
+    # Set project
+    local project="${GCP_PROJECT:-$(gcloud config get-value project 2>/dev/null)}"
+    if [[ -z "$project" || "$project" == "(unset)" ]]; then
+        log_error "No GCP project set. Run: gcloud config set project YOUR_PROJECT"
+        return 1
+    fi
+    export GCP_PROJECT="$project"
+    log_info "Using GCP project: $project"
+}
+
+ensure_ssh_key() {
+    local key_path="$HOME/.ssh/id_ed25519" pub_path="${key_path}.pub"
+    if [[ ! -f "$key_path" ]]; then
+        log_warn "Generating SSH key..."
+        mkdir -p "$HOME/.ssh"
+        ssh-keygen -t ed25519 -f "$key_path" -N "" -q
+        log_info "SSH key generated at $key_path"
+    fi
+    # GCP handles SSH keys via project/instance metadata, added during create
+    log_info "SSH key ready"
+}
+
+get_server_name() {
+    if [[ -n "$GCP_INSTANCE_NAME" ]]; then
+        log_info "Using instance name from environment: $GCP_INSTANCE_NAME"
+        echo "$GCP_INSTANCE_NAME"; return 0
+    fi
+    local server_name=$(safe_read "Enter instance name: ")
+    if [[ -z "$server_name" ]]; then
+        log_error "Instance name is required"
+        log_warn "Set GCP_INSTANCE_NAME environment variable for non-interactive usage"; return 1
+    fi
+    echo "$server_name"
+}
+
+get_cloud_init_userdata() {
+    cat << 'CLOUD_INIT_EOF'
+#!/bin/bash
+apt-get update -y
+apt-get install -y curl unzip git zsh
+# Install Bun
+su - $(logname 2>/dev/null || echo "$(whoami)") -c 'curl -fsSL https://bun.sh/install | bash' || true
+# Install Claude Code
+su - $(logname 2>/dev/null || echo "$(whoami)") -c 'curl -fsSL https://claude.ai/install.sh | bash' || true
+# Configure PATH for all users
+echo 'export PATH="$HOME/.claude/local/bin:$HOME/.bun/bin:$PATH"' >> /etc/profile.d/spawn.sh
+chmod +x /etc/profile.d/spawn.sh
+touch /tmp/.cloud-init-complete
+CLOUD_INIT_EOF
+}
+
+create_server() {
+    local name="$1"
+    local machine_type="${GCP_MACHINE_TYPE:-e2-medium}"
+    local zone="${GCP_ZONE:-us-central1-a}"
+    local image_family="ubuntu-2404-lts-amd64"
+    local image_project="ubuntu-os-cloud"
+
+    log_warn "Creating GCP instance '$name' (type: $machine_type, zone: $zone)..."
+
+    local userdata=$(get_cloud_init_userdata)
+    local pub_key=$(cat "$HOME/.ssh/id_ed25519.pub")
+    local username=$(whoami)
+
+    gcloud compute instances create "$name" \
+        --zone="$zone" \
+        --machine-type="$machine_type" \
+        --image-family="$image_family" \
+        --image-project="$image_project" \
+        --metadata="startup-script=$userdata,ssh-keys=${username}:${pub_key}" \
+        --project="$GCP_PROJECT" \
+        --quiet \
+        >/dev/null 2>&1
+
+    if [[ $? -ne 0 ]]; then
+        log_error "Failed to create GCP instance"
+        return 1
+    fi
+
+    export GCP_INSTANCE_NAME_ACTUAL="$name"
+    export GCP_ZONE="$zone"
+
+    # Get external IP
+    GCP_SERVER_IP=$(gcloud compute instances describe "$name" \
+        --zone="$zone" \
+        --project="$GCP_PROJECT" \
+        --format='get(networkInterfaces[0].accessConfigs[0].natIP)' 2>/dev/null)
+    export GCP_SERVER_IP
+
+    log_info "Instance created: IP=$GCP_SERVER_IP"
+}
+
+verify_server_connectivity() {
+    local ip="$1" max_attempts=${2:-30} attempt=1
+    local username=$(whoami)
+    log_warn "Waiting for SSH connectivity to $ip..."
+    while [[ $attempt -le $max_attempts ]]; do
+        if ssh $SSH_OPTS -o ConnectTimeout=5 "${username}@$ip" "echo ok" >/dev/null 2>&1; then
+            log_info "SSH connection established"; return 0
+        fi
+        log_warn "Waiting for SSH... ($attempt/$max_attempts)"; sleep 5; ((attempt++))
+    done
+    log_error "Server failed to respond via SSH after $max_attempts attempts"; return 1
+}
+
+wait_for_cloud_init() {
+    local ip="$1" max_attempts=${2:-60} attempt=1
+    local username=$(whoami)
+    log_warn "Waiting for startup script to complete..."
+    while [[ $attempt -le $max_attempts ]]; do
+        if ssh $SSH_OPTS "${username}@$ip" "test -f /tmp/.cloud-init-complete" >/dev/null 2>&1; then
+            log_info "Startup script completed"; return 0
+        fi
+        log_warn "Startup script in progress... ($attempt/$max_attempts)"; sleep 5; ((attempt++))
+    done
+    log_error "Startup script did not complete after $max_attempts attempts"; return 1
+}
+
+# GCP uses current username
+run_server() {
+    local ip="$1" cmd="$2"
+    local username=$(whoami)
+    ssh $SSH_OPTS "${username}@$ip" "$cmd"
+}
+
+upload_file() {
+    local ip="$1" local_path="$2" remote_path="$3"
+    local username=$(whoami)
+    scp $SSH_OPTS "$local_path" "${username}@$ip:$remote_path"
+}
+
+interactive_session() {
+    local ip="$1" cmd="$2"
+    local username=$(whoami)
+    ssh -t $SSH_OPTS "${username}@$ip" "$cmd"
+}
+
+destroy_server() {
+    local name="$1"
+    local zone="${GCP_ZONE:-us-central1-a}"
+    log_warn "Destroying GCP instance $name..."
+    gcloud compute instances delete "$name" --zone="$zone" --project="$GCP_PROJECT" --quiet >/dev/null 2>&1
+    log_info "Instance $name destroyed"
+}
+
+list_servers() {
+    gcloud compute instances list --project="$GCP_PROJECT" --format='table(name,zone,status,networkInterfaces[0].accessConfigs[0].natIP:label=EXTERNAL_IP,machineType.basename())'
+}

--- a/gcp/nanoclaw.sh
+++ b/gcp/nanoclaw.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "NanoClaw on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Install Node.js deps and clone nanoclaw
+log_warn "Installing tsx..."
+run_server "$GCP_SERVER_IP" "source ~/.bashrc && bun install -g tsx"
+
+log_warn "Cloning and building nanoclaw..."
+run_server "$GCP_SERVER_IP" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
+log_info "NanoClaw installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export ANTHROPIC_API_KEY="${OPENROUTER_API_KEY}"
+export ANTHROPIC_BASE_URL="https://openrouter.ai/api"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+# 8. Create nanoclaw .env file
+log_warn "Configuring nanoclaw..."
+
+DOTENV_TEMP=$(mktemp)
+cat > "$DOTENV_TEMP" << EOF
+ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
+EOF
+
+upload_file "$GCP_SERVER_IP" "$DOTENV_TEMP" "~/nanoclaw/.env"
+rm "$DOTENV_TEMP"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 9. Start nanoclaw
+log_warn "Starting nanoclaw..."
+log_warn "You will need to scan a WhatsApp QR code to authenticate."
+echo ""
+interactive_session "$GCP_SERVER_IP" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/gcp/openclaw.sh
+++ b/gcp/openclaw.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -e
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)
+fi
+
+log_info "OpenClaw on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$GCP_SERVER_IP"
+wait_for_cloud_init "$GCP_SERVER_IP"
+
+# 5. Install openclaw via bun
+log_warn "Installing openclaw..."
+run_server "$GCP_SERVER_IP" "source ~/.bashrc && bun install -g openclaw"
+log_info "OpenClaw installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "$OPENROUTER_API_KEY" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Get model preference
+echo ""
+log_warn "Browse models at: https://openrouter.ai/models"
+log_warn "Which model would you like to use?"
+MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
+MODEL_ID="${MODEL_ID:-openrouter/auto}"
+
+# 8. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+ENV_TEMP=$(mktemp)
+cat > "$ENV_TEMP" << EOF
+
+# [spawn:env]
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export ANTHROPIC_API_KEY="${OPENROUTER_API_KEY}"
+export ANTHROPIC_BASE_URL="https://openrouter.ai/api"
+EOF
+
+upload_file "$GCP_SERVER_IP" "$ENV_TEMP" "/tmp/env_config"
+run_server "$GCP_SERVER_IP" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+rm "$ENV_TEMP"
+
+# 9. Configure openclaw
+log_warn "Configuring openclaw..."
+
+run_server "$GCP_SERVER_IP" "rm -rf ~/.openclaw && mkdir -p ~/.openclaw"
+
+# Generate a random gateway token
+GATEWAY_TOKEN=$(openssl rand -hex 16)
+
+OPENCLAW_CONFIG_TEMP=$(mktemp)
+cat > "$OPENCLAW_CONFIG_TEMP" << EOF
+{
+  "env": {
+    "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+  },
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "token": "${GATEWAY_TOKEN}"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "openrouter/${MODEL_ID}"
+      }
+    }
+  }
+}
+EOF
+
+upload_file "$GCP_SERVER_IP" "$OPENCLAW_CONFIG_TEMP" "~/.openclaw/openclaw.json"
+rm "$OPENCLAW_CONFIG_TEMP"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_IP)"
+echo ""
+
+# 10. Start openclaw gateway in background and launch TUI
+log_warn "Starting openclaw..."
+run_server "$GCP_SERVER_IP" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+sleep 2
+interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && openclaw tui"

--- a/manifest.json
+++ b/manifest.json
@@ -263,6 +263,22 @@
         "blueprint": "ubuntu_24_04"
       },
       "notes": "Uses 'ubuntu' user instead of 'root'. Requires AWS CLI installed and configured."
+    },
+    "gcp": {
+      "name": "GCP Compute Engine",
+      "description": "Google Cloud Compute Engine instances via gcloud CLI",
+      "url": "https://cloud.google.com/compute",
+      "type": "cli",
+      "auth": "gcloud auth login",
+      "provision_method": "gcloud compute instances create with --metadata startup-script",
+      "exec_method": "ssh user@IP",
+      "interactive_method": "ssh -t user@IP",
+      "defaults": {
+        "machine_type": "e2-medium",
+        "zone": "us-central1-a",
+        "image_family": "ubuntu-2404-lts-amd64"
+      },
+      "notes": "Uses current username for SSH. Requires gcloud CLI installed and configured."
     }
   },
   "matrix": {
@@ -335,6 +351,16 @@
     "vultr/cline": "implemented",
     "linode/cline": "implemented",
     "lambda/cline": "implemented",
-    "aws-lightsail/cline": "implemented"
+    "aws-lightsail/cline": "implemented",
+    "gcp/claude": "implemented",
+    "gcp/openclaw": "implemented",
+    "gcp/nanoclaw": "implemented",
+    "gcp/aider": "implemented",
+    "gcp/goose": "implemented",
+    "gcp/codex": "implemented",
+    "gcp/interpreter": "implemented",
+    "gcp/gemini": "implemented",
+    "gcp/amazonq": "implemented",
+    "gcp/cline": "implemented"
   }
 }


### PR DESCRIPTION
## Summary
- Adds [GCP Compute Engine](https://cloud.google.com/compute) as eighth cloud provider
- Uses `gcloud` CLI with startup-script for provisioning
- SSH as current user (not root/ubuntu)
- All 10 agents implemented
- Matrix now **10 agents x 8 clouds = 80/80**

🤖 Generated with [Claude Code](https://claude.com/claude-code)