### PR TITLE
Fix OAuth server hanging on startup

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -253,7 +253,7 @@ start_oauth_server() {
                     ;;
             esac
         done
-    ) </dev/null &
+    ) </dev/null >/dev/null 2>&1 &
 
     echo $!
 }


### PR DESCRIPTION
## Summary
Fixes the script hanging at "Starting local OAuth server on port 5180..." and never reaching "Opening browser..."

**Root cause:** `start_oauth_server` is called inside `$(...)` to capture the PID. The backgrounded nc subshell inherits the `$()` stdout pipe. Since `$()` waits for ALL writers on that pipe to finish, it blocks forever — nc is listening, so it never closes stdout.

**Fix:** `>/dev/null 2>&1` on the subshell so it doesn't hold the `$()` pipe open. The `echo $!` that returns the PID still runs in the parent scope, after `&` backgrounds the child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)