### PR TITLE
feat: Add vastai/kilocode.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -897,6 +897,6 @@
     "vastai/gptme": "missing",
     "vastai/opencode": "implemented",
     "vastai/plandex": "implemented",
-    "vastai/kilocode": "missing"
+    "vastai/kilocode": "implemented"
   }
 }

--- a/vastai/kilocode.sh
+++ b/vastai/kilocode.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=vastai/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vastai/lib/common.sh)"
+fi
+
+log_info "Kilo Code on Vast.ai"
+echo ""
+
+# 1. Ensure vastai CLI and API key are configured
+ensure_vastai_cli
+ensure_vastai_token
+
+# 2. Get instance name and create instance
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for SSH connectivity and install base tools
+verify_server_connectivity
+install_base_tools
+
+# 4. Install Kilo Code
+log_warn "Installing Kilo Code..."
+run_server "${VASTAI_INSTANCE_ID}" "npm install -g @kilocode/cli"
+log_info "Kilo Code installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${VASTAI_INSTANCE_ID}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Vast.ai instance setup completed successfully!"
+log_info "Instance: ${SERVER_NAME} (ID: ${VASTAI_INSTANCE_ID})"
+echo ""
+
+# 7. Start Kilo Code interactively
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${VASTAI_INSTANCE_ID}" "source ~/.zshrc && kilocode"


### PR DESCRIPTION
## Summary
- Implement Kilo Code agent deployment on Vast.ai
- Installs via `npm install -g @kilocode/cli`
- Configures `KILO_PROVIDER_TYPE=openrouter` and `KILO_OPEN_ROUTER_API_KEY` for OpenRouter integration

## Test plan
- [ ] `bash -n vastai/kilocode.sh` passes
- [ ] Script follows Vast.ai pattern (ensure CLI, create server, verify connectivity, install, inject env, launch)