### PR TITLE
Enforce PR merge-or-close-with-comment policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,8 @@ When running autonomous improvement/refactoring loops (`./improve.sh --loop`):
 - Always work on a feature branch — never commit directly to main (except urgent one-line fixes)
 - Before creating a PR, check `git status` and `git log` to verify branch state
 - Use `gh pr create` from the feature branch, then `gh pr merge --squash`
+- **Every PR must be MERGED or CLOSED with a comment** — never close silently
+- If a PR can't be merged (conflicts, superseded, wrong approach), close it with `gh pr close {number} --comment "Reason"`
 - Never rebase main or use `--force` unless explicitly asked
 
 ## After Each Change

--- a/improve.sh
+++ b/improve.sh
@@ -154,12 +154,23 @@ git checkout main && git pull --rebase origin main
 2. Do the work, commit
 3. Push: `git push -u origin {branch-name}`
 4. Create PR: `gh pr create --title "..." --body "..."`
-5. Merge immediately: `gh pr merge --squash`
-6. Switch back: `git checkout main && git pull --rebase origin main`
-7. Delete branch: `git push origin --delete {branch-name}`
+5. Try to merge: `gh pr merge --squash --delete-branch`
+6. **If merge fails** (conflicts, CI, etc.):
+   - Comment on the PR explaining WHY it cannot be merged
+   - Close with: `gh pr close {number} --comment "Closing: {reason}"`
+   - Acceptable reasons: merge conflict with a concurrent PR, superseded by another PR, implementation found to be incorrect after review
+   - NEVER close a PR silently — every closed PR MUST have a comment
+7. Switch back: `git checkout main && git pull --rebase origin main`
+
+### PR Policy (MANDATORY):
+Every PR must reach one of these terminal states:
+- **MERGED** — the happy path, always preferred
+- **CLOSED with comment** — only when merge is impossible, with a clear explanation
 
 ### NEVER:
 - Push directly to main
+- Close a PR without a comment explaining why
+- Leave PRs open/abandoned — resolve them in the same cycle
 - Leave branches hanging after merge
 - Work on a stale checkout — always pull latest main before each unit of work
 
@@ -196,6 +207,7 @@ Copy the output and replace the matrix table between `## Matrix` and `## Develop
 - `bash -n {file}` syntax-check before committing
 - Each teammate works on DIFFERENT files
 - Each unit of work gets its own branch → PR → merge → cleanup
+- **Every PR must be merged OR closed with a comment** — no silent closes, no abandoned PRs
 - Update manifest.json, the cloud's README.md, AND the root README.md matrix
 - NEVER revert prior macOS/curl-bash compatibility fixes
 PROMPT_EOF

--- a/refactor.sh
+++ b/refactor.sh
@@ -96,6 +96,8 @@ When fixing a bug reported in a GitHub issue:
 7. Switch back to main: git checkout main && git pull origin main
 
 NEVER leave an issue open after the fix is merged. NEVER leave a PR unmerged.
+If a PR cannot be merged (conflicts, superseded, etc.), close it WITH a comment explaining why.
+NEVER close a PR silently — every closed PR MUST have a comment.
 The full cycle is: branch -> fix -> PR (references issue) -> merge PR -> close issue.
 
 ## Workflow


### PR DESCRIPTION
## Summary
- Updates `improve.sh`, `refactor.sh`, and `CLAUDE.md` to enforce that every PR must be either **merged** or **closed with a comment explaining why**
- No more silent closes — agents must always document their reasoning
- Previously, PRs like #41 and #32 were closed without any explanation

## Changes
- **improve.sh**: Rewrote Git Workflow section with explicit merge-or-close-with-comment steps, added PR Policy section, expanded NEVER rules
- **refactor.sh**: Added close-with-comment requirement to Issue Fix Workflow
- **CLAUDE.md**: Added PR policy to Git Workflow section

## Test plan
- [x] `bash -n` syntax check passes on both .sh files
- [x] No functional changes to script logic — only prompt/documentation updates

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>