### PR TITLE
feat: Add render/goose.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1034,7 +1034,7 @@
     "render/openclaw": "implemented",
     "render/nanoclaw": "implemented",
     "render/aider": "implemented",
-    "render/goose": "missing",
+    "render/goose": "implemented",
     "render/codex": "implemented",
     "render/interpreter": "implemented",
     "render/gemini": "missing",

--- a/render/README.md
+++ b/render/README.md
@@ -57,6 +57,14 @@ bash <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/re
 
 Deploys Aider with OpenRouter model routing. Prompts for model selection (default: `openrouter/auto`).
 
+### Goose
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/render/goose.sh)
+```
+
+Deploys Goose AI coding agent by Block with native OpenRouter support.
+
 ### Codex CLI
 
 ```bash

--- a/render/goose.sh
+++ b/render/goose.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/render/lib/common.sh)"
+fi
+
+log_info "Goose on Render"
+echo ""
+
+# 1. Ensure Render CLI and API key
+ensure_render_cli
+ensure_render_api_key
+
+# 2. Create service
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Wait for service readiness
+wait_for_cloud_init
+
+# 4. Install Goose
+log_warn "Installing Goose..."
+run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+
+# Verify installation
+if ! run_server "command -v goose" >/dev/null 2>&1; then
+    log_error "Goose installation failed"
+    exit 1
+fi
+log_info "Goose installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+
+inject_env_vars \
+    "GOOSE_PROVIDER=openrouter" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Render service setup completed successfully!"
+log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
+echo ""
+
+# 7. Start Goose interactively
+log_warn "Starting Goose..."
+sleep 1
+clear
+interactive_session "source /root/.bashrc && goose"


### PR DESCRIPTION
## Summary
- Implements Goose agent on Render cloud platform
- Uses Block's official download_cli.sh installer
- Configures native OpenRouter support via GOOSE_PROVIDER
- Minimal setup with clean environment injection

## Test plan
- [x] Bash syntax check passes
- [x] Manifest.json updated to "implemented"
- [x] README.md updated with usage instructions

Part of filling Render matrix gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)