### PR TITLE
fix: Prevent shell/Python injection in Codespaces, Render, and FluidStack

### DIFF
--- a/github-codespaces/aider.sh
+++ b/github-codespaces/aider.sh
@@ -31,12 +31,15 @@ fi
 
 log_info "Codespace created: $CODESPACE"
 
+# Set CODESPACE_NAME for upload_file/run_server/inject_env_vars helpers
+CODESPACE_NAME="$CODESPACE"
+
 # 3. Wait for codespace to be ready
 wait_for_codespace "$CODESPACE"
 
 # 4. Install Aider
 log_warn "Installing Aider..."
-run_in_codespace "$CODESPACE" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
+run_server "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
 # 5. Get OpenRouter API key
@@ -50,16 +53,9 @@ fi
 # 6. Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-# 7. Inject environment variables into ~/.bashrc
-log_warn "Setting up environment variables..."
-
-ENV_VARS="
-export OPENROUTER_API_KEY='${OPENROUTER_API_KEY}'
-"
-
-run_in_codespace "$CODESPACE" "cat >> ~/.bashrc << 'ENVEOF'
-$ENV_VARS
-ENVEOF"
+# 7. Inject environment variables via safe temp file upload
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""
 log_info "GitHub Codespace setup completed successfully!"
@@ -73,4 +69,4 @@ echo ""
 sleep 1
 
 # Launch Aider with model
-run_in_codespace "$CODESPACE" "source ~/.bashrc && aider --model openrouter/${MODEL_ID}"
+run_server "source ~/.bashrc && aider --model openrouter/${MODEL_ID}"

--- a/github-codespaces/claude.sh
+++ b/github-codespaces/claude.sh
@@ -31,15 +31,18 @@ fi
 
 log_info "Codespace created: $CODESPACE"
 
+# Set CODESPACE_NAME for upload_file/run_server/inject_env_vars helpers
+CODESPACE_NAME="$CODESPACE"
+
 # 3. Wait for codespace to be ready
 wait_for_codespace "$CODESPACE"
 
 # 4. Install Claude Code
 log_warn "Installing Claude Code..."
-run_in_codespace "$CODESPACE" "curl -fsSL https://claude.ai/install.sh | bash"
+run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
-if ! run_in_codespace "$CODESPACE" "command -v claude" &>/dev/null; then
+if ! run_server "command -v claude" &>/dev/null; then
     log_error "Claude Code installation failed"
     delete_codespace "$CODESPACE"
     exit 1
@@ -54,59 +57,18 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-# 6. Inject environment variables into ~/.bashrc
-log_warn "Setting up environment variables..."
+# 6. Inject environment variables via safe temp file upload
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
+    "ANTHROPIC_AUTH_TOKEN=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=" \
+    "CLAUDE_CODE_SKIP_ONBOARDING=1" \
+    "CLAUDE_CODE_ENABLE_TELEMETRY=0" \
+    "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
-ENV_VARS="
-export OPENROUTER_API_KEY='${OPENROUTER_API_KEY}'
-export ANTHROPIC_BASE_URL='https://openrouter.ai/api'
-export ANTHROPIC_AUTH_TOKEN='${OPENROUTER_API_KEY}'
-export ANTHROPIC_API_KEY=''
-export CLAUDE_CODE_SKIP_ONBOARDING='1'
-export CLAUDE_CODE_ENABLE_TELEMETRY='0'
-export PATH=\"\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH\"
-"
-
-run_in_codespace "$CODESPACE" "cat >> ~/.bashrc << 'ENVEOF'
-$ENV_VARS
-ENVEOF"
-
-# 7. Configure Claude Code settings
-log_warn "Configuring Claude Code..."
-
-run_in_codespace "$CODESPACE" "mkdir -p ~/.claude"
-
-# Create settings.json
-SETTINGS_JSON="{
-  \"theme\": \"dark\",
-  \"editor\": \"vim\",
-  \"env\": {
-    \"CLAUDE_CODE_ENABLE_TELEMETRY\": \"0\",
-    \"ANTHROPIC_BASE_URL\": \"https://openrouter.ai/api\",
-    \"ANTHROPIC_AUTH_TOKEN\": \"${OPENROUTER_API_KEY}\"
-  },
-  \"permissions\": {
-    \"defaultMode\": \"bypassPermissions\",
-    \"dangerouslySkipPermissions\": true
-  }
-}"
-
-run_in_codespace "$CODESPACE" "cat > ~/.claude/settings.json << 'SETTINGSEOF'
-$SETTINGS_JSON
-SETTINGSEOF"
-
-# Create global state file
-GLOBAL_STATE="{
-  \"hasCompletedOnboarding\": true,
-  \"bypassPermissionsModeAccepted\": true
-}"
-
-run_in_codespace "$CODESPACE" "cat > ~/.claude.json << 'STATEEOF'
-$GLOBAL_STATE
-STATEEOF"
-
-# Create empty CLAUDE.md
-run_in_codespace "$CODESPACE" "touch ~/.claude/CLAUDE.md"
+# 7. Configure Claude Code settings via shared helper
+setup_claude_code_config "$OPENROUTER_API_KEY" "upload_file" "run_server"
 
 echo ""
 log_info "Setup complete. Opening interactive session..."

