### PR TITLE
fix: Show identifier keys in CLI output and fix prompt flag conflict

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -388,8 +388,11 @@ export async function cmdAgents(): Promise<void> {
   console.log();
   for (const key of agentKeys(manifest)) {
     const a = manifest.agents[key];
-    console.log(`  ${pc.green(a.name.padEnd(NAME_COLUMN_WIDTH))} ${pc.dim(a.description)}`);
+    const implCount = getImplementedClouds(manifest, key).length;
+    console.log(`  ${pc.green(key.padEnd(NAME_COLUMN_WIDTH))} ${a.name.padEnd(NAME_COLUMN_WIDTH)} ${pc.dim(`${implCount} clouds`)}`);
   }
+  console.log();
+  console.log(pc.dim(`  Usage: spawn <agent> <cloud>`));
   console.log();
 }
 
@@ -403,8 +406,10 @@ export async function cmdClouds(): Promise<void> {
   console.log();
   for (const key of cloudKeys(manifest)) {
     const c = manifest.clouds[key];
-    console.log(`  ${pc.green(c.name.padEnd(NAME_COLUMN_WIDTH))} ${pc.dim(c.description)}`);
+    console.log(`  ${pc.green(key.padEnd(NAME_COLUMN_WIDTH))} ${c.name.padEnd(NAME_COLUMN_WIDTH)} ${pc.dim(c.description)}`);
   }
+  console.log();
+  console.log(pc.dim(`  Usage: spawn <agent> <cloud>`));
   console.log();
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,7 +10,6 @@ import {
   cmdUpdate,
   cmdHelp,
 } from "./commands.js";
-import { loadManifest } from "./manifest.js";
 import { VERSION } from "./version.js";
 
 function isInteractiveTTY(): boolean {
@@ -51,20 +50,6 @@ function extractFlagValue(
 }
 
 async function handleDefaultCommand(agent: string, cloud: string | undefined, prompt?: string): Promise<void> {
-  const manifest = await loadManifest();
-  if (!manifest.agents[agent]) {
-    console.error(`Error: Unknown agent "${agent}"`);
-    console.error(`\nAvailable agents:`);
-    const agentEntries = Object.entries(manifest.agents).slice(0, 5);
-    agentEntries.forEach(([key, a]) => console.error(`  - ${key.padEnd(16)} ${a.name}`));
-    if (Object.keys(manifest.agents).length > 5) {
-      console.error(`  ... and ${Object.keys(manifest.agents).length - 5} more`);
-    }
-    console.error(`\nRun 'spawn agents' to see all agents.`);
-    console.error(`Run 'spawn help' for complete usage.`);
-    process.exit(1);
-  }
-
   if (cloud) {
     await cmdRun(agent, cloud, prompt);
   } else {
@@ -91,6 +76,14 @@ async function main(): Promise<void> {
     "spawn <agent> <cloud> --prompt-file instructions.txt"
   );
   filteredArgs = finalArgs;
+
+  if (prompt && promptFile) {
+    console.error("Error: --prompt and --prompt-file cannot be used together");
+    console.error(`\nUse one or the other:`);
+    console.error(`  spawn <agent> <cloud> --prompt "your prompt here"`);
+    console.error(`  spawn <agent> <cloud> --prompt-file instructions.txt`);
+    process.exit(1);
+  }
 
   if (promptFile) {
     const { readFileSync } = await import("fs");


### PR DESCRIPTION
## Summary
- **`spawn agents` now shows the identifier key** (e.g., `claude`) users need to type, alongside the display name and cloud count, instead of only showing display names
- **`spawn clouds` now shows the identifier key** (e.g., `sprite`) alongside the display name and description
- Both commands include a usage hint (`Usage: spawn <agent> <cloud>`) at the bottom
- **Error on conflicting prompt flags**: `--prompt` and `--prompt-file` used together now produces a clear error instead of silently overwriting
- **Consistent error handling**: Removed duplicate agent validation in `handleDefaultCommand` that loaded the manifest twice (without spinner) and showed different error formatting than the downstream validators

## Test plan
- [x] All 302 existing tests pass with 0 failures
- [x] `spawn agents` output shows key, name, and cloud count
- [x] `spawn clouds` output shows key, name, and description
- [x] `--prompt` + `--prompt-file` together produces error

🤖 Generated with [Claude Code](https://claude.com/claude-code)