### PR TITLE
fix: Add time budget and periodic issue re-scan to refactor service

### DIFF
--- a/.claude/skills/setup-trigger-service/refactor.sh
+++ b/.claude/skills/setup-trigger-service/refactor.sh
@@ -92,6 +92,20 @@ You are the Team Lead for the spawn continuous refactoring service.
 
 Your mission: Spawn a team of specialized agents to maintain and improve the spawn codebase autonomously.
 
+## Time Budget
+
+Each cycle MUST complete within 15 minutes. This is a HARD deadline.
+
+- At cycle start, note the current time
+- At the 10-minute mark, stop spawning new work and tell all agents to wrap up
+- At the 12-minute mark, send shutdown_request to any agent that hasn't finished
+- At 15 minutes, force shutdown — the cycle is over regardless
+
+Agents should aim for ONE high-impact PR each, not many small ones.
+Complexity-hunter: pick the top 1-2 worst functions, fix them, PR, done. Do NOT exhaustively refactor everything.
+Test-engineer: add ONE focused test file, PR, done. Do NOT aim for 100% coverage.
+Security-auditor: scan for HIGH/CRITICAL only. Document medium/low, don't fix them.
+
 ## Team Structure
 
 Create these teammates:
@@ -100,6 +114,7 @@ Create these teammates:
    - Scan all .sh scripts for command injection, path traversal, credential leaks
    - Check TypeScript code for XSS, prototype pollution, unsafe eval
    - Review OpenRouter API key handling
+   - Fix HIGH/CRITICAL only. Document medium/low for future cycles (see #104, #105, #106 for examples).
    - Fix vulnerabilities immediately
 
 2. **ux-engineer** (Sonnet)
@@ -110,11 +125,13 @@ Create these teammates:
 
 3. **complexity-hunter** (Haiku)
    - Find bash functions >50 lines or TypeScript functions >80 lines
+   - Pick the top 2-3 functions only. ONE PR with all fixes. Do not keep finding more.
    - Reduce cyclomatic complexity without breaking features
    - Extract repeated code patterns into shared utilities
    - Run tests after each refactoring to verify no regressions
 
 4. **test-engineer** (Haiku)
+   - ONE test PR maximum. Focus on the most critical gaps.
    - Add missing tests for new features
    - Verify all bash scripts with shellcheck
    - Run 'bun test' and fix failures
@@ -157,6 +174,12 @@ Create these teammates:
    - For feature requests: comment acknowledging the request, label as enhancement, and close with a note pointing to discussions
    - For questions: answer directly in a comment, then close
    - GOAL: Every issue reporter should feel heard and informed. No cold trails.
+   - PERIODIC RE-SCAN: After your initial scan AND after every 5 minutes, re-run
+     `gh issue list --repo OpenRouterTeam/spawn --state open --json number,title,body,labels,createdAt`
+     to catch issues filed DURING the cycle. Apply the same dedup + engagement workflow.
+   - FINAL SWEEP (MANDATORY before shutdown): Do one last issue scan. Any new issues must be
+     acknowledged before the cycle ends. If there's no time to fix them, at minimum post an
+     acknowledgment comment so the reporter knows we've seen it.
    - EVERY open issue must be engaged by end of cycle. No dangling issues.
    - NEVER post duplicate comments. One acknowledgment per issue. One resolution per issue.
 
@@ -294,7 +317,9 @@ You MUST remain active until ALL of the following are true:
 
 1. **All tasks are completed**: Run TaskList and confirm every task has status "completed"
 2. **All PRs are resolved**: Run `gh pr list --repo OpenRouterTeam/spawn --state open --author @me` and confirm zero open PRs from this cycle. Every PR must be either merged or closed with a comment.
-3. **All issues are engaged**: Run `gh issue list --repo OpenRouterTeam/spawn --state open` and confirm every open issue has been commented on (or was already engaged).
+3. **All issues are engaged**: Run `gh issue list --repo OpenRouterTeam/spawn --state open`
+   and for EACH open issue, verify it has at least one comment. If any issue has zero comments,
+   the community-coordinator MUST post an acknowledgment before shutdown proceeds.
 4. **All worktrees are cleaned**: Run `git worktree list` and confirm only the main worktree exists. Run `rm -rf /tmp/spawn-worktrees` and `git worktree prune`.
 5. **All teammates are shut down**: Send `shutdown_request` to EVERY teammate. Wait for each to confirm. Do NOT exit while any teammate is still active.
 


### PR DESCRIPTION
## Summary
- Add 15-minute hard deadline with escalation at 10/12/15 minute marks to prevent runaway cycles
- Limit each agent to ONE PR (complexity-hunter was making 5+ granular commits)
- Add periodic issue re-scan every 5 minutes + mandatory final sweep before shutdown
- Update shutdown checklist to verify each open issue has at least one comment

## Test plan
- [x] `bash -n refactor.sh` passes
- [x] Service starts successfully after changes