### PR TITLE
Add Plandex coding agent

### DIFF
--- a/aws-lightsail/plandex.sh
+++ b/aws-lightsail/plandex.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=aws-lightsail/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws-lightsail/lib/common.sh)"
+fi
+
+log_info "Plandex on AWS Lightsail"
+echo ""
+
+# 1. Ensure AWS CLI is configured
+ensure_aws_cli
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get instance name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
+wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
+
+# 5. Install Plandex
+log_warn "Installing Plandex..."
+run_server "${LIGHTSAIL_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+log_info "Plandex installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Lightsail instance setup completed successfully!"
+log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
+echo ""
+
+# 8. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/civo/plandex.sh
+++ b/civo/plandex.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=civo/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/civo/lib/common.sh)"
+fi
+
+log_info "Plandex on Civo"
+echo ""
+
+ensure_civo_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CIVO_SERVER_IP}"
+
+log_warn "Waiting for cloud-init to complete..."
+generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
+
+log_warn "Installing Plandex..."
+run_server "${CIVO_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+log_info "Plandex installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Civo instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
+echo ""
+
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/daytona/plandex.sh
+++ b/daytona/plandex.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=daytona/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/daytona/lib/common.sh)"
+fi
+
+log_info "Plandex on Daytona"
+echo ""
+
+# 1. Ensure Daytona CLI and API token
+ensure_daytona_cli
+ensure_daytona_token
+
+# 2. Get sandbox name and create sandbox
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for base tools
+wait_for_cloud_init
+
+# 4. Install Plandex
+log_warn "Installing Plandex..."
+run_server "curl -sL https://plandex.ai/install.sh | bash"
+log_info "Plandex installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Daytona sandbox setup completed successfully!"
+log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
+echo ""
+
+# 7. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "source ~/.zshrc && plandex"

--- a/digitalocean/plandex.sh
+++ b/digitalocean/plandex.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=digitalocean/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/digitalocean/lib/common.sh)"
+fi
+
+log_info "Plandex on DigitalOcean"
+echo ""
+
+# 1. Resolve DigitalOcean API token
+ensure_do_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get droplet name and create droplet
+DROPLET_NAME=$(get_server_name)
+create_server "${DROPLET_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${DO_SERVER_IP}"
+wait_for_cloud_init "${DO_SERVER_IP}" 60
+
+# 5. Install Plandex
+log_warn "Installing Plandex..."
+run_server "${DO_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${DO_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    log_error "The 'plandex' command is not available or not working properly on server ${DO_SERVER_IP}"
+    exit 1
+fi
+log_info "Plandex installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "DigitalOcean droplet setup completed successfully!"
+log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
+echo ""
+
+# 7. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/e2b/plandex.sh
+++ b/e2b/plandex.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=e2b/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/e2b/lib/common.sh)"
+fi
+
+log_info "Plandex on E2B"
+echo ""
+
+# 1. Ensure E2B CLI and API token
+ensure_e2b_cli
+ensure_e2b_token
+
+# 2. Get sandbox name and create sandbox
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for base tools
+wait_for_cloud_init
+
+# 4. Install Plandex
+log_warn "Installing Plandex..."
+run_server "curl -sL https://plandex.ai/install.sh | bash"
+log_info "Plandex installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "E2B sandbox setup completed successfully!"
+log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
+echo ""
+
+# 7. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "source ~/.zshrc && plandex"

--- a/fly/plandex.sh
+++ b/fly/plandex.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/fly/lib/common.sh)"
+fi
+
+log_info "Plandex on Fly.io"
+echo ""
+
+# 1. Ensure flyctl CLI and API token
+ensure_fly_cli
+ensure_fly_token
+
+# 2. Get app name and create machine
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Install base tools
+wait_for_cloud_init
+
+# 4. Install Plandex
+log_warn "Installing Plandex..."
+run_server "curl -sL https://plandex.ai/install.sh | bash"
+log_info "Plandex installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+inject_env_vars_fly \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "PATH=\$HOME/.bun/bin:\$PATH"
+
+echo ""
+log_info "Fly.io machine setup completed successfully!"
+log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
+echo ""
+
+# 7. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && plandex"

