### PR TITLE
fix: Improve CLI info pages with counts and type grouping

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/commands-display.test.ts
+++ b/cli/src/__tests__/commands-display.test.ts
@@ -386,26 +386,24 @@ describe("Commands Display Output", () => {
       expect(output).toContain("Hetzner Cloud");
     });
 
-    it("should show agent counts for each cloud", async () => {
+    it("should show agent counts for each cloud as ratio", async () => {
       await cmdClouds();
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");
-      // sprite has 2 agents, hetzner has 1 agent
-      expect(output).toContain("2 agents");
-      expect(output).toContain("1 agent");
+      // sprite has 2/2 agents, hetzner has 1/2 agents - shown as X/Y ratio
+      expect(output).toContain("2/2");
+      expect(output).toContain("1/2");
     });
 
-    it("should show correct singular/plural for agent count", async () => {
+    it("should group clouds by type", async () => {
       await cmdClouds();
-      const calls = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" "));
-      // hetzner has 1 agent (singular)
-      const hetznerLine = calls.find(
-        (line: string) => line.includes("hetzner") && line.includes("agent")
-      );
-      expect(hetznerLine).toBeDefined();
-      expect(hetznerLine).toContain("1 agent");
-      expect(hetznerLine).not.toContain("1 agents");
+      const output = consoleMocks.log.mock.calls
+        .map((c: any[]) => c.join(" "))
+        .join("\n");
+      // Mock manifest has clouds with types "vm" and "cloud"
+      expect(output).toContain("vm");
+      expect(output).toContain("cloud");
     });
 
     it("should show cloud descriptions", async () => {

--- a/cli/src/__tests__/commands-output.test.ts
+++ b/cli/src/__tests__/commands-output.test.ts
@@ -187,10 +187,9 @@ describe("Command Output Functions", () => {
     it("should show agent count per cloud", async () => {
       await cmdClouds();
       const output = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-      // sprite has 2 agents (claude, aider), hetzner has 1 (claude)
-      expect(output).toContain("2 agents");
-      expect(output).toContain("1 agent");
-      expect(output).not.toContain("1 agents");
+      // sprite has 2 agents (claude, aider), hetzner has 1 (claude) - shown as X/Y ratio
+      expect(output).toContain("2/2");
+      expect(output).toContain("1/2");
     });
 
     it("should show cloud descriptions", async () => {


### PR DESCRIPTION
## Summary
- **Agent info** (`spawn <agent>`) now shows "X of Y" cloud count and groups clouds by type (api, cli, sandbox) for easier scanning when choosing a provider
- **Cloud info** (`spawn <cloud>`) now shows "X of Y" agent count, displays the auth method upfront, and lists missing agents when there are 5 or fewer
- **Cloud listing** (`spawn clouds`) groups providers by type with X/Y ratio counts instead of singular/plural text, making it easier to scan 29+ providers

## Test plan
- [x] All 1403 tests pass (0 fail, 11 skip)
- [x] Updated `commands-display.test.ts` and `commands-output.test.ts` for new output format
- [x] CLI version bumped to 0.2.26

Generated with Claude Code