### PR TITLE
fix: Prevent duplicate work, add graceful shutdown, and enforce team lifecycle

### DIFF
--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -20,5 +20,5 @@ jobs:
           SPRITE_URL: ${{ secrets.REFACTOR_SPRITE_URL }}
           TRIGGER_SECRET: ${{ secrets.REFACTOR_TRIGGER_SECRET }}
         run: |
-          curl -sf -X POST "${SPRITE_URL}/trigger?reason=${{ github.event_name }}" \
+          curl -sf -X POST "${SPRITE_URL}/trigger?reason=${{ github.event_name }}&issue=${{ github.event.issue.number || '' }}" \
             -H "Authorization: Bearer ${TRIGGER_SECRET}"


### PR DESCRIPTION
## Summary

Fixes three operational issues with the refactor trigger service:

- **Duplicate work**: Concurrent cycles (MAX_CONCURRENT=3) were responding to the same GitHub issues, causing duplicate comments (e.g., issue #79 got 3 identical resolution comments). Changed default to MAX_CONCURRENT=1.
- **Orphaned agents**: Team lead was exiting before agents finished work, leaving PRs unmerged (e.g., PR #83). Added mandatory Lifecycle Management section requiring shutdown_request to all teammates before exit.
- **Unclean kills**: Service restarts killed running cycles with no cleanup. Added SIGTERM/SIGINT handling in trigger-server (waits up to 15 min for scripts to finish) and cleanup trap in refactor.sh.

Also adds:
- Pre-cycle cleanup of stale worktrees, merged branches, and abandoned PRs
- Dedup checks for community-coordinator (check existing comments before posting)
- Issue number in workflow trigger reason for logging

## Test plan

- [x] `bash -n refactor.sh` passes
- [x] trigger-server starts with `MAX_CONCURRENT=1`
- [x] Health endpoint returns `{"status":"ok","running":0,"shuttingDown":false}`
- [ ] Next triggered cycle completes full lifecycle (all agents shut down, all PRs merged)
- [ ] No duplicate comments on issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)