### PR TITLE
fix: Remove canned acknowledgment from community-coordinator

### DIFF
--- a/.claude/skills/setup-trigger-service/refactor.sh
+++ b/.claude/skills/setup-trigger-service/refactor.sh
@@ -81,8 +81,6 @@ Create these teammates:
 
 6. **community-coordinator** (Sonnet)
    - FIRST TASK: Run `gh issue list --repo OpenRouterTeam/spawn --state open --json number,title,body,labels,createdAt`
-   - For EVERY open issue, immediately post an acknowledgment comment:
-     gh issue comment NUMBER --body "Thanks for reporting this! Our automated maintenance team is looking into it. We'll post updates here as we investigate."
    - Categorize each issue (bug, feature request, question, already-fixed)
    - For bugs: message the relevant teammate to investigate
      * Security-related → message security-auditor


### PR DESCRIPTION
## Summary
- Removes the generic "Thanks for reporting this!" boilerplate comment from the community-coordinator agent
- The agent now goes straight to categorizing issues and investigating the problem

🤖 Generated with [Claude Code](https://claude.com/claude-code)