### PR TITLE
Use safe defaults for all env var checks

### DIFF
--- a/aws-lightsail/aider.sh
+++ b/aws-lightsail/aider.sh
@@ -33,7 +33,7 @@ log_info "Aider installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/aws-lightsail/amazonq.sh
+++ b/aws-lightsail/amazonq.sh
@@ -33,7 +33,7 @@ log_info "Amazon Q CLI installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/aws-lightsail/claude.sh
+++ b/aws-lightsail/claude.sh
@@ -36,7 +36,7 @@ log_info "Claude Code is installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/aws-lightsail/cline.sh
+++ b/aws-lightsail/cline.sh
@@ -33,7 +33,7 @@ log_info "Cline installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/aws-lightsail/codex.sh
+++ b/aws-lightsail/codex.sh
@@ -33,7 +33,7 @@ log_info "Codex CLI installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/aws-lightsail/gemini.sh
+++ b/aws-lightsail/gemini.sh
@@ -33,7 +33,7 @@ log_info "Gemini CLI installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/aws-lightsail/goose.sh
+++ b/aws-lightsail/goose.sh
@@ -33,7 +33,7 @@ log_info "Goose installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/aws-lightsail/interpreter.sh
+++ b/aws-lightsail/interpreter.sh
@@ -33,7 +33,7 @@ log_info "Open Interpreter installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/aws-lightsail/lib/common.sh
+++ b/aws-lightsail/lib/common.sh
@@ -158,7 +158,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    if [[ -n "$LIGHTSAIL_SERVER_NAME" ]]; then
+    if [[ -n "${LIGHTSAIL_SERVER_NAME:-}" ]]; then
         log_info "Using instance name from environment: $LIGHTSAIL_SERVER_NAME"
         echo "$LIGHTSAIL_SERVER_NAME"; return 0
     fi

--- a/aws-lightsail/nanoclaw.sh
+++ b/aws-lightsail/nanoclaw.sh
@@ -36,7 +36,7 @@ log_info "NanoClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/aws-lightsail/openclaw.sh
+++ b/aws-lightsail/openclaw.sh
@@ -33,7 +33,7 @@ log_info "OpenClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/aider.sh
+++ b/digitalocean/aider.sh
@@ -40,7 +40,7 @@ log_info "Aider installation verified successfully"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/amazonq.sh
+++ b/digitalocean/amazonq.sh
@@ -24,7 +24,7 @@ run_server "$DO_SERVER_IP" "curl -fsSL https://desktop-release.q.us-east-1.amazo
 log_info "Amazon Q CLI installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -46,7 +46,7 @@ log_info "Claude Code installation verified successfully"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/cline.sh
+++ b/digitalocean/cline.sh
@@ -24,7 +24,7 @@ run_server "$DO_SERVER_IP" "npm install -g cline"
 log_info "Cline installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/codex.sh
+++ b/digitalocean/codex.sh
@@ -24,7 +24,7 @@ run_server "$DO_SERVER_IP" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/gemini.sh
+++ b/digitalocean/gemini.sh
@@ -24,7 +24,7 @@ run_server "$DO_SERVER_IP" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/goose.sh
+++ b/digitalocean/goose.sh
@@ -33,7 +33,7 @@ log_info "Goose installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/interpreter.sh
+++ b/digitalocean/interpreter.sh
@@ -24,7 +24,7 @@ run_server "$DO_SERVER_IP" "pip install open-interpreter 2>/dev/null || pip3 ins
 log_info "Open Interpreter installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -39,7 +39,7 @@ ensure_do_token() {
     check_python_available || return 1
 
     # 1. Check environment variable
-    if [[ -n "$DO_API_TOKEN" ]]; then
+    if [[ -n "${DO_API_TOKEN:-}" ]]; then
         log_info "Using DigitalOcean API token from environment"
         return 0
     fi
