### PR TITLE
fix: Add typo suggestions and --help flag handling

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/commands-helpers.test.ts
+++ b/cli/src/__tests__/commands-helpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { levenshtein, findClosestMatch } from "../commands";
 
 /**
  * Tests for helper functions in commands.ts
@@ -6,6 +7,76 @@ import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
  */
 
 describe("Command Helpers", () => {
+  describe("levenshtein", () => {
+    it("should return 0 for identical strings", () => {
+      expect(levenshtein("claude", "claude")).toBe(0);
+    });
+
+    it("should return string length for empty comparison", () => {
+      expect(levenshtein("abc", "")).toBe(3);
+      expect(levenshtein("", "abc")).toBe(3);
+    });
+
+    it("should return 0 for two empty strings", () => {
+      expect(levenshtein("", "")).toBe(0);
+    });
+
+    it("should count single character substitution", () => {
+      expect(levenshtein("cat", "car")).toBe(1);
+    });
+
+    it("should count single insertion", () => {
+      expect(levenshtein("claud", "claude")).toBe(1);
+    });
+
+    it("should count single deletion", () => {
+      expect(levenshtein("claudee", "claude")).toBe(1);
+    });
+
+    it("should handle transpositions as two edits", () => {
+      expect(levenshtein("ab", "ba")).toBe(2);
+    });
+
+    it("should handle completely different strings", () => {
+      expect(levenshtein("abc", "xyz")).toBe(3);
+    });
+  });
+
+  describe("findClosestMatch", () => {
+    const agents = ["claude", "aider", "openclaw", "nanoclaw", "codex", "goose"];
+
+    it("should find exact match (distance 0)", () => {
+      expect(findClosestMatch("claude", agents)).toBe("claude");
+    });
+
+    it("should find close typo (distance 1)", () => {
+      expect(findClosestMatch("cloude", agents)).toBe("claude");
+      expect(findClosestMatch("claud", agents)).toBe("claude");
+      expect(findClosestMatch("aidr", agents)).toBe("aider");
+    });
+
+    it("should find matches with distance 2", () => {
+      expect(findClosestMatch("claudee", agents)).toBe("claude");
+    });
+
+    it("should return null for very different strings", () => {
+      expect(findClosestMatch("kubernetes", agents)).toBeNull();
+    });
+
+    it("should return null for empty candidates", () => {
+      expect(findClosestMatch("claude", [])).toBeNull();
+    });
+
+    it("should be case insensitive", () => {
+      expect(findClosestMatch("Claude", agents)).toBe("claude");
+      expect(findClosestMatch("AIDER", agents)).toBe("aider");
+    });
+
+    it("should pick the closest match among multiple candidates", () => {
+      expect(findClosestMatch("cldude", agents)).toBe("claude");
+    });
+  });
+
   describe("getErrorMessage", () => {
     it("should extract message from Error objects", () => {
       const err = new Error("Test error");

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -52,7 +52,14 @@ function extractFlagValue(
   return [value, remaining];
 }
 
+const HELP_FLAGS = ["--help", "-h", "help"];
+
 async function handleDefaultCommand(agent: string, cloud: string | undefined, prompt?: string): Promise<void> {
+  // Handle "spawn <agent> --help" / "spawn <agent> -h" / "spawn <agent> help"
+  if (cloud && HELP_FLAGS.includes(cloud)) {
+    await cmdAgentInfo(agent);
+    return;
+  }
   if (cloud) {
     await cmdRun(agent, cloud, prompt);
   } else {
@@ -129,6 +136,9 @@ async function main(): Promise<void> {
       return;
     }
 
+    // If second arg is --help/-h, show general help for known subcommands
+    const hasHelpFlag = filteredArgs.slice(1).some(a => HELP_FLAGS.includes(a));
+
     switch (cmd) {
       case "help":
       case "--help":
@@ -145,23 +155,43 @@ async function main(): Promise<void> {
 
       case "list":
       case "ls":
-        await cmdList();
+        if (hasHelpFlag) {
+          cmdHelp();
+        } else {
+          await cmdList();
+        }
         break;
 
       case "agents":
-        await cmdAgents();
+        if (hasHelpFlag) {
+          cmdHelp();
+        } else {
+          await cmdAgents();
+        }
         break;
 
       case "clouds":
-        await cmdClouds();
+        if (hasHelpFlag) {
+          cmdHelp();
+        } else {
+          await cmdClouds();
+        }
         break;
 
       case "improve":
-        await cmdImprove(filteredArgs.slice(1));
+        if (hasHelpFlag) {
+          cmdHelp();
+        } else {
+          await cmdImprove(filteredArgs.slice(1));
+        }
         break;
 
       case "update":
-        await cmdUpdate();
+        if (hasHelpFlag) {
+          cmdHelp();
+        } else {
+          await cmdUpdate();
+        }
         break;
 
       default:


### PR DESCRIPTION
## Summary
- Add "Did you mean?" suggestions when users mistype agent or cloud names (e.g., `spawn claudee` suggests `claude`)
- Fix `spawn <agent> --help` crashing with "invalid characters" error instead of showing agent info
- Handle `--help` flag after subcommands (`spawn list --help`, `spawn agents --help`, etc.)

## Changes
- **`cli/src/commands.ts`**: Added `levenshtein()` and `findClosestMatch()` helpers; updated `validateAgent` and `validateCloud` to suggest closest match on typo
- **`cli/src/index.ts`**: Handle `--help`/`-h` as second argument in `handleDefaultCommand` and after known subcommands
- **`cli/package.json`**: Version bump to 0.2.13
- **`cli/src/__tests__/commands-helpers.test.ts`**: 15 new tests for levenshtein distance and fuzzy matching

## Before/After

### Before: `spawn claudee`
```
ERROR  Unknown agent: claudee
INFO  Run spawn agents to see available agents.
```

### After: `spawn claudee`
```
ERROR  Unknown agent: claudee
INFO  Did you mean claude?
INFO  Run spawn agents to see available agents.
```

### Before: `spawn claude --help`
```
ERROR  Cloud name "--help" contains invalid characters.
```

### After: `spawn claude --help`
Shows agent info for Claude (same as `spawn claude`)

## Test plan
- [x] All 516 tests pass (15 new tests added)
- [x] Verify `levenshtein` returns correct edit distances
- [x] Verify `findClosestMatch` returns closest match within threshold
- [x] Verify null returned when no candidates are close enough

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)