### PR TITLE
feat: Add Cline support for Railway

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1025,7 +1025,7 @@
     "railway/interpreter": "missing",
     "railway/gemini": "implemented",
     "railway/amazonq": "implemented",
-    "railway/cline": "missing",
+    "railway/cline": "implemented",
     "railway/gptme": "implemented",
     "railway/opencode": "missing",
     "railway/plandex": "missing",

--- a/railway/README.md
+++ b/railway/README.md
@@ -52,6 +52,12 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/gemini.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/amazonq.sh)
 ```
 
+#### Cline
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/cline.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/railway/cline.sh
+++ b/railway/cline.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/railway/lib/common.sh)"
+fi
+
+log_info "Cline on Railway"
+echo ""
+
+# 1. Ensure Railway CLI and API token
+ensure_railway_cli
+ensure_railway_token
+
+# 2. Create service
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Install base tools
+wait_for_cloud_init
+
+# 4. Install Cline
+log_warn "Installing Cline..."
+run_server "npm install -g cline"
+log_info "Cline installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Railway service setup completed successfully!"
+log_info "Service: $RAILWAY_SERVICE_NAME"
+echo ""
+
+# 7. Start Cline interactively
+log_warn "Starting Cline..."
+sleep 1
+clear
+interactive_session "source /root/.bashrc && cline"


### PR DESCRIPTION
## Summary
- Implements `railway/cline.sh` following Railway's standard pattern
- Installs `cline` via npm
- Injects OpenRouter credentials via `OPENAI_API_KEY` and `OPENAI_BASE_URL`
- Updates `manifest.json` to mark `railway/cline` as implemented
- Updates `railway/README.md` with usage instructions

## Test plan
- [x] Syntax validated with `bash -n`
- [x] Follows Railway cloud primitives pattern
- [x] Matches Cline agent env vars from manifest.json
- [x] Commit includes `Agent: gap-filler` trailer

🤖 Generated with [Claude Code](https://claude.com/claude-code)