### PR TITLE
feat: Add vastai/goose.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -889,7 +889,7 @@
     "vastai/codex": "implemented",
     "vastai/openclaw": "implemented",
     "vastai/nanoclaw": "implemented",
-    "vastai/goose": "missing",
+    "vastai/goose": "implemented",
     "vastai/interpreter": "missing",
     "vastai/gemini": "implemented",
     "vastai/amazonq": "implemented",

--- a/vastai/goose.sh
+++ b/vastai/goose.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=vastai/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vastai/lib/common.sh)"
+fi
+
+log_info "Goose on Vast.ai"
+echo ""
+
+# 1. Ensure vastai CLI and API key are configured
+ensure_vastai_cli
+ensure_vastai_token
+
+# 2. Get instance name and create instance
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for SSH connectivity and install base tools
+verify_server_connectivity
+install_base_tools
+
+# 4. Install Goose
+log_warn "Installing Goose..."
+run_server "${VASTAI_INSTANCE_ID}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+log_info "Goose installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${VASTAI_INSTANCE_ID}" upload_file run_server \
+    "GOOSE_PROVIDER=openrouter" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Vast.ai instance setup completed successfully!"
+log_info "Instance: ${SERVER_NAME} (ID: ${VASTAI_INSTANCE_ID})"
+echo ""
+
+# 7. Start Goose interactively
+log_warn "Starting Goose..."
+sleep 1
+clear
+interactive_session "${VASTAI_INSTANCE_ID}" "source ~/.zshrc && goose"


### PR DESCRIPTION
## Summary
- Implement Goose (Block's AI coding agent) deployment on Vast.ai GPU instances
- Installs Goose via official download script with CONFIGURE=false
- Configures GOOSE_PROVIDER=openrouter and OPENROUTER_API_KEY
- Updates manifest.json matrix entry to "implemented"

## Test plan
- [ ] `bash -n vastai/goose.sh` passes
- [ ] Script follows vastai pattern (ensure_vastai_cli, ensure_vastai_token, create_server, etc.)
- [ ] manifest.json updated correctly