### PR TITLE
fix: Add hard 20-minute timeout to refactor cycles

### DIFF
--- a/.claude/skills/setup-trigger-service/trigger-server.ts
+++ b/.claude/skills/setup-trigger-service/trigger-server.ts
@@ -233,6 +233,12 @@ const server = Bun.serve({
   },
 });
 
+// Proactively reap stale runs every 60 seconds instead of only on requests
+const reapInterval = setInterval(() => {
+  if (runs.size > 0) reapAndEnforce();
+}, 60_000);
+reapInterval.unref?.();
+
 console.log(`[trigger] Listening on port ${server.port}`);
 console.log(`[trigger] TARGET_SCRIPT=${TARGET_SCRIPT}`);
 console.log(`[trigger] MAX_CONCURRENT=${MAX_CONCURRENT}`);


### PR DESCRIPTION
## Summary
- Wraps `claude -p` in `timeout 1200` (20 min SIGTERM, +60s SIGKILL) in `refactor.sh` — the prompt-based 15-min budget was advisory only and cycles ran for 9.5 hours
- Adds 60-second interval timer in `trigger-server.ts` to proactively reap stale runs instead of only checking on incoming requests
- Distinguishes timeout exit (124) from failure in logs and still creates checkpoints for partial work

## Test plan
- [ ] `bash -n refactor.sh` passes
- [ ] Restart service and verify cycles complete within 20 min
- [ ] Verify trigger server health endpoint still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)