### PR TITLE
fix: Unified agent+cloud suggestions for unknown commands

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- When a user types `spawn hetzne` (typo of cloud name), it previously showed "Unknown agent: hetzne" with no useful suggestion because it only searched agent names
- Now searches both agent AND cloud name pools for typo suggestions, showing e.g. "Did you mean hetzner (cloud)?"
- Also shows helpful next-step commands (`spawn agents`, `spawn clouds`, `spawn help`)

## Changes
- `cli/src/index.ts`: Updated `handleDefaultCommand` to provide a unified error when input matches neither an agent nor a cloud, with typo suggestions from both pools
- `cli/src/__tests__/index-edge-cases.test.ts`: Added 10 new tests for the updated routing logic and unified suggestion behavior
- `cli/package.json`: Version bump 0.2.16 -> 0.2.17

## Test plan
- [x] All 690 existing + new tests pass (0 failures)
- [x] `spawn hetzne` now shows "Did you mean hetzner (cloud)?" instead of "Unknown agent: hetzne"
- [x] `spawn claud` still shows "Did you mean claude (agent)?"
- [x] `spawn zzzzz` shows help commands without suggestions when nothing is close
- [x] `spawn claude` still correctly shows agent info
- [x] `spawn hetzner` still correctly shows cloud info

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)