### PR TITLE
feat: Add oracle/openclaw.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -873,7 +873,7 @@
     "oracle/claude": "implemented",
     "oracle/aider": "implemented",
     "oracle/goose": "implemented",
-    "oracle/openclaw": "missing",
+    "oracle/openclaw": "implemented",
     "oracle/nanoclaw": "missing",
     "oracle/codex": "missing",
     "oracle/interpreter": "missing",

--- a/oracle/openclaw.sh
+++ b/oracle/openclaw.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=oracle/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/oracle/lib/common.sh)"
+fi
+
+# Variables exported by create_server() in lib/common.sh
+# shellcheck disable=SC2154
+: "${OCI_SERVER_IP:?}" "${OCI_INSTANCE_NAME_ACTUAL:?}"
+
+
+log_info "OpenClaw on Oracle Cloud Infrastructure"
+echo ""
+
+# 1. Ensure OCI CLI is configured
+ensure_oci_cli
+
+# 2. Generate SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${OCI_SERVER_IP}"
+wait_for_cloud_init "${OCI_SERVER_IP}" 60
+
+# 5. Install openclaw via bun
+log_warn "Installing openclaw..."
+run_server "${OCI_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
+log_info "OpenClaw installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
+
+# 8. Inject environment variables
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
+
+# 9. Configure openclaw
+setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" \
+    "upload_file ${OCI_SERVER_IP}" \
+    "run_server ${OCI_SERVER_IP}"
+
+echo ""
+log_info "OCI instance setup completed successfully!"
+log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
+echo ""
+
+# 10. Start openclaw gateway in background and launch TUI
+log_warn "Starting openclaw..."
+run_server "${OCI_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+sleep 2
+interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && openclaw tui"


### PR DESCRIPTION
## Summary
- Implement OpenClaw agent deployment on Oracle Cloud Infrastructure
- Uses OCI CLI for provisioning, bun for openclaw installation
- Configures OpenRouter API with ANTHROPIC_BASE_URL proxy
- Launches gateway in background then TUI for interactive session

## Test plan
- [ ] `bash -n oracle/openclaw.sh` passes
- [ ] manifest.json updated: `oracle/openclaw` -> `implemented`

🤖 Generated with [Claude Code](https://claude.com/claude-code)