### PR TITLE
refactor: Add validatePrompt tests and improve auth UX

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -644,7 +644,8 @@ get_openrouter_api_key_oauth() {
         echo "${api_key}"
         return 0
     else
-        log_error "Authentication cancelled by user"
+        log_error "Authentication cancelled"
+        log_error "Cannot proceed without an API key"
         return 1
     fi
 }


### PR DESCRIPTION
## Summary
- Add 16 comprehensive tests for `validatePrompt()` - previously untested security validation function
- Add 2 edge case tests for `validateScriptContent()` (dd if=, wget|sh)
- Improve auth cancellation error message to explain API key requirement

## Test plan
- [x] All 90 tests pass, 0 failures
- [x] bash -n syntax check passes on shared/common.sh
- [x] No functional changes to production code (only test additions + UX message tweak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)