### PR TITLE
feat: Add Amazon Q agent for Northflank

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1010,7 +1010,7 @@
     "northflank/codex": "implemented",
     "northflank/interpreter": "implemented",
     "northflank/gemini": "implemented",
-    "northflank/amazonq": "missing",
+    "northflank/amazonq": "implemented",
     "northflank/cline": "missing",
     "northflank/gptme": "missing",
     "northflank/opencode": "missing",

--- a/northflank/README.md
+++ b/northflank/README.md
@@ -54,6 +54,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/interpreter.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/gemini.sh)
 ```
 
+#### Amazon Q CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/amazonq.sh)
+```
+
 ## Setup
 
 1. Create a Northflank account at https://northflank.com

--- a/northflank/amazonq.sh
+++ b/northflank/amazonq.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - local or remote fallback
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/northflank/lib/common.sh)"
+fi
+
+log_info "Amazon Q on Northflank"
+echo ""
+
+ensure_northflank_cli
+ensure_northflank_token
+
+SERVICE_NAME=$(get_server_name)
+PROJECT_NAME=$(get_project_name)
+
+create_server "${SERVICE_NAME}"
+wait_for_cloud_init
+
+log_warn "Installing Amazon Q CLI..."
+run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_northflank \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Northflank service setup completed successfully!"
+echo ""
+
+log_warn "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && q chat"


### PR DESCRIPTION
## Summary
- Implements `northflank/amazonq.sh` with Amazon Q CLI support
- Updates manifest.json: `northflank/amazonq` → `"implemented"`
- Updates northflank/README.md with Amazon Q usage instructions

## Pattern
- Amazon Q CLI installation from AWS CDN
- OpenRouter API key injection (OAuth or environment variable)
- OPENAI_BASE_URL override for OpenRouter compatibility
- Interactive `q chat` session via northflank exec

Generated with [Claude Code](https://claude.com/claude-code)