### PR TITLE
Fix shared/common.sh remote fallback for curl execution

### DIFF
--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -8,12 +8,13 @@ set -euo pipefail
 # Provider-agnostic functions
 # ============================================================
 
-# Source shared provider-agnostic functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../../shared/common.sh" || {
-    echo "ERROR: Failed to load shared/common.sh" >&2
-    exit 1
-}
+# Source shared provider-agnostic functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
+    source "$SCRIPT_DIR/../../shared/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh
 

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -6,12 +6,13 @@ set -euo pipefail
 # Provider-agnostic functions
 # ============================================================
 
-# Source shared provider-agnostic functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../../shared/common.sh" || {
-    echo "ERROR: Failed to load shared/common.sh" >&2
-    exit 1
-}
+# Source shared provider-agnostic functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
+    source "$SCRIPT_DIR/../../shared/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh
 

--- a/linode/lib/common.sh
+++ b/linode/lib/common.sh
@@ -8,12 +8,13 @@ set -euo pipefail
 # Provider-agnostic functions
 # ============================================================
 
-# Source shared provider-agnostic functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../../shared/common.sh" || {
-    echo "ERROR: Failed to load shared/common.sh" >&2
-    exit 1
-}
+# Source shared provider-agnostic functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
+    source "$SCRIPT_DIR/../../shared/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh
 

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -2,12 +2,13 @@
 set -euo pipefail
 # Common bash functions shared between spawn scripts
 
-# Source shared provider-agnostic functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../../shared/common.sh" || {
-    echo "ERROR: Failed to load shared/common.sh" >&2
-    exit 1
-}
+# Source shared provider-agnostic functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
+    source "$SCRIPT_DIR/../../shared/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+fi
 
 # Check if sprite CLI is installed, install if not
 ensure_sprite_installed() {

--- a/vultr/lib/common.sh
+++ b/vultr/lib/common.sh
@@ -8,12 +8,13 @@ set -euo pipefail
 # Provider-agnostic functions
 # ============================================================
 
-# Source shared provider-agnostic functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../../shared/common.sh" || {
-    echo "ERROR: Failed to load shared/common.sh" >&2
-    exit 1
-}
+# Source shared provider-agnostic functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
+    source "$SCRIPT_DIR/../../shared/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh
 


### PR DESCRIPTION
## Summary

Fixes `No such file or directory: /dev/fd/../../shared/common.sh` when running:
```bash
bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/claude.sh)
```

The autonomous refactoring (shared/common.sh extraction) broke remote execution because `{cloud}/lib/common.sh` does a hard `source "$SCRIPT_DIR/../../shared/common.sh"` — but when loaded via eval+curl, `SCRIPT_DIR` is empty/invalid.

Fix: same local-or-remote fallback pattern used everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)