@@ -143,7 +143,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    if [[ -n "$DO_DROPLET_NAME" ]]; then
+    if [[ -n "${DO_DROPLET_NAME:-}" ]]; then
         log_info "Using droplet name from environment: $DO_DROPLET_NAME"
         if ! validate_server_name "$DO_DROPLET_NAME"; then
             return 1

--- a/digitalocean/nanoclaw.sh
+++ b/digitalocean/nanoclaw.sh
@@ -36,7 +36,7 @@ log_info "NanoClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/digitalocean/openclaw.sh
+++ b/digitalocean/openclaw.sh
@@ -33,7 +33,7 @@ log_info "OpenClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/aider.sh
+++ b/e2b/aider.sh
@@ -30,7 +30,7 @@ log_info "Aider installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/amazonq.sh
+++ b/e2b/amazonq.sh
@@ -30,7 +30,7 @@ log_info "Amazon Q CLI installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/claude.sh
+++ b/e2b/claude.sh
@@ -33,7 +33,7 @@ log_info "Claude Code is installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/cline.sh
+++ b/e2b/cline.sh
@@ -30,7 +30,7 @@ log_info "Cline installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/codex.sh
+++ b/e2b/codex.sh
@@ -30,7 +30,7 @@ log_info "Codex CLI installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/gemini.sh
+++ b/e2b/gemini.sh
@@ -30,7 +30,7 @@ log_info "Gemini CLI installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/goose.sh
+++ b/e2b/goose.sh
@@ -30,7 +30,7 @@ log_info "Goose installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/interpreter.sh
+++ b/e2b/interpreter.sh
@@ -30,7 +30,7 @@ log_info "Open Interpreter installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/nanoclaw.sh
+++ b/e2b/nanoclaw.sh
@@ -33,7 +33,7 @@ log_info "NanoClaw installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/e2b/openclaw.sh
+++ b/e2b/openclaw.sh
@@ -30,7 +30,7 @@ log_info "OpenClaw installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/aider.sh
+++ b/gcp/aider.sh
@@ -33,7 +33,7 @@ log_info "Aider installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/amazonq.sh
+++ b/gcp/amazonq.sh
@@ -33,7 +33,7 @@ log_info "Amazon Q CLI installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -36,7 +36,7 @@ log_info "Claude Code is installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/cline.sh
+++ b/gcp/cline.sh
@@ -33,7 +33,7 @@ log_info "Cline installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/codex.sh
+++ b/gcp/codex.sh
@@ -33,7 +33,7 @@ log_info "Codex CLI installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/gemini.sh
+++ b/gcp/gemini.sh
@@ -33,7 +33,7 @@ log_info "Gemini CLI installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/goose.sh
+++ b/gcp/goose.sh
@@ -33,7 +33,7 @@ log_info "Goose installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/interpreter.sh
+++ b/gcp/interpreter.sh
@@ -33,7 +33,7 @@ log_info "Open Interpreter installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -151,7 +151,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    if [[ -n "$GCP_INSTANCE_NAME" ]]; then
+    if [[ -n "${GCP_INSTANCE_NAME:-}" ]]; then
         log_info "Using instance name from environment: $GCP_INSTANCE_NAME"
         echo "$GCP_INSTANCE_NAME"; return 0
     fi

--- a/gcp/nanoclaw.sh
+++ b/gcp/nanoclaw.sh
@@ -36,7 +36,7 @@ log_info "NanoClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/gcp/openclaw.sh
+++ b/gcp/openclaw.sh
@@ -33,7 +33,7 @@ log_info "OpenClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/aider.sh
+++ b/hetzner/aider.sh
@@ -40,7 +40,7 @@ log_info "Aider installation verified successfully"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/amazonq.sh
+++ b/hetzner/amazonq.sh
@@ -24,7 +24,7 @@ run_server "$HETZNER_SERVER_IP" "curl -fsSL https://desktop-release.q.us-east-1.
 log_info "Amazon Q CLI installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -43,7 +43,7 @@ log_info "Claude Code installation verified successfully"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/cline.sh
