### PR TITLE
feat: Add Railway cloud provider

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -588,6 +588,20 @@
         "image": "Ubuntu Server 24.04 LTS R5504 UEFI"
       },
       "notes": "GPU cloud provider. Competitive pricing on RTX A6000 ($0.50/hr). Requires HYPERSTACK_API_KEY from https://infrahub.hyperstack.cloud"
+    },
+    "railway": {
+      "name": "Railway",
+      "description": "Railway container PaaS via CLI and GraphQL API",
+      "url": "https://railway.app/",
+      "type": "cli",
+      "auth": "railway login OR RAILWAY_TOKEN",
+      "provision_method": "railway init + railway up (Dockerfile deployment)",
+      "exec_method": "railway run COMMAND",
+      "interactive_method": "railway run bash or railway ssh",
+      "defaults": {
+        "image": "ubuntu:24.04"
+      },
+      "notes": "Container PaaS with per-minute billing, instant deployments, and built-in SSH via 'railway ssh'. Uses Railway CLI for all operations."
     }
   },
   "matrix": {
@@ -926,6 +940,20 @@
     "hyperstack/gptme": "missing",
     "hyperstack/opencode": "missing",
     "hyperstack/plandex": "missing",
-    "hyperstack/kilocode": "missing"
+    "hyperstack/kilocode": "missing",
+    "railway/claude": "implemented",
+    "railway/openclaw": "implemented",
+    "railway/nanoclaw": "missing",
+    "railway/aider": "implemented",
+    "railway/goose": "missing",
+    "railway/codex": "missing",
+    "railway/interpreter": "missing",
+    "railway/gemini": "missing",
+    "railway/amazonq": "missing",
+    "railway/cline": "missing",
+    "railway/gptme": "implemented",
+    "railway/opencode": "missing",
+    "railway/plandex": "missing",
+    "railway/kilocode": "missing"
   }
 }

--- a/railway/openclaw.sh
+++ b/railway/openclaw.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/railway/lib/common.sh)"
+fi
+
+log_info "OpenClaw on Railway"
+echo ""
+
+# 1. Ensure Railway CLI and token
+ensure_railway_cli
+ensure_railway_token
+
+# 2. Get project name and create service
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Install base tools
+wait_for_cloud_init
+
+# 4. Install openclaw via bun
+log_warn "Installing openclaw..."
+run_server "source ~/.bashrc && bun install -g openclaw"
+log_info "OpenClaw installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_railway \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
+
+# 6. Configure openclaw
+setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" \
+    "upload_file" \
+    "run_server"
+
+echo ""
+log_info "Railway service setup completed successfully!"
+log_info "Project: $SERVER_NAME"
+echo ""
+
+# 7. Start openclaw gateway in background and launch TUI
+log_warn "Starting openclaw..."
+run_server "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+sleep 2
+interactive_session "source ~/.zshrc && openclaw tui"


### PR DESCRIPTION
## Summary
- Add Railway as a new cloud provider to the spawn matrix
- Container PaaS platform with CLI-based deployment and pay-per-minute billing
- Implement 4 agents: Claude Code, Aider, gptme, and OpenClaw

## Changes
- Added Railway cloud entry to manifest.json with provider details
- Added 14 matrix entries for railway/* agent combinations
- Created railway/openclaw.sh deployment script following established patterns
- Marked 4 implemented agents in matrix (claude, aider, gptme, openclaw)
- Railway implementation uses CLI-based approach (railway init, up, run)

## Implementation Details
- railway/lib/common.sh: Provider primitives for Railway CLI operations
- railway/claude.sh: Claude Code deployment (already existed)
- railway/aider.sh: Aider deployment (already existed)
- railway/gptme.sh: gptme deployment (already existed)
- railway/openclaw.sh: OpenClaw deployment (newly created)
- railway/README.md: Documentation and usage examples (already existed)

## Test Plan
- [x] All bash scripts pass syntax validation (bash -n)
- [x] Manifest.json is valid JSON
- [x] Matrix entries correctly added for all 14 agents
- [x] 4 agents marked as "implemented" in matrix
- [x] Agent scripts follow established patterns from other clouds

Generated with Claude Code