### PR TITLE
refactor: Extract helpers from complex cloud provider functions

### DIFF
--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -96,6 +96,53 @@ test_ovh_token() {
     return 0
 }
 
+# Try to load OVH credentials from config file
+# Returns 0 if all 4 credentials loaded, 1 otherwise
+_load_ovh_config() {
+    local config_file="$1"
+    [[ -f "${config_file}" ]] || return 1
+
+    local creds
+    creds=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+for k in ('application_key','application_secret','consumer_key','project_id'):
+    print(d.get(k, ''))
+" "${config_file}" 2>/dev/null) || return 1
+
+    [[ -n "${creds}" ]] || return 1
+
+    local saved_ak saved_as saved_ck saved_pid
+    { read -r saved_ak; read -r saved_as; read -r saved_ck; read -r saved_pid; } <<< "${creds}"
+    if [[ -n "${saved_ak}" && -n "${saved_as}" && -n "${saved_ck}" && -n "${saved_pid}" ]]; then
+        export OVH_APPLICATION_KEY="${saved_ak}"
+        export OVH_APPLICATION_SECRET="${saved_as}"
+        export OVH_CONSUMER_KEY="${saved_ck}"
+        export OVH_PROJECT_ID="${saved_pid}"
+        log_info "Using OVHcloud credentials from ${config_file}"
+        return 0
+    fi
+    return 1
+}
+
+# Save OVH credentials to config file
+_save_ovh_config() {
+    local config_file="$1"
+    local app_key="$2"
+    local app_secret="$3"
+    local consumer_key="$4"
+    local project_id="$5"
+
+    local config_dir
+    config_dir=$(dirname "${config_file}")
+    mkdir -p "${config_dir}"
+    printf '{\n  "application_key": "%s",\n  "application_secret": "%s",\n  "consumer_key": "%s",\n  "project_id": "%s"\n}\n' \
+        "$(json_escape "${app_key}")" "$(json_escape "${app_secret}")" \
+        "$(json_escape "${consumer_key}")" "$(json_escape "${project_id}")" > "${config_file}"
+    chmod 600 "${config_file}"
+    log_info "OVHcloud credentials saved to ${config_file}"
+}
+
 # Ensure OVH credentials are available (env vars -> config file -> prompt+save)
 ensure_ovh_authenticated() {
     check_python_available || return 1
@@ -109,26 +156,8 @@ ensure_ovh_authenticated() {
     fi
 
     # Try config file
-    if [[ -f "${config_file}" ]]; then
-        local creds
-        creds=$(python3 -c "
-import json, sys
-d = json.load(open(sys.argv[1]))
-for k in ('application_key','application_secret','consumer_key','project_id'):
-    print(d.get(k, ''))
-" "${config_file}" 2>/dev/null) || true
-        if [[ -n "${creds}" ]]; then
-            local saved_ak saved_as saved_ck saved_pid
-            { read -r saved_ak; read -r saved_as; read -r saved_ck; read -r saved_pid; } <<< "${creds}"
-            if [[ -n "${saved_ak}" && -n "${saved_as}" && -n "${saved_ck}" && -n "${saved_pid}" ]]; then
-                export OVH_APPLICATION_KEY="${saved_ak}"
-                export OVH_APPLICATION_SECRET="${saved_as}"
-                export OVH_CONSUMER_KEY="${saved_ck}"
-                export OVH_PROJECT_ID="${saved_pid}"
-                log_info "Using OVHcloud credentials from ${config_file}"
-                return 0
-            fi
-        fi
+    if _load_ovh_config "${config_file}"; then
+        return 0
     fi
 
     # Prompt for credentials
@@ -166,15 +195,7 @@ for k in ('application_key','application_secret','consumer_key','project_id'):
         return 1
     fi
 
-    # Save to config file
-    local config_dir
-    config_dir=$(dirname "${config_file}")
-    mkdir -p "${config_dir}"
-    printf '{\n  "application_key": "%s",\n  "application_secret": "%s",\n  "consumer_key": "%s",\n  "project_id": "%s"\n}\n' \
-        "$(json_escape "${app_key}")" "$(json_escape "${app_secret}")" \
-        "$(json_escape "${consumer_key}")" "$(json_escape "${project_id}")" > "${config_file}"
-    chmod 600 "${config_file}"
-    log_info "OVHcloud credentials saved to ${config_file}"
+    _save_ovh_config "${config_file}" "${app_key}" "${app_secret}" "${consumer_key}" "${project_id}"
     return 0
 }
 


### PR DESCRIPTION
## Summary
- **kamatera**: Replace 65-line custom `kamatera_api()` retry loop with a call to the shared `generic_cloud_api_custom_auth()` wrapper (65 -> 8 lines). Extract `_load_kamatera_config()` and `_validate_kamatera_credentials()` from `ensure_kamatera_token()`.
- **ovh**: Extract `_load_ovh_config()` and `_save_ovh_config()` from the 79-line `ensure_ovh_authenticated()`, reducing it to 47 lines.
- **upcloud**: Extract `_load_upcloud_config()` from `ensure_upcloud_credentials()` (69 -> 49 lines). Extract `_wait_for_upcloud_server_ip()` from `create_server()` (58 -> 39 lines).

No behavioral changes. All functions maintain the same external interface.

## Test plan
- [x] `bash -n` syntax check on all 3 modified files
- [x] All 395 CLI tests pass (0 failures)
- [x] No changes to shared/common.sh or any TypeScript files

Agent: complexity-hunter

🤖 Generated with [Claude Code](https://claude.com/claude-code)