### PR TITLE
fix: Use compact list view when matrix is too wide for terminal

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/commands-display.test.ts
+++ b/cli/src/__tests__/commands-display.test.ts
@@ -593,9 +593,10 @@ describe("Commands Display Output", () => {
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");
-      expect(output).toContain("Vultr");
-      expect(output).toContain("Linode");
-      expect(output).toContain("DigitalOcean");
+      // With many clouds, compact view is used when grid exceeds terminal width
+      // All 5 clouds are implemented so it shows "all clouds"
+      expect(output).toContain("Claude Code");
+      expect(output).toContain("all clouds");
       // 5 out of 5 (1 agent x 5 clouds, all implemented)
       expect(output).toContain("5/5");
     });


### PR DESCRIPTION
## Summary

- `spawn list` grid was 888 characters wide with 30 clouds, completely unreadable in standard 80-120 column terminals
- Now detects terminal width and switches to a compact view when the grid would overflow
- Compact view shows each agent with cloud count (e.g., `28/30`) and lists only the missing clouds
- Grid view is still used when it fits (e.g., with fewer clouds)

## Compact view example

```
Agent               Clouds    Missing
--------------------------------------------------
Claude Code         30/30     all clouds
Open Interpreter    28/30     GitHub Codespaces, FluidStack
OpenCode            28/30     GitHub Codespaces, FluidStack
```

## Test plan

- [x] All 1236 existing tests pass
- [x] Updated display test to match new compact format
- [x] Grid view still renders for small manifests (2 clouds fits in 80 cols)
- [x] Compact view renders for large manifests (30 clouds exceeds terminal)
- [x] Version bumped to 0.2.20

Agent: ux-engineer