+++ b/hetzner/cline.sh
@@ -24,7 +24,7 @@ run_server "$HETZNER_SERVER_IP" "npm install -g cline"
 log_info "Cline installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/codex.sh
+++ b/hetzner/codex.sh
@@ -24,7 +24,7 @@ run_server "$HETZNER_SERVER_IP" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/gemini.sh
+++ b/hetzner/gemini.sh
@@ -24,7 +24,7 @@ run_server "$HETZNER_SERVER_IP" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/goose.sh
+++ b/hetzner/goose.sh
@@ -40,7 +40,7 @@ log_info "Goose installation verified successfully"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/interpreter.sh
+++ b/hetzner/interpreter.sh
@@ -24,7 +24,7 @@ run_server "$HETZNER_SERVER_IP" "pip install open-interpreter 2>/dev/null || pip
 log_info "Open Interpreter installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -37,7 +37,7 @@ ensure_hcloud_token() {
     check_python_available || return 1
 
     # 1. Check environment variable
-    if [[ -n "$HCLOUD_TOKEN" ]]; then
+    if [[ -n "${HCLOUD_TOKEN:-}" ]]; then
         log_info "Using Hetzner API token from environment"
         return 0
     fi
@@ -139,7 +139,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    if [[ -n "$HETZNER_SERVER_NAME" ]]; then
+    if [[ -n "${HETZNER_SERVER_NAME:-}" ]]; then
         log_info "Using server name from environment: $HETZNER_SERVER_NAME"
         if ! validate_server_name "$HETZNER_SERVER_NAME"; then
             return 1

