### PR TITLE
feat: Add render/interpreter implementation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1036,7 +1036,7 @@
     "render/aider": "implemented",
     "render/goose": "missing",
     "render/codex": "implemented",
-    "render/interpreter": "missing",
+    "render/interpreter": "implemented",
     "render/gemini": "missing",
     "render/amazonq": "missing",
     "render/cline": "missing",

--- a/render/README.md
+++ b/render/README.md
@@ -49,6 +49,14 @@ bash <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/re
 
 Deploys Codex CLI with OpenRouter integration via OPENAI_BASE_URL override.
 
+### Open Interpreter
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/render/interpreter.sh)
+```
+
+Deploys Open Interpreter with OpenRouter integration via OPENAI_BASE_URL override.
+
 ## Service Details
 
 - **Plan**: Starter (can be configured)

--- a/render/interpreter.sh
+++ b/render/interpreter.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/render/lib/common.sh)"
+fi
+
+log_info "Open Interpreter on Render"
+echo ""
+
+# 1. Ensure Render CLI and API key
+ensure_render_cli
+ensure_render_api_key
+
+# 2. Create service
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Wait for service readiness
+wait_for_cloud_init
+
+# 4. Install Python and Open Interpreter
+log_warn "Installing Open Interpreter..."
+run_server "apt-get update && apt-get install -y python3 python3-pip"
+run_server "pip3 install open-interpreter"
+
+# Verify installation
+if ! run_server "command -v interpreter" >/dev/null 2>&1; then
+    log_error "Open Interpreter installation failed"
+    exit 1
+fi
+log_info "Open Interpreter installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Render service setup completed successfully!"
+log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
+echo ""
+
+# 7. Start Open Interpreter interactively
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "source /root/.bashrc && interpreter"


### PR DESCRIPTION
## Summary
- Implement render/interpreter.sh following standard pattern
- Install Open Interpreter via pip on Render service
- Configure OpenRouter credentials via OPENAI_BASE_URL override
- Update manifest.json and render/README.md

## Test plan
- [x] Syntax check passes (`bash -n`)
- [x] Follows render cloud primitives pattern
- [x] Uses standard OpenRouter env var injection
- [x] Manifest matrix updated to "implemented"
- [ ] Manual test on Render (requires RENDER_API_KEY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)