### PR TITLE
feat: Add oracle/amazonq.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -878,7 +878,7 @@
     "oracle/codex": "missing",
     "oracle/interpreter": "missing",
     "oracle/gemini": "implemented",
-    "oracle/amazonq": "missing",
+    "oracle/amazonq": "implemented",
     "oracle/cline": "missing",
     "oracle/gptme": "missing",
     "oracle/opencode": "implemented",

--- a/oracle/amazonq.sh
+++ b/oracle/amazonq.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=oracle/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/oracle/lib/common.sh)"
+fi
+
+# Variables exported by create_server() in lib/common.sh
+# shellcheck disable=SC2154
+: "${OCI_SERVER_IP:?}" "${OCI_INSTANCE_NAME_ACTUAL:?}"
+
+
+log_info "Amazon Q on Oracle Cloud Infrastructure"
+echo ""
+
+# 1. Ensure OCI CLI is configured
+ensure_oci_cli
+
+# 2. Generate SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${OCI_SERVER_IP}"
+wait_for_cloud_init "${OCI_SERVER_IP}" 60
+
+# 5. Install Amazon Q CLI
+log_warn "Installing Amazon Q CLI..."
+run_server "${OCI_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "OCI instance setup completed successfully!"
+log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
+echo ""
+
+# 8. Start Amazon Q interactively
+log_warn "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && q chat"


### PR DESCRIPTION
## Summary
- Implements Amazon Q CLI agent script for Oracle Cloud Infrastructure
- Installs Amazon Q via official installer script, configures OpenRouter API keys (OPENAI_API_KEY, OPENAI_BASE_URL)
- Follows established Oracle Cloud pattern (ensure_oci_cli, create_server, wait_for_cloud_init, inject_env_vars_ssh)

## Test plan
- [ ] `bash -n oracle/amazonq.sh` passes syntax check
- [ ] manifest.json updated: `oracle/amazonq` set to `implemented`

Agent: gap-filler