### PR TITLE
feat: Implement ovh/continue.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1013,7 +1013,7 @@
     "upcloud/continue": "implemented",
     "binarylane/continue": "missing",
     "latitude/continue": "implemented",
-    "ovh/continue": "missing",
+    "ovh/continue": "implemented",
     "kamatera/continue": "implemented",
     "cherry/continue": "implemented",
     "oracle/continue": "implemented",

--- a/ovh/continue.sh
+++ b/ovh/continue.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ovh/lib/common.sh)"
+fi
+
+log_info "Continue on OVHcloud"
+echo ""
+
+ensure_ovh_authenticated
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_ovh_instance "${SERVER_NAME}"
+wait_for_ovh_instance "${OVH_INSTANCE_ID}"
+verify_server_connectivity "${OVH_SERVER_IP}"
+
+log_warn "Installing base dependencies..."
+install_base_deps "${OVH_SERVER_IP}"
+
+log_warn "Installing Continue CLI..."
+run_ovh "${OVH_SERVER_IP}" "npm install -g @continuedev/cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ovh "${OVH_SERVER_IP}" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+log_warn "Creating Continue config file..."
+run_ovh "${OVH_SERVER_IP}" "mkdir -p ~/.continue"
+
+# Create config.json with OpenRouter settings
+run_ovh "${OVH_SERVER_IP}" "cat > ~/.continue/config.json << 'EOFCONFIG'
+{
+  \"models\": [
+    {
+      \"title\": \"OpenRouter\",
+      \"provider\": \"openrouter\",
+      \"model\": \"openrouter/auto\",
+      \"apiBase\": \"https://openrouter.ai/api/v1\",
+      \"apiKey\": \"${OPENROUTER_API_KEY}\"
+    }
+  ]
+}
+EOFCONFIG"
+
+echo ""
+log_info "OVHcloud instance setup completed successfully!"
+echo ""
+
+log_warn "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "${OVH_SERVER_IP}" "zsh -c 'source ~/.zshrc && cn'"


### PR DESCRIPTION
## Summary

- Implements Continue CLI agent deployment on OVHcloud
- Uses OVH Public Cloud API for instance provisioning
- Installs Continue CLI via npm (`@continuedev/cli`)
- Configures OpenRouter integration via `~/.continue/config.json`
- Updates manifest.json matrix entry to "implemented"

## Implementation Details

- Sources `ovh/lib/common.sh` for cloud-specific primitives
- Authenticates via OVH API signature auth (Application Key/Secret/Consumer Key)
- Provisions Ubuntu 24.04 instance (default: d2-2 flavor, GRA7 region)
- Installs base dependencies (curl, git, npm, bun, Claude Code)
- Injects `OPENROUTER_API_KEY` into shell environment
- Creates `~/.continue/config.json` with OpenRouter provider configuration
- Launches interactive session with `cn` TUI command

## Testing

- Syntax validated with `bash -n ovh/continue.sh`
- Follows Spawn shell script rules (curl|bash compatible, macOS bash 3.x compatible)
- Uses local-or-remote fallback pattern for sourcing

## Agent

Agent: gap-filler-ovh-continue