### PR TITLE
feat: Add Genesis Cloud agent scripts (batch 1)

### DIFF
--- a/genesiscloud/aider.sh
+++ b/genesiscloud/aider.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=genesiscloud/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/genesiscloud/lib/common.sh)"
+fi
+
+log_info "Aider on Genesis Cloud"
+echo ""
+
+ensure_genesis_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${GENESIS_SERVER_IP}"
+wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
+
+log_warn "Installing Aider..."
+run_server "${GENESIS_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
+
+if ! run_server "${GENESIS_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
+    log_error "Aider installation verification failed"
+    exit 1
+fi
+log_info "Aider installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Genesis Cloud server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
+echo ""
+
+log_warn "Starting Aider..."
+sleep 1
+clear
+interactive_session "${GENESIS_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/genesiscloud/claude.sh
+++ b/genesiscloud/claude.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=genesiscloud/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/genesiscloud/lib/common.sh)"
+fi
+
+log_info "Claude Code on Genesis Cloud"
+echo ""
+
+ensure_genesis_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${GENESIS_SERVER_IP}"
+wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
+
+log_warn "Verifying Claude Code installation..."
+if ! run_server "${GENESIS_SERVER_IP}" "command -v claude" >/dev/null 2>&1; then
+    log_warn "Claude Code not found, installing manually..."
+    run_server "${GENESIS_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
+fi
+log_info "Claude Code is installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
+    "ANTHROPIC_AUTH_TOKEN=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=" \
+    "CLAUDE_CODE_SKIP_ONBOARDING=1" \
+    "CLAUDE_CODE_ENABLE_TELEMETRY=0"
+
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${GENESIS_SERVER_IP}" \
+    "run_server ${GENESIS_SERVER_IP}"
+
+echo ""
+log_info "Genesis Cloud server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
+echo ""
+
+log_warn "Starting Claude Code..."
+sleep 1
+clear
+interactive_session "${GENESIS_SERVER_IP}" "source ~/.zshrc && claude"

--- a/genesiscloud/openclaw.sh
+++ b/genesiscloud/openclaw.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=genesiscloud/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/genesiscloud/lib/common.sh)"
+fi
+
+log_info "OpenClaw on Genesis Cloud"
+echo ""
+
+ensure_genesis_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${GENESIS_SERVER_IP}"
+wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
+
+log_warn "Installing openclaw..."
+run_server "${GENESIS_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
+log_info "OpenClaw installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
+
+setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" \
+    "upload_file ${GENESIS_SERVER_IP}" \
+    "run_server ${GENESIS_SERVER_IP}"
+
+echo ""
+log_info "Genesis Cloud server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
+echo ""
+
+log_warn "Starting openclaw..."
+run_server "${GENESIS_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+sleep 2
+interactive_session "${GENESIS_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/genesiscloud/plandex.sh
+++ b/genesiscloud/plandex.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=genesiscloud/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/genesiscloud/lib/common.sh)"
+fi
+
+log_info "Plandex on Genesis Cloud"
+echo ""
+
+ensure_genesis_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${GENESIS_SERVER_IP}"
+wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
+
+log_warn "Installing Plandex..."
+run_server "${GENESIS_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+
+log_warn "Verifying Plandex installation..."
+if ! run_server "${GENESIS_SERVER_IP}" "command -v plandex" >/dev/null 2>&1; then
+    log_error "Plandex installation failed"
+    exit 1
+fi
+log_info "Plandex is installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Genesis Cloud server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
+echo ""
+
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${GENESIS_SERVER_IP}" "source ~/.zshrc && plandex"


### PR DESCRIPTION
## Summary
- Add 4 Genesis Cloud agent deployment scripts: claude, openclaw, aider, plandex
- All scripts follow the standard spawn pattern: authenticate, provision, install, inject OpenRouter creds, launch
- Scripts use the Genesis Cloud lib/common.sh primitives (ensure_genesis_token, create_server, etc.)

## Scripts added
- `genesiscloud/claude.sh` - Claude Code with full OpenRouter proxy config + setup_claude_code_config
- `genesiscloud/openclaw.sh` - OpenClaw with gateway daemon + TUI launch
- `genesiscloud/aider.sh` - Aider with interactive model selection via OpenRouter
- `genesiscloud/plandex.sh` - Plandex CLI with installation verification

## Test plan
- [x] All 4 scripts pass `bash -n` syntax validation
- [x] All scripts follow the BinaryLane reference pattern adapted for Genesis Cloud
- [x] OpenRouter injection is present in all scripts
- [ ] Manual deployment test on Genesis Cloud instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)