### PR TITLE
feat: Add render/openclaw.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1031,7 +1031,7 @@
     "railway/plandex": "missing",
     "railway/kilocode": "missing",
     "render/claude": "implemented",
-    "render/openclaw": "missing",
+    "render/openclaw": "implemented",
     "render/nanoclaw": "missing",
     "render/aider": "implemented",
     "render/goose": "missing",

--- a/render/README.md
+++ b/render/README.md
@@ -33,6 +33,14 @@ Deploys Claude Code with OpenRouter integration. Configures:
 - Bypass permissions mode for autonomous operation
 - Dark theme and vim editor settings
 
+### OpenClaw
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/render/openclaw.sh)
+```
+
+Deploys OpenClaw with multi-channel gateway and TUI. Starts gateway in background, then launches interactive TUI. Prompts for model selection (default: `openrouter/auto`).
+
 ### Aider
 
 ```bash

--- a/render/openclaw.sh
+++ b/render/openclaw.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/render/lib/common.sh)"
+fi
+
+log_info "OpenClaw on Render"
+echo ""
+
+# 1. Ensure Render CLI and API key
+ensure_render_cli
+ensure_render_api_key
+
+# 2. Create service
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Wait for service readiness
+wait_for_cloud_init
+
+# 4. Install Bun
+log_warn "Installing Bun..."
+run_server "curl -fsSL https://bun.sh/install | bash"
+
+# Verify Bun installation
+if ! run_server "command -v /root/.bun/bin/bun" >/dev/null 2>&1; then
+    log_error "Bun installation failed"
+    exit 1
+fi
+log_info "Bun installed"
+
+# 5. Install openclaw using Bun
+log_warn "Installing openclaw..."
+run_server "/root/.bun/bin/bun install -g openclaw"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
+
+# 8. Inject environment variables
+log_warn "Setting up environment variables..."
+
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
+    "PATH=\$HOME/.bun/bin:\$PATH"
+
+# 9. Configure openclaw settings
+log_warn "Configuring openclaw..."
+
+run_server "mkdir -p /root/.openclaw"
+
+# Create openclaw config with API key and model
+OPENCLAW_CONFIG_TEMP=$(mktemp)
+chmod 600 "$OPENCLAW_CONFIG_TEMP"
+cat > "$OPENCLAW_CONFIG_TEMP" << EOF
+{
+  "model": "${MODEL_ID}",
+  "apiKey": "${OPENROUTER_API_KEY}",
+  "baseUrl": "https://openrouter.ai/api"
+}
+EOF
+
+upload_file "$OPENCLAW_CONFIG_TEMP" "/root/.openclaw/config.json"
+rm "$OPENCLAW_CONFIG_TEMP"
+
+echo ""
+log_info "Render service setup completed successfully!"
+log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
+echo ""
+
+# 10. Start openclaw
+log_warn "Starting openclaw..."
+log_info "Starting gateway in background, then launching TUI..."
+sleep 1
+clear
+interactive_session "source /root/.bashrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 & sleep 2 && openclaw tui"


### PR DESCRIPTION
## Summary
- Implements OpenClaw agent on Render cloud platform
- Installs Bun and openclaw globally
- Configures OpenRouter integration with model selection
- Starts gateway in background and launches interactive TUI

## Test plan
- [x] Bash syntax check passes
- [x] Manifest.json updated to "implemented"
- [x] README.md updated with usage instructions

Part of filling Render matrix gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)