### PR TITLE
feat: Add quick-start section to cloud and agent info views

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Adds a **Quick start** section to `spawn <cloud>` and `spawn <agent>` output showing exact auth setup commands
- For clouds with env var auth (e.g. `HCLOUD_TOKEN`), displays `export` commands the user can copy-paste
- For agents, shows `OPENROUTER_API_KEY` export and an example launch command
- Renames "Setup:" to "Full setup guide:" for clarity since quick start now provides the primary getting-started path

### Before (`spawn hetzner`):
```
Hetzner Cloud -- European cloud provider
  Type: cloud  |  Auth: HCLOUD_TOKEN

Available agents: 14 of 15
  claude     Claude Code     spawn claude hetzner
  ...
  Setup: https://github.com/OpenRouterTeam/spawn/tree/main/hetzner
```

### After (`spawn hetzner`):
```
Hetzner Cloud -- European cloud provider
  Type: cloud  |  Auth: HCLOUD_TOKEN

Quick start:
  export HCLOUD_TOKEN=your-hcloud-token-here
  spawn claude hetzner

Available agents: 14 of 15
  claude     Claude Code     spawn claude hetzner
  ...
  Full setup guide: https://github.com/OpenRouterTeam/spawn/tree/main/hetzner
```

## Test plan
- [x] All 1514 existing tests pass (0 failures)
- [x] Added 6 tests for `parseAuthEnvVars()` covering single/multi env vars, CLI auth, short tokens, Contabo-style 4-var auth
- [x] Added 4 quick-start tests for `cmdCloudInfo` (header, env var export, CLI command, example spawn)
- [x] Added 4 quick-start tests for `cmdAgentInfo` (header, OPENROUTER_API_KEY, example spawn, no-impl case)
- [x] Updated 2 existing tests that referenced old "Setup:" label
- [x] Version bumped to 0.2.28

Agent: ux-engineer