--- a/gcp/plandex.sh
+++ b/gcp/plandex.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=gcp/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/gcp/lib/common.sh)"
+fi
+
+# Variables exported by create_server() in lib/common.sh
+# shellcheck disable=SC2154
+: "${GCP_SERVER_IP:?}" "${GCP_INSTANCE_NAME_ACTUAL:?}" "${GCP_ZONE:?}"
+
+
+log_info "Plandex on GCP Compute Engine"
+echo ""
+
+# 1. Ensure gcloud is configured
+ensure_gcloud
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${GCP_SERVER_IP}"
+wait_for_cloud_init "${GCP_SERVER_IP}" 60
+
+# 5. Install Plandex
+log_warn "Installing Plandex..."
+run_server "${GCP_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+log_info "Plandex installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "GCP instance setup completed successfully!"
+log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SERVER_IP})"
+echo ""
+
+# 8. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/hetzner/plandex.sh
+++ b/hetzner/plandex.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hetzner/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hetzner/lib/common.sh)"
+fi
+
+log_info "Plandex on Hetzner Cloud"
+echo ""
+
+# 1. Resolve Hetzner API token
+ensure_hcloud_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${HETZNER_SERVER_IP}"
+wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
+
+# 5. Install Plandex
+log_warn "Installing Plandex..."
+run_server "${HETZNER_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${HETZNER_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    log_error "The 'plandex' command is not available or not working properly on server ${HETZNER_SERVER_IP}"
+    exit 1
+fi
+log_info "Plandex installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Hetzner server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
+echo ""
+
+# 7. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/lambda/plandex.sh
+++ b/lambda/plandex.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=lambda/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/lambda/lib/common.sh)"
+fi
+
+log_info "Plandex on Lambda Cloud"
+echo ""
+
+# 1. Ensure Lambda API key is configured
+ensure_lambda_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get instance name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${LAMBDA_SERVER_IP}"
+wait_for_cloud_init "${LAMBDA_SERVER_IP}"
+
+# 5. Install Plandex
+log_warn "Installing Plandex..."
+run_server "${LAMBDA_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+log_info "Plandex installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${LAMBDA_INSTANCE_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Lambda Cloud instance setup completed successfully!"
+log_info "Instance: ${SERVER_NAME} (IP: ${LAMBDA_SERVER_IP})"
+echo ""
+
+# 8. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${LAMBDA_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/linode/plandex.sh
+++ b/linode/plandex.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=linode/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then source "${SCRIPT_DIR}/lib/common.sh"
+else eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/linode/lib/common.sh)"; fi
+log_info "Plandex on Linode"
+echo ""
+ensure_linode_token
+ensure_ssh_key
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${LINODE_SERVER_IP}"
+wait_for_cloud_init "${LINODE_SERVER_IP}" 60
+log_warn "Installing Plandex..."
+run_server "${LINODE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+if ! run_server "${LINODE_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    exit 1
+fi
+log_info "Plandex installed"
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
+else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+echo ""
+log_info "Linode setup completed successfully!"
+echo ""
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/manifest.json
+++ b/manifest.json
@@ -189,6 +189,17 @@
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
       "notes": "Natively supports OpenRouter via OPENROUTER_API_KEY env var. Go-based TUI using Bubble Tea."
+    },
+    "plandex": {
+      "name": "Plandex",
+      "description": "Open source AI coding agent for complex tasks",
+      "url": "https://github.com/plandex-ai/plandex",
+      "install": "curl -sL https://plandex.ai/install.sh | bash",
+      "launch": "plandex",
+      "env": {
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "notes": "Natively supports OpenRouter via OPENROUTER_API_KEY env var. Go-based CLI with sandbox and version control for AI changes."
     }
   },
   "clouds": {
@@ -571,6 +582,20 @@
     "daytona/amazonq": "implemented",
     "daytona/cline": "implemented",
     "daytona/gptme": "implemented",
-    "daytona/opencode": "implemented"
+    "daytona/opencode": "implemented",
+    "sprite/plandex": "implemented",
+    "hetzner/plandex": "implemented",
+    "digitalocean/plandex": "implemented",
+    "vultr/plandex": "implemented",
+    "linode/plandex": "implemented",
+    "lambda/plandex": "implemented",
+    "aws-lightsail/plandex": "implemented",
+    "gcp/plandex": "implemented",
+    "e2b/plandex": "implemented",
+    "modal/plandex": "implemented",
+    "fly/plandex": "implemented",
+    "civo/plandex": "implemented",
+    "scaleway/plandex": "implemented",
+    "daytona/plandex": "implemented"
   }
 }

--- a/modal/plandex.sh
+++ b/modal/plandex.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=modal/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/modal/lib/common.sh)"
+fi
+
+log_info "Plandex on Modal"
+echo ""
+
+# 1. Ensure Modal CLI
+ensure_modal_cli
+
+# 2. Get sandbox name and create sandbox
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}" || {
+    log_error "Failed to create Modal sandbox"
+    exit 1
+}
+if [[ -z "${MODAL_SANDBOX_ID}" ]]; then
+    log_error "MODAL_SANDBOX_ID not set after create_server"
+    exit 1
+fi
+
+# 3. Wait for base tools
+wait_for_cloud_init
+
+# 4. Install Plandex
+log_warn "Installing Plandex..."
+run_server "curl -sL https://plandex.ai/install.sh | bash"
+log_info "Plandex installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Modal sandbox setup completed successfully!"
+log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
+echo ""
+
+# 7. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "source ~/.zshrc && plandex"

