### PR TITLE
feat: Add oracle/gptme.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -880,7 +880,7 @@
     "oracle/gemini": "implemented",
     "oracle/amazonq": "implemented",
     "oracle/cline": "implemented",
-    "oracle/gptme": "missing",
+    "oracle/gptme": "implemented",
     "oracle/opencode": "implemented",
     "oracle/plandex": "implemented",
     "oracle/kilocode": "implemented",

--- a/oracle/gptme.sh
+++ b/oracle/gptme.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=oracle/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/oracle/lib/common.sh)"
+fi
+
+# Variables exported by create_server() in lib/common.sh
+# shellcheck disable=SC2154
+: "${OCI_SERVER_IP:?}" "${OCI_INSTANCE_NAME_ACTUAL:?}"
+
+
+log_info "gptme on Oracle Cloud Infrastructure"
+echo ""
+
+# 1. Ensure OCI CLI is configured
+ensure_oci_cli
+
+# 2. Generate SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${OCI_SERVER_IP}"
+wait_for_cloud_init "${OCI_SERVER_IP}" 60
+
+# 5. Install gptme
+log_warn "Installing gptme..."
+run_server "${OCI_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
+
+# Verify installation succeeded
+if ! run_server "${OCI_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
+    log_error "gptme installation verification failed"
+    log_error "The 'gptme' command is not available or not working properly on server ${OCI_SERVER_IP}"
+    exit 1
+fi
+log_info "gptme installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
+
+# 8. Inject environment variables into ~/.zshrc
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "OCI instance setup completed successfully!"
+log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
+echo ""
+
+# 9. Start gptme interactively
+log_warn "Starting gptme..."
+sleep 1
+clear
+interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"


### PR DESCRIPTION
## Summary
- Implements gptme agent script for Oracle Cloud Infrastructure
- Installs `gptme` via pip with installation verification
- Prompts for model selection via `get_model_id_interactive`, launches with `gptme -m openrouter/${MODEL_ID}`
- Follows established Oracle Cloud pattern (ensure_oci_cli, create_server, wait_for_cloud_init, inject_env_vars_ssh)

## Test plan
- [ ] `bash -n oracle/gptme.sh` passes syntax check
- [ ] manifest.json updated: `oracle/gptme` set to `implemented`

Agent: gap-filler