### PR TITLE
feat: Add Render support for opencode and plandex

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1099,8 +1099,8 @@
     "render/amazonq": "implemented",
     "render/cline": "implemented",
     "render/gptme": "implemented",
-    "render/opencode": "missing",
-    "render/plandex": "missing",
+    "render/opencode": "implemented",
+    "render/plandex": "implemented",
     "render/kilocode": "implemented"
   }
 }

--- a/render/opencode.sh
+++ b/render/opencode.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/render/lib/common.sh)"
+fi
+
+log_info "OpenCode on Render"
+echo ""
+
+# 1. Ensure Render CLI and API key
+ensure_render_cli
+ensure_render_api_key
+
+# 2. Create service
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Wait for service readiness
+wait_for_cloud_init
+
+# 4. Install OpenCode
+log_warn "Installing OpenCode..."
+run_server "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
+
+# Verify installation
+if ! run_server "command -v opencode" >/dev/null 2>&1; then
+    log_error "OpenCode installation failed"
+    exit 1
+fi
+log_info "OpenCode installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "PATH=\$HOME/.local/bin:\$PATH"
+
+echo ""
+log_info "Render service setup completed successfully!"
+log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
+echo ""
+
+# 7. Start OpenCode interactively
+log_warn "Starting OpenCode..."
+sleep 1
+clear
+interactive_session "source /root/.bashrc && opencode"

--- a/render/plandex.sh
+++ b/render/plandex.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/render/lib/common.sh)"
+fi
+
+log_info "Plandex on Render"
+echo ""
+
+# 1. Ensure Render CLI and API key
+ensure_render_cli
+ensure_render_api_key
+
+# 2. Create service
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 3. Wait for service readiness
+wait_for_cloud_init
+
+# 4. Install Plandex
+log_warn "Installing Plandex..."
+run_server "curl -sL https://plandex.ai/install.sh | bash"
+
+# Verify installation
+if ! run_server "command -v plandex && plandex version" >/dev/null 2>&1; then
+    log_error "Plandex installation failed"
+    exit 1
+fi
+log_info "Plandex installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables
+log_warn "Setting up environment variables..."
+
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Render service setup completed successfully!"
+log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
+echo ""
+
+# 7. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "source /root/.bashrc && plandex"


### PR DESCRIPTION
## Summary
- Implements two final Render matrix entries: opencode and plandex
- **Completes Render cloud provider support (14/14 agents implemented)**
- Both scripts follow Render pattern with API-based provisioning and SSH exec

## Implementation Details

### render/opencode.sh
- Installs OpenCode via official install script from opencode-ai/opencode
- Natively supports OpenRouter via `OPENROUTER_API_KEY` env var
- Go-based TUI using Bubble Tea

### render/plandex.sh
- Installs Plandex via plandex.ai/install.sh
- Natively supports OpenRouter via `OPENROUTER_API_KEY` env var
- Go-based CLI with sandbox and version control for AI changes

## Changes
- ✅ Created `render/opencode.sh` (executable)
- ✅ Created `render/plandex.sh` (executable)
- ✅ Updated `manifest.json` matrix entries to "implemented"
- ✅ All scripts pass `bash -n` syntax validation

## Testing
- ✅ Both scripts validated with `bash -n`
- ✅ Scripts follow Render pattern (common.sh sourcing, ensure_render_cli, ensure_render_api_key)
- ✅ OpenRouter API key injection via OAuth or environment variable

🤖 Generated with Claude Code