### PR TITLE
Add Genesis Cloud scripts: amazonq, cline, gptme, opencode, plandex

### DIFF
--- a/genesiscloud/README.md
+++ b/genesiscloud/README.md
@@ -1,0 +1,73 @@
+# Genesis Cloud
+
+Genesis Cloud GPU instances via REST API. [Genesis Cloud](https://www.genesiscloud.com/)
+
+## Agents
+
+#### Claude Code
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/genesiscloud/claude.sh)
+```
+
+#### OpenClaw
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/genesiscloud/openclaw.sh)
+```
+
+#### Aider
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/genesiscloud/aider.sh)
+```
+
+#### Amazon Q CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/genesiscloud/amazonq.sh)
+```
+
+#### Cline
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/genesiscloud/cline.sh)
+```
+
+#### gptme
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/genesiscloud/gptme.sh)
+```
+
+#### OpenCode
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/genesiscloud/opencode.sh)
+```
+
+#### Plandex
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/genesiscloud/plandex.sh)
+```
+
+## Non-Interactive Mode
+
+```bash
+GENESIS_SERVER_NAME=dev-gpu \
+GENESIS_API_KEY=your-api-key \
+OPENROUTER_API_KEY=sk-or-v1-xxxxx \
+  bash <(curl -fsSL https://openrouter.ai/lab/spawn/genesiscloud/claude.sh)
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GENESIS_API_KEY` | Genesis Cloud API key | _(prompted)_ |
+| `GENESIS_SERVER_NAME` | Instance name | _(prompted)_ |
+| `GENESIS_INSTANCE_TYPE` | Instance type | `vcpu-4_memory-12g_nvidia-rtx-3080-1` |
+| `GENESIS_REGION` | Datacenter region | `ARC-IS-HAF-1` |
+| `GENESIS_IMAGE` | OS image | `Ubuntu 24.04` |
+| `OPENROUTER_API_KEY` | OpenRouter API key | _(OAuth or prompted)_ |

--- a/genesiscloud/amazonq.sh
+++ b/genesiscloud/amazonq.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=genesiscloud/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/genesiscloud/lib/common.sh)"
+fi
+
+log_info "Amazon Q on Genesis Cloud"
+echo ""
+
+ensure_genesis_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${GENESIS_SERVER_IP}"
+wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
+
+log_warn "Installing Amazon Q CLI..."
+run_server "${GENESIS_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Genesis Cloud server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
+echo ""
+
+log_warn "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${GENESIS_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/genesiscloud/cline.sh
+++ b/genesiscloud/cline.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=genesiscloud/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/genesiscloud/lib/common.sh)"
+fi
+
+log_info "Cline on Genesis Cloud"
+echo ""
+
+ensure_genesis_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${GENESIS_SERVER_IP}"
+wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
+
+log_warn "Installing Cline..."
+run_server "${GENESIS_SERVER_IP}" "npm install -g cline"
+log_info "Cline installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Genesis Cloud server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
+echo ""
+
+log_warn "Starting Cline..."
+sleep 1
+clear
+interactive_session "${GENESIS_SERVER_IP}" "source ~/.zshrc && cline"

--- a/genesiscloud/gptme.sh
+++ b/genesiscloud/gptme.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/genesiscloud/lib/common.sh)"
+fi
+
+log_info "gptme on Genesis Cloud"
+echo ""
+
+ensure_genesis_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${GENESIS_SERVER_IP}"
+wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
+
+log_warn "Installing gptme..."
+run_server "${GENESIS_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
+
+if ! run_server "${GENESIS_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
+    log_error "gptme installation verification failed"
+    log_error "The 'gptme' command is not available or not working properly on server ${GENESIS_SERVER_IP}"
+    exit 1
+fi
+log_info "gptme installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Genesis Cloud instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
+echo ""
+
+log_warn "Starting gptme..."
+sleep 1
+clear
+interactive_session "${GENESIS_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/genesiscloud/opencode.sh
+++ b/genesiscloud/opencode.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/genesiscloud/lib/common.sh)"
+fi
+
+log_info "OpenCode on Genesis Cloud"
+echo ""
+
+ensure_genesis_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${GENESIS_SERVER_IP}"
+wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
+
+log_warn "Installing OpenCode..."
+run_server "${GENESIS_SERVER_IP}" "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
+log_info "OpenCode installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Genesis Cloud instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
+echo ""
+
+log_warn "Starting OpenCode..."
+sleep 1
+clear
+interactive_session "${GENESIS_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/manifest.json
+++ b/manifest.json
@@ -715,6 +715,6 @@
     "genesiscloud/cline": "implemented",
     "genesiscloud/gptme": "implemented",
     "genesiscloud/opencode": "implemented",
-    "genesiscloud/plandex": "missing"
+    "genesiscloud/plandex": "implemented"
   }
 }


### PR DESCRIPTION
## Summary
- Add 5 Genesis Cloud agent deployment scripts: amazonq.sh, cline.sh, gptme.sh, opencode.sh, plandex.sh
- Add Genesis Cloud README.md with usage docs and environment variables
- Update manifest.json to mark genesiscloud/plandex as implemented (the other 4 entries were already updated by batch 1)

All scripts follow the standard Genesis Cloud pattern: authenticate, provision GPU instance, wait for cloud-init, install agent, configure OpenRouter env vars, launch interactive session.

## Test plan
- [x] `bash -n` syntax check passes for all 5 scripts
- [x] Scripts match the patterns used by other Genesis Cloud agents (batch 1)
- [x] All 5 manifest entries marked as "implemented"
- [x] README.md includes usage instructions for all agents