### PR TITLE
feat: Add Continue agent support for Daytona

### DIFF
--- a/daytona/continue.sh
+++ b/daytona/continue.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/daytona/lib/common.sh)"
+fi
+
+log_info "Continue on Daytona"
+echo ""
+
+ensure_daytona_cli
+ensure_daytona_token
+
+SANDBOX_NAME=$(get_server_name)
+create_server "${SANDBOX_NAME}"
+wait_for_cloud_init
+
+log_warn "Installing Continue CLI..."
+run_server "npm install -g @continuedev/cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
+run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+
+log_warn "Creating Continue config file..."
+run_server "mkdir -p ~/.continue"
+run_server "cat > ~/.continue/config.json << 'EOF'
+{
+  \"models\": [
+    {
+      \"title\": \"OpenRouter\",
+      \"provider\": \"openrouter\",
+      \"model\": \"openrouter/auto\",
+      \"apiBase\": \"https://openrouter.ai/api/v1\",
+      \"apiKey\": \"${OPENROUTER_API_KEY}\"
+    }
+  ]
+}
+EOF"
+
+echo ""
+log_info "Sandbox setup completed successfully!"
+echo ""
+
+log_warn "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && cn"

--- a/manifest.json
+++ b/manifest.json
@@ -1009,7 +1009,7 @@
     "fly/continue": "implemented",
     "civo/continue": "missing",
     "scaleway/continue": "implemented",
-    "daytona/continue": "missing",
+    "daytona/continue": "implemented",
     "upcloud/continue": "implemented",
     "binarylane/continue": "implemented",
     "latitude/continue": "implemented",


### PR DESCRIPTION
## Summary
Implements the `daytona/continue.sh` script to run Continue agent on Daytona sandboxes.

## Changes
- **daytona/continue.sh**: New deployment script following standard pattern
  - Sources `daytona/lib/common.sh` for cloud-specific primitives
  - Installs Continue CLI via npm (`@continuedev/cli`)
  - Injects `OPENROUTER_API_KEY` into shell environment
  - Creates `~/.continue/config.json` with OpenRouter provider configuration
  - Launches Continue TUI via interactive session
- **manifest.json**: Updated `daytona/continue` matrix entry to `"implemented"`

## Testing
- ✅ Syntax check passed (`bash -n daytona/continue.sh`)
- Follows CLAUDE.md Shell Script Rules (curl|bash compatibility, macOS bash 3.x compat)
- Uses local-or-remote fallback pattern for sourcing

Closes gap in the matrix: daytona/continue

🤖 Generated by gap-filler-daytona-continue