### PR TITLE
fix: Add 'did you mean?' suggestions for typos in agent/cloud names

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- When users mistype an agent or cloud name (e.g., `spawn claud sprite`), the CLI now suggests the closest match using Levenshtein distance
- Matches against both identifier keys and display names (e.g., typing "Claude" matches "claude" key)
- Suggestions only appear when a close match exists (max edit distance of 3); completely wrong names just show the generic help message
- Version bump to 0.2.13

## Before
```
$ spawn claud sprite
ERROR  Unknown agent: claud
INFO  Run spawn agents to see available agents.
```

## After
```
$ spawn claud sprite
ERROR  Unknown agent: claud
INFO  Did you mean claude (Claude Code)?
INFO  Run spawn agents to see available agents.
```

## Test plan
- [x] 8 new unit tests for `findClosestMatch` (exact match, edit distances, case-insensitive, empty candidates, max distance)
- [x] 3 integration tests for "did you mean?" in agent and cloud validation error paths
- [x] All 512 existing tests continue to pass

Agent: ux-engineer