### PR TITLE
fix: Prevent command injection in Koyeb and Hyperstack env var injection

### DIFF
--- a/hyperstack/codex.sh
+++ b/hyperstack/codex.sh
@@ -34,11 +34,10 @@ else
 fi
 
 log_warn "Setting up environment variables..."
-run_server "$HYPERSTACK_VM_IP" "cat >> ~/.bashrc << 'EOF'
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_BASE_URL=https://openrouter.ai/api/v1
-EOF"
+inject_env_vars_ssh "$HYPERSTACK_VM_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "Hyperstack VM setup completed successfully!"
@@ -47,4 +46,4 @@ echo ""
 log_warn "Starting Codex..."
 sleep 1
 clear
-interactive_session "$HYPERSTACK_VM_IP" "bash -c 'source ~/.bashrc && codex'"
+interactive_session "$HYPERSTACK_VM_IP" "source ~/.zshrc && codex"

--- a/hyperstack/gemini.sh
+++ b/hyperstack/gemini.sh
@@ -32,12 +32,11 @@ else
 fi
 
 log_warn "Setting up environment variables..."
-run_server "$HYPERSTACK_VM_IP" "cat >> ~/.bashrc << 'EOF'
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-export GEMINI_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_BASE_URL=https://openrouter.ai/api/v1
-EOF"
+inject_env_vars_ssh "$HYPERSTACK_VM_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "Hyperstack setup completed successfully!"
@@ -46,4 +45,4 @@ echo ""
 log_warn "Starting Gemini..."
 sleep 1
 clear
-interactive_session "$HYPERSTACK_VM_IP" "bash -c 'source ~/.bashrc && gemini'"
+interactive_session "$HYPERSTACK_VM_IP" "source ~/.zshrc && gemini"

--- a/hyperstack/goose.sh
+++ b/hyperstack/goose.sh
@@ -47,7 +47,9 @@ else
 fi
 
 log_warn "Setting up environment variables..."
-run_server "$HYPERSTACK_VM_IP" "printf '\nexport GOOSE_PROVIDER=openrouter\nexport OPENROUTER_API_KEY=%s\n' '$OPENROUTER_API_KEY' >> ~/.bashrc"
+inject_env_vars_ssh "$HYPERSTACK_VM_IP" upload_file run_server \
+    "GOOSE_PROVIDER=openrouter" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""
 log_info "Hyperstack VM setup completed successfully!"
@@ -57,4 +59,4 @@ echo ""
 log_warn "Starting Goose..."
 sleep 1
 clear
-interactive_session "$HYPERSTACK_VM_IP" "bash -c 'source ~/.bashrc && goose'"
+interactive_session "$HYPERSTACK_VM_IP" "source ~/.zshrc && goose"

--- a/hyperstack/interpreter.sh
+++ b/hyperstack/interpreter.sh
@@ -34,11 +34,10 @@ else
 fi
 
 log_warn "Setting up environment variables..."
-run_server "$HYPERSTACK_VM_IP" "cat >> ~/.bashrc << 'ENVEOF'
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_BASE_URL=https://openrouter.ai/api/v1
-ENVEOF"
+inject_env_vars_ssh "$HYPERSTACK_VM_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "Hyperstack VM setup completed successfully!"
@@ -47,4 +46,4 @@ echo ""
 log_warn "Starting Open Interpreter..."
 sleep 1
 clear
-interactive_session "$HYPERSTACK_VM_IP" "bash -c 'source ~/.bashrc && interpreter'"
+interactive_session "$HYPERSTACK_VM_IP" "source ~/.zshrc && interpreter"

--- a/koyeb/lib/common.sh
+++ b/koyeb/lib/common.sh
@@ -233,7 +233,7 @@ run_server() {
     koyeb instances exec "$KOYEB_INSTANCE_ID" -- bash -c "$cmd"
 }
 
-# Upload a file to the Koyeb instance
+# Upload a file to the Koyeb instance via base64 encoding
 upload_file() {
     local local_path="$1"
     local remote_path="$2"
@@ -243,12 +243,18 @@ upload_file() {
         return 1
     fi
 
-    # Read file content and encode
+    # Validate remote_path to prevent command injection
+    if [[ "$remote_path" == *"'"* || "$remote_path" == *'$'* || "$remote_path" == *'`'* || "$remote_path" == *$'\n'* ]]; then
+        log_error "Invalid remote path (contains unsafe characters): $remote_path"
+        return 1
+    fi
+
+    # Read file content and encode (base64 output is safe for shell embedding)
     local content
-    content=$(cat "$local_path" | base64)
+    content=$(base64 < "$local_path")
 
     # Write file on remote instance
-    run_server "echo '$content' | base64 -d > '$remote_path'"
+    run_server "printf '%s' '$content' | base64 -d > '$remote_path'"
 }
 
 # Wait for cloud-init or basic system readiness
@@ -265,16 +271,20 @@ wait_for_cloud_init() {
 }
 
 # Inject environment variables into shell config
+# Writes to a temp file and uploads to avoid shell interpolation of values
 inject_env_vars() {
-    local shell_rc="/root/.bashrc"
-
     log_warn "Injecting environment variables..."
 
-    for env_var in "$@"; do
-        # Escape special characters for sed
-        local escaped_var=$(echo "$env_var" | sed 's/[&/\]/\\&/g')
-        run_server "echo 'export $escaped_var' >> $shell_rc"
-    done
+    local env_temp
+    env_temp=$(mktemp)
+    chmod 600 "${env_temp}"
+    track_temp_file "${env_temp}"
+
+    generate_env_config "$@" > "${env_temp}"
+
+    # Upload and append to .bashrc (Koyeb containers use bash, not zsh)
+    upload_file "${env_temp}" "/tmp/env_config"
+    run_server "cat /tmp/env_config >> /root/.bashrc && rm /tmp/env_config"
 
     log_info "Environment variables configured"
 }


### PR DESCRIPTION
## Summary

- **Koyeb `inject_env_vars`** (koyeb/lib/common.sh): Replaced broken sed-based escaping with file-based injection using `generate_env_config` + `upload_file`. The old code only escaped `&`, `/`, `\` but not single quotes, allowing API key values containing `'` to break out of the shell command passed to `koyeb instances exec`.

- **Hyperstack goose/gemini/interpreter/codex**: Replaced direct `$OPENROUTER_API_KEY` interpolation in double-quoted SSH command strings with `inject_env_vars_ssh` (the shared safe pattern that writes to a temp file and uploads via SCP). The old code allowed API keys containing `"`, `` ` ``, or `$()` to execute arbitrary commands on the remote VM.

- **Koyeb `upload_file`**: Added validation to reject remote paths containing shell metacharacters (`'`, `$`, `` ` ``, newline).

## Severity

HIGH - User-controllable API key values (from environment or OAuth) could inject arbitrary shell commands into:
- Koyeb container instances (via `koyeb instances exec`)
- Hyperstack VMs (via SSH)

## Test plan

- [ ] `bash -n` passes on all 5 modified files (verified)
- [ ] Koyeb scripts use file-based env injection matching shared/common.sh pattern
- [ ] Hyperstack scripts use `inject_env_vars_ssh` matching claude/aider/openclaw pattern
- [ ] Interactive sessions source `~/.zshrc` (matching `inject_env_vars_ssh` target)