### PR TITLE
fix: Remove printf %q escaping in run_sprite that broke command parsing

### DIFF
--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -143,14 +143,12 @@ verify_sprite_connectivity() {
 }
 
 # Helper function to run commands on sprite
-# SECURITY: Uses printf %q to properly escape commands to prevent injection
+# The command string is passed directly to bash -c for shell parsing.
+# All callers pass trusted, hardcoded command strings (not user input).
 run_sprite() {
     local sprite_name=${1}
     local command=${2}
-    # Use printf %q for proper shell escaping to prevent command injection
-    local escaped_command
-    escaped_command=$(printf '%q' "${command}")
-    sprite exec -s "${sprite_name}" -- bash -c "${escaped_command}"
+    sprite exec -s "${sprite_name}" -- bash -c "${command}"
 }
 
 # Configure shell environment (PATH, zsh setup)


### PR DESCRIPTION
## Summary
- `run_sprite()` used `printf '%q'` to escape the command string before passing it to `bash -c`, which turned `"claude install"` into `"claude\ install"` — bash then looked for a binary literally named `claude install` (with space)
- This broke all multi-word commands, pipes, redirects, and `&&` chains passed to `run_sprite`
- Fix: pass the command string directly to `bash -c` since all callers use trusted, hardcoded strings

Fixes #88

## Test plan
- [x] `bash -n sprite/lib/common.sh` passes
- [x] All 225 tests pass
- [ ] Manual test: `bash <(curl -fsSL .../sprite/claude.sh)` installs Claude Code successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)