### PR TITLE
feat: Concurrent issue-fix and refactor cycles

### DIFF
--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -26,6 +26,8 @@ jobs:
           cat /tmp/response.json
           if [ "$HTTP_CODE" = "429" ]; then
             echo "Cycle already running, skipping"
+          elif [ "$HTTP_CODE" = "409" ]; then
+            echo "Run for this issue already in progress, skipping"
           elif [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
             echo "Triggered successfully"
           else


### PR DESCRIPTION
## Summary

- Issue triggers (`?issue=N`) now spawn lightweight 2-agent runs (issue-fixer + issue-tester) with a 15-min timeout, isolated in their own worktree (`/tmp/spawn-worktrees/issue-N/`)
- Refactor cycles continue independently with the full 6-agent team and a 30-min timeout in `/tmp/spawn-worktrees/refactor/`
- `MAX_CONCURRENT` bumped to 3 (allows 1 refactor + 2 issue runs simultaneously)
- Duplicate issue runs rejected with 409 Conflict
- Each mode gets its own log file, team name, and cleanup scope — no cross-contamination

## Test plan

- [ ] `bash -n refactor.sh` passes
- [ ] `bun test` passes (477/477)
- [ ] Restart service, `curl localhost:8080/health` shows `max: 3`
- [ ] `curl -X POST "localhost:8080/trigger?reason=issues&issue=132"` starts issue mode
- [ ] Concurrent refactor trigger starts independently
- [ ] Duplicate `issue=132` trigger returns 409
- [ ] Issue run completes in <15 min with isolated worktree
- [ ] Refactor run completes in <30 min without interfering

🤖 Generated with [Claude Code](https://claude.com/claude-code)