--- a/hetzner/nanoclaw.sh
+++ b/hetzner/nanoclaw.sh
@@ -36,7 +36,7 @@ log_info "NanoClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/hetzner/openclaw.sh
+++ b/hetzner/openclaw.sh
@@ -33,7 +33,7 @@ log_info "OpenClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/aider.sh
+++ b/lambda/aider.sh
@@ -33,7 +33,7 @@ log_info "Aider installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/amazonq.sh
+++ b/lambda/amazonq.sh
@@ -33,7 +33,7 @@ log_info "Amazon Q CLI installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/claude.sh
+++ b/lambda/claude.sh
@@ -36,7 +36,7 @@ log_info "Claude Code is installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/cline.sh
+++ b/lambda/cline.sh
@@ -33,7 +33,7 @@ log_info "Cline installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/codex.sh
+++ b/lambda/codex.sh
@@ -33,7 +33,7 @@ log_info "Codex CLI installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/gemini.sh
+++ b/lambda/gemini.sh
@@ -33,7 +33,7 @@ log_info "Gemini CLI installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/goose.sh
+++ b/lambda/goose.sh
@@ -33,7 +33,7 @@ log_info "Goose installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/interpreter.sh
+++ b/lambda/interpreter.sh
@@ -33,7 +33,7 @@ log_info "Open Interpreter installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/lib/common.sh
+++ b/lambda/lib/common.sh
@@ -126,7 +126,7 @@ lambda_api() {
 }
 
 ensure_lambda_token() {
-    if [[ -n "$LAMBDA_API_KEY" ]]; then
+    if [[ -n "${LAMBDA_API_KEY:-}" ]]; then
         log_info "Using Lambda API key from environment"; return 0
     fi
     local config_dir="$HOME/.config/spawn" config_file="$config_dir/lambda.json"
@@ -182,7 +182,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    if [[ -n "$LAMBDA_SERVER_NAME" ]]; then
+    if [[ -n "${LAMBDA_SERVER_NAME:-}" ]]; then
         log_info "Using server name from environment: $LAMBDA_SERVER_NAME"
         echo "$LAMBDA_SERVER_NAME"; return 0
     fi

--- a/lambda/nanoclaw.sh
+++ b/lambda/nanoclaw.sh
@@ -36,7 +36,7 @@ log_info "NanoClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/lambda/openclaw.sh
+++ b/lambda/openclaw.sh
@@ -33,7 +33,7 @@ log_info "OpenClaw installed"
 
 # 6. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/linode/aider.sh
+++ b/linode/aider.sh
@@ -15,7 +15,7 @@ log_warn "Installing Aider..."
 run_server "$LINODE_SERVER_IP" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 log_warn "Setting up environment variables..."

--- a/linode/amazonq.sh
+++ b/linode/amazonq.sh
@@ -15,7 +15,7 @@ log_warn "Installing Amazon Q CLI..."
 run_server "$LINODE_SERVER_IP" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 log_warn "Setting up environment variables..."
 ENV_TEMP=$(mktemp)

--- a/linode/claude.sh
+++ b/linode/claude.sh
@@ -18,7 +18,7 @@ if ! run_server "$LINODE_SERVER_IP" "command -v claude" >/dev/null 2>&1; then
 fi
 log_info "Claude Code is installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 log_warn "Setting up environment variables..."
 inject_env_vars_ssh "$LINODE_SERVER_IP" upload_file run_server \

--- a/linode/cline.sh
+++ b/linode/cline.sh
@@ -15,7 +15,7 @@ log_warn "Installing Cline..."
 run_server "$LINODE_SERVER_IP" "npm install -g cline"
 log_info "Cline installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 log_warn "Setting up environment variables..."
 ENV_TEMP=$(mktemp)

--- a/linode/codex.sh
+++ b/linode/codex.sh
@@ -15,7 +15,7 @@ log_warn "Installing Codex CLI..."
 run_server "$LINODE_SERVER_IP" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 log_warn "Setting up environment variables..."
 inject_env_vars_ssh "$LINODE_SERVER_IP" upload_file run_server \

--- a/linode/gemini.sh
+++ b/linode/gemini.sh
@@ -15,7 +15,7 @@ log_warn "Installing Gemini CLI..."
 run_server "$LINODE_SERVER_IP" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 log_warn "Setting up environment variables..."
 ENV_TEMP=$(mktemp)

--- a/linode/goose.sh
+++ b/linode/goose.sh
@@ -15,7 +15,7 @@ log_warn "Installing Goose..."
 run_server "$LINODE_SERVER_IP" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 log_warn "Setting up environment variables..."
 inject_env_vars_ssh "$LINODE_SERVER_IP" upload_file run_server \

--- a/linode/interpreter.sh
+++ b/linode/interpreter.sh
@@ -15,7 +15,7 @@ log_warn "Installing Open Interpreter..."
 run_server "$LINODE_SERVER_IP" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 log_warn "Setting up environment variables..."
 inject_env_vars_ssh "$LINODE_SERVER_IP" upload_file run_server \

--- a/linode/lib/common.sh
+++ b/linode/lib/common.sh
@@ -34,7 +34,7 @@ ensure_linode_token() {
     # Check Python 3 is available (required for JSON parsing)
     check_python_available || return 1
 
-    if [[ -n "$LINODE_API_TOKEN" ]]; then
+    if [[ -n "${LINODE_API_TOKEN:-}" ]]; then
         log_info "Using Linode API token from environment"; return 0
     fi
     local config_dir="$HOME/.config/spawn" config_file="$config_dir/linode.json"
@@ -113,7 +113,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    if [[ -n "$LINODE_SERVER_NAME" ]]; then
+    if [[ -n "${LINODE_SERVER_NAME:-}" ]]; then
         log_info "Using server name from environment: $LINODE_SERVER_NAME"
         if ! validate_server_name "$LINODE_SERVER_NAME"; then
             return 1

--- a/linode/nanoclaw.sh
+++ b/linode/nanoclaw.sh
@@ -17,7 +17,7 @@ log_warn "Cloning and building nanoclaw..."
 run_server "$LINODE_SERVER_IP" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 log_warn "Setting up environment variables..."
 inject_env_vars_ssh "$LINODE_SERVER_IP" upload_file run_server \

--- a/linode/openclaw.sh
+++ b/linode/openclaw.sh
@@ -15,7 +15,7 @@ log_warn "Installing openclaw..."
 run_server "$LINODE_SERVER_IP" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then log_info "Using OpenRouter API key from environment"
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 log_warn "Setting up environment variables..."

--- a/modal/aider.sh
+++ b/modal/aider.sh
@@ -29,7 +29,7 @@ log_info "Aider installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/modal/amazonq.sh
+++ b/modal/amazonq.sh
@@ -29,7 +29,7 @@ log_info "Amazon Q CLI installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/modal/claude.sh
+++ b/modal/claude.sh
@@ -32,7 +32,7 @@ log_info "Claude Code is installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/modal/cline.sh
+++ b/modal/cline.sh
@@ -29,7 +29,7 @@ log_info "Cline installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/modal/codex.sh
+++ b/modal/codex.sh
@@ -29,7 +29,7 @@ log_info "Codex CLI installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/modal/gemini.sh
+++ b/modal/gemini.sh
@@ -29,7 +29,7 @@ log_info "Gemini CLI installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/modal/goose.sh
+++ b/modal/goose.sh
@@ -29,7 +29,7 @@ log_info "Goose installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/modal/interpreter.sh
+++ b/modal/interpreter.sh
@@ -29,7 +29,7 @@ log_info "Open Interpreter installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/modal/lib/common.sh
+++ b/modal/lib/common.sh
@@ -134,7 +134,7 @@ ensure_modal_cli() {
 }
 
 get_server_name() {
-    if [[ -n "$MODAL_SANDBOX_NAME" ]]; then
+    if [[ -n "${MODAL_SANDBOX_NAME:-}" ]]; then
         log_info "Using sandbox name from environment: $MODAL_SANDBOX_NAME"
         echo "$MODAL_SANDBOX_NAME"; return 0
     fi

--- a/modal/nanoclaw.sh
+++ b/modal/nanoclaw.sh
@@ -32,7 +32,7 @@ log_info "NanoClaw installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/modal/openclaw.sh
+++ b/modal/openclaw.sh
@@ -29,7 +29,7 @@ log_info "OpenClaw installed"
 
 # 5. Get OpenRouter API key
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/sprite/aider.sh
+++ b/sprite/aider.sh
@@ -39,7 +39,7 @@ log_info "Aider installation verified successfully"
 
 # Get OpenRouter API key via OAuth
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/sprite/amazonq.sh
+++ b/sprite/amazonq.sh
@@ -25,7 +25,7 @@ log_warn "Installing Amazon Q CLI..."
 run_sprite "$SPRITE_NAME" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/sprite/cline.sh
+++ b/sprite/cline.sh
@@ -25,7 +25,7 @@ log_warn "Installing Cline..."
 run_sprite "$SPRITE_NAME" "npm install -g cline"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/sprite/codex.sh
+++ b/sprite/codex.sh
@@ -25,7 +25,7 @@ log_warn "Installing Codex CLI..."
 run_sprite "$SPRITE_NAME" "npm install -g @openai/codex"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/sprite/gemini.sh
+++ b/sprite/gemini.sh
@@ -25,7 +25,7 @@ log_warn "Installing Gemini CLI..."
 run_sprite "$SPRITE_NAME" "npm install -g @google/gemini-cli"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/sprite/goose.sh
+++ b/sprite/goose.sh
@@ -39,7 +39,7 @@ log_info "Goose installation verified successfully"
 
 # Get OpenRouter API key via OAuth
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/sprite/interpreter.sh
+++ b/sprite/interpreter.sh
@@ -25,7 +25,7 @@ log_warn "Installing Open Interpreter..."
 run_sprite "$SPRITE_NAME" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -30,7 +30,7 @@ ensure_sprite_authenticated() {
 # Prompt for sprite name
 get_sprite_name() {
     # Check if SPRITE_NAME is already set in environment
-    if [[ -n "$SPRITE_NAME" ]]; then
+    if [[ -n "${SPRITE_NAME:-}" ]]; then
         log_info "Using sprite name from environment: $SPRITE_NAME"
         if ! validate_server_name "$SPRITE_NAME"; then
             return 1

--- a/vultr/aider.sh
+++ b/vultr/aider.sh
@@ -24,7 +24,7 @@ run_server "$VULTR_SERVER_IP" "pip install aider-chat 2>/dev/null || pip3 instal
 log_info "Aider installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/vultr/amazonq.sh
+++ b/vultr/amazonq.sh
@@ -24,7 +24,7 @@ run_server "$VULTR_SERVER_IP" "curl -fsSL https://desktop-release.q.us-east-1.am
 log_info "Amazon Q CLI installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/vultr/claude.sh
+++ b/vultr/claude.sh
@@ -27,7 +27,7 @@ fi
 log_info "Claude Code is installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/vultr/cline.sh
+++ b/vultr/cline.sh
@@ -24,7 +24,7 @@ run_server "$VULTR_SERVER_IP" "npm install -g cline"
 log_info "Cline installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/vultr/codex.sh
+++ b/vultr/codex.sh
@@ -24,7 +24,7 @@ run_server "$VULTR_SERVER_IP" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/vultr/gemini.sh
+++ b/vultr/gemini.sh
@@ -24,7 +24,7 @@ run_server "$VULTR_SERVER_IP" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/vultr/goose.sh
+++ b/vultr/goose.sh
@@ -24,7 +24,7 @@ run_server "$VULTR_SERVER_IP" "CONFIGURE=false curl -fsSL https://github.com/blo
 log_info "Goose installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/vultr/interpreter.sh
+++ b/vultr/interpreter.sh
@@ -24,7 +24,7 @@ run_server "$VULTR_SERVER_IP" "pip install open-interpreter 2>/dev/null || pip3 
 log_info "Open Interpreter installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/vultr/lib/common.sh
+++ b/vultr/lib/common.sh
@@ -36,7 +36,7 @@ ensure_vultr_token() {
     # Check Python 3 is available (required for JSON parsing)
     check_python_available || return 1
 
-    if [[ -n "$VULTR_API_KEY" ]]; then
+    if [[ -n "${VULTR_API_KEY:-}" ]]; then
         log_info "Using Vultr API key from environment"
         return 0
     fi
@@ -129,7 +129,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    if [[ -n "$VULTR_SERVER_NAME" ]]; then
+    if [[ -n "${VULTR_SERVER_NAME:-}" ]]; then
         log_info "Using server name from environment: $VULTR_SERVER_NAME"
         if ! validate_server_name "$VULTR_SERVER_NAME"; then
             return 1

--- a/vultr/nanoclaw.sh
+++ b/vultr/nanoclaw.sh
@@ -26,7 +26,7 @@ run_server "$VULTR_SERVER_IP" "git clone https://github.com/gavrielc/nanoclaw.gi
 log_info "NanoClaw installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)

--- a/vultr/openclaw.sh
+++ b/vultr/openclaw.sh
@@ -24,7 +24,7 @@ run_server "$VULTR_SERVER_IP" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
 echo ""
-if [[ -n "$OPENROUTER_API_KEY" ]]; then
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
 else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)


### PR DESCRIPTION
## Summary
Fixes `SPRITE_NAME: unbound variable` and similar crashes.

Every `[[ -n "$ENV_VAR" ]]` check now uses `[[ -n "${ENV_VAR:-}" ]]` to safely default to empty when the var is unset. Covers SPRITE_NAME, OPENROUTER_API_KEY, HCLOUD_TOKEN, DO_API_TOKEN, VULTR_API_KEY, LINODE_API_TOKEN, etc. across all scripts.

Belt-and-suspenders fix — works regardless of whether `set -u` is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)