### PR TITLE
feat: Add Kilo Code agent to spawn matrix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -202,6 +202,19 @@
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
       "notes": "Natively supports OpenRouter via OPENROUTER_API_KEY env var. Go-based CLI with sandbox and version control for AI changes."
+    },
+    "kilocode": {
+      "name": "Kilo Code",
+      "description": "All-in-one agentic engineering platform with CLI",
+      "url": "https://github.com/Kilo-Org/kilocode",
+      "install": "npm install -g @kilocode/cli",
+      "launch": "kilocode",
+      "env": {
+        "KILO_PROVIDER_TYPE": "openrouter",
+        "KILO_OPEN_ROUTER_API_KEY": "${OPENROUTER_API_KEY}",
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "notes": "Natively supports OpenRouter as a provider via KILO_PROVIDER_TYPE=openrouter. CLI installable via npm as @kilocode/cli, invocable as 'kilocode' or 'kilo'."
     }
   },
   "clouds": {
@@ -804,6 +817,27 @@
     "kamatera/cline": "implemented",
     "kamatera/gptme": "implemented",
     "kamatera/opencode": "implemented",
-    "kamatera/plandex": "implemented"
+    "kamatera/plandex": "implemented",
+    "sprite/kilocode": "implemented",
+    "hetzner/kilocode": "missing",
+    "digitalocean/kilocode": "missing",
+    "vultr/kilocode": "missing",
+    "linode/kilocode": "missing",
+    "lambda/kilocode": "missing",
+    "aws-lightsail/kilocode": "missing",
+    "gcp/kilocode": "missing",
+    "e2b/kilocode": "missing",
+    "modal/kilocode": "missing",
+    "fly/kilocode": "missing",
+    "civo/kilocode": "missing",
+    "scaleway/kilocode": "missing",
+    "daytona/kilocode": "missing",
+    "runpod/kilocode": "missing",
+    "upcloud/kilocode": "missing",
+    "binarylane/kilocode": "missing",
+    "genesiscloud/kilocode": "missing",
+    "latitude/kilocode": "missing",
+    "ovh/kilocode": "missing",
+    "kamatera/kilocode": "missing"
   }
 }

--- a/sprite/kilocode.sh
+++ b/sprite/kilocode.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sprite/lib/common.sh)"
+fi
+
+log_info "Kilo Code on Sprite"
+echo ""
+
+ensure_sprite_installed
+ensure_sprite_authenticated
+
+SPRITE_NAME=$(get_sprite_name)
+ensure_sprite_exists "${SPRITE_NAME}" 5
+verify_sprite_connectivity "${SPRITE_NAME}"
+
+log_warn "Setting up sprite environment..."
+setup_shell_environment "${SPRITE_NAME}"
+
+log_warn "Installing Kilo Code CLI..."
+run_sprite "${SPRITE_NAME}" "npm install -g @kilocode/cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_sprite "${SPRITE_NAME}" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Sprite setup completed successfully!"
+echo ""
+
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && kilocode"


### PR DESCRIPTION
## Summary
- Adds **Kilo Code** as a new agent (14th agent in the matrix)
- Kilo Code is an all-in-one agentic engineering platform with a CLI (`@kilocode/cli` on npm)
- Native OpenRouter support via `KILO_PROVIDER_TYPE=openrouter`
- Implements `sprite/kilocode.sh` deployment script
- Adds matrix entries for all 21 clouds (sprite implemented, rest missing)

## Evidence of Community Demand
- **15,129 GitHub stars** on [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode)
- **98 points** on Hacker News
- **$8M seed round** (December 2025)

Supersedes #95 (rebased to resolve manifest.json conflict with Kamatera PR #96).

## Test plan
- [x] `bash -n sprite/kilocode.sh` passes
- [x] Valid JSON in manifest.json
- [ ] Manual test on Sprite

🤖 Generated with [Claude Code](https://claude.com/claude-code)