### PR TITLE
feat: Add oracle/kilocode.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -883,7 +883,7 @@
     "oracle/gptme": "missing",
     "oracle/opencode": "implemented",
     "oracle/plandex": "implemented",
-    "oracle/kilocode": "missing",
+    "oracle/kilocode": "implemented",
     "vastai/claude": "implemented",
     "vastai/aider": "implemented",
     "vastai/codex": "implemented",

--- a/oracle/kilocode.sh
+++ b/oracle/kilocode.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=oracle/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/oracle/lib/common.sh)"
+fi
+
+# Variables exported by create_server() in lib/common.sh
+: "${OCI_SERVER_IP:?}" "${OCI_INSTANCE_NAME_ACTUAL:?}"
+
+log_info "Kilo Code on Oracle Cloud Infrastructure"
+echo ""
+
+# 1. Ensure OCI CLI is configured
+ensure_oci_cli
+
+# 2. Generate SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${OCI_SERVER_IP}"
+wait_for_cloud_init "${OCI_SERVER_IP}" 60
+
+# 5. Install Kilo Code
+log_warn "Installing Kilo Code..."
+run_server "${OCI_SERVER_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "OCI instance setup completed successfully!"
+log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
+echo ""
+
+# 8. Start Kilo Code interactively
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && kilocode"


### PR DESCRIPTION
## Summary
- Implement Kilo Code agent deployment on Oracle Cloud Infrastructure
- Sets `KILO_PROVIDER_TYPE=openrouter` and `KILO_OPEN_ROUTER_API_KEY` env vars
- Updates manifest.json matrix entry to "implemented"

## Test plan
- [ ] `bash -n oracle/kilocode.sh` passes
- [ ] Script follows Oracle Cloud pattern (OCI CLI, SSH, cloud-init)
- [ ] Kilo Code env vars correctly configured for OpenRouter