### PR TITLE
feat: Implement fly/continue.sh script

### DIFF
--- a/fly/continue.sh
+++ b/fly/continue.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/fly/lib/common.sh)"
+fi
+
+log_info "Continue on Fly.io"
+echo ""
+
+ensure_fly_cli
+ensure_fly_token
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+wait_for_cloud_init
+
+log_warn "Installing Continue CLI..."
+run_server "npm install -g @continuedev/cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_fly \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+log_warn "Creating Continue config file..."
+run_server "mkdir -p ~/.continue"
+run_server "cat > ~/.continue/config.json << 'EOF'
+{
+  \"models\": [
+    {
+      \"title\": \"OpenRouter\",
+      \"provider\": \"openrouter\",
+      \"model\": \"openrouter/auto\",
+      \"apiBase\": \"https://openrouter.ai/api/v1\",
+      \"apiKey\": \"${OPENROUTER_API_KEY}\"
+    }
+  ]
+}
+EOF"
+
+echo ""
+log_info "Fly.io setup completed successfully!"
+echo ""
+
+log_warn "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "source ~/.zshrc && cn"

--- a/manifest.json
+++ b/manifest.json
@@ -1006,7 +1006,7 @@
     "github-codespaces/continue": "implemented",
     "e2b/continue": "implemented",
     "modal/continue": "implemented",
-    "fly/continue": "missing",
+    "fly/continue": "implemented",
     "civo/continue": "missing",
     "scaleway/continue": "missing",
     "daytona/continue": "missing",


### PR DESCRIPTION
## Summary
- Implements `fly/continue.sh` to deploy Continue CLI on Fly.io
- Uses Fly.io Machines API primitives from `fly/lib/common.sh`
- Follows Continue setup pattern from `sprite/continue.sh`
- Injects OpenRouter credentials via `~/.continue/config.json`
- Updates `manifest.json` matrix entry from "missing" to "implemented"

## Test plan
- [x] Syntax validated with `bash -n fly/continue.sh`
- [x] Script follows curl|bash compatibility pattern
- [x] OpenRouter config injection matches Continue's expected format
- [ ] Manual test: Run script to verify Continue CLI launches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)