### PR TITLE
fix: Improve CLI error messages with actionable guidance

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -128,9 +128,19 @@ function validateCloud(manifest: Manifest, cloud: string): asserts cloud is keyo
 function validateImplementation(manifest: Manifest, cloud: string, agent: string): void {
   const status = matrixStatus(manifest, cloud, agent);
   if (status !== "implemented") {
-    errorMessage(
-      `${manifest.agents[agent].name} on ${manifest.clouds[cloud].name} is not yet implemented.`
-    );
+    const agentName = manifest.agents[agent].name;
+    const cloudName = manifest.clouds[cloud].name;
+    p.log.error(`${agentName} on ${cloudName} is not yet implemented.`);
+
+    const availableClouds = getImplementedClouds(manifest, agent);
+    if (availableClouds.length > 0) {
+      const cloudNames = availableClouds.slice(0, 5).map((c) => manifest.clouds[c].name);
+      p.log.info(`${agentName} is available on: ${cloudNames.join(", ")}${availableClouds.length > 5 ? `, and ${availableClouds.length - 5} more` : ""}`);
+      p.log.info(`Run ${pc.cyan(`spawn ${agent}`)} to see all available clouds.`);
+    } else {
+      p.log.info(`Run ${pc.cyan("spawn list")} to see the full availability matrix.`);
+    }
+    process.exit(1);
   }
 }
 
@@ -152,6 +162,8 @@ export async function cmdInteractive(): Promise<void> {
 
   if (clouds.length === 0) {
     p.log.error(`No clouds available for ${manifest.agents[agentChoice].name}`);
+    p.log.info(`This agent has no implemented cloud providers yet.`);
+    p.log.info(`Run ${pc.cyan("spawn list")} to see the full availability matrix.`);
     process.exit(1);
   }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ function handleError(err: unknown): never {
   } else {
     console.error(`Error: ${String(err)}`);
   }
+  console.error(`\nRun 'spawn help' for usage information.`);
   process.exit(1);
 }
 
@@ -32,8 +33,8 @@ async function handleDefaultCommand(agent: string, cloud: string | undefined, pr
   if (!manifest.agents[agent]) {
     console.error(`Error: Unknown agent "${agent}"`);
     console.error(`\nAvailable agents:`);
-    const agentNames = Object.values(manifest.agents).map(a => a.name).slice(0, 5);
-    agentNames.forEach(name => console.error(`  - ${name}`));
+    const agentEntries = Object.entries(manifest.agents).slice(0, 5);
+    agentEntries.forEach(([key, a]) => console.error(`  - ${key.padEnd(16)} ${a.name}`));
     if (Object.keys(manifest.agents).length > 5) {
       console.error(`  ... and ${Object.keys(manifest.agents).length - 5} more`);
     }


### PR DESCRIPTION
## Summary
- When users run an unimplemented agent+cloud combination (e.g., `spawn claude somecloud`), the error now shows which clouds ARE available for that agent, instead of just saying "not yet implemented"
- Unknown agent errors now show agent keys alongside display names (e.g., `claude  Claude Code`) so users know the correct identifier to type
- All generic errors now include a `spawn help` hint so users can self-serve
- Interactive mode "no clouds available" error now suggests `spawn list`

## Test plan
- [x] All 225 CLI tests pass (`bun test`)
- [ ] Manual: `spawn claude nonexistent-cloud` should show available clouds
- [ ] Manual: `spawn nonexistent` should show agent keys + names
- [ ] Manual: Verify interactive picker gracefully handles agents with no clouds

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)