### PR TITLE
feat: Add upcloud/continue.sh implementation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1010,7 +1010,7 @@
     "civo/continue": "missing",
     "scaleway/continue": "missing",
     "daytona/continue": "missing",
-    "upcloud/continue": "missing",
+    "upcloud/continue": "implemented",
     "binarylane/continue": "missing",
     "latitude/continue": "missing",
     "ovh/continue": "missing",

--- a/upcloud/continue.sh
+++ b/upcloud/continue.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/upcloud/lib/common.sh)"
+fi
+
+log_info "Continue on UpCloud"
+echo ""
+
+generate_ssh_key_if_missing
+ensure_upcloud_credentials
+
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+verify_server_connectivity "$UPCLOUD_SERVER_IP"
+
+install_base_tools "$UPCLOUD_SERVER_IP"
+
+log_warn "Installing Continue CLI..."
+run_server "$UPCLOUD_SERVER_IP" "npm install -g @continuedev/cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.bashrc"
+run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.zshrc"
+
+log_warn "Creating Continue config file..."
+run_server "$UPCLOUD_SERVER_IP" "mkdir -p ~/.continue"
+run_server "$UPCLOUD_SERVER_IP" "cat > ~/.continue/config.json << 'EOF'
+{
+  \"models\": [
+    {
+      \"title\": \"OpenRouter\",
+      \"provider\": \"openrouter\",
+      \"model\": \"openrouter/auto\",
+      \"apiBase\": \"https://openrouter.ai/api/v1\",
+      \"apiKey\": \"${OPENROUTER_API_KEY}\"
+    }
+  ]
+}
+EOF"
+
+echo ""
+log_info "UpCloud server setup completed successfully!"
+echo ""
+
+log_warn "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "$UPCLOUD_SERVER_IP" "source ~/.zshrc && cn"


### PR DESCRIPTION
## Summary
- Implements Continue.dev CLI agent on UpCloud cloud platform
- Uses UpCloud REST API to provision server with Ubuntu 24.04
- Installs Continue CLI via npm
- Injects OpenRouter API key into shell environment
- Creates ~/.continue/config.json with OpenRouter provider configuration
- Launches Continue in interactive TUI mode

## Test plan
- [x] Syntax check passes (`bash -n upcloud/continue.sh`)
- [x] manifest.json updated to mark upcloud/continue as "implemented"
- [ ] Manual test: Run script and verify Continue CLI launches with OpenRouter integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)