--- a/scaleway/plandex.sh
+++ b/scaleway/plandex.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=scaleway/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/scaleway/lib/common.sh)"
+fi
+
+log_info "Plandex on Scaleway"
+echo ""
+
+ensure_scaleway_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${SCALEWAY_SERVER_IP}"
+install_base_packages "${SCALEWAY_SERVER_IP}"
+
+log_warn "Installing Plandex..."
+run_server "${SCALEWAY_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+log_info "Plandex installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Scaleway instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
+echo ""
+
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/sprite/plandex.sh
+++ b/sprite/plandex.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sprite/lib/common.sh)"
+fi
+
+log_info "Plandex on Sprite"
+echo ""
+
+# Setup sprite environment
+ensure_sprite_installed
+ensure_sprite_authenticated
+
+SPRITE_NAME=$(get_sprite_name)
+ensure_sprite_exists "${SPRITE_NAME}" 5
+verify_sprite_connectivity "${SPRITE_NAME}"
+
+log_warn "Setting up sprite environment..."
+
+# Configure shell environment
+setup_shell_environment "${SPRITE_NAME}"
+
+# Install Plandex
+log_warn "Installing Plandex..."
+run_sprite "${SPRITE_NAME}" "curl -sL https://plandex.ai/install.sh | bash"
+
+# Verify installation succeeded
+if ! run_sprite "${SPRITE_NAME}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    log_error "The 'plandex' command is not available or not working properly"
+    exit 1
+fi
+log_info "Plandex installation verified successfully"
+
+# Get OpenRouter API key via OAuth
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_sprite "${SPRITE_NAME}" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Sprite setup completed successfully!"
+echo ""
+
+# Check if running in non-interactive mode
+if [[ -n "${SPAWN_PROMPT:-}" ]]; then
+    # Non-interactive mode: execute prompt and exit
+    log_warn "Executing Plandex with prompt..."
+
+    # Escape prompt for safe shell execution
+    escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
+
+    # Execute without -tty flag
+    sprite exec -s "${SPRITE_NAME}" -- zsh -c "source ~/.zshrc && plandex new && plandex tell ${escaped_prompt}"
+else
+    # Interactive mode: start Plandex normally
+    log_warn "Starting Plandex..."
+    sleep 1
+    clear
+    sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && plandex"
+fi

--- a/vultr/plandex.sh
+++ b/vultr/plandex.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=vultr/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vultr/lib/common.sh)"
+fi
+
+log_info "Plandex on Vultr"
+echo ""
+
+ensure_vultr_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${VULTR_SERVER_IP}"
+wait_for_cloud_init "${VULTR_SERVER_IP}" 60
+
+log_warn "Installing Plandex..."
+run_server "${VULTR_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+
+if ! run_server "${VULTR_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    exit 1
+fi
+log_info "Plandex installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Vultr instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
+echo ""
+
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && plandex"


### PR DESCRIPTION
## Summary
- Add **Plandex** as a new agent to the Spawn matrix (15k+ GitHub stars, 304-point HN post)
- Plandex is an open source, terminal-native AI coding agent for complex tasks
- Natively supports `OPENROUTER_API_KEY` — no base URL override needed
- Implemented across all **14 clouds**: sprite, hetzner, digitalocean, vultr, linode, lambda, aws-lightsail, gcp, e2b, modal, fly, civo, scaleway, daytona

## Evidence of community demand
- **GitHub**: 15,000+ stars on [plandex-ai/plandex](https://github.com/plandex-ai/plandex)
- **Hacker News**: [Show HN: Plandex v1](https://news.ycombinator.com/item?id=39918500) — 304 points, 111 comments
- **Hacker News**: [Show HN: Plandex v2](https://news.ycombinator.com/item?id=43709200) — 257 points, 81 comments

## Why Plandex?
- **Terminal-native**: Go binary, runs entirely in CLI — no IDE/GUI required
- **Single-command install**: `curl -sL https://plandex.ai/install.sh | bash`
- **Native OpenRouter support**: Just `export OPENROUTER_API_KEY=...` and launch
- **Built for complex tasks**: Sandbox approach with version control for AI-generated changes
- **Active development**: v2 released April 2025 with full auto mode and 2M context

## Test plan
- [ ] `bash -n` passes on all 14 scripts (verified locally)
- [ ] `manifest.json` is valid JSON (verified locally)
- [ ] All 14 matrix entries marked as `"implemented"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)