### PR TITLE
feat: Add Cline agent for Northflank

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1011,7 +1011,7 @@
     "northflank/interpreter": "implemented",
     "northflank/gemini": "implemented",
     "northflank/amazonq": "implemented",
-    "northflank/cline": "missing",
+    "northflank/cline": "implemented",
     "northflank/gptme": "missing",
     "northflank/opencode": "missing",
     "northflank/plandex": "missing",

--- a/northflank/README.md
+++ b/northflank/README.md
@@ -60,6 +60,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/gemini.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/amazonq.sh)
 ```
 
+#### Cline
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/cline.sh)
+```
+
 ## Setup
 
 1. Create a Northflank account at https://northflank.com

--- a/northflank/cline.sh
+++ b/northflank/cline.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - local or remote fallback
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/northflank/lib/common.sh)"
+fi
+
+log_info "Cline on Northflank"
+echo ""
+
+ensure_northflank_cli
+ensure_northflank_token
+
+SERVICE_NAME=$(get_server_name)
+PROJECT_NAME=$(get_project_name)
+
+create_server "${SERVICE_NAME}"
+wait_for_cloud_init
+
+log_warn "Installing Cline..."
+run_server "npm install -g cline"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_northflank \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Northflank service setup completed successfully!"
+echo ""
+
+log_warn "Starting Cline..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && cline"


### PR DESCRIPTION
## Summary
- Implements `northflank/cline.sh` with Cline support
- Updates manifest.json: `northflank/cline` → `"implemented"`
- Updates northflank/README.md with Cline usage instructions

## Pattern
- Cline installation via npm
- OpenRouter API key injection (OAuth or environment variable)
- OPENAI_BASE_URL override for OpenRouter compatibility
- Interactive `cline` session via northflank exec

Generated with [Claude Code](https://claude.com/claude-code)