### PR TITLE
fix: Validate env var inputs in Hostinger and Contabo create_server

### DIFF
--- a/contabo/lib/common.sh
+++ b/contabo/lib/common.sh
@@ -249,6 +249,16 @@ create_server() {
     local image_id="${CONTABO_IMAGE_ID:-ubuntu-24.04}"
     local period="${CONTABO_PERIOD:-1}"  # 1 month
 
+    # Validate inputs to prevent injection into Python code
+    validate_resource_name "$product_id" || { log_error "Invalid CONTABO_PRODUCT_ID"; return 1; }
+    validate_region_name "$region" || { log_error "Invalid CONTABO_REGION"; return 1; }
+    validate_resource_name "$image_id" || { log_error "Invalid CONTABO_IMAGE_ID"; return 1; }
+    # Period must be a positive integer
+    if [[ ! "$period" =~ ^[0-9]+$ ]]; then
+        log_error "Invalid CONTABO_PERIOD: must be a positive integer"
+        return 1
+    fi
+
     log_warn "Creating Contabo instance '$name' (product: $product_id, region: $region)..."
 
     # Get all SSH secret IDs

--- a/hostinger/lib/common.sh
+++ b/hostinger/lib/common.sh
@@ -256,6 +256,7 @@ create_server() {
     # Validate inputs to prevent injection into Python code
     validate_resource_name "$plan" || { log_error "Invalid HOSTINGER_PLAN"; return 1; }
     validate_region_name "$location" || { log_error "Invalid HOSTINGER_LOCATION"; return 1; }
+    validate_resource_name "$os_template" || { log_error "Invalid HOSTINGER_OS_TEMPLATE"; return 1; }
 
     log_warn "Creating Hostinger VPS '$name' (plan: $plan, location: $location)..."
 


### PR DESCRIPTION
## Summary
- **Hostinger**: `HOSTINGER_OS_TEMPLATE` was interpolated into Python code without validation, allowing Python code injection via environment variable. Added `validate_resource_name` check.
- **Contabo**: `CONTABO_PRODUCT_ID`, `CONTABO_REGION`, `CONTABO_IMAGE_ID` were interpolated into Python strings without validation. `CONTABO_PERIOD` was interpolated as bare Python (unquoted), allowing arbitrary code execution. Added `validate_resource_name`, `validate_region_name`, and integer validation checks.

## Severity
HIGH - Python code injection via env vars in cloud provider `create_server` functions.

## Test plan
- [x] `bash -n` passes on both modified files
- [ ] Verify Hostinger VPS creation still works with default and custom `HOSTINGER_OS_TEMPLATE`
- [ ] Verify Contabo instance creation still works with default and custom env vars
- [ ] Verify invalid env var values are rejected with clear error messages

Agent: security-auditor