### PR TITLE
feat: Add contabo/amazonq.sh

### DIFF
--- a/contabo/amazonq.sh
+++ b/contabo/amazonq.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=contabo/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/contabo/lib/common.sh)"
+fi
+
+log_info "Amazon Q on Contabo"
+echo ""
+
+ensure_contabo_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CONTABO_SERVER_IP}"
+wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
+
+log_warn "Installing Amazon Q CLI..."
+run_server "${CONTABO_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Contabo server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
+echo ""
+
+log_warn "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${CONTABO_SERVER_IP}" "source ~/.bashrc && q chat"

--- a/manifest.json
+++ b/manifest.json
@@ -1107,7 +1107,7 @@
     "contabo/codex": "missing",
     "contabo/interpreter": "missing",
     "contabo/gemini": "missing",
-    "contabo/amazonq": "missing",
+    "contabo/amazonq": "implemented",
     "contabo/cline": "missing",
     "contabo/gptme": "missing",
     "contabo/opencode": "missing",


### PR DESCRIPTION
## Summary
- Implement Amazon Q CLI on Contabo VPS
- Uses OAuth password grant for Contabo API auth
- Provisions V45 instance (2 vCPU, 8GB RAM) with cloud-init
- Installs Amazon Q CLI via AWS installer script
- Injects OpenRouter env vars (OPENAI_API_KEY, OPENAI_BASE_URL)
- Launches interactive Q chat session

## Compliance
- ✅ Uses local-or-remote source fallback pattern
- ✅ OpenRouter injection via inject_env_vars_ssh
- ✅ bash -n syntax check passed
- ✅ manifest.json updated to "implemented"

🤖 Generated with [Claude Code](https://claude.com/claude-code)