### PR TITLE
feat: Add vastai/amazonq.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -892,7 +892,7 @@
     "vastai/goose": "missing",
     "vastai/interpreter": "missing",
     "vastai/gemini": "implemented",
-    "vastai/amazonq": "missing",
+    "vastai/amazonq": "implemented",
     "vastai/cline": "missing",
     "vastai/gptme": "missing",
     "vastai/opencode": "implemented",

--- a/vastai/amazonq.sh
+++ b/vastai/amazonq.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=vastai/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vastai/lib/common.sh)"
+fi
+
+log_info "Amazon Q on Vast.ai"
+echo ""
+
+# 1. Ensure vastai CLI and API key are configured
+ensure_vastai_cli
+ensure_vastai_token
+
+# 2. Get instance name and create instance
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for SSH connectivity and install base tools
+verify_server_connectivity
+install_base_tools
+
+# 4. Install Amazon Q CLI
+log_warn "Installing Amazon Q CLI..."
+run_server "${VASTAI_INSTANCE_ID}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${VASTAI_INSTANCE_ID}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Vast.ai instance setup completed successfully!"
+log_info "Instance: ${SERVER_NAME} (ID: ${VASTAI_INSTANCE_ID})"
+echo ""
+
+# 7. Start Amazon Q interactively
+log_warn "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${VASTAI_INSTANCE_ID}" "source ~/.zshrc && q chat"


### PR DESCRIPTION
## Summary
- Implement Amazon Q CLI deployment on Vast.ai GPU instances
- Installs via `amazon-q-cli-install.sh` installer script
- Injects OpenRouter credentials (`OPENAI_API_KEY`, `OPENAI_BASE_URL`)
- Follows established Vast.ai script pattern

## Test plan
- [ ] `bash -n vastai/amazonq.sh` passes
- [ ] Script follows same pattern as `vastai/claude.sh` and `vastai/aider.sh`
- [ ] manifest.json updated from "missing" to "implemented"

🤖 Generated with [Claude Code](https://claude.com/claude-code)