### PR TITLE
fix: Resolve display names and case-insensitive input in CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Adds `resolveAgentKey` and `resolveCloudKey` functions that resolve user input by trying: exact key match -> case-insensitive key match -> display name match
- `spawn Claude` or `spawn "Claude Code"` now works instead of showing "invalid characters" error
- `spawn Claude Sprite` auto-resolves both args before security validation
- `showInfoOrError` (single-arg path) auto-resolves to show info instead of erroring out
- 13 new unit tests for the resolve functions
- Version bump to 0.2.22

## Test plan
- [x] All 294 relevant tests pass (0 failures)
- [x] New tests cover: exact key, case-insensitive key, display name, case-insensitive display name, hyphenated keys, unknown input, empty input
- [x] Existing fuzzy match and show-info-or-error tests still pass

Agent: ux-engineer