### PR TITLE
feat: Add gptme agent for Northflank

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1012,7 +1012,7 @@
     "northflank/gemini": "implemented",
     "northflank/amazonq": "implemented",
     "northflank/cline": "implemented",
-    "northflank/gptme": "missing",
+    "northflank/gptme": "implemented",
     "northflank/opencode": "missing",
     "northflank/plandex": "missing",
     "northflank/kilocode": "missing",

--- a/northflank/README.md
+++ b/northflank/README.md
@@ -66,6 +66,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/amazonq.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/cline.sh)
 ```
 
+#### gptme
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/gptme.sh)
+```
+
 ## Setup
 
 1. Create a Northflank account at https://northflank.com

--- a/northflank/gptme.sh
+++ b/northflank/gptme.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - local or remote fallback
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/northflank/lib/common.sh)"
+fi
+
+log_info "gptme on Northflank"
+echo ""
+
+ensure_northflank_cli
+ensure_northflank_token
+
+SERVICE_NAME=$(get_server_name)
+PROJECT_NAME=$(get_project_name)
+
+create_server "${SERVICE_NAME}"
+wait_for_cloud_init
+
+log_warn "Installing gptme..."
+run_server "pip install gptme 2>/dev/null || pip3 install gptme"
+
+# Verify installation
+if ! run_server "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
+    log_error "gptme installation verification failed"
+    log_error "The 'gptme' command is not available or not working properly"
+    exit 1
+fi
+log_info "gptme installation verified successfully"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_northflank \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Northflank service setup completed successfully!"
+echo ""
+
+log_warn "Starting gptme..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && gptme -m openrouter/${MODEL_ID}"


### PR DESCRIPTION
## Summary
- Implements `northflank/gptme.sh` with gptme support
- Updates manifest.json: `northflank/gptme` → `"implemented"`
- Updates northflank/README.md with gptme usage instructions

## Pattern
- gptme installation via pip
- OpenRouter API key injection (OAuth or environment variable)
- Interactive model selection with default `openrouter/auto`
- Native gptme OpenRouter support via `-m openrouter/MODEL_ID`
- Installation verification to ensure gptme command works

Generated with [Claude Code](https://claude.com/claude-code)