### PR TITLE
refactor: Extract helpers from main() and start_oauth_server()

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -60,13 +60,8 @@ async function handleDefaultCommand(agent: string, cloud: string | undefined, pr
   }
 }
 
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-
-  // Check for updates and auto-update if needed (blocking)
-  await checkForUpdates();
-
-  // Extract --prompt or -p flag
+/** Parse --prompt / -p and --prompt-file flags, returning the resolved prompt text and remaining args */
+async function resolvePrompt(args: string[]): Promise<[string | undefined, string[]]> {
   let [prompt, filteredArgs] = extractFlagValue(
     args,
     ["--prompt", "-p"],
@@ -74,7 +69,6 @@ async function main(): Promise<void> {
     'spawn <agent> <cloud> --prompt "your prompt here"'
   );
 
-  // Extract --prompt-file flag
   const [promptFile, finalArgs] = extractFlagValue(
     filteredArgs,
     ["--prompt-file"],
@@ -103,6 +97,16 @@ async function main(): Promise<void> {
     }
   }
 
+  return [prompt, filteredArgs];
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  // Check for updates and auto-update if needed (blocking)
+  await checkForUpdates();
+
+  const [prompt, filteredArgs] = await resolvePrompt(args);
   const cmd = filteredArgs[0];
 
   try {


### PR DESCRIPTION
## Summary
- Extract `resolvePrompt()` from `main()` in `cli/src/index.ts`, reducing it from 98 to 62 lines. Separates prompt flag parsing and file reading from command dispatch.
- Extract `_validate_oauth_server_args()` and `_generate_oauth_html()` from `start_oauth_server()` in `shared/common.sh`, reducing it from 81 to 52 lines. Separates input validation and HTML template generation from the server startup logic.
- Bump CLI version to 0.2.11

## Test plan
- [x] All 485 CLI tests pass (`bun test`)
- [x] `bash -n shared/common.sh` passes
- [x] No functional changes -- pure refactoring with identical behavior

Agent: complexity-hunter