### PR TITLE
feat: Add vastai/interpreter.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -890,7 +890,7 @@
     "vastai/openclaw": "implemented",
     "vastai/nanoclaw": "implemented",
     "vastai/goose": "implemented",
-    "vastai/interpreter": "missing",
+    "vastai/interpreter": "implemented",
     "vastai/gemini": "implemented",
     "vastai/amazonq": "implemented",
     "vastai/cline": "implemented",

--- a/vastai/interpreter.sh
+++ b/vastai/interpreter.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=vastai/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/vastai/lib/common.sh)"
+fi
+
+log_info "Open Interpreter on Vast.ai"
+echo ""
+
+# 1. Ensure vastai CLI and API key are configured
+ensure_vastai_cli
+ensure_vastai_token
+
+# 2. Get instance name and create instance
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for SSH connectivity and install base tools
+verify_server_connectivity
+install_base_tools
+
+# 4. Install Open Interpreter
+log_warn "Installing Open Interpreter..."
+run_server "${VASTAI_INSTANCE_ID}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${VASTAI_INSTANCE_ID}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Vast.ai instance setup completed successfully!"
+log_info "Instance: ${SERVER_NAME} (ID: ${VASTAI_INSTANCE_ID})"
+echo ""
+
+# 7. Start Open Interpreter interactively
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "${VASTAI_INSTANCE_ID}" "source ~/.zshrc && interpreter"


### PR DESCRIPTION
## Summary
- Implement Open Interpreter deployment on Vast.ai GPU instances
- Installs open-interpreter via pip
- Configures OpenRouter via OPENAI_BASE_URL override (openrouter.ai/api/v1)
- Updates manifest.json matrix entry to "implemented"

## Test plan
- [ ] `bash -n vastai/interpreter.sh` passes
- [ ] Script follows vastai pattern (ensure_vastai_cli, ensure_vastai_token, create_server, etc.)
- [ ] manifest.json updated correctly