### PR TITLE
feat: Add missing Cherry Servers agent scripts for 12 agents

### DIFF
--- a/cherry/aider.sh
+++ b/cherry/aider.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "Aider on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Aider
+log_warn "Installing Aider..."
+run_server "${CHERRY_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
+
+# Verify installation succeeded
+if ! run_server "${CHERRY_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
+    log_error "Aider installation verification failed"
+    log_error "The 'aider' command is not available or not working properly on server ${CHERRY_SERVER_IP}"
+    exit 1
+fi
+log_info "Aider installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start Aider interactively
+log_warn "Starting Aider..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/cherry/amazonq.sh
+++ b/cherry/amazonq.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "Amazon Q on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Amazon Q CLI
+log_warn "Installing Amazon Q CLI..."
+run_server "${CHERRY_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start Amazon Q interactively
+log_warn "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/cherry/claude.sh
+++ b/cherry/claude.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "Claude Code on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Claude Code
+log_warn "Installing Claude Code..."
+run_server "${CHERRY_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${CHERRY_SERVER_IP}" "command -v claude &> /dev/null && claude --version &> /dev/null"; then
+    log_error "Claude Code installation verification failed"
+    log_error "The 'claude' command is not available or not working properly on server ${CHERRY_SERVER_IP}"
+    exit 1
+fi
+log_info "Claude Code installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
+    "ANTHROPIC_AUTH_TOKEN=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=" \
+    "CLAUDE_CODE_SKIP_ONBOARDING=1" \
+    "CLAUDE_CODE_ENABLE_TELEMETRY=0"
+
+# 7. Configure Claude Code settings
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${CHERRY_SERVER_IP}" \
+    "run_server ${CHERRY_SERVER_IP}"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 8. Start Claude Code interactively
+log_warn "Starting Claude Code..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && claude"

--- a/cherry/cline.sh
+++ b/cherry/cline.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "Cline on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Cline
+log_warn "Installing Cline..."
+run_server "${CHERRY_SERVER_IP}" "npm install -g cline"
+log_info "Cline installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start Cline interactively
+log_warn "Starting Cline..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && cline"

--- a/cherry/codex.sh
+++ b/cherry/codex.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "Codex CLI on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Codex CLI
+log_warn "Installing Codex CLI..."
+run_server "${CHERRY_SERVER_IP}" "npm install -g @openai/codex"
+log_info "Codex CLI installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start Codex interactively
+log_warn "Starting Codex..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && codex"

--- a/cherry/gemini.sh
+++ b/cherry/gemini.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "Gemini CLI on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Gemini CLI
+log_warn "Installing Gemini CLI..."
+run_server "${CHERRY_SERVER_IP}" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start Gemini interactively
+log_warn "Starting Gemini..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/cherry/gptme.sh
+++ b/cherry/gptme.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "gptme on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install gptme
+log_warn "Installing gptme..."
+run_server "${CHERRY_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
+
+# Verify installation succeeded
+if ! run_server "${CHERRY_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
+    log_error "gptme installation verification failed"
+    log_error "The 'gptme' command is not available or not working properly on server ${CHERRY_SERVER_IP}"
+    exit 1
+fi
+log_info "gptme installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start gptme interactively
+log_warn "Starting gptme..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/cherry/interpreter.sh
+++ b/cherry/interpreter.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "Open Interpreter on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Open Interpreter
+log_warn "Installing Open Interpreter..."
+run_server "${CHERRY_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start Open Interpreter interactively
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/cherry/kilocode.sh
+++ b/cherry/kilocode.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "Kilo Code on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Kilo Code
+log_warn "Installing Kilo Code..."
+run_server "${CHERRY_SERVER_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start Kilo Code interactively
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/cherry/nanoclaw.sh
+++ b/cherry/nanoclaw.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "NanoClaw on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Node.js deps and clone nanoclaw
+log_warn "Installing tsx..."
+run_server "${CHERRY_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
+
+log_warn "Cloning and building nanoclaw..."
+run_server "${CHERRY_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
+log_info "NanoClaw installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
+
+# 7. Create nanoclaw .env file
+log_warn "Configuring nanoclaw..."
+
+DOTENV_TEMP=$(mktemp)
+trap 'rm -f "${DOTENV_TEMP}"' EXIT
+chmod 600 "${DOTENV_TEMP}"
+cat > "${DOTENV_TEMP}" << EOF
+ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
+EOF
+
+upload_file "${CHERRY_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 8. Start nanoclaw
+log_warn "Starting nanoclaw..."
+log_warn "You will need to scan a WhatsApp QR code to authenticate."
+echo ""
+interactive_session "${CHERRY_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/cherry/opencode.sh
+++ b/cherry/opencode.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "OpenCode on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install OpenCode
+log_warn "Installing OpenCode..."
+run_server "${CHERRY_SERVER_IP}" "$(opencode_install_cmd)"
+log_info "OpenCode installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start OpenCode interactively
+log_warn "Starting OpenCode..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/cherry/plandex.sh
+++ b/cherry/plandex.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cherry/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cherry/lib/common.sh)"
+fi
+
+log_info "Plandex on Cherry Servers"
+echo ""
+
+# 1. Resolve Cherry Servers API token
+ensure_cherry_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CHERRY_SERVER_IP}"
+wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
+
+# 5. Install Plandex
+log_warn "Installing Plandex..."
+run_server "${CHERRY_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${CHERRY_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    log_error "The 'plandex' command is not available or not working properly on server ${CHERRY_SERVER_IP}"
+    exit 1
+fi
+log_info "Plandex installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Cherry Servers server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
+echo ""
+
+# 7. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && plandex"


### PR DESCRIPTION
## Summary

- Adds 12 missing agent deployment scripts for Cherry Servers (claude, nanoclaw, aider, codex, interpreter, gemini, amazonq, cline, gptme, opencode, plandex, kilocode)
- These were marked as "implemented" in manifest.json but had no corresponding .sh files
- Fixes 12 failing tests in script-syntax.test.ts (343 -> 355 implemented scripts found)

## Details

Each script follows the standard Cherry Servers pattern from existing `cherry/goose.sh` and `cherry/openclaw.sh`:
1. Source `cherry/lib/common.sh` (local or remote fallback)
2. Authenticate with `ensure_cherry_token`
3. Create server with `create_server`
4. Wait for SSH with `verify_server_connectivity` and `wait_for_cloud_init`
5. Install the agent
6. Get OpenRouter API key via env or OAuth
7. Inject env vars with `inject_env_vars_ssh`
8. Launch interactive session

All scripts pass `bash -n` syntax checking.

## Test plan

- [x] All 12 new scripts pass `bash -n` syntax check
- [x] `script-syntax.test.ts`: 385 pass, 0 fail (was 372 pass, 13 fail)
- [x] `manifest-integrity.test.ts`: 26 pass, 0 fail
- [x] Full test suite: no new failures introduced

Agent: test-engineer