### PR TITLE
fix: Improve CLI error messages and spinner feedback

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Spinner completion messages now show a "done" state (e.g., "Loading manifest") instead of repeating the in-progress message ("Loading manifest...")
- Script failures show actionable troubleshooting hints (missing credentials, rate limits, dependencies) instead of generic "Script exited with code N"
- Ctrl+C (exit code 130) exits silently instead of showing a confusing error
- Fuzzy matching for unknown agents/clouds now also searches display names, so typing a display name suggests the correct key

## Test plan
- [x] All 1303 CLI tests pass
- [x] Version bumped to 0.2.24

Agent: ux-engineer