### PR TITLE
feat: Add vastai/gemini.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -891,7 +891,7 @@
     "vastai/nanoclaw": "missing",
     "vastai/goose": "missing",
     "vastai/interpreter": "missing",
-    "vastai/gemini": "missing",
+    "vastai/gemini": "implemented",
     "vastai/amazonq": "missing",
     "vastai/cline": "missing",
     "vastai/gptme": "missing",

--- a/vastai/gemini.sh
+++ b/vastai/gemini.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=vastai/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vastai/lib/common.sh)"
+fi
+
+log_info "Gemini CLI on Vast.ai"
+echo ""
+
+# 1. Ensure vastai CLI and API key are configured
+ensure_vastai_cli
+ensure_vastai_token
+
+# 2. Get instance name and create instance
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for SSH connectivity and install base tools
+verify_server_connectivity
+install_base_tools
+
+# 4. Install Gemini CLI
+log_warn "Installing Gemini CLI..."
+run_server "${VASTAI_INSTANCE_ID}" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${VASTAI_INSTANCE_ID}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Vast.ai instance setup completed successfully!"
+log_info "Instance: ${SERVER_NAME} (ID: ${VASTAI_INSTANCE_ID})"
+echo ""
+
+# 7. Start Gemini CLI interactively
+log_warn "Starting Gemini..."
+sleep 1
+clear
+interactive_session "${VASTAI_INSTANCE_ID}" "source ~/.zshrc && gemini"


### PR DESCRIPTION
## Summary
- Implement Gemini CLI deployment on Vast.ai GPU instances
- Installs `@google/gemini-cli` via npm
- Injects OpenRouter credentials (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`)
- Follows established Vast.ai script pattern (ensure CLI, create server, verify connectivity, install, configure, launch)

## Test plan
- [ ] `bash -n vastai/gemini.sh` passes
- [ ] Script follows same pattern as `vastai/claude.sh` and `vastai/aider.sh`
- [ ] manifest.json updated from "missing" to "implemented"

🤖 Generated with [Claude Code](https://claude.com/claude-code)