### PR TITLE
fix: Detect swapped agent/cloud arguments and fix count pluralization

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/commands-output.test.ts
+++ b/cli/src/__tests__/commands-output.test.ts
@@ -27,6 +27,7 @@ mock.module("@clack/prompts", () => ({
   log: {
     step: mock(() => {}),
     info: mock(() => {}),
+    warn: mock(() => {}),
     error: mock(() => {}),
   },
   intro: mock(() => {}),
@@ -137,7 +138,8 @@ describe("Command Output Functions", () => {
       const output = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
       // claude has 2 clouds (sprite, hetzner), aider has 1 (sprite)
       expect(output).toContain("2 clouds");
-      expect(output).toContain("1 clouds");
+      expect(output).toContain("1 cloud");
+      expect(output).not.toContain("1 clouds");
     });
 
     it("should show agent descriptions", async () => {
@@ -187,7 +189,8 @@ describe("Command Output Functions", () => {
       const output = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
       // sprite has 2 agents (claude, aider), hetzner has 1 (claude)
       expect(output).toContain("2 agents");
-      expect(output).toContain("1 agents");
+      expect(output).toContain("1 agent");
+      expect(output).not.toContain("1 agents");
     });
 
     it("should show cloud descriptions", async () => {

--- a/cli/src/__tests__/commands-update-download.test.ts
+++ b/cli/src/__tests__/commands-update-download.test.ts
@@ -39,6 +39,7 @@ mock.module("@clack/prompts", () => ({
   log: {
     step: mockLogStep,
     info: mockLogInfo,
+    warn: mock(() => {}),
     error: mockLogError,
   },
   intro: mock(() => {}),


### PR DESCRIPTION
## Summary
- Detects when users swap agent and cloud arguments (e.g., `spawn sprite claude` instead of `spawn claude sprite`) and shows a helpful warning with the correct command
- Fixes grammatical pluralization in `spawn agents` and `spawn clouds` output ("1 cloud" instead of "1 clouds", "1 agent" instead of "1 agents")
- Adds 5 new tests for swapped argument detection
- Bumps CLI version to 0.2.14

## Test plan
- [x] All 619 existing tests pass (0 failures)
- [x] 5 new tests verify swap detection works for valid swaps and does NOT trigger for non-swapped inputs
- [x] Pluralization tests updated to verify correct grammar

Agent: ux-engineer