### PR TITLE
fix: Secure upload_file() against command injection

### DIFF
--- a/modal/lib/common.sh
+++ b/modal/lib/common.sh
@@ -165,9 +165,11 @@ upload_file() {
     local remote_path="${2}"
     local content
     content=$(base64 -w0 "${local_path}" 2>/dev/null || base64 "${local_path}")
-    # base64 output is safe (alphanumeric + /+=) so no injection risk in the echo
-    # Remote path needs quoting for spaces/special chars in the remote shell
-    run_server "echo '${content}' | base64 -d > '${remote_path}'"
+    # SECURITY: Properly escape remote_path to prevent single-quote breakout injection
+    local escaped_path
+    escaped_path=$(printf '%q' "${remote_path}")
+    # base64 output is safe (alphanumeric + /+=) so no injection risk
+    run_server "printf '%s' '${content}' | base64 -d > ${escaped_path}"
 }
 
 interactive_session() {


### PR DESCRIPTION
## Summary
- **Railway** (CRITICAL): Fix command injection in `upload_file()` — missing `base64 -w0` caused newline injection, unescaped `remote_path` in single quotes allowed single-quote breakout. Now uses `base64 -w0` with macOS fallback, `printf '%q'` for path escaping, and routes through `run_server`.
- **Modal**: Fix single-quote breakout in `remote_path` by replacing single-quote embedding with `printf '%q'` escaping.
- **Koyeb**: Replace fragile deny-list character validation with `printf '%q'` escaping, add `base64 -w0` with macOS fallback.

## Audit scope
Audited all 25 cloud providers' `upload_file()` functions:
- 18 providers use `scp` (no shell injection surface): digitalocean, scaleway, upcloud, civo, hetzner, latitude, kamatera, binarylane, vultr, gcp, hyperstack, genesiscloud, linode, oracle, lambda, aws-lightsail, runpod, vastai
- 4 providers already use `printf '%q'` escaping (safe): e2b, northflank, daytona, fly
- 3 providers fixed in this PR: railway, modal, koyeb

## Test plan
- [x] `bash -n` syntax check passes on all 3 modified files
- [ ] Verify base64 encoding works on both Linux and macOS
- [ ] Verify file upload works on Railway, Modal, and Koyeb

Agent: security-auditor