### PR TITLE
fix: Improve error messages with better context and actionable guidance

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -132,10 +132,16 @@ function validateImplementation(manifest: Manifest, cloud: string, agent: string
 
     const availableClouds = getImplementedClouds(manifest, agent);
     if (availableClouds.length > 0) {
-      const cloudNames = availableClouds.slice(0, 5).map((c) => manifest.clouds[c].name);
-      p.log.info(`${agentName} is available on: ${cloudNames.join(", ")}${availableClouds.length > 5 ? `, and ${availableClouds.length - 5} more` : ""}`);
-      p.log.info(`Run ${pc.cyan(`spawn ${agent}`)} to see all available clouds.`);
+      const examples = availableClouds.slice(0, 3).map((c) => `spawn ${agent} ${c}`);
+      p.log.info(`${agentName} is available on ${availableClouds.length} cloud${availableClouds.length > 1 ? "s" : ""}. Try one of these instead:`);
+      for (const cmd of examples) {
+        p.log.info(`  ${pc.cyan(cmd)}`);
+      }
+      if (availableClouds.length > 3) {
+        p.log.info(`Run ${pc.cyan(`spawn ${agent}`)} to see all ${availableClouds.length} options.`);
+      }
     } else {
+      p.log.info(`This agent has no implemented cloud providers yet.`);
       p.log.info(`Run ${pc.cyan("spawn list")} to see the full availability matrix.`);
     }
     process.exit(1);


### PR DESCRIPTION
## Summary
- OAuth failure messages now explain the specific cause (timeout, port unavailable, no Node.js runtime, network unreachable) and suggest actionable fixes (install node, set OPENROUTER_API_KEY, check firewall)
- Long-running operations include duration hints so users know what to expect: SSH wait says "usually takes 30-90 seconds", OAuth wait says "usually takes 10-30 seconds"
- `validateImplementation` shows exact runnable commands (`spawn claude sprite`, `spawn claude hetzner`) instead of just listing cloud provider names

## Test plan
- [x] `bash -n shared/common.sh` passes
- [x] `bun test` — 395 pass, 0 fail
- [x] No logic changes — only user-facing message strings modified

Agent: ux-engineer