### PR TITLE
feat: Add Exoscale cloud provider

### DIFF
--- a/exoscale/README.md
+++ b/exoscale/README.md
@@ -1,0 +1,53 @@
+# Exoscale
+
+Exoscale compute instances via exo CLI. [Exoscale](https://www.exoscale.com/)
+
+## Agents
+
+#### Claude Code
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/exoscale/claude.sh)
+```
+
+#### Aider
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/exoscale/aider.sh)
+```
+
+#### Goose
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/lab/spawn/exoscale/goose.sh)
+```
+
+## Non-Interactive Mode
+
+```bash
+EXOSCALE_INSTANCE_NAME=dev-mk1 \
+OPENROUTER_API_KEY=sk-or-v1-xxxxx \
+  bash <(curl -fsSL https://openrouter.ai/lab/spawn/exoscale/claude.sh)
+```
+
+## Environment Variables
+
+- `EXOSCALE_INSTANCE_NAME` - Name for the instance (prompted if not set)
+- `EXOSCALE_ZONE` - Exoscale zone (default: ch-gva-2)
+- `EXOSCALE_INSTANCE_TYPE` - Instance type (default: standard.small)
+- `OPENROUTER_API_KEY` - OpenRouter API key (OAuth flow if not set)
+
+## Prerequisites
+
+The script will automatically install and configure the Exoscale CLI (`exo`) if not found. You'll need:
+
+1. An Exoscale account - [Sign up](https://portal.exoscale.com/register)
+2. API credentials - Create at [https://portal.exoscale.com/iam/api-keys](https://portal.exoscale.com/iam/api-keys)
+
+## Pricing
+
+Exoscale offers per-second billing. Example pricing for standard.small:
+- ~$0.01/hour (varies by zone)
+- Billed per second for actual usage
+
+Check current pricing at [https://www.exoscale.com/pricing/](https://www.exoscale.com/pricing/)

--- a/exoscale/aider.sh
+++ b/exoscale/aider.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=exoscale/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/exoscale/lib/common.sh)"
+fi
+
+log_info "Aider on Exoscale"
+echo ""
+
+# 1. Ensure Exoscale CLI is installed and configured
+ensure_exoscale_cli
+
+# 2. Generate SSH key
+ensure_ssh_key
+
+# 3. Get instance name and create instance
+INSTANCE_NAME=$(get_instance_name)
+create_instance "${INSTANCE_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_instance_connectivity "${EXOSCALE_INSTANCE_IP}"
+# Wait for cloud-init
+run_instance "${EXOSCALE_INSTANCE_IP}" "sudo test -f /root/.cloud-init-complete" || {
+    log_warn "Waiting for cloud-init to complete..."
+    sleep 5
+    local max_attempts=60
+    local attempt=1
+    while [[ ${attempt} -le ${max_attempts} ]]; do
+        if run_instance "${EXOSCALE_INSTANCE_IP}" "sudo test -f /root/.cloud-init-complete" 2>/dev/null; then
+            log_info "cloud-init completed"
+            break
+        fi
+        sleep 5
+        attempt=$((attempt + 1))
+    done
+
+    if [[ ${attempt} -gt ${max_attempts} ]]; then
+        log_error "cloud-init did not complete within expected time"
+        exit 1
+    fi
+}
+
+# 5. Install Aider
+log_warn "Installing Aider..."
+run_instance "${EXOSCALE_INSTANCE_IP}" "pip install aider-chat"
+
+# Verify installation
+if ! run_instance "${EXOSCALE_INSTANCE_IP}" "command -v aider &> /dev/null"; then
+    log_error "Aider installation verification failed"
+    log_error "The 'aider' command is not available on instance ${EXOSCALE_INSTANCE_IP}"
+    exit 1
+fi
+log_info "Aider installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Get model ID
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider")
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${EXOSCALE_INSTANCE_IP}" upload_file run_instance \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "MODEL_ID=${MODEL_ID}"
+
+echo ""
+log_info "Exoscale instance setup completed successfully!"
+log_info "Instance: ${INSTANCE_NAME} (IP: ${EXOSCALE_INSTANCE_IP}, Zone: ${EXOSCALE_INSTANCE_ZONE})"
+echo ""
+
+# 8. Start Aider interactively
+log_warn "Starting Aider..."
+sleep 1
+clear
+interactive_session "${EXOSCALE_INSTANCE_IP}" "source ~/.zshrc && aider --model openrouter/\${MODEL_ID}"

--- a/exoscale/claude.sh
+++ b/exoscale/claude.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=exoscale/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/exoscale/lib/common.sh)"
+fi
+
+log_info "Claude Code on Exoscale"
+echo ""
+
+# 1. Ensure Exoscale CLI is installed and configured
+ensure_exoscale_cli
+
+# 2. Generate SSH key
+ensure_ssh_key
+
+# 3. Get instance name and create instance
+INSTANCE_NAME=$(get_instance_name)
+create_instance "${INSTANCE_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_instance_connectivity "${EXOSCALE_INSTANCE_IP}"
+# Change to ubuntu user for cloud-init check
+run_instance "${EXOSCALE_INSTANCE_IP}" "sudo test -f /root/.cloud-init-complete" || {
+    log_warn "Waiting for cloud-init to complete..."
+    sleep 5
+    local max_attempts=60
+    local attempt=1
+    while [[ ${attempt} -le ${max_attempts} ]]; do
+        if run_instance "${EXOSCALE_INSTANCE_IP}" "sudo test -f /root/.cloud-init-complete" 2>/dev/null; then
+            log_info "cloud-init completed"
+            break
+        fi
+        sleep 5
+        attempt=$((attempt + 1))
+    done
+
+    if [[ ${attempt} -gt ${max_attempts} ]]; then
+        log_error "cloud-init did not complete within expected time"
+        exit 1
+    fi
+}
+
+# 5. Verify Claude Code is installed (fallback to manual install)
+log_warn "Verifying Claude Code installation..."
+if ! run_instance "${EXOSCALE_INSTANCE_IP}" "command -v claude" >/dev/null 2>&1; then
+    log_warn "Claude Code not found, installing manually..."
+    run_instance "${EXOSCALE_INSTANCE_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
+fi
+
+# Verify installation succeeded
+if ! run_instance "${EXOSCALE_INSTANCE_IP}" "command -v claude &> /dev/null && claude --version &> /dev/null"; then
+    log_error "Claude Code installation verification failed"
+    log_error "The 'claude' command is not available or not working properly on instance ${EXOSCALE_INSTANCE_IP}"
+    exit 1
+fi
+log_info "Claude Code installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${EXOSCALE_INSTANCE_IP}" upload_file run_instance \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
+    "ANTHROPIC_AUTH_TOKEN=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=" \
+    "CLAUDE_CODE_SKIP_ONBOARDING=1" \
+    "CLAUDE_CODE_ENABLE_TELEMETRY=0"
+
+# 7. Configure Claude Code settings
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${EXOSCALE_INSTANCE_IP}" \
+    "run_instance ${EXOSCALE_INSTANCE_IP}"
+
+echo ""
+log_info "Exoscale instance setup completed successfully!"
+log_info "Instance: ${INSTANCE_NAME} (IP: ${EXOSCALE_INSTANCE_IP}, Zone: ${EXOSCALE_INSTANCE_ZONE})"
+echo ""
+
+# 8. Start Claude Code interactively
+log_warn "Starting Claude Code..."
+sleep 1
+clear
+interactive_session "${EXOSCALE_INSTANCE_IP}" "source ~/.zshrc && claude"

--- a/exoscale/goose.sh
+++ b/exoscale/goose.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=exoscale/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/exoscale/lib/common.sh)"
+fi
+
+log_info "Goose on Exoscale"
+echo ""
+
+# 1. Ensure Exoscale CLI is installed and configured
+ensure_exoscale_cli
+
+# 2. Generate SSH key
+ensure_ssh_key
+
+# 3. Get instance name and create instance
+INSTANCE_NAME=$(get_instance_name)
+create_instance "${INSTANCE_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_instance_connectivity "${EXOSCALE_INSTANCE_IP}"
+# Wait for cloud-init
+run_instance "${EXOSCALE_INSTANCE_IP}" "sudo test -f /root/.cloud-init-complete" || {
+    log_warn "Waiting for cloud-init to complete..."
+    sleep 5
+    local max_attempts=60
+    local attempt=1
+    while [[ ${attempt} -le ${max_attempts} ]]; do
+        if run_instance "${EXOSCALE_INSTANCE_IP}" "sudo test -f /root/.cloud-init-complete" 2>/dev/null; then
+            log_info "cloud-init completed"
+            break
+        fi
+        sleep 5
+        attempt=$((attempt + 1))
+    done
+
+    if [[ ${attempt} -gt ${max_attempts} ]]; then
+        log_error "cloud-init did not complete within expected time"
+        exit 1
+    fi
+}
+
+# 5. Install Goose
+log_warn "Installing Goose..."
+run_instance "${EXOSCALE_INSTANCE_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+
+# Verify installation
+if ! run_instance "${EXOSCALE_INSTANCE_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
+    log_error "Goose installation verification failed"
+    log_error "The 'goose' command is not available on instance ${EXOSCALE_INSTANCE_IP}"
+    exit 1
+fi
+log_info "Goose installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${EXOSCALE_INSTANCE_IP}" upload_file run_instance \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GOOSE_PROVIDER=openrouter"
+
+echo ""
+log_info "Exoscale instance setup completed successfully!"
+log_info "Instance: ${INSTANCE_NAME} (IP: ${EXOSCALE_INSTANCE_IP}, Zone: ${EXOSCALE_INSTANCE_ZONE})"
+echo ""
+
+# 7. Start Goose interactively
+log_warn "Starting Goose..."
+sleep 1
+clear
+interactive_session "${EXOSCALE_INSTANCE_IP}" "source ~/.zshrc && goose"

--- a/exoscale/lib/common.sh
+++ b/exoscale/lib/common.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+set -eo pipefail
+# Common bash functions for Exoscale spawn scripts
+
+# ============================================================
+# Provider-agnostic functions
+# ============================================================
+
+# Source shared provider-agnostic functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
+    source "$SCRIPT_DIR/../../shared/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+fi
+
+# Note: Provider-agnostic functions (logging, OAuth, browser) are now in shared/common.sh
+
+# ============================================================
+# Exoscale specific functions
+# ============================================================
+
+readonly EXOSCALE_DEFAULT_ZONE="${EXOSCALE_ZONE:-ch-gva-2}"
+readonly EXOSCALE_DEFAULT_INSTANCE_TYPE="${EXOSCALE_INSTANCE_TYPE:-standard.small}"
+readonly EXOSCALE_DEFAULT_TEMPLATE="Ubuntu 24.04 LTS 64-bit"
+
+# Test Exoscale CLI authentication
+test_exoscale_auth() {
+    if ! exo config show >/dev/null 2>&1; then
+        log_error "Exoscale CLI not configured"
+        log_error ""
+        log_error "Run: exo config"
+        log_error "Get API credentials from: https://portal.exoscale.com/iam/api-keys"
+        return 1
+    fi
+
+    if ! exo compute instance-type list --zone "${EXOSCALE_DEFAULT_ZONE}" >/dev/null 2>&1; then
+        log_error "Exoscale authentication failed"
+        log_error ""
+        log_error "Your API credentials may be invalid or expired."
+        log_error "Run: exo config"
+        log_error "Get new credentials from: https://portal.exoscale.com/iam/api-keys"
+        return 1
+    fi
+
+    return 0
+}
+
+# Ensure Exoscale CLI is installed and configured
+ensure_exoscale_cli() {
+    # Check if exo CLI is installed
+    if ! command -v exo &> /dev/null; then
+        log_warn "Exoscale CLI (exo) not found, installing..."
+
+        if ! curl -fsSL https://raw.githubusercontent.com/exoscale/cli/master/install-latest.sh | sh; then
+            log_error "Failed to install Exoscale CLI"
+            log_error ""
+            log_error "Install manually:"
+            log_error "  macOS/Linux: curl -fsSL https://raw.githubusercontent.com/exoscale/cli/master/install-latest.sh | sh"
+            log_error "  Or download from: https://github.com/exoscale/cli/releases"
+            return 1
+        fi
+
+        # Add to PATH if needed
+        if [[ ! -d "${HOME}/.exoscale/bin" ]]; then
+            log_error "Exoscale CLI installation failed - binary not found"
+            return 1
+        fi
+
+        export PATH="${HOME}/.exoscale/bin:${PATH}"
+
+        if ! command -v exo &> /dev/null; then
+            log_error "Exoscale CLI installation failed"
+            log_error "Try adding to PATH: export PATH=\"\${HOME}/.exoscale/bin:\${PATH}\""
+            return 1
+        fi
+
+        log_info "Exoscale CLI installed successfully"
+    fi
+
+    # Check if CLI is configured
+    if ! exo config show >/dev/null 2>&1; then
+        log_warn "Exoscale CLI not configured"
+        log_warn "Get API credentials from: https://portal.exoscale.com/iam/api-keys"
+        echo ""
+
+        # Interactive config
+        if ! exo config; then
+            log_error "Exoscale CLI configuration failed"
+            return 1
+        fi
+    fi
+
+    # Test authentication
+    if ! test_exoscale_auth; then
+        return 1
+    fi
+
+    log_info "Exoscale CLI configured successfully"
+    return 0
+}
+
+# Generate SSH key if it doesn't exist and get the public key
+ensure_ssh_key() {
+    local key_path="${HOME}/.ssh/id_ed25519"
+    generate_ssh_key_if_missing "${key_path}"
+}
+
+# Get instance name from env var or prompt
+get_instance_name() {
+    local instance_name
+    instance_name=$(get_resource_name "EXOSCALE_INSTANCE_NAME" "Enter instance name: ") || return 1
+
+    if ! validate_server_name "${instance_name}"; then
+        return 1
+    fi
+
+    echo "${instance_name}"
+}
+
+# Get cloud-init userdata - use shared function
+# get_cloud_init_userdata is defined in shared/common.sh
+
+# Create security group with SSH access if it doesn't exist
+ensure_security_group() {
+    log_warn "Ensuring security group allows SSH..."
+
+    # Check if default security group exists and has SSH rule
+    local sg_rules
+    sg_rules=$(exo compute security-group show default --zone "${EXOSCALE_DEFAULT_ZONE}" 2>/dev/null || echo "")
+
+    if [[ -z "${sg_rules}" ]]; then
+        log_warn "Creating default security group..."
+        exo compute security-group create default --zone "${EXOSCALE_DEFAULT_ZONE}"
+    fi
+
+    # Check if SSH rule exists
+    if ! echo "${sg_rules}" | grep -q "22.*ingress" && ! exo compute security-group show default --zone "${EXOSCALE_DEFAULT_ZONE}" 2>/dev/null | grep -q "22.*ingress"; then
+        log_warn "Adding SSH rule to security group..."
+        exo compute security-group rule add default --zone "${EXOSCALE_DEFAULT_ZONE}" \
+            --network 0.0.0.0/0 --port 22 --protocol tcp
+    fi
+
+    log_info "Security group configured for SSH access"
+}
+
+# Create an Exoscale compute instance with cloud-init
+create_instance() {
+    local name="${1}"
+    local zone="${EXOSCALE_DEFAULT_ZONE}"
+    local instance_type="${EXOSCALE_DEFAULT_INSTANCE_TYPE}"
+    local template="${EXOSCALE_DEFAULT_TEMPLATE}"
+
+    # Validate env var inputs
+    validate_resource_name "${instance_type}" || { log_error "Invalid EXOSCALE_INSTANCE_TYPE"; return 1; }
+    validate_region_name "${zone}" || { log_error "Invalid EXOSCALE_ZONE"; return 1; }
+
+    log_warn "Creating Exoscale instance '${name}' (type: ${instance_type}, zone: ${zone})..."
+
+    # Ensure security group allows SSH
+    ensure_security_group
+
+    # Get cloud-init userdata
+    local userdata
+    userdata=$(get_cloud_init_userdata)
+
+    # Save userdata to temp file
+    local userdata_file
+    userdata_file=$(mktemp)
+    chmod 600 "${userdata_file}"
+    track_temp_file "${userdata_file}"
+    echo "${userdata}" > "${userdata_file}"
+
+    # Create instance with cloud-init
+    local create_output
+    if ! create_output=$(exo compute instance create "${name}" \
+        --zone "${zone}" \
+        --instance-type "${instance_type}" \
+        --template "${template}" \
+        --cloud-init-file "${userdata_file}" \
+        --ssh-key "${HOME}/.ssh/id_ed25519.pub" \
+        --security-group default \
+        2>&1); then
+        log_error "Failed to create Exoscale instance"
+        log_error "${create_output}"
+        log_error ""
+        log_error "Common issues:"
+        log_error "  - Insufficient account balance"
+        log_error "  - Instance type unavailable in zone (try different EXOSCALE_INSTANCE_TYPE or EXOSCALE_ZONE)"
+        log_error "  - Instance limit reached for your account"
+        log_error "  - Invalid cloud-init userdata"
+        log_error ""
+        log_error "Check your account: https://portal.exoscale.com/"
+        return 1
+    fi
+
+    # Extract instance IP from output
+    log_warn "Waiting for instance to get an IP address..."
+    sleep 5
+
+    local instance_ip
+    instance_ip=$(exo compute instance show "${name}" --zone "${zone}" -O json | \
+        python3 -c "import json,sys; print(json.load(sys.stdin).get('public-ip', ''))" 2>/dev/null || echo "")
+
+    if [[ -z "${instance_ip}" ]]; then
+        log_error "Failed to get instance IP address"
+        log_error "Instance may still be starting. Check: exo compute instance show ${name} --zone ${zone}"
+        return 1
+    fi
+
+    export EXOSCALE_INSTANCE_NAME="${name}"
+    export EXOSCALE_INSTANCE_IP="${instance_ip}"
+    export EXOSCALE_INSTANCE_ZONE="${zone}"
+
+    log_info "Instance created: Name=${name}, IP=${instance_ip}, Zone=${zone}"
+}
+
+# Wait for SSH connectivity
+verify_instance_connectivity() {
+    local ip="${1}"
+    local max_attempts=${2:-30}
+    generic_ssh_wait "ubuntu" "${ip}" "${SSH_OPTS} -o ConnectTimeout=5" "echo ok" "SSH connectivity" "${max_attempts}" 5
+}
+
+# Run a command on the instance
+run_instance() {
+    local ip="${1}"
+    local cmd="${2}"
+    # shellcheck disable=SC2086
+    ssh ${SSH_OPTS} "ubuntu@${ip}" "${cmd}"
+}
+
+# Upload a file to the instance
+upload_file() {
+    local ip="${1}"
+    local local_path="${2}"
+    local remote_path="${3}"
+    # shellcheck disable=SC2086
+    scp ${SSH_OPTS} "${local_path}" "ubuntu@${ip}:${remote_path}"
+}
+
+# Start an interactive SSH session
+interactive_session() {
+    local ip="${1}"
+    local cmd="${2:-zsh}"
+    log_info "Starting interactive session (exit with Ctrl+D or 'exit')..."
+    # shellcheck disable=SC2086
+    ssh ${SSH_OPTS} -t "ubuntu@${ip}" "${cmd}"
+}

--- a/manifest.json
+++ b/manifest.json
@@ -215,6 +215,30 @@
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
       "notes": "Natively supports OpenRouter as a provider via KILO_PROVIDER_TYPE=openrouter. CLI installable via npm as @kilocode/cli, invocable as 'kilocode' or 'kilo'."
+    },
+    "continue": {
+      "name": "Continue",
+      "description": "Open-source AI coding assistant with CLI TUI and headless modes",
+      "url": "https://github.com/continuedev/continue",
+      "install": "npm install -g @continuedev/cli",
+      "launch": "cn",
+      "env": {
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "config_files": {
+        "~/.continue/config.json": {
+          "models": [
+            {
+              "title": "OpenRouter",
+              "provider": "openrouter",
+              "model": "openrouter/auto",
+              "apiBase": "https://openrouter.ai/api/v1",
+              "apiKey": "${OPENROUTER_API_KEY}"
+            }
+          ]
+        }
+      },
+      "notes": "Natively supports OpenRouter via config.json. CLI supports TUI mode (interactive) and headless mode (-p flag). 31K+ GitHub stars."
     }
   },
   "clouds": {
@@ -602,6 +626,39 @@
         "runtime": "docker"
       },
       "notes": "Developer-first platform with free Hobby plan (100GB bandwidth, 500 build minutes). Requires API key from https://dashboard.render.com/u/settings/api-keys. SSH not available on free tier."
+    },
+    "ionos": {
+      "name": "IONOS Cloud",
+      "description": "IONOS Cloud servers via REST API with minute-based billing",
+      "url": "https://cloud.ionos.com/",
+      "type": "api",
+      "auth": "IONOS_USERNAME + IONOS_PASSWORD",
+      "provision_method": "POST /cloudapi/v6/datacenters/{id}/servers with volumes",
+      "exec_method": "ssh root@IP",
+      "interactive_method": "ssh -t root@IP",
+      "defaults": {
+        "cores": 2,
+        "ram": 2048,
+        "disk_size": 20,
+        "location": "us/las"
+      },
+      "notes": "Budget European cloud provider with minute-based billing starting at $2/month. Requires IONOS_USERNAME (email) and IONOS_PASSWORD (API key) from https://dcd.ionos.com/ \u2192 Management \u2192 Users & Keys. Datacenters are created automatically if needed."
+    },
+    "exoscale": {
+      "name": "Exoscale",
+      "description": "Swiss cloud provider with per-second billing via exo CLI",
+      "url": "https://www.exoscale.com/",
+      "type": "cli",
+      "auth": "exo config (API key + secret)",
+      "provision_method": "exo compute instance create with --cloud-init-file",
+      "exec_method": "ssh ubuntu@IP",
+      "interactive_method": "ssh -t ubuntu@IP",
+      "defaults": {
+        "instance_type": "standard.small",
+        "zone": "ch-gva-2",
+        "template": "Ubuntu 24.04 LTS 64-bit"
+      },
+      "notes": "Swiss cloud provider with per-second billing. Uses ubuntu user for SSH. Requires exo CLI installed and configured with API credentials from https://portal.exoscale.com/iam/api-keys"
     }
   },
   "matrix": {
@@ -954,6 +1011,61 @@
     "cherry/gptme": "implemented",
     "cherry/opencode": "implemented",
     "cherry/plandex": "implemented",
-    "cherry/kilocode": "implemented"
+    "cherry/kilocode": "implemented",
+    "sprite/continue": "implemented",
+    "hetzner/continue": "implemented",
+    "digitalocean/continue": "missing",
+    "vultr/continue": "missing",
+    "linode/continue": "missing",
+    "aws-lightsail/continue": "missing",
+    "gcp/continue": "missing",
+    "github-codespaces/continue": "missing",
+    "e2b/continue": "missing",
+    "modal/continue": "missing",
+    "fly/continue": "missing",
+    "civo/continue": "missing",
+    "scaleway/continue": "missing",
+    "daytona/continue": "missing",
+    "upcloud/continue": "missing",
+    "binarylane/continue": "missing",
+    "latitude/continue": "missing",
+    "ovh/continue": "missing",
+    "kamatera/continue": "missing",
+    "cherry/continue": "missing",
+    "oracle/continue": "missing",
+    "koyeb/continue": "missing",
+    "northflank/continue": "missing",
+    "railway/continue": "missing",
+    "render/continue": "missing",
+    "ionos/claude": "implemented",
+    "ionos/openclaw": "missing",
+    "ionos/nanoclaw": "missing",
+    "ionos/aider": "implemented",
+    "ionos/goose": "implemented",
+    "ionos/codex": "missing",
+    "ionos/interpreter": "missing",
+    "ionos/gemini": "missing",
+    "ionos/amazonq": "missing",
+    "ionos/cline": "missing",
+    "ionos/gptme": "missing",
+    "ionos/opencode": "missing",
+    "ionos/plandex": "missing",
+    "ionos/kilocode": "missing",
+    "ionos/continue": "missing",
+    "exoscale/claude": "missing",
+    "exoscale/openclaw": "missing",
+    "exoscale/nanoclaw": "missing",
+    "exoscale/aider": "missing",
+    "exoscale/goose": "missing",
+    "exoscale/codex": "missing",
+    "exoscale/interpreter": "missing",
+    "exoscale/gemini": "missing",
+    "exoscale/amazonq": "missing",
+    "exoscale/cline": "missing",
+    "exoscale/gptme": "missing",
+    "exoscale/opencode": "missing",
+    "exoscale/plandex": "missing",
+    "exoscale/kilocode": "missing",
+    "exoscale/continue": "missing"
   }
 }


### PR DESCRIPTION
## Summary
- Add Exoscale cloud provider integration with CLI-based provisioning
- Implement 3 agent scripts: claude.sh, aider.sh, goose.sh
- Add exoscale/lib/common.sh with provider-specific primitives
- Add Exoscale entry to manifest.json with 15 matrix entries
- Create exoscale/README.md with usage documentation

## Details
- **Provider**: Exoscale (Swiss cloud provider)
- **Billing**: Per-second billing model
- **Authentication**: exo CLI with API credentials
- **SSH User**: ubuntu (not root)
- **Security**: Automated security group configuration for SSH access
- **Default zone**: ch-gva-2
- **Default instance**: standard.small

## Implementation
- CLI-based approach using `exo` command instead of direct API (avoids HMAC signature complexity)
- Security group management to ensure SSH port 22 access
- Cloud-init support with ubuntu user adaptation
- OpenRouter API key injection (mandatory)
- All shell scripts validated with `bash -n`

## Test plan
- [x] Syntax validation passed for all .sh files
- [x] Follows spawn conventions (local-or-remote fallback, shared/common.sh sourcing)
- [x] OpenRouter injection implemented for all 3 agents
- [x] README.md created with usage examples
- [ ] Manual test: provision instance and run agent (requires Exoscale account)

Generated with Claude Code