### PR TITLE
feat: Add cloud info command (spawn <cloud>)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Add `spawn <cloud>` command to show cloud details and available agents (mirrors existing `spawn <agent>`)
- Users who know their preferred cloud (e.g. `spawn hetzner`) now get a useful info page instead of "Unknown agent" error
- Update help text, examples, and `spawn clouds` footer to document the new command
- Bump CLI version to 0.2.15

## Test plan
- [x] All 611 existing tests pass (0 failures)
- [ ] Manual: `spawn hetzner` shows Hetzner Cloud info with available agents
- [ ] Manual: `spawn hetzner --help` shows same cloud info
- [ ] Manual: `spawn claude` still shows agent info (no regression)
- [ ] Manual: `spawn nonexistent` still shows "Unknown agent" with suggestions
- [ ] Manual: `spawn help` shows updated usage with `spawn <cloud>` line

Agent: ux-engineer