### PR TITLE
feat: Add vastai/openclaw.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -887,7 +887,7 @@
     "vastai/claude": "implemented",
     "vastai/aider": "implemented",
     "vastai/codex": "implemented",
-    "vastai/openclaw": "missing",
+    "vastai/openclaw": "implemented",
     "vastai/nanoclaw": "missing",
     "vastai/goose": "missing",
     "vastai/interpreter": "missing",

--- a/vastai/openclaw.sh
+++ b/vastai/openclaw.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=vastai/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vastai/lib/common.sh)"
+fi
+
+log_info "OpenClaw on Vast.ai"
+echo ""
+
+# 1. Ensure vastai CLI and API key are configured
+ensure_vastai_cli
+ensure_vastai_token
+
+# 2. Get instance name and create instance
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for SSH connectivity and install base tools
+verify_server_connectivity
+install_base_tools
+
+# 4. Install openclaw via bun
+log_warn "Installing openclaw..."
+run_server "${VASTAI_INSTANCE_ID}" "source ~/.bashrc && bun install -g openclaw"
+log_info "OpenClaw installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${VASTAI_INSTANCE_ID}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
+
+# 7. Configure openclaw
+setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" \
+    "upload_file ${VASTAI_INSTANCE_ID}" \
+    "run_server ${VASTAI_INSTANCE_ID}"
+
+echo ""
+log_info "Vast.ai instance setup completed successfully!"
+log_info "Instance: ${SERVER_NAME} (ID: ${VASTAI_INSTANCE_ID})"
+echo ""
+
+# 8. Start openclaw gateway in background and launch TUI
+log_warn "Starting openclaw..."
+run_server "${VASTAI_INSTANCE_ID}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+sleep 2
+interactive_session "${VASTAI_INSTANCE_ID}" "source ~/.zshrc && openclaw tui"


### PR DESCRIPTION
## Summary
- Implement OpenClaw deployment on Vast.ai GPU instances
- Sources vastai/lib/common.sh, installs openclaw via bun
- Configures OpenRouter API with model selection, starts gateway in background and launches TUI
- Updates manifest.json matrix entry to "implemented"

## Test plan
- [ ] `bash -n vastai/openclaw.sh` passes
- [ ] Script follows vastai pattern (ensure_vastai_cli, ensure_vastai_token, create_server, etc.)
- [ ] manifest.json updated correctly