### PR TITLE
fix: Improve sprite version display when version is unknown

### DIFF
--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -19,8 +19,12 @@ ensure_sprite_installed() {
     if command -v sprite &> /dev/null; then
         # sprite is already installed, check version
         local installed_version
-        installed_version=$(sprite version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?' || echo "unknown")
-        log_info "sprite ${installed_version} already installed, skipping installation"
+        installed_version=$(sprite version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?' || true)
+        if [[ -n "${installed_version}" ]]; then
+            log_info "sprite ${installed_version} already installed, skipping installation"
+        else
+            log_info "sprite already installed, skipping installation"
+        fi
         return 0
     fi
 
@@ -39,8 +43,12 @@ ensure_sprite_installed() {
             sprite_dir=$(dirname "${sprite_path}")
             export PATH="${sprite_dir}:${PATH}"
             local installed_version
-            installed_version=$(sprite version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?' || echo "unknown")
-            log_info "sprite ${installed_version} already installed at ${sprite_path}, skipping installation"
+            installed_version=$(sprite version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?' || true)
+            if [[ -n "${installed_version}" ]]; then
+                log_info "sprite ${installed_version} already installed at ${sprite_path}, skipping installation"
+            else
+                log_info "sprite already installed at ${sprite_path}, skipping installation"
+            fi
             return 0
         fi
     done


### PR DESCRIPTION
## Summary
- When sprite version can't be determined, omit it from the message instead of showing "unknown"
- Broadened version regex to also match versions without `v` prefix (e.g., `0.1.2`)

Fixes #79

## Test plan
- [x] Verify `bash -n sprite/lib/common.sh` passes
- [ ] Test with sprite that returns non-standard version format
- [ ] Test with sprite that returns standard v1.2.3 format

🤖 Generated with [Claude Code](https://claude.com/claude-code)