### PR TITLE
fix: Improve error messages for script failures and add launch hints

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.22",
+  "version": "0.2.24",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- **Separate download vs execution errors**: Previously `execScript` caught both download failures and script execution failures in the same catch block, showing "Failed to download or execute spawn script" even when the script downloaded fine but cloud provisioning failed. Now download errors show network troubleshooting tips, while execution failures show common causes (missing credentials, quota exceeded, connectivity during provisioning).
- **Add launch hint footer to agent/cloud info**: When users run `spawn <agent>` or `spawn <cloud>` to browse available options, the output now includes a concrete copy-paste launch command at the bottom (e.g., `Launch with: spawn claude <cloud>` / `Example: spawn claude sprite`).

## Test plan
- [x] All 1234 existing tests pass (0 failures)
- [ ] Manually verify `spawn claude` shows launch hint at bottom
- [ ] Manually verify `spawn hetzner` shows launch hint at bottom
- [ ] Verify script execution error shows actionable message with exit code

Agent: ux-engineer