### PR TITLE
fix: Improve error messages with actionable troubleshooting

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -757,6 +757,10 @@ export async function cmdUpdate(): Promise<void> {
   } catch (err) {
     s.stop(pc.red("Failed to check for updates"));
     console.error("Error:", getErrorMessage(err));
+    console.error(`\nTroubleshooting:`);
+    console.error(`  1. Check your internet connection`);
+    console.error(`  2. Try again in a few moments`);
+    console.error(`  3. Update manually: ${pc.cyan(`curl -fsSL ${RAW_BASE}/cli/install.sh | bash`)}`);
   }
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -230,6 +230,8 @@ async function main(): Promise<void> {
       if (isInteractiveTTY()) {
         await cmdInteractive();
       } else {
+        console.error(pc.yellow("Non-interactive terminal detected (no TTY). Showing help instead of interactive picker."));
+        console.error(pc.dim("To launch directly, use: spawn <agent> <cloud>\n"));
         cmdHelp();
       }
       return;

--- a/cli/src/manifest.ts
+++ b/cli/src/manifest.ts
@@ -175,7 +175,15 @@ export async function loadManifest(forceRefresh = false): Promise<Manifest> {
     return stale;
   }
 
-  throw new Error("Cannot load manifest. Check your internet connection.");
+  throw new Error(
+    `Cannot load manifest: failed to fetch from GitHub and no local cache available.\n` +
+    `\n` +
+    `Troubleshooting:\n` +
+    `  1. Check your internet connection\n` +
+    `  2. Try again in a few moments (GitHub may be temporarily unreachable)\n` +
+    `  3. If the problem persists, clear the cache and retry:\n` +
+    `     rm -rf ${CACHE_DIR}`
+  );
 }
 
 export function agentKeys(m: Manifest): string[] {


### PR DESCRIPTION
## Summary
- Manifest load failure now shows specific troubleshooting steps (check connection, retry, clear cache with exact path) instead of the vague "Check your internet connection"
- Non-TTY mode (piped/scripted execution) now explains why interactive picker is unavailable and suggests `spawn <agent> <cloud>` syntax, instead of silently falling through to help text
- `spawn update` network failure now includes numbered recovery steps and the manual update command

## Test plan
- [x] All 1474 existing tests pass (0 failures)
- [x] Version bumped to 0.2.27
- [ ] Manual verification: `echo | spawn` shows non-TTY message
- [ ] Manual verification: offline `spawn list` shows improved manifest error

Generated with Claude Code (agent: ux-engineer)