### PR TITLE
fix: Fix broken gptme script and update provider READMEs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1026,7 +1026,7 @@
     "railway/gemini": "missing",
     "railway/amazonq": "missing",
     "railway/cline": "missing",
-    "railway/gptme": "missing",
+    "railway/gptme": "implemented",
     "railway/opencode": "missing",
     "railway/plandex": "missing",
     "railway/kilocode": "missing"

--- a/northflank/README.md
+++ b/northflank/README.md
@@ -24,6 +24,36 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/openclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/aider.sh)
 ```
 
+#### NanoClaw
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/nanoclaw.sh)
+```
+
+#### Goose
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/goose.sh)
+```
+
+#### Codex CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/codex.sh)
+```
+
+#### Open Interpreter
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/interpreter.sh)
+```
+
+#### Gemini CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/gemini.sh)
+```
+
 ## Setup
 
 1. Create a Northflank account at https://northflank.com
@@ -43,6 +73,15 @@ NORTHFLANK_TOKEN=your-token \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
   bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/claude.sh)
 ```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORTHFLANK_TOKEN` | Northflank API token | _(prompted)_ |
+| `NORTHFLANK_SERVICE_NAME` | Service name | _(prompted)_ |
+| `NORTHFLANK_PROJECT_NAME` | Project name | `spawn-project` |
+| `OPENROUTER_API_KEY` | OpenRouter API key | _(OAuth or prompted)_ |
 
 ## Free Tier
 

--- a/northflank/aider.sh
+++ b/northflank/aider.sh
@@ -48,7 +48,7 @@ MODEL_ID="${MODEL_ID:-openrouter/auto}"
 # 7. Inject environment variables into shell configs
 log_warn "Setting up environment variables..."
 
-inject_env_vars_local upload_file run_server \
+inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""

--- a/northflank/claude.sh
+++ b/northflank/claude.sh
@@ -47,7 +47,7 @@ fi
 # 6. Inject environment variables into shell configs
 log_warn "Setting up environment variables..."
 
-inject_env_vars_local upload_file run_server \
+inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
     "ANTHROPIC_AUTH_TOKEN=${OPENROUTER_API_KEY}" \

--- a/northflank/openclaw.sh
+++ b/northflank/openclaw.sh
@@ -44,7 +44,7 @@ MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 # 7. Inject environment variables into shell configs
 log_warn "Setting up environment variables..."
 
-inject_env_vars_local upload_file run_server \
+inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"

--- a/railway/README.md
+++ b/railway/README.md
@@ -22,6 +22,18 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/openclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/aider.sh)
 ```
 
+#### NanoClaw
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/nanoclaw.sh)
+```
+
+#### gptme
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/gptme.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/railway/gptme.sh
+++ b/railway/gptme.sh
@@ -42,7 +42,7 @@ MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 # 7. Inject environment variables into shell config
 log_warn "Setting up environment variables..."
 
-inject_env_vars_railway \
+inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "PATH=\$HOME/.bun/bin:\$PATH"
 


### PR DESCRIPTION
## Summary

- **Fix runtime crash in `railway/gptme.sh`**: Script called `inject_env_vars_railway` which doesn't exist -- corrected to `inject_env_vars`
- **Fix missing env vars in Northflank scripts**: `claude.sh`, `openclaw.sh`, and `aider.sh` used `inject_env_vars_local` (only writes to `.zshrc`) instead of `inject_env_vars_northflank` (writes to both `.bashrc` and `.zshrc`). Since interactive sessions run `source ~/.bashrc`, env vars were not being loaded in bash
- **Update Railway README**: Added NanoClaw and gptme to agent listings
- **Update Northflank README**: Added NanoClaw, Goose, Codex CLI, Open Interpreter, Gemini CLI to agent listings; added Environment Variables table
- **Update manifest**: Marked `railway/gptme` as `implemented`

## Test plan

- [x] `bash -n` passes on all modified shell scripts
- [ ] Verify `railway/gptme.sh` deploys correctly with the fixed function call
- [ ] Verify Northflank claude/openclaw/aider env vars are available in bash sessions

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)