### PR TITLE
fix: Use git fetch --prune to clean stale remote-tracking refs

### DIFF
--- a/.claude/skills/setup-trigger-service/improve.sh
+++ b/.claude/skills/setup-trigger-service/improve.sh
@@ -345,9 +345,10 @@ EOF
 cleanup_between_cycles() {
     log_info "Cleaning up between cycles..."
 
-    # Ensure we're on main and up to date
+    # Ensure we're on main and up to date, prune stale remote-tracking refs
     cd "${REPO_ROOT}"
     git checkout main 2>/dev/null || true
+    git fetch --prune origin 2>/dev/null || true
     git pull --rebase origin main 2>/dev/null || true
 
     # Prune stale worktrees
@@ -370,9 +371,10 @@ cleanup_between_cycles() {
 }
 
 run_team_cycle() {
-    # Always start fresh from latest main
+    # Always start fresh from latest main, prune stale remote-tracking refs
     cd "${REPO_ROOT}"
     git checkout main 2>/dev/null || true
+    git fetch --prune origin 2>/dev/null || true
     git pull --rebase origin main 2>/dev/null || true
 
     # Set up worktree directory for parallel agent work
@@ -395,6 +397,7 @@ run_team_cycle() {
 run_single_cycle() {
     cd "${REPO_ROOT}"
     git checkout main 2>/dev/null || true
+    git fetch --prune origin 2>/dev/null || true
     git pull --rebase origin main 2>/dev/null || true
 
     local prompt
@@ -410,6 +413,7 @@ log_info "Spawn Improvement System"
 log_info "Mode: ${MODE}"
 cd "${REPO_ROOT}"
 git checkout main 2>/dev/null || true
+git fetch --prune origin 2>/dev/null || true
 git pull --rebase origin main 2>/dev/null || true
 get_matrix_summary
 echo ""

--- a/.claude/skills/setup-trigger-service/refactor.sh
+++ b/.claude/skills/setup-trigger-service/refactor.sh
@@ -25,7 +25,7 @@ log "Log file: ${LOG_FILE}"
 
 # Ensure we're on latest main
 log "Syncing with origin/main..."
-git fetch origin main 2>&1 | tee -a "${LOG_FILE}" || true
+git fetch --prune origin 2>&1 | tee -a "${LOG_FILE}" || true
 git reset --hard origin/main 2>&1 | tee -a "${LOG_FILE}" || true
 
 # Launch Claude Code with team instructions


### PR DESCRIPTION
## Summary
- Stale remote branches were accumulating because `git fetch` doesn't prune deleted refs by default
- Added `--prune` to every `git fetch` call in both `improve.sh` and `refactor.sh`
- Affected: main entry point, `run_team_cycle`, `run_single_cycle`, `cleanup_between_cycles` in improve.sh; sync step in refactor.sh

## Root cause
When `gh pr merge --squash --delete-branch` deletes a branch on GitHub, the local git still keeps the stale `origin/branch` tracking ref until explicitly pruned. Without `--prune`, `git branch -r` keeps showing branches that no longer exist on the remote.

## Test plan
- [x] `bash -n improve.sh` passes
- [x] `bash -n refactor.sh` passes
- [x] Manually verified: `git fetch --prune origin` cleaned 9 stale refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)