### PR TITLE
fix: Security audit - prevent injection via env vars and triple-quote strings

### DIFF
--- a/aws-lightsail/lib/common.sh
+++ b/aws-lightsail/lib/common.sh
@@ -94,6 +94,10 @@ create_server() {
     local az="${region}a"
     local blueprint="ubuntu_24_04"
 
+    # Validate env var inputs to prevent command injection
+    validate_resource_name "${bundle}" || { log_error "Invalid LIGHTSAIL_BUNDLE"; return 1; }
+    validate_region_name "${region}" || { log_error "Invalid AWS_DEFAULT_REGION"; return 1; }
+
     log_warn "Creating Lightsail instance '${name}' (bundle: ${bundle}, AZ: ${az})..."
 
     local userdata

--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -100,6 +100,11 @@ create_server() {
     local memory="${DAYTONA_MEMORY:-2048}"
     local disk="${DAYTONA_DISK:-5}"
 
+    # Validate numeric env vars to prevent command injection
+    if [[ ! "${cpu}" =~ ^[0-9]+$ ]]; then log_error "Invalid DAYTONA_CPU: must be numeric"; return 1; fi
+    if [[ ! "${memory}" =~ ^[0-9]+$ ]]; then log_error "Invalid DAYTONA_MEMORY: must be numeric"; return 1; fi
+    if [[ ! "${disk}" =~ ^[0-9]+$ ]]; then log_error "Invalid DAYTONA_DISK: must be numeric"; return 1; fi
+
     log_warn "Creating Daytona sandbox '${name}' (${cpu} vCPU / ${memory}MB RAM / ${disk}GB disk)..."
 
     # Create sandbox with resource flags and auto-stop disabled

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -128,6 +128,10 @@ create_server() {
     local region="${DO_REGION:-nyc3}"
     local image="ubuntu-24-04-x64"
 
+    # Validate env var inputs to prevent injection into Python code
+    validate_resource_name "$size" || { log_error "Invalid DO_DROPLET_SIZE"; return 1; }
+    validate_region_name "$region" || { log_error "Invalid DO_REGION"; return 1; }
+
     log_warn "Creating DigitalOcean droplet '$name' (size: $size, region: $region)..."
 
     # Get all SSH key IDs

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -197,6 +197,11 @@ create_server() {
     local vm_size="${FLY_VM_SIZE:-shared-cpu-1x}"
     local vm_memory="${FLY_VM_MEMORY:-1024}"
 
+    # Validate env var inputs to prevent injection into Python code
+    validate_region_name "$region" || { log_error "Invalid FLY_REGION"; return 1; }
+    validate_resource_name "$vm_size" || { log_error "Invalid FLY_VM_SIZE"; return 1; }
+    if [[ ! "$vm_memory" =~ ^[0-9]+$ ]]; then log_error "Invalid FLY_VM_MEMORY: must be numeric"; return 1; fi
+
     # Step 1: Create the app
     log_warn "Creating Fly.io app '$name'..."
     local org=$(get_fly_org)

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -86,6 +86,10 @@ create_server() {
     local image_family="ubuntu-2404-lts-amd64"
     local image_project="ubuntu-os-cloud"
 
+    # Validate env var inputs to prevent command injection
+    validate_resource_name "${machine_type}" || { log_error "Invalid GCP_MACHINE_TYPE"; return 1; }
+    validate_region_name "${zone}" || { log_error "Invalid GCP_ZONE"; return 1; }
+
     log_warn "Creating GCP instance '${name}' (type: ${machine_type}, zone: ${zone})..."
 
     local userdata

--- a/genesiscloud/lib/common.sh
+++ b/genesiscloud/lib/common.sh
@@ -117,6 +117,12 @@ create_server() {
     local region="${GENESIS_REGION:-ARC-IS-HAF-1}"
     local image="${GENESIS_IMAGE:-Ubuntu 24.04}"
 
+    # Validate env var inputs to prevent injection into Python code
+    validate_resource_name "$instance_type" || { log_error "Invalid GENESIS_INSTANCE_TYPE"; return 1; }
+    validate_region_name "$region" || { log_error "Invalid GENESIS_REGION"; return 1; }
+    # Image names may contain spaces (e.g. "Ubuntu 24.04") but must not contain quotes or shell metacharacters
+    if [[ "$image" =~ [\'\"\`\$\;\\] ]]; then log_error "Invalid GENESIS_IMAGE: contains unsafe characters"; return 1; fi
+
     log_warn "Creating Genesis Cloud instance '$name' (type: $instance_type, region: $region)..."
 
     # Get all SSH key IDs

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -122,6 +122,10 @@ create_server() {
     local location="${HETZNER_LOCATION:-fsn1}"
     local image="ubuntu-24.04"
 
+    # Validate env var inputs to prevent injection into Python code
+    validate_resource_name "$server_type" || { log_error "Invalid HETZNER_SERVER_TYPE"; return 1; }
+    validate_region_name "$location" || { log_error "Invalid HETZNER_LOCATION"; return 1; }
+
     log_warn "Creating Hetzner server '$name' (type: $server_type, location: $location)..."
 
     # Get all SSH key IDs

--- a/lambda/lib/common.sh
+++ b/lambda/lib/common.sh
@@ -107,6 +107,10 @@ create_server() {
     local instance_type="${LAMBDA_INSTANCE_TYPE:-gpu_1x_a10}"
     local region="${LAMBDA_REGION:-us-east-1}"
 
+    # Validate env var inputs to prevent injection into Python code
+    validate_resource_name "${instance_type}" || { log_error "Invalid LAMBDA_INSTANCE_TYPE"; return 1; }
+    validate_region_name "${region}" || { log_error "Invalid LAMBDA_REGION"; return 1; }
+
     log_warn "Creating Lambda instance '${name}' (type: ${instance_type}, region: ${region})..."
 
     # Get all SSH key IDs

--- a/latitude/lib/common.sh
+++ b/latitude/lib/common.sh
@@ -185,6 +185,11 @@ create_server() {
     local site="${LATITUDE_SITE:-DAL2}"
     local os="${LATITUDE_OS:-ubuntu_24_04_x64_lts}"
 
+    # Validate env var inputs to prevent injection into Python code
+    validate_resource_name "$plan" || { log_error "Invalid LATITUDE_PLAN"; return 1; }
+    validate_region_name "$site" || { log_error "Invalid LATITUDE_SITE"; return 1; }
+    validate_resource_name "$os" || { log_error "Invalid LATITUDE_OS"; return 1; }
+
     log_warn "Creating Latitude.sh server '$hostname' (plan: $plan, site: $site)..."
 
     # Get project ID

--- a/linode/lib/common.sh
+++ b/linode/lib/common.sh
@@ -119,6 +119,10 @@ create_server() {
     local region="${LINODE_REGION:-us-east}"
     local image="linode/ubuntu24.04"
 
+    # Validate env var inputs to prevent injection into Python code
+    validate_resource_name "$type" || { log_error "Invalid LINODE_TYPE"; return 1; }
+    validate_region_name "$region" || { log_error "Invalid LINODE_REGION"; return 1; }
+
     log_warn "Creating Linode '$name' (type: $type, region: $region)..."
 
     # Get all SSH key IDs

--- a/modal/lib/common.sh
+++ b/modal/lib/common.sh
@@ -61,6 +61,12 @@ create_server() {
     local name="${1}"
     local image="${MODAL_IMAGE:-debian_slim}"
 
+    # Validate image name - used as Python attribute name (e.g. modal.Image.debian_slim())
+    if [[ ! "${image}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        log_error "Invalid MODAL_IMAGE: must be a valid Python identifier (letters, digits, underscores)"
+        return 1
+    fi
+
     log_warn "Creating Modal sandbox '${name}'..."
 
     # Capture both stdout and stderr from Python SDK

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -303,6 +303,10 @@ create_ovh_instance() {
     local flavor="${OVH_FLAVOR:-d2-2}"
     local region="${OVH_REGION:-GRA7}"
 
+    # Validate env var inputs to prevent injection into Python code
+    validate_resource_name "$flavor" || { log_error "Invalid OVH_FLAVOR"; return 1; }
+    validate_region_name "$region" || { log_error "Invalid OVH_REGION"; return 1; }
+
     log_warn "Creating OVHcloud instance '$name' (flavor: $flavor, region: $region)..."
 
     # Find image ID

--- a/vultr/lib/common.sh
+++ b/vultr/lib/common.sh
@@ -122,6 +122,11 @@ create_server() {
     # Ubuntu 24.04 x64 OS ID
     local os_id="${VULTR_OS_ID:-2284}"
 
+    # Validate env var inputs to prevent injection into Python code
+    validate_resource_name "$plan" || { log_error "Invalid VULTR_PLAN"; return 1; }
+    validate_region_name "$region" || { log_error "Invalid VULTR_REGION"; return 1; }
+    if [[ ! "$os_id" =~ ^[0-9]+$ ]]; then log_error "Invalid VULTR_OS_ID: must be numeric"; return 1; fi
+
     log_warn "Creating Vultr instance '$name' (plan: $plan, region: $region)..."
 
     # Get all SSH key IDs


### PR DESCRIPTION
## Summary
- **Fix triple-quote Python injection** in 6 providers (Scaleway, UpCloud, BinaryLane, Civo, Kamatera, RunPod) by passing untrusted data via stdin/`json_escape` instead of inline string interpolation
- **Add input validation for env vars** across all 19 cloud providers using `validate_region_name`/`validate_resource_name` to block shell metacharacters before they reach Python string interpolation
- **Validate Modal image name** as a Python identifier to prevent arbitrary code execution via `MODAL_IMAGE`

## Vulnerabilities Fixed

### HIGH: Triple-quote injection (6 providers)
Python triple-quote strings (`'''$var'''`) can be escaped if `$var` contains `'''`, allowing arbitrary Python code execution:
- `scaleway/lib/common.sh` - SSH public key in `scaleway_register_ssh_key`
- `upcloud/lib/common.sh` - SSH public key in `create_server`
- `binarylane/lib/common.sh` - cloud-init userdata in `create_server`
- `civo/lib/common.sh` - init script in `create_server`
- `kamatera/lib/common.sh` - SSH key and init script in `create_server`
- `runpod/lib/common.sh` - GraphQL query in `runpod_api`

### MEDIUM: Env var injection into Python single-quote strings (all providers)
Environment variables like `OVH_REGION`, `KAMATERA_DATACENTER`, `VULTR_PLAN` etc. flow directly into Python `'$var'` strings. A malicious value containing `'` could break out and execute arbitrary Python code. Now validated with allowlist patterns.

## Test plan
- [x] `bash -n` syntax check passes on all 19 modified files
- [x] All 302 CLI tests pass (0 failures)
- [ ] Manual smoke test of at least one cloud provider (Hetzner or DigitalOcean)

Agent: security-auditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)