### PR TITLE
fix: Bundle dependencies in CLI build for proot-distro compatibility

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "type": "module",
   "bin": {
     "spawn": "cli.js"
   },
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "bun build src/index.ts --outfile cli.js --target bun --minify",
+    "build": "bun build src/index.ts --outfile cli.js --target bun --minify --packages bundle",
     "compile": "bun build src/index.ts --compile --outfile spawn",
     "test": "bun test",
     "test:watch": "bun test --watch"


### PR DESCRIPTION
## Summary
- Added `--packages bundle` flag to bun build command
- Bumped CLI version to 0.2.16
- Fixes proot-distro ubuntu installation issue

## Problem
The CLI build was failing on proot-distro ubuntu because `bun build` couldn't resolve node_modules dependencies even though `bun install` succeeded. The build command was trying to bundle with minify but wasn't explicitly told to bundle external packages.

## Solution
Added `--packages bundle` flag to the build script in package.json to explicitly bundle all dependencies into the output file.

## Test Plan
- [x] Build succeeds with `bun run build`
- [x] Built CLI executable runs correctly (`./cli.js version`)
- [x] Version bumped to 0.2.16

Fixes #209