### PR TITLE
feat: Implement latitude/continue.sh

### DIFF
--- a/latitude/continue.sh
+++ b/latitude/continue.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/latitude/lib/common.sh)"
+fi
+
+log_info "Continue on Latitude.sh"
+echo ""
+
+ensure_latitude_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+wait_for_server_ready "$LATITUDE_SERVER_ID"
+verify_server_connectivity "$LATITUDE_SERVER_IP"
+
+install_base_tools "$LATITUDE_SERVER_IP"
+
+log_warn "Installing Continue CLI..."
+run_server "$LATITUDE_SERVER_IP" "npm install -g @continuedev/cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.bashrc"
+run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.zshrc"
+
+log_warn "Creating Continue config file..."
+run_server "$LATITUDE_SERVER_IP" "mkdir -p ~/.continue"
+run_server "$LATITUDE_SERVER_IP" "cat > ~/.continue/config.json << 'EOF'
+{
+  \"models\": [
+    {
+      \"title\": \"OpenRouter\",
+      \"provider\": \"openrouter\",
+      \"model\": \"openrouter/auto\",
+      \"apiBase\": \"https://openrouter.ai/api/v1\",
+      \"apiKey\": \"${OPENROUTER_API_KEY}\"
+    }
+  ]
+}
+EOF"
+
+echo ""
+log_info "Latitude.sh setup completed successfully!"
+echo ""
+
+log_warn "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "$LATITUDE_SERVER_IP" "zsh -c 'source ~/.zshrc && cn'"

--- a/manifest.json
+++ b/manifest.json
@@ -1012,7 +1012,7 @@
     "daytona/continue": "missing",
     "upcloud/continue": "missing",
     "binarylane/continue": "missing",
-    "latitude/continue": "missing",
+    "latitude/continue": "implemented",
     "ovh/continue": "missing",
     "kamatera/continue": "implemented",
     "cherry/continue": "implemented",


### PR DESCRIPTION
## Summary
- Implement Continue agent support for Latitude.sh cloud provider
- Install Continue CLI via npm on Latitude.sh VM
- Configure OpenRouter API key in environment and config file
- Create ~/.continue/config.json with OpenRouter provider settings
- Launch interactive TUI mode with `cn` command

## Matrix Update
- `latitude/continue`: `"missing"` → `"implemented"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)