### PR TITLE
feat: Add Hyperstack GPU cloud provider

### DIFF
--- a/hyperstack/README.md
+++ b/hyperstack/README.md
@@ -1,0 +1,152 @@
+# Hyperstack Cloud Scripts
+
+Spawn scripts for deploying AI agents on [Hyperstack](https://www.hyperstack.cloud/) GPU cloud infrastructure.
+
+## What is Hyperstack?
+
+Hyperstack (formerly NexGen Cloud) is a GPU cloud provider offering competitive pricing on NVIDIA GPUs, including:
+- **RTX A6000** (48GB) - $0.50/hour on-demand, $0.35/hour reserved
+- **RTX A4000**, **A100**, **H100**, and other high-performance GPUs
+- Pay-per-minute billing for on-demand instances
+- Global availability across multiple regions
+
+## Setup
+
+### 1. Get Hyperstack API Key
+
+1. Sign up at [Hyperstack Infrahub](https://infrahub.hyperstack.cloud)
+2. Navigate to **Settings → API Keys**
+3. Create a new API key
+4. Copy the API key
+
+### 2. Set Environment Variable
+
+```bash
+export HYPERSTACK_API_KEY="your-api-key-here"
+```
+
+Or the script will prompt you and save it to `~/.config/spawn/hyperstack.json`.
+
+### 3. Choose an Environment
+
+Hyperstack organizes resources by "environments" (e.g., `default-CANADA-1`, `default-EU-1`). The script will:
+- Use `HYPERSTACK_ENVIRONMENT` if set
+- Otherwise, fetch available environments and prompt you to choose
+
+List available environments:
+```bash
+curl -H "api_key: YOUR_API_KEY" \
+  https://infrahub-api.nexgencloud.com/v1/core/environments | jq '.environments[] | {name, region}'
+```
+
+## Usage
+
+```bash
+# Claude Code on Hyperstack
+bash <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hyperstack/claude.sh)
+
+# Aider on Hyperstack
+bash <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hyperstack/aider.sh)
+
+# OpenClaw on Hyperstack
+bash <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hyperstack/openclaw.sh)
+```
+
+## Configuration Options
+
+### Environment Variables
+
+- `HYPERSTACK_API_KEY` - API key from Hyperstack Infrahub (required)
+- `HYPERSTACK_ENVIRONMENT` - Environment name (e.g., `default-CANADA-1`)
+- `HYPERSTACK_FLAVOR` - VM flavor/size (default: `n1-cpu-small`)
+- `HYPERSTACK_IMAGE` - OS image (default: `Ubuntu Server 24.04 LTS R5504 UEFI`)
+- `HYPERSTACK_VM_NAME` - Custom VM name (default: prompts interactively)
+- `HYPERSTACK_SSH_KEY_NAME` - SSH key name (default: `spawn-key-$(whoami)`)
+
+### Example with Environment Variables
+
+```bash
+export HYPERSTACK_API_KEY="your-key"
+export HYPERSTACK_ENVIRONMENT="default-CANADA-1"
+export HYPERSTACK_FLAVOR="n1-cpu-medium"
+export HYPERSTACK_VM_NAME="my-claude-vm"
+
+bash <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hyperstack/claude.sh)
+```
+
+## Available Flavors
+
+To list available VM flavors:
+
+```bash
+curl -H "api_key: YOUR_API_KEY" \
+  https://infrahub-api.nexgencloud.com/v1/core/flavors | jq '.flavors[] | {name, cpu, ram, gpu}'
+```
+
+Common flavors:
+- `n1-cpu-small` - 1 vCPU, 2GB RAM
+- `n1-cpu-medium` - 2 vCPU, 4GB RAM
+- `n1-cpu-large` - 4 vCPU, 8GB RAM
+- GPU flavors with RTX A6000, A100, H100, etc.
+
+## Available Images
+
+To list available OS images:
+
+```bash
+curl -H "api_key: YOUR_API_KEY" \
+  https://infrahub-api.nexgencloud.com/v1/core/images | jq '.images[] | {name, version}'
+```
+
+## Pricing
+
+Hyperstack uses pay-per-minute billing for on-demand instances. Pricing is calculated per GPU per hour.
+
+**Example pricing** (subject to change):
+- RTX A6000 (48GB): $0.50/hour on-demand, $0.35/hour reserved
+- Reserved instances offer ~30% savings over on-demand
+
+Check current pricing at [Hyperstack Pricing](https://www.hyperstack.cloud/pricing) or via the API pricebook endpoints.
+
+## API Documentation
+
+Full API reference: [Hyperstack API Docs](https://docs.hyperstack.cloud)
+
+Base URL: `https://infrahub-api.nexgencloud.com/v1`
+
+## Billing Notes
+
+- VMs are only billed when in `ACTIVE` or `SHUTOFF` states
+- `HIBERNATED` VMs only charge for storage and public IP
+- Transitional states (e.g., `HIBERNATING`, `RESTORING`) are not charged
+- Minimum billing period is 1 minute
+
+## Troubleshooting
+
+### API Key Invalid
+
+If you see authentication errors:
+1. Verify your API key at https://infrahub.hyperstack.cloud
+2. Ensure the key has proper permissions (not read-only)
+3. Check that the key hasn't been revoked
+
+### Environment Not Found
+
+If the environment name is invalid:
+1. List available environments: `curl -H "api_key: KEY" https://infrahub-api.nexgencloud.com/v1/core/environments`
+2. Use the exact name from the API response (case-sensitive)
+3. Set `HYPERSTACK_ENVIRONMENT` to the correct name
+
+### VM Creation Fails
+
+Common issues:
+- Insufficient quota in the selected environment
+- Flavor not available in the selected region
+- SSH key name conflicts with existing key
+- Invalid security rules
+
+## Support
+
+- [Hyperstack Documentation](https://docs.hyperstack.cloud)
+- [Hyperstack Support](https://www.hyperstack.cloud/support)
+- [Spawn GitHub Issues](https://github.com/OpenRouterTeam/spawn/issues)

--- a/hyperstack/aider.sh
+++ b/hyperstack/aider.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hyperstack/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hyperstack/lib/common.sh)"
+fi
+
+log_info "Aider on Hyperstack"
+echo ""
+
+# 1. Resolve Hyperstack API key
+ensure_hyperstack_api_key
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get VM name and environment
+VM_NAME=$(get_vm_name)
+ENVIRONMENT=$(get_environment_name)
+
+# 4. Create VM
+create_vm "${VM_NAME}" "${ENVIRONMENT}"
+
+# 5. Wait for SSH
+verify_server_connectivity "${HYPERSTACK_VM_IP}"
+
+# 6. Install Aider
+log_warn "Installing Aider..."
+run_server "${HYPERSTACK_VM_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
+
+# Verify installation succeeded
+if ! run_server "${HYPERSTACK_VM_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
+    log_error "Aider installation verification failed"
+    log_error "The 'aider' command is not available or not working properly on VM ${HYPERSTACK_VM_IP}"
+    exit 1
+fi
+log_info "Aider installation verified successfully"
+
+# 7. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${HYPERSTACK_VM_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Hyperstack VM setup completed successfully!"
+log_info "VM: ${VM_NAME} (ID: ${HYPERSTACK_VM_ID}, IP: ${HYPERSTACK_VM_IP})"
+echo ""
+
+# 8. Start Aider interactively
+log_warn "Starting Aider..."
+sleep 1
+clear
+interactive_session "${HYPERSTACK_VM_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/hyperstack/claude.sh
+++ b/hyperstack/claude.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hyperstack/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hyperstack/lib/common.sh)"
+fi
+
+log_info "Claude Code on Hyperstack"
+echo ""
+
+# 1. Resolve Hyperstack API key
+ensure_hyperstack_api_key
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get VM name and environment
+VM_NAME=$(get_vm_name)
+ENVIRONMENT=$(get_environment_name)
+
+# 4. Create VM
+create_vm "${VM_NAME}" "${ENVIRONMENT}"
+
+# 5. Wait for SSH
+verify_server_connectivity "${HYPERSTACK_VM_IP}"
+
+# 6. Install Claude Code
+log_warn "Installing Claude Code..."
+run_server "${HYPERSTACK_VM_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${HYPERSTACK_VM_IP}" "command -v claude &> /dev/null && claude --version &> /dev/null"; then
+    log_error "Claude Code installation verification failed"
+    log_error "The 'claude' command is not available or not working properly on VM ${HYPERSTACK_VM_IP}"
+    exit 1
+fi
+log_info "Claude Code installation verified successfully"
+
+# 7. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${HYPERSTACK_VM_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
+    "ANTHROPIC_AUTH_TOKEN=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=" \
+    "CLAUDE_CODE_SKIP_ONBOARDING=1" \
+    "CLAUDE_CODE_ENABLE_TELEMETRY=0"
+
+# 8. Configure Claude Code settings
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${HYPERSTACK_VM_IP}" \
+    "run_server ${HYPERSTACK_VM_IP}"
+
+echo ""
+log_info "Hyperstack VM setup completed successfully!"
+log_info "VM: ${VM_NAME} (ID: ${HYPERSTACK_VM_ID}, IP: ${HYPERSTACK_VM_IP})"
+echo ""
+
+# 9. Start Claude Code interactively
+log_warn "Starting Claude Code..."
+sleep 1
+clear
+interactive_session "${HYPERSTACK_VM_IP}" "source ~/.zshrc && claude"

--- a/hyperstack/lib/common.sh
+++ b/hyperstack/lib/common.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+set -eo pipefail
+# Common bash functions for Hyperstack spawn scripts
+
+# ============================================================
+# Provider-agnostic functions
+# ============================================================
+
+# Source shared provider-agnostic functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
+    source "$SCRIPT_DIR/../../shared/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+fi
+
+# Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh
+
+# ============================================================
+# Hyperstack specific functions
+# ============================================================
+
+readonly HYPERSTACK_API_BASE="https://infrahub-api.nexgencloud.com/v1"
+# SSH_OPTS is now defined in shared/common.sh
+
+# Centralized curl wrapper for Hyperstack API
+hyperstack_api() {
+    local method="$1"
+    local endpoint="$2"
+    local body="${3:-}"
+    # shellcheck disable=SC2154
+    generic_cloud_api "$HYPERSTACK_API_BASE" "$HYPERSTACK_API_KEY" "$method" "$endpoint" "$body" "api_key"
+}
+
+test_hyperstack_api_key() {
+    local response
+    response=$(hyperstack_api GET "/core/virtual-machines?per_page=1")
+    if echo "$response" | grep -q '"status".*4[0-9][0-9]'; then
+        # Parse error details
+        local error_msg
+        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','No details available'))" 2>/dev/null || echo "Unable to parse error")
+        log_error "API Error: $error_msg"
+        log_error ""
+        log_error "How to fix:"
+        log_error "  1. Verify your API key at: https://infrahub.hyperstack.cloud"
+        log_error "  2. Ensure the API key has proper permissions"
+        log_error "  3. Check the key hasn't been revoked"
+        return 1
+    fi
+    return 0
+}
+
+# Ensure HYPERSTACK_API_KEY is available (env var → config file → prompt+save)
+ensure_hyperstack_api_key() {
+    ensure_api_token_with_provider \
+        "Hyperstack" \
+        "HYPERSTACK_API_KEY" \
+        "$HOME/.config/spawn/hyperstack.json" \
+        "https://infrahub.hyperstack.cloud → Settings → API Keys" \
+        "test_hyperstack_api_key"
+}
+
+# Check if SSH key is registered with Hyperstack
+hyperstack_check_ssh_key() {
+    local fingerprint="$1"
+    local existing_keys
+    existing_keys=$(hyperstack_api GET "/core/keypairs")
+    echo "$existing_keys" | grep -q "$fingerprint"
+}
+
+# Register SSH key with Hyperstack
+hyperstack_register_ssh_key() {
+    local key_name="$1"
+    local pub_path="$2"
+    local pub_key
+    pub_key=$(cat "$pub_path")
+    local json_pub_key
+    json_pub_key=$(json_escape "$pub_key")
+    local register_body="{\"name\":\"$key_name\",\"public_key\":$json_pub_key}"
+    local register_response
+    register_response=$(hyperstack_api POST "/core/keypairs" "$register_body")
+
+    if echo "$register_response" | grep -q '"status".*4[0-9][0-9]'; then
+        # Parse error details
+        local error_msg
+        error_msg=$(echo "$register_response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','Unknown error'))" 2>/dev/null || echo "$register_response")
+        log_error "API Error: $error_msg"
+        log_error ""
+        log_error "Common causes:"
+        log_error "  - SSH key already registered with this name"
+        log_error "  - Invalid SSH key format (must be valid ed25519 or RSA public key)"
+        log_error "  - API key lacks write permissions"
+        return 1
+    fi
+
+    return 0
+}
+
+# Ensure SSH key exists locally and is registered with Hyperstack
+ensure_ssh_key() {
+    ensure_ssh_key_with_provider hyperstack_check_ssh_key hyperstack_register_ssh_key "Hyperstack"
+}
+
+# Get VM name from env var or prompt
+get_vm_name() {
+    local vm_name
+    vm_name=$(get_resource_name "HYPERSTACK_VM_NAME" "Enter VM name: ") || return 1
+
+    if ! validate_server_name "$vm_name"; then
+        return 1
+    fi
+
+    echo "$vm_name"
+}
+
+# Get environment name (required for VM creation)
+get_environment_name() {
+    local env_name="${HYPERSTACK_ENVIRONMENT:-}"
+
+    if [[ -z "$env_name" ]]; then
+        log_warn "Fetching available environments..."
+        local envs_response
+        envs_response=$(hyperstack_api GET "/core/environments")
+        local env_list
+        env_list=$(echo "$envs_response" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+envs = data.get('environments', [])
+if envs:
+    for env in envs[:5]:
+        print(f\"  - {env['name']} (region: {env.get('region', 'N/A')})\")
+" 2>/dev/null)
+
+        if [[ -n "$env_list" ]]; then
+            log_info "Available environments:"
+            echo "$env_list" >&2
+        fi
+
+        env_name=$(safe_read "Enter environment name (e.g., default-CANADA-1): ")
+    fi
+
+    echo "$env_name"
+}
+
+# Create a Hyperstack VM
+create_vm() {
+    local name="$1"
+    local environment="${2:-}"
+    local flavor="${HYPERSTACK_FLAVOR:-n1-cpu-small}"
+    local image="${HYPERSTACK_IMAGE:-Ubuntu Server 24.04 LTS R5504 UEFI}"
+    local key_name="${HYPERSTACK_SSH_KEY_NAME:-spawn-key-$(whoami)}"
+
+    # Validate env var inputs to prevent injection
+    validate_resource_name "$flavor" || { log_error "Invalid HYPERSTACK_FLAVOR"; return 1; }
+    validate_resource_name "$key_name" || { log_error "Invalid HYPERSTACK_SSH_KEY_NAME"; return 1; }
+
+    log_warn "Creating Hyperstack VM '$name' (flavor: $flavor, env: $environment)..."
+
+    # Build request body
+    local body
+    body=$(python3 -c "
+import json
+body = {
+    'name': '$name',
+    'environment_name': '$environment',
+    'key_name': '$key_name',
+    'image_name': '$image',
+    'flavor_name': '$flavor',
+    'count': 1,
+    'assign_floating_ip': True,
+    'security_rules': [
+        {
+            'direction': 'ingress',
+            'ethertype': 'IPv4',
+            'protocol': 'tcp',
+            'remote_ip_prefix': '0.0.0.0/0',
+            'port_range_min': 22,
+            'port_range_max': 22
+        }
+    ]
+}
+print(json.dumps(body))
+")
+
+    local response
+    response=$(hyperstack_api POST "/core/virtual-machines" "$body")
+
+    # Check for errors
+    if echo "$response" | grep -q '"status".*4[0-9][0-9]'; then
+        local error_msg
+        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','Unknown error'))" 2>/dev/null || echo "$response")
+        log_error "Failed to create VM: $error_msg"
+        return 1
+    fi
+
+    # Extract VM details from response
+    HYPERSTACK_VM_ID=$(echo "$response" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+vms = data.get('virtual_machines', [])
+if vms:
+    print(vms[0].get('id', ''))
+")
+
+    if [[ -z "$HYPERSTACK_VM_ID" ]]; then
+        log_error "Failed to extract VM ID from response"
+        return 1
+    fi
+
+    log_info "VM created with ID: $HYPERSTACK_VM_ID"
+
+    # Wait for VM to become active and get IP
+    log_warn "Waiting for VM to become active..."
+    local max_wait=300
+    local elapsed=0
+
+    while [[ $elapsed -lt $max_wait ]]; do
+        local vm_info
+        vm_info=$(hyperstack_api GET "/core/virtual-machines/$HYPERSTACK_VM_ID")
+
+        local status
+        status=$(echo "$vm_info" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+print(data.get('status', ''))
+" 2>/dev/null)
+
+        if [[ "$status" == "ACTIVE" ]]; then
+            HYPERSTACK_VM_IP=$(echo "$vm_info" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+print(data.get('floating_ip', ''))
+" 2>/dev/null)
+
+            if [[ -n "$HYPERSTACK_VM_IP" ]]; then
+                log_info "VM is active with IP: $HYPERSTACK_VM_IP"
+                export HYPERSTACK_VM_IP
+                export HYPERSTACK_VM_ID
+                return 0
+            fi
+        fi
+
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+
+    log_error "VM did not become active within ${max_wait}s"
+    return 1
+}
+
+# Verify server connectivity via SSH
+verify_server_connectivity() {
+    local ip="$1"
+    generic_ssh_wait "$ip" "root" 180
+}
+
+# Run command on Hyperstack VM via SSH
+run_server() {
+    local ip="$1"
+    shift
+    # shellcheck disable=SC2086
+    ssh $SSH_OPTS "root@$ip" "$@"
+}
+
+# Upload file to Hyperstack VM via SCP
+upload_file() {
+    local ip="$1"
+    local src="$2"
+    local dst="$3"
+    # shellcheck disable=SC2086
+    scp $SSH_OPTS "$src" "root@$ip:$dst"
+}
+
+# Start interactive session on Hyperstack VM
+interactive_session() {
+    local ip="$1"
+    local cmd="${2:-bash}"
+    # shellcheck disable=SC2086
+    ssh $SSH_OPTS -t "root@$ip" "$cmd"
+}
+
+# Ensure Python 3 is available on local machine
+check_python_available

--- a/hyperstack/openclaw.sh
+++ b/hyperstack/openclaw.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hyperstack/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hyperstack/lib/common.sh)"
+fi
+
+log_info "OpenClaw on Hyperstack"
+echo ""
+
+# 1. Resolve Hyperstack API key
+ensure_hyperstack_api_key
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get VM name and environment
+VM_NAME=$(get_vm_name)
+ENVIRONMENT=$(get_environment_name)
+
+# 4. Create VM
+create_vm "${VM_NAME}" "${ENVIRONMENT}"
+
+# 5. Wait for SSH
+verify_server_connectivity "${HYPERSTACK_VM_IP}"
+
+# 6. Install Bun and openclaw
+log_warn "Installing Bun..."
+run_server "${HYPERSTACK_VM_IP}" "curl -fsSL https://bun.sh/install | bash"
+
+log_warn "Installing openclaw..."
+run_server "${HYPERSTACK_VM_IP}" "source ~/.bashrc && bun install -g openclaw"
+log_info "OpenClaw installed"
+
+# 7. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${HYPERSTACK_VM_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
+
+# 8. Configure openclaw
+setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" \
+    "upload_file ${HYPERSTACK_VM_IP}" \
+    "run_server ${HYPERSTACK_VM_IP}"
+
+echo ""
+log_info "Hyperstack VM setup completed successfully!"
+log_info "VM: ${VM_NAME} (ID: ${HYPERSTACK_VM_ID}, IP: ${HYPERSTACK_VM_IP})"
+echo ""
+
+# 9. Start openclaw gateway in background and launch TUI
+log_warn "Starting openclaw..."
+run_server "${HYPERSTACK_VM_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+sleep 2
+interactive_session "${HYPERSTACK_VM_IP}" "source ~/.zshrc && openclaw tui"

--- a/manifest.json
+++ b/manifest.json
@@ -573,6 +573,21 @@
         "image": "nvidia/cuda:12.1.0-devel-ubuntu22.04"
       },
       "notes": "GPU marketplace with per-hour pricing. Uses vastai CLI (pip install vastai). SSH via dynamic port mapping. Docker-based instances with CUDA pre-installed."
+    },
+    "hyperstack": {
+      "name": "Hyperstack",
+      "description": "Hyperstack GPU cloud via REST API",
+      "url": "https://www.hyperstack.cloud/",
+      "type": "api",
+      "auth": "HYPERSTACK_API_KEY",
+      "provision_method": "POST /core/virtual-machines",
+      "exec_method": "ssh root@IP",
+      "interactive_method": "ssh -t root@IP",
+      "defaults": {
+        "flavor": "n1-cpu-small",
+        "image": "Ubuntu Server 24.04 LTS R5504 UEFI"
+      },
+      "notes": "GPU cloud provider. Competitive pricing on RTX A6000 ($0.50/hr). Requires HYPERSTACK_API_KEY from https://infrahub.hyperstack.cloud"
     }
   },
   "matrix": {
@@ -897,6 +912,20 @@
     "vastai/gptme": "implemented",
     "vastai/opencode": "implemented",
     "vastai/plandex": "implemented",
-    "vastai/kilocode": "implemented"
+    "vastai/kilocode": "implemented",
+    "hyperstack/claude": "implemented",
+    "hyperstack/openclaw": "implemented",
+    "hyperstack/nanoclaw": "missing",
+    "hyperstack/aider": "implemented",
+    "hyperstack/goose": "missing",
+    "hyperstack/codex": "missing",
+    "hyperstack/interpreter": "missing",
+    "hyperstack/gemini": "missing",
+    "hyperstack/amazonq": "missing",
+    "hyperstack/cline": "missing",
+    "hyperstack/gptme": "missing",
+    "hyperstack/opencode": "missing",
+    "hyperstack/plandex": "missing",
+    "hyperstack/kilocode": "missing"
   }
 }


### PR DESCRIPTION
## Summary

Add **Hyperstack** (formerly NexGen Cloud) as a new GPU cloud provider to the spawn matrix.

### Why Hyperstack?

1. **Competitive GPU pricing**: RTX A6000 (48GB) at $0.50/hour on-demand, $0.35/hour reserved
2. **Flexible billing**: Pay-per-minute for on-demand instances
3. **Global availability**: Multiple regions (CANADA-1, EU-1, etc.)
4. **REST API**: Clean API at infrahub-api.nexgencloud.com/v1
5. **SSH access**: Standard SSH connectivity to VMs

### Implementation Details

- Created `hyperstack/lib/common.sh` with API wrappers
- Implemented 3 agent scripts:
  - `claude.sh` - Claude Code
  - `aider.sh` - Aider AI pair programming
  - `openclaw.sh` - OpenClaw multi-channel assistant
- Added comprehensive `hyperstack/README.md` with setup instructions
- Updated `manifest.json` with 14 matrix entries (3 implemented, 11 missing)

### Matrix Update

- **Before**: 21 clouds × 14 agents = 294 entries
- **After**: 22 clouds × 14 agents = 308 entries
- **New entries**: 14 (claude, aider, openclaw implemented)

### Testing

- All bash scripts pass syntax check (`bash -n`)
- Follows spawn conventions:
  - Local-or-remote fallback for sourcing
  - SSH key management
  - OAuth flow for OpenRouter API key
  - Environment variable injection

### API Authentication

Uses `api_key` header for authentication. Users can:
1. Set `HYPERSTACK_API_KEY` env var
2. Script prompts and saves to `~/.config/spawn/hyperstack.json`

Get API key from: https://infrahub.hyperstack.cloud → Settings → API Keys

🤖 Generated by cloud-scout-2 agent