--- a/render/claude.sh
+++ b/render/claude.sh
@@ -54,48 +54,8 @@ inject_env_vars \
     "CLAUDE_CODE_ENABLE_TELEMETRY=0" \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
-# 7. Configure Claude Code settings
-log_warn "Configuring Claude Code..."
-
-run_server "mkdir -p /root/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch /root/.claude/CLAUDE.md"
+# 7. Configure Claude Code settings via shared helper (uses json_escape for safe key handling)
+setup_claude_code_config "$OPENROUTER_API_KEY" "upload_file" "run_server"
 
 echo ""
 log_info "Render service setup completed successfully!"

--- a/render/nanoclaw.sh
+++ b/render/nanoclaw.sh
@@ -58,17 +58,15 @@ inject_env_vars \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-# 9. Create nanoclaw .env file
+# 9. Create nanoclaw .env file safely via temp file
 log_warn "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 chmod 600 "$DOTENV_TEMP"
-cat > "$DOTENV_TEMP" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+track_temp_file "$DOTENV_TEMP"
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "$DOTENV_TEMP"
 
 upload_file "$DOTENV_TEMP" "/root/nanoclaw/.env"
-rm "$DOTENV_TEMP"
 
 echo ""
 log_info "Render service setup completed successfully!"

--- a/render/openclaw.sh
+++ b/render/openclaw.sh
@@ -58,24 +58,8 @@ inject_env_vars \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
     "PATH=\$HOME/.bun/bin:\$PATH"
 
-# 9. Configure openclaw settings
-log_warn "Configuring openclaw..."
-
-run_server "mkdir -p /root/.openclaw"
-
-# Create openclaw config with API key and model
-OPENCLAW_CONFIG_TEMP=$(mktemp)
-chmod 600 "$OPENCLAW_CONFIG_TEMP"
-cat > "$OPENCLAW_CONFIG_TEMP" << EOF
-{
-  "model": "${MODEL_ID}",
-  "apiKey": "${OPENROUTER_API_KEY}",
-  "baseUrl": "https://openrouter.ai/api"
-}
-EOF
-
-upload_file "$OPENCLAW_CONFIG_TEMP" "/root/.openclaw/config.json"
-rm "$OPENCLAW_CONFIG_TEMP"
+# 9. Configure openclaw settings via shared helper (uses json_escape for safe key handling)
+setup_openclaw_config "$OPENROUTER_API_KEY" "$MODEL_ID" "upload_file" "run_server"
 
 echo ""
 log_info "Render service setup completed successfully!"


### PR DESCRIPTION
## Summary

- **GitHub Codespaces (HIGH)**: All 3 agent scripts (claude, aider, gptme) embedded `OPENROUTER_API_KEY` directly into heredocs sent via `gh codespace ssh`, enabling single-quote breakout for command injection on the remote codespace. Fixed by adding `upload_file`, `run_server`, and `inject_env_vars` helpers to `github-codespaces/lib/common.sh` that use the safe temp-file-upload pattern (matching Railway/Render providers).
- **Render claude.sh + openclaw.sh (HIGH)**: Built JSON config files via unescaped `<< EOF` heredocs with raw `${OPENROUTER_API_KEY}` interpolation. Fixed by using shared `setup_claude_code_config` / `setup_openclaw_config` helpers which properly `json_escape` values.
- **Render nanoclaw.sh (MEDIUM)**: `.env` file built via unescaped heredoc. Fixed with `printf` to temp file.
- **FluidStack (HIGH)**: `fluidstack_register_ssh_key` embedded SSH public key content in Python triple-quotes (`'''${pub_key}'''`), enabling triple-quote breakout for arbitrary Python execution. `fluidstack_check_ssh_key` interpolated fingerprint into Python string. `create_server` validation missed single-quote in allowlist. Fixed by reading values via stdin/argv instead of string interpolation.

## Files changed

- `github-codespaces/lib/common.sh` — Added `upload_file`, `run_server`, `inject_env_vars`
- `github-codespaces/claude.sh` — Use safe `inject_env_vars` + `setup_claude_code_config`
- `github-codespaces/aider.sh` — Use safe `inject_env_vars` + `run_server`
- `github-codespaces/gptme.sh` — Use safe `inject_env_vars` + `run_server`
- `render/claude.sh` — Use `setup_claude_code_config` shared helper
- `render/openclaw.sh` — Use `setup_openclaw_config` shared helper
- `render/nanoclaw.sh` — Use `printf` instead of unescaped heredoc
- `fluidstack/lib/common.sh` — Read SSH key + fingerprint via stdin/argv, add `'` to validation

## Test plan

- [x] All 8 changed files pass `bash -n` syntax check
- [ ] Verify Codespaces scripts still create codespaces and install agents correctly
- [ ] Verify Render scripts still deploy and configure services
- [ ] Verify FluidStack SSH key registration still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)