### PR TITLE
fix: Use curl installer for Claude Code on Sprite (#88)

### DIFF
--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -25,9 +25,9 @@ log_warn "Setting up sprite environment..."
 # Configure shell environment
 setup_shell_environment "${SPRITE_NAME}"
 
-# Install Claude Code using claude install
+# Install Claude Code
 log_warn "Installing Claude Code..."
-run_sprite "${SPRITE_NAME}" "claude install"
+run_sprite "${SPRITE_NAME}" "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_sprite "${SPRITE_NAME}" "command -v claude &> /dev/null && claude --version &> /dev/null"; then


### PR DESCRIPTION
## Summary
- Fixes the Claude Code install command on Sprite to use the curl installer
- The previous command `claude install` assumed claude was already on PATH, causing `command not found` errors
- Now uses `curl -fsSL https://claude.ai/install.sh | bash` to install Claude Code from scratch

Fixes #88

## Test plan
- [x] Run `bash -n sprite/claude.sh` to verify syntax
- [ ] Test the install flow on a Sprite VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)