### PR TITLE
feat: Add hyperstack/gptme script

### DIFF
--- a/hyperstack/gptme.sh
+++ b/hyperstack/gptme.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hyperstack/lib/common.sh)"
+fi
+
+log_info "gptme on Hyperstack"
+echo ""
+
+# 1. Resolve Hyperstack API key
+ensure_hyperstack_api_key
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get VM name and environment
+VM_NAME=$(get_vm_name)
+ENVIRONMENT=$(get_environment_name)
+
+# 4. Create VM
+create_vm "$VM_NAME" "$ENVIRONMENT"
+
+# 5. Wait for SSH
+verify_server_connectivity "$HYPERSTACK_VM_IP"
+
+# 6. Install gptme
+log_warn "Installing gptme..."
+run_server "$HYPERSTACK_VM_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
+
+# Verify installation succeeded
+if ! run_server "$HYPERSTACK_VM_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
+    log_error "gptme installation verification failed"
+    log_error "The 'gptme' command is not available or not working properly on server $HYPERSTACK_VM_IP"
+    exit 1
+fi
+log_info "gptme installation verified successfully"
+
+# 7. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5181)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "$HYPERSTACK_VM_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
+
+echo ""
+log_info "Hyperstack VM setup completed successfully!"
+log_info "VM: $VM_NAME (ID: $HYPERSTACK_VM_ID, IP: $HYPERSTACK_VM_IP)"
+echo ""
+
+# 8. Start gptme interactively
+log_warn "Starting gptme..."
+sleep 1
+clear
+interactive_session "$HYPERSTACK_VM_IP" "source ~/.bashrc && gptme -m openrouter/${MODEL_ID}"

--- a/manifest.json
+++ b/manifest.json
@@ -938,7 +938,7 @@
     "hyperstack/gemini": "implemented",
     "hyperstack/amazonq": "missing",
     "hyperstack/cline": "missing",
-    "hyperstack/gptme": "missing",
+    "hyperstack/gptme": "implemented",
     "hyperstack/opencode": "missing",
     "hyperstack/plandex": "missing",
     "hyperstack/kilocode": "missing",


### PR DESCRIPTION
Implements gptme agent on Hyperstack cloud platform.

## Changes
- Created `hyperstack/gptme.sh` using Hyperstack lib primitives
- Updated `manifest.json` to mark `hyperstack/gptme` as `"implemented"`

## Implementation Details
- **Install**: `pip install gptme` (with pip3 fallback)
- **Launch**: `gptme -m openrouter/${MODEL_ID}`
- **OpenRouter**: Native support via `OPENROUTER_API_KEY`
- **OAuth**: Port 5181 for API key acquisition
- **Shell**: Uses `.bashrc` for env var sourcing

## Pattern
Follows the standard spawn pattern:
1. Authenticate with Hyperstack API
2. Generate/register SSH key
3. Provision VM with environment
4. Install agent via pip
5. Inject OpenRouter credentials
6. Launch interactive session

Built by gap-filler-hyperstack-3 agent.