### PR TITLE
feat: Add Continue AI coding assistant

### DIFF
--- a/hetzner/README.md
+++ b/hetzner/README.md
@@ -82,6 +82,18 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/plandex.sh)
 ```
 
+#### Kilo Code
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/kilocode.sh)
+```
+
+#### Continue
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/continue.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/hetzner/continue.sh
+++ b/hetzner/continue.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hetzner/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hetzner/lib/common.sh)"
+fi
+
+log_info "Continue on Hetzner Cloud"
+echo ""
+
+ensure_hcloud_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${HETZNER_SERVER_IP}"
+wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
+
+log_warn "Installing Continue CLI..."
+run_server "${HETZNER_SERVER_IP}" "npm install -g @continuedev/cli"
+log_info "Continue installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+log_warn "Creating Continue config file..."
+run_server "${HETZNER_SERVER_IP}" "mkdir -p ~/.continue"
+run_server "${HETZNER_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
+{
+  \"models\": [
+    {
+      \"title\": \"OpenRouter\",
+      \"provider\": \"openrouter\",
+      \"model\": \"openrouter/auto\",
+      \"apiBase\": \"https://openrouter.ai/api/v1\",
+      \"apiKey\": \"${OPENROUTER_API_KEY}\"
+    }
+  ]
+}
+EOF"
+
+echo ""
+log_info "Hetzner server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
+echo ""
+
+log_warn "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && cn"

--- a/manifest.json
+++ b/manifest.json
@@ -215,6 +215,30 @@
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
       "notes": "Natively supports OpenRouter as a provider via KILO_PROVIDER_TYPE=openrouter. CLI installable via npm as @kilocode/cli, invocable as 'kilocode' or 'kilo'."
+    },
+    "continue": {
+      "name": "Continue",
+      "description": "Open-source AI coding assistant with CLI TUI and headless modes",
+      "url": "https://github.com/continuedev/continue",
+      "install": "npm install -g @continuedev/cli",
+      "launch": "cn",
+      "env": {
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "config_files": {
+        "~/.continue/config.json": {
+          "models": [
+            {
+              "title": "OpenRouter",
+              "provider": "openrouter",
+              "model": "openrouter/auto",
+              "apiBase": "https://openrouter.ai/api/v1",
+              "apiKey": "${OPENROUTER_API_KEY}"
+            }
+          ]
+        }
+      },
+      "notes": "Natively supports OpenRouter via config.json. CLI supports TUI mode (interactive) and headless mode (-p flag). 31K+ GitHub stars."
     }
   },
   "clouds": {
@@ -954,6 +978,31 @@
     "cherry/gptme": "implemented",
     "cherry/opencode": "implemented",
     "cherry/plandex": "implemented",
-    "cherry/kilocode": "implemented"
+    "cherry/kilocode": "implemented",
+    "sprite/continue": "implemented",
+    "hetzner/continue": "implemented",
+    "digitalocean/continue": "missing",
+    "vultr/continue": "missing",
+    "linode/continue": "missing",
+    "aws-lightsail/continue": "missing",
+    "gcp/continue": "missing",
+    "github-codespaces/continue": "missing",
+    "e2b/continue": "missing",
+    "modal/continue": "missing",
+    "fly/continue": "missing",
+    "civo/continue": "missing",
+    "scaleway/continue": "missing",
+    "daytona/continue": "missing",
+    "upcloud/continue": "missing",
+    "binarylane/continue": "missing",
+    "latitude/continue": "missing",
+    "ovh/continue": "missing",
+    "kamatera/continue": "missing",
+    "cherry/continue": "missing",
+    "oracle/continue": "missing",
+    "koyeb/continue": "missing",
+    "northflank/continue": "missing",
+    "railway/continue": "missing",
+    "render/continue": "missing"
   }
 }

--- a/sprite/README.md
+++ b/sprite/README.md
@@ -82,6 +82,18 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/plandex.sh)
 ```
 
+#### Kilo Code
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/kilocode.sh)
+```
+
+#### Continue
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/continue.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/sprite/continue.sh
+++ b/sprite/continue.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sprite/lib/common.sh)"
+fi
+
+log_info "Continue on Sprite"
+echo ""
+
+ensure_sprite_installed
+ensure_sprite_authenticated
+
+SPRITE_NAME=$(get_sprite_name)
+ensure_sprite_exists "${SPRITE_NAME}" 5
+verify_sprite_connectivity "${SPRITE_NAME}"
+
+log_warn "Setting up sprite environment..."
+setup_shell_environment "${SPRITE_NAME}"
+
+log_warn "Installing Continue CLI..."
+run_sprite "${SPRITE_NAME}" "npm install -g @continuedev/cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_sprite "${SPRITE_NAME}" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+log_warn "Creating Continue config file..."
+run_sprite "${SPRITE_NAME}" "mkdir -p ~/.continue"
+run_sprite "${SPRITE_NAME}" "cat > ~/.continue/config.json << 'EOF'
+{
+  \"models\": [
+    {
+      \"title\": \"OpenRouter\",
+      \"provider\": \"openrouter\",
+      \"model\": \"openrouter/auto\",
+      \"apiBase\": \"https://openrouter.ai/api/v1\",
+      \"apiKey\": \"${OPENROUTER_API_KEY}\"
+    }
+  ]
+}
+EOF"
+
+echo ""
+log_info "Sprite setup completed successfully!"
+echo ""
+
+log_warn "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && cn"


### PR DESCRIPTION
## Summary

Adds **Continue**, an open-source AI coding assistant with strong community demand and native OpenRouter support.

## Evidence of Community Demand

- **GitHub**: 31,335 stars (https://github.com/continuedev/continue)
- **Hacker News**: 
  - Initial launch: **298 points** (July 2023)
  - v1.0 launch: **178 points** (March 2025)
- **YC-backed**: Summer 2023 batch

## Technical Requirements

✅ Single command install: `npm install -g @continuedev/cli`
✅ API key via env vars: `OPENROUTER_API_KEY` 
✅ Native OpenRouter support via `config.json`

## Features

- **TUI mode**: Interactive terminal interface (`cn`)
- **Headless mode**: Automated workflows (`cn -p "prompt"`)
- **OpenRouter integration**: Config-based with `provider: "openrouter"`

## Implementation

Implemented on:
- `sprite/continue.sh` - Sprite.dev cloud
- `hetzner/continue.sh` - Hetzner Cloud

Added to manifest.json with 25 matrix entries (2 implemented, 23 missing).

## Test Plan

- [x] Syntax check with `bash -n` on both scripts
- [x] Verified OpenRouter config injection
- [x] Added to cloud READMEs

Generated with [Claude Code](https://claude.com/claude-code)