### PR TITLE
Fix: Replace instanceof Error checks with duck typing

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,8 +18,11 @@ function isInteractiveTTY(): boolean {
 }
 
 function handleError(err: unknown): never {
-  if (err instanceof Error) {
+  // Use duck typing instead of instanceof to avoid prototype chain issues
+  if (err && typeof err === "object" && "message" in err) {
     console.error(`Error: ${err.message}`);
+  } else {
+    console.error(`Error: ${String(err)}`);
   }
   process.exit(1);
 }
@@ -69,7 +72,8 @@ async function main(): Promise<void> {
       // Remove --prompt-file and its value from args
       filteredArgs.splice(promptFileIndex, 2);
     } catch (err) {
-      console.error(`Error reading prompt file: ${err instanceof Error ? err.message : String(err)}`);
+      console.error(`Error reading prompt file '${args[promptFileIndex + 1]}': ${err && typeof err === "object" && "message" in err ? err.message : String(err)}`);
+      console.error(`\nMake sure the file exists and is readable.`);
       process.exit(1);
     }
   }


### PR DESCRIPTION
Fixes #59

## Summary
- Fixed "instanceof called on an object with an invalid prototype property" error
- The instanceof operator can fail in bundled/minified code or when errors cross execution realm boundaries
- Replaced all instanceof Error checks with safer duck typing (checking for object with 'message' property)
- This is more reliable across different execution contexts and bundling scenarios

## Changes
- **index.ts**: Updated `handleError()` and prompt file error handling to use duck typing
- **commands.ts**: Updated `getErrorMessage()` helper to use duck typing
- Added some code cleanup (extracted helper functions for better readability)

## Test plan
- [x] All existing tests pass (`bun test`)
- [x] Verified `spawn` (no args) now shows help text instead of throwing error
- [x] Verified error messages still display correctly with the new approach
- [x] Manual testing confirms the fix resolves the reported issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)