### PR TITLE
feat: Add Koyeb interpreter script

### DIFF
--- a/koyeb/interpreter.sh
+++ b/koyeb/interpreter.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/koyeb/lib/common.sh)"
+fi
+
+log_info "Open Interpreter on Koyeb"
+echo ""
+
+# 1. Ensure Koyeb CLI and API token
+ensure_koyeb_cli
+ensure_koyeb_token
+
+# 2. Create service
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Install base tools
+wait_for_cloud_init
+
+# 4. Install Open Interpreter
+log_warn "Installing Open Interpreter..."
+run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1" \
+    "PATH=\$HOME/.local/bin:\$PATH"
+
+echo ""
+log_info "Koyeb service setup completed successfully!"
+log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
+echo ""
+
+# 7. Start Open Interpreter interactively
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "source /root/.bashrc && interpreter"

--- a/manifest.json
+++ b/manifest.json
@@ -948,7 +948,7 @@
     "koyeb/aider": "implemented",
     "koyeb/goose": "implemented",
     "koyeb/codex": "implemented",
-    "koyeb/interpreter": "missing",
+    "koyeb/interpreter": "implemented",
     "koyeb/gemini": "missing",
     "koyeb/amazonq": "missing",
     "koyeb/cline": "missing",


### PR DESCRIPTION
## Summary
- Implements koyeb/interpreter matrix entry
- Installs Open Interpreter via pip
- Injects OpenRouter API key via OPENAI_BASE_URL override
- Launches interactive interpreter session

## Test plan
- [x] bash -n syntax check passed
- [x] manifest.json updated to "implemented"

🤖 Generated by gap-filler-koyeb-1