### PR TITLE
feat: Add Amazon Q CLI support for Railway

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1024,7 +1024,7 @@
     "railway/codex": "missing",
     "railway/interpreter": "missing",
     "railway/gemini": "implemented",
-    "railway/amazonq": "missing",
+    "railway/amazonq": "implemented",
     "railway/cline": "missing",
     "railway/gptme": "implemented",
     "railway/opencode": "missing",

--- a/railway/README.md
+++ b/railway/README.md
@@ -40,6 +40,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/gptme.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/gemini.sh)
 ```
 
+#### Amazon Q CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/amazonq.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/railway/amazonq.sh
+++ b/railway/amazonq.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/railway/lib/common.sh)"
+fi
+
+log_info "Amazon Q CLI on Railway"
+echo ""
+
+# 1. Ensure Railway CLI and API token
+ensure_railway_cli
+ensure_railway_token
+
+# 2. Create service
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Install base tools
+wait_for_cloud_init
+
+# 4. Install Amazon Q CLI
+log_warn "Installing Amazon Q CLI..."
+run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Railway service setup completed successfully!"
+log_info "Service: $RAILWAY_SERVICE_NAME"
+echo ""
+
+# 7. Start Amazon Q interactively
+log_warn "Starting Amazon Q CLI..."
+sleep 1
+clear
+interactive_session "source /root/.bashrc && q chat"


### PR DESCRIPTION
## Summary
- Implements `railway/amazonq.sh` following Railway's standard pattern
- Installs Amazon Q CLI via AWS installer script
- Injects OpenRouter credentials via `OPENAI_API_KEY` and `OPENAI_BASE_URL`
- Updates `manifest.json` to mark `railway/amazonq` as implemented
- Updates `railway/README.md` with usage instructions

## Test plan
- [x] Syntax validated with `bash -n`
- [x] Follows Railway cloud primitives pattern
- [x] Matches Amazon Q agent env vars from manifest.json
- [x] Commit includes `Agent: gap-filler` trailer

🤖 Generated with [Claude Code](https://claude.com/claude-code)