### PR TITLE
fix: Kill claude process tree reliably via captured PID

### DIFF
--- a/.claude/skills/setup-trigger-service/refactor.sh
+++ b/.claude/skills/setup-trigger-service/refactor.sh
@@ -584,8 +584,7 @@ while kill -0 "${PIPE_PID}" 2>/dev/null; do
     # Hard wall-clock timeout as final safety net
     if [[ "${WALL_ELAPSED}" -ge "${HARD_TIMEOUT}" ]]; then
         log "Hard timeout: ${WALL_ELAPSED}s elapsed — killing process"
-        kill -- -"${PIPE_PID}" 2>/dev/null || kill "${PIPE_PID}" 2>/dev/null || true
-        pkill -P "${PIPE_PID}" 2>/dev/null || true
+        kill_claude
         break
     fi
 done


### PR DESCRIPTION
## Summary
- The watchdog was killing `tee` (last in the pipe), not `claude` — killing `tee` doesn't propagate to `claude` or its agent subprocesses, leaving zombie processes blocking the trigger server slot
- Now captures claude's actual PID via `( claude & echo $! > pidfile; wait )` wrapper
- `kill_claude()` sends SIGTERM to children first, then claude, with 5s grace before SIGKILL
- All 3 kill paths (result detection, idle watchdog, hard timeout) use the same reliable kill function

## Test plan
- [ ] `bash -n refactor.sh` passes
- [ ] Next cycle: process exits cleanly after result event, no zombies left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)