### PR TITLE
fix: ASCII fallback for unicode rendering

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1,3 +1,4 @@
+import "./unicode-detect.js"; // Must be first: configures TERM before clack reads it
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { spawn } from "child_process";
@@ -584,6 +585,7 @@ ${pc.bold("TROUBLESHOOTING")}
   ${pc.dim("*")} Script not found: Run ${pc.cyan("spawn list")} to verify the combination exists
   ${pc.dim("*")} Missing credentials: Check cloud-specific READMEs in the repo
   ${pc.dim("*")} Update issues: Try ${pc.cyan("spawn update")} or reinstall manually
+  ${pc.dim("*")} Garbled unicode: Set ${pc.cyan("SPAWN_NO_UNICODE=1")} for ASCII-only output
 
 ${pc.bold("MORE INFO")}
   Repository:  https://github.com/${REPO}

--- a/cli/src/unicode-detect.ts
+++ b/cli/src/unicode-detect.ts
@@ -1,0 +1,28 @@
+// Side-effect module: must be imported BEFORE @clack/prompts
+// to influence its unicode detection (which runs at import time).
+//
+// @clack/prompts checks: process.env.TERM !== "linux" on non-Windows.
+// Setting TERM=linux forces ASCII fallback symbols (>, *, |, etc.)
+
+const shouldForceAscii = (): boolean => {
+  // Explicit user override
+  if (process.env.SPAWN_NO_UNICODE === "1" || process.env.SPAWN_ASCII === "1") {
+    return true;
+  }
+
+  // Already detected as needing ASCII by clack's own logic
+  if (process.env.TERM === "linux") {
+    return false; // clack will handle this
+  }
+
+  // Dumb terminals and serial consoles lack unicode support
+  if (process.env.TERM === "dumb" || !process.env.TERM) {
+    return true;
+  }
+
+  return false;
+};
+
+if (shouldForceAscii()) {
+  process.env.TERM = "linux";
+}


### PR DESCRIPTION
## Summary
- Fixes #132
- Adds a `unicode-detect.ts` side-effect module that runs before `@clack/prompts` is imported, overriding its unicode detection when needed
- Forces ASCII mode when `SPAWN_NO_UNICODE=1` or `SPAWN_ASCII=1` env var is set (explicit user override)
- Automatically forces ASCII mode when `TERM=dumb` or `TERM` is unset (common in basic/serial terminals)
- Adds troubleshooting hint in `spawn help` output

## How it works
`@clack/prompts` detects unicode support at import time by checking `process.env.TERM !== "linux"`. The new `unicode-detect.ts` module is imported first (before clack) and sets `TERM=linux` when ASCII mode is needed, which causes clack to use its built-in ASCII fallbacks (`>`, `*`, `|`, `-` instead of `●`, `◆`, `│`, `─`).

## Test plan
- [x] All 460 tests pass
- [x] Verified `SPAWN_NO_UNICODE=1` forces ASCII mode
- [x] Verified `TERM=dumb` triggers ASCII fallback
- [x] Verified `TERM=xterm-256color` preserves unicode mode
- [x] Verified `SPAWN_NO_UNICODE=1` overrides even `TERM=xterm-256color`

🤖 Generated with [Claude Code](https://claude.com/claude-code)