### PR TITLE
fix: UX improvements for update, prompt validation, and banner

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -56,6 +56,11 @@ async function handleDefaultCommand(agent: string, cloud: string | undefined, pr
   if (cloud) {
     await cmdRun(agent, cloud, prompt);
   } else {
+    if (prompt) {
+      console.error("Error: --prompt requires both <agent> and <cloud>");
+      console.error(`\nUsage: spawn ${agent} <cloud> --prompt "your prompt here"`);
+      process.exit(1);
+    }
     await cmdAgentInfo(agent);
   }
 }
@@ -107,6 +112,11 @@ async function main(): Promise<void> {
 
   try {
     if (!cmd) {
+      if (prompt) {
+        console.error("Error: --prompt requires both <agent> and <cloud>");
+        console.error(`\nUsage: spawn <agent> <cloud> --prompt "your prompt here"`);
+        process.exit(1);
+      }
       if (isInteractiveTTY()) {
         await cmdInteractive();
       } else {

--- a/cli/src/update-check.ts
+++ b/cli/src/update-check.ts
@@ -47,20 +47,27 @@ function compareVersions(current: string, latest: string): boolean {
 }
 
 function performAutoUpdate(latestVersion: string): void {
+  const line1 = `Update available: v${VERSION} -> v${latestVersion}`;
+  const line2 = "Updating automatically...";
+  const width = Math.max(line1.length, line2.length) + 4;
+  const border = "+" + "-".repeat(width) + "+";
+
   console.error(); // Use stderr so it doesn't interfere with parseable output
-  console.error(pc.yellow("+------------------------------------------------------------+"));
+  console.error(pc.yellow(border));
   console.error(
     pc.yellow("| ") +
     pc.bold(`Update available: v${VERSION} -> `) +
     pc.green(pc.bold(`v${latestVersion}`)) +
-    pc.yellow("                       |")
+    " ".repeat(width - 2 - line1.length) +
+    pc.yellow(" |")
   );
   console.error(
     pc.yellow("| ") +
-    pc.bold("Updating automatically...") +
-    pc.yellow("                                  |")
+    pc.bold(line2) +
+    " ".repeat(width - 2 - line2.length) +
+    pc.yellow(" |")
   );
-  console.error(pc.yellow("+------------------------------------------------------------+"));
+  console.error(pc.yellow(border));
   console.error();
 
   try {


### PR DESCRIPTION
## Summary
- **`spawn update` now auto-updates**: Previously just printed a curl command for the user to copy; now runs the install script directly (matching the auto-update behavior in `checkForUpdates`)
- **`--prompt` no longer silently dropped**: `spawn --prompt "text"` and `spawn claude --prompt "text"` now error with actionable messages instead of silently ignoring the prompt
- **Update banner box alignment fixed**: Dynamic padding replaces hardcoded whitespace that broke with different version string lengths

## Test plan
- [x] All 496 tests pass (485 pass, 11 skip)
- [x] Updated `commands-update-download.test.ts` to match new `cmdUpdate` behavior
- [x] Version bumped to 0.2.11

Agent: ux-engineer