### PR TITLE
fix: Remove redirect from claude install command to fix Termux error

### DIFF
--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -27,7 +27,7 @@ setup_shell_environment "${SPRITE_NAME}"
 
 # Install Claude Code using claude install
 log_warn "Installing Claude Code..."
-run_sprite "${SPRITE_NAME}" "claude install > /dev/null 2>&1"
+run_sprite "${SPRITE_NAME}" "claude install"
 
 # Verify installation succeeded
 if ! run_sprite "${SPRITE_NAME}" "command -v claude &> /dev/null && claude --version &> /dev/null"; then


### PR DESCRIPTION
## Summary
- Removes the problematic `> /dev/null 2>&1` redirect from the `claude install` command on line 30
- The redirect was being escaped by `run_sprite`'s `printf %q`, causing the error: `/usr/bin/bash: line 1: claude install > /dev/null 2>&1: No such file or directory`
- Users can now see installation progress, and success is still verified by the check on line 33

Fixes #80

## Test plan
- [x] Verify `bash -n sprite/claude.sh` passes
- [ ] Test on Termux environment to confirm `claude install` executes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)