### PR TITLE
feat: Add kilocode for 7 remaining clouds

### DIFF
--- a/binarylane/kilocode.sh
+++ b/binarylane/kilocode.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=binarylane/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/binarylane/lib/common.sh)"
+fi
+
+log_info "Kilo Code on BinaryLane"
+echo ""
+
+ensure_binarylane_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${BINARYLANE_SERVER_IP}"
+wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
+
+log_warn "Installing Kilo Code CLI..."
+run_server "${BINARYLANE_SERVER_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "BinaryLane server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
+echo ""
+
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/genesiscloud/kilocode.sh
+++ b/genesiscloud/kilocode.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=genesiscloud/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/genesiscloud/lib/common.sh)"
+fi
+
+log_info "Kilo Code on Genesis Cloud"
+echo ""
+
+ensure_genesis_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${GENESIS_SERVER_IP}"
+wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
+
+log_warn "Installing Kilo Code CLI..."
+run_server "${GENESIS_SERVER_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Genesis Cloud server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
+echo ""
+
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${GENESIS_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/kamatera/kilocode.sh
+++ b/kamatera/kilocode.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=kamatera/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/kamatera/lib/common.sh)"
+fi
+
+log_info "Kilo Code on Kamatera"
+echo ""
+
+ensure_kamatera_token
+generate_ssh_key_if_missing "${HOME}/.ssh/id_ed25519"
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${KAMATERA_SERVER_IP}"
+
+log_warn "Waiting for init script to complete..."
+generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
+
+log_warn "Installing Kilo Code CLI..."
+run_server "${KAMATERA_SERVER_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Kamatera server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
+echo ""
+
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/latitude/kilocode.sh
+++ b/latitude/kilocode.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/latitude/lib/common.sh)"
+fi
+
+log_info "Kilo Code on Latitude.sh"
+echo ""
+
+ensure_latitude_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+wait_for_server_ready "${LATITUDE_SERVER_ID}" 60
+verify_server_connectivity "${LATITUDE_SERVER_IP}"
+install_base_tools "${LATITUDE_SERVER_IP}"
+
+log_warn "Installing Kilo Code CLI..."
+run_server "${LATITUDE_SERVER_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Latitude.sh server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERVER_IP})"
+echo ""
+
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/manifest.json
+++ b/manifest.json
@@ -832,12 +832,12 @@
     "civo/kilocode": "implemented",
     "scaleway/kilocode": "implemented",
     "daytona/kilocode": "implemented",
-    "runpod/kilocode": "missing",
-    "upcloud/kilocode": "missing",
-    "binarylane/kilocode": "missing",
-    "genesiscloud/kilocode": "missing",
-    "latitude/kilocode": "missing",
-    "ovh/kilocode": "missing",
-    "kamatera/kilocode": "missing"
+    "runpod/kilocode": "implemented",
+    "upcloud/kilocode": "implemented",
+    "binarylane/kilocode": "implemented",
+    "genesiscloud/kilocode": "implemented",
+    "latitude/kilocode": "implemented",
+    "ovh/kilocode": "implemented",
+    "kamatera/kilocode": "implemented"
   }
 }

--- a/ovh/kilocode.sh
+++ b/ovh/kilocode.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=ovh/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ovh/lib/common.sh)"
+fi
+
+log_info "Kilo Code on OVHcloud"
+echo ""
+
+ensure_ovh_authenticated
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_ovh_instance "${SERVER_NAME}"
+wait_for_ovh_instance "${OVH_INSTANCE_ID}"
+verify_server_connectivity "${OVH_SERVER_IP}"
+
+# Install base dependencies
+install_base_deps "${OVH_SERVER_IP}"
+
+log_warn "Installing Kilo Code CLI..."
+run_ovh "${OVH_SERVER_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ovh "${OVH_SERVER_IP}" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "OVHcloud instance setup completed successfully!"
+log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP})"
+echo ""
+
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/runpod/kilocode.sh
+++ b/runpod/kilocode.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=runpod/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/runpod/lib/common.sh)"
+fi
+
+log_info "Kilo Code on RunPod"
+echo ""
+
+ensure_runpod_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity
+install_base_tools
+
+log_warn "Installing Kilo Code CLI..."
+run_server "${RUNPOD_POD_ID}" "npm install -g @kilocode/cli"
+log_info "Kilo Code CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${RUNPOD_POD_ID}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "RunPod pod setup completed successfully!"
+log_info "Pod: ${SERVER_NAME} (ID: ${RUNPOD_POD_ID})"
+echo ""
+
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${RUNPOD_POD_ID}" "source ~/.zshrc && kilocode"

--- a/upcloud/kilocode.sh
+++ b/upcloud/kilocode.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/upcloud/lib/common.sh)"
+fi
+
+log_info "Kilo Code on UpCloud"
+echo ""
+
+ensure_upcloud_credentials
+generate_ssh_key_if_missing "${HOME}/.ssh/id_ed25519"
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${UPCLOUD_SERVER_IP}"
+install_base_tools "${UPCLOUD_SERVER_IP}"
+
+log_warn "Installing Kilo Code CLI..."
+run_server "${UPCLOUD_SERVER_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "UpCloud server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
+echo ""
+
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && kilocode"


### PR DESCRIPTION
## Summary
- Adds kilocode.sh for runpod, upcloud, binarylane, genesiscloud, latitude, ovh, kamatera
- Updates manifest.json matrix entries from "missing" to "implemented"
- Each script follows the exact provisioning pattern of its cloud's existing agent scripts (cline.sh reference)
- Kilocode env vars: `KILO_PROVIDER_TYPE=openrouter`, `KILO_OPEN_ROUTER_API_KEY`, `OPENROUTER_API_KEY`

## Test plan
- [x] `bash -n` passes for all 7 scripts
- [x] manifest.json has correct entries updated to "implemented"

🤖 Generated with [Claude Code](https://claude.com/claude-code)