### PR TITLE
fix: Escape API keys in continue.sh JSON configs to prevent injection

### DIFF
--- a/aws-lightsail/continue.sh
+++ b/aws-lightsail/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${LIGHTSAIL_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${LIGHTSAIL_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${LIGHTSAIL_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${LIGHTSAIL_SERVER_IP}" \
+    "run_server ${LIGHTSAIL_SERVER_IP}"
 
 echo ""
 log_info "Lightsail instance setup completed successfully!"

--- a/binarylane/continue.sh
+++ b/binarylane/continue.sh
@@ -34,21 +34,9 @@ fi
 log_warn "Setting up environment variables..."
 run_server "${BINARYLANE_SERVER_IP}" "echo 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> ~/.bashrc"
 
-log_warn "Creating Continue config file..."
-run_server "${BINARYLANE_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${BINARYLANE_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${BINARYLANE_SERVER_IP}" \
+    "run_server ${BINARYLANE_SERVER_IP}"
 
 echo ""
 log_info "BinaryLane server setup completed successfully!"

--- a/cherry/continue.sh
+++ b/cherry/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${CHERRY_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${CHERRY_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${CHERRY_SERVER_IP}" \
+    "run_server ${CHERRY_SERVER_IP}"
 
 echo ""
 log_info "Cherry Servers setup completed successfully!"

--- a/civo/continue.sh
+++ b/civo/continue.sh
@@ -40,21 +40,9 @@ export PATH=\"\$HOME/.bun/bin:\$PATH\"
 export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
 ENV_EOF"
 
-log_warn "Creating Continue config file..."
-run_server "${CIVO_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${CIVO_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${CIVO_SERVER_IP}" \
+    "run_server ${CIVO_SERVER_IP}"
 
 echo ""
 log_info "Server setup completed successfully!"

--- a/daytona/continue.sh
+++ b/daytona/continue.sh
@@ -32,21 +32,7 @@ log_warn "Setting up environment variables..."
 run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
 run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
 
-log_warn "Creating Continue config file..."
-run_server "mkdir -p ~/.continue"
-run_server "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Sandbox setup completed successfully!"

--- a/digitalocean/continue.sh
+++ b/digitalocean/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${DO_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${DO_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${DO_SERVER_IP}" \
+    "run_server ${DO_SERVER_IP}"
 
 echo ""
 log_info "DigitalOcean droplet setup completed successfully!"

--- a/e2b/continue.sh
+++ b/e2b/continue.sh
@@ -36,21 +36,7 @@ log_warn "Setting up environment variables..."
 run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
 run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
 
-log_warn "Creating Continue config file..."
-run_server "mkdir -p ~/.continue"
-run_server "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "E2B sandbox setup completed successfully!"

--- a/exoscale/continue.sh
+++ b/exoscale/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${EXOSCALE_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${EXOSCALE_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${EXOSCALE_SERVER_IP}" \
+    "run_server ${EXOSCALE_SERVER_IP}"
 
 echo ""
 log_info "Exoscale server setup completed successfully!"

--- a/fly/continue.sh
+++ b/fly/continue.sh
@@ -32,21 +32,7 @@ log_warn "Setting up environment variables..."
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "mkdir -p ~/.continue"
-run_server "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Fly.io setup completed successfully!"

--- a/gcp/continue.sh
+++ b/gcp/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${GCP_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${GCP_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${GCP_SERVER_IP}" \
+    "run_server ${GCP_SERVER_IP}"
 
 echo ""
 log_info "GCP instance setup completed successfully!"

--- a/github-codespaces/continue.sh
+++ b/github-codespaces/continue.sh
@@ -41,21 +41,7 @@ log_warn "Setting up environment variables..."
 run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
 run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
 
-log_warn "Creating Continue config file..."
-run_in_codespace "${CODESPACE_NAME}" "mkdir -p ~/.continue"
-run_in_codespace "${CODESPACE_NAME}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Codespace setup completed successfully!"

--- a/hetzner/continue.sh
+++ b/hetzner/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${HETZNER_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${HETZNER_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${HETZNER_SERVER_IP}" \
+    "run_server ${HETZNER_SERVER_IP}"
 
 echo ""
 log_info "Hetzner server setup completed successfully!"

--- a/ionos/continue.sh
+++ b/ionos/continue.sh
@@ -54,21 +54,9 @@ inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 # 7. Create Continue config file
-log_warn "Creating Continue config file..."
-run_server "${IONOS_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${IONOS_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${IONOS_SERVER_IP}" \
+    "run_server ${IONOS_SERVER_IP}"
 
 echo ""
 log_info "IONOS server setup completed successfully!"

--- a/kamatera/continue.sh
+++ b/kamatera/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${KAMATERA_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${KAMATERA_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${KAMATERA_SERVER_IP}" \
+    "run_server ${KAMATERA_SERVER_IP}"
 
 echo ""
 log_info "Kamatera server setup completed successfully!"

--- a/koyeb/continue.sh
+++ b/koyeb/continue.sh
@@ -35,21 +35,7 @@ log_warn "Setting up environment variables..."
 
 inject_env_vars_koyeb "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "mkdir -p ~/.continue"
-run_server "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Koyeb service setup completed successfully!"

--- a/latitude/continue.sh
+++ b/latitude/continue.sh
@@ -35,21 +35,9 @@ log_warn "Setting up environment variables..."
 run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.bashrc"
 run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.zshrc"
 
-log_warn "Creating Continue config file..."
-run_server "$LATITUDE_SERVER_IP" "mkdir -p ~/.continue"
-run_server "$LATITUDE_SERVER_IP" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${LATITUDE_SERVER_IP}" \
+    "run_server ${LATITUDE_SERVER_IP}"
 
 echo ""
 log_info "Latitude.sh setup completed successfully!"

--- a/linode/continue.sh
+++ b/linode/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${LINODE_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${LINODE_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${LINODE_SERVER_IP}" \
+    "run_server ${LINODE_SERVER_IP}"
 
 echo ""
 log_info "Linode setup completed successfully!"

--- a/modal/continue.sh
+++ b/modal/continue.sh
@@ -35,21 +35,7 @@ log_warn "Setting up environment variables..."
 run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
 run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
 
-log_warn "Creating Continue config file..."
-run_server "mkdir -p ~/.continue"
-run_server "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Modal sandbox setup completed successfully!"

--- a/northflank/continue.sh
+++ b/northflank/continue.sh
@@ -35,21 +35,7 @@ log_warn "Setting up environment variables..."
 
 inject_env_vars_northflank "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "mkdir -p ~/.continue"
-run_server "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Northflank service setup completed successfully!"

--- a/oracle/continue.sh
+++ b/oracle/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${OCI_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${OCI_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${OCI_SERVER_IP}" \
+    "run_server ${OCI_SERVER_IP}"
 
 echo ""
 log_info "Oracle Cloud instance setup completed successfully!"

--- a/ovh/continue.sh
+++ b/ovh/continue.sh
@@ -36,23 +36,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_ovh "${OVH_SERVER_IP}" "mkdir -p ~/.continue"
-
-# Create config.json with OpenRouter settings
-run_ovh "${OVH_SERVER_IP}" "cat > ~/.continue/config.json << 'EOFCONFIG'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOFCONFIG"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file_ovh ${OVH_SERVER_IP}" \
+    "run_ovh ${OVH_SERVER_IP}"
 
 echo ""
 log_info "OVHcloud instance setup completed successfully!"

--- a/railway/continue.sh
+++ b/railway/continue.sh
@@ -35,21 +35,7 @@ log_warn "Setting up environment variables..."
 
 inject_env_vars_railway "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "mkdir -p ~/.continue"
-run_server "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Railway service setup completed successfully!"

--- a/render/continue.sh
+++ b/render/continue.sh
@@ -35,21 +35,7 @@ log_warn "Setting up environment variables..."
 
 inject_env_vars_render "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "mkdir -p ~/.continue"
-run_server "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Render service setup completed successfully!"

--- a/scaleway/continue.sh
+++ b/scaleway/continue.sh
@@ -37,21 +37,9 @@ log_warn "Setting up environment variables..."
 run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.bashrc"
 run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.zshrc"
 
-log_warn "Creating Continue config file..."
-run_server "${SCALEWAY_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${SCALEWAY_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${SCALEWAY_SERVER_IP}" \
+    "run_server ${SCALEWAY_SERVER_IP}"
 
 echo ""
 log_info "Scaleway setup completed successfully!"

--- a/sprite/continue.sh
+++ b/sprite/continue.sh
@@ -35,21 +35,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_sprite "${SPRITE_NAME}" "mkdir -p ~/.continue"
-run_sprite "${SPRITE_NAME}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file_sprite ${SPRITE_NAME}" \
+    "run_sprite ${SPRITE_NAME}"
 
 echo ""
 log_info "Sprite setup completed successfully!"

--- a/upcloud/continue.sh
+++ b/upcloud/continue.sh
@@ -34,21 +34,9 @@ log_warn "Setting up environment variables..."
 run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.bashrc"
 run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.zshrc"
 
-log_warn "Creating Continue config file..."
-run_server "$UPCLOUD_SERVER_IP" "mkdir -p ~/.continue"
-run_server "$UPCLOUD_SERVER_IP" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${UPCLOUD_SERVER_IP}" \
+    "run_server ${UPCLOUD_SERVER_IP}"
 
 echo ""
 log_info "UpCloud server setup completed successfully!"

--- a/vultr/continue.sh
+++ b/vultr/continue.sh
@@ -38,21 +38,9 @@ log_warn "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-log_warn "Creating Continue config file..."
-run_server "${VULTR_SERVER_IP}" "mkdir -p ~/.continue"
-run_server "${VULTR_SERVER_IP}" "cat > ~/.continue/config.json << 'EOF'
-{
-  \"models\": [
-    {
-      \"title\": \"OpenRouter\",
-      \"provider\": \"openrouter\",
-      \"model\": \"openrouter/auto\",
-      \"apiBase\": \"https://openrouter.ai/api/v1\",
-      \"apiKey\": \"${OPENROUTER_API_KEY}\"
-    }
-  ]
-}
-EOF"
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${VULTR_SERVER_IP}" \
+    "run_server ${VULTR_SERVER_IP}"
 
 echo ""
 log_info "Vultr instance setup completed successfully!"


### PR DESCRIPTION
## Summary

- Add `setup_continue_config()` helper to `shared/common.sh` that uses `json_escape()` + `upload_config_file()` to safely write Continue config files, following the same pattern as `setup_claude_code_config()` and `setup_openclaw_config()`
- Replace vulnerable heredoc patterns across all 27 `continue.sh` scripts that embedded `${OPENROUTER_API_KEY}` inside double-quoted strings passed to `run_server`, which caused shell expansion before the heredoc reached the remote server
- Fix `_save_token_to_config()` which had the same unescaped token injection in a local heredoc

## Problem

The `'EOF'` delimiter inside a double-quoted `run_server` argument does NOT prevent variable expansion -- the outer double quotes cause `${OPENROUTER_API_KEY}` to be expanded by the local shell first. If the API key contains `"`, `}`, or other JSON-special characters, it could corrupt the config file or inject additional JSON fields.

## Fix approach

Uses the existing safe pattern already established in the codebase:
1. `json_escape()` properly escapes the value for JSON embedding (handles quotes, backslashes, control chars)
2. `upload_config_file()` writes to a local temp file and uploads via the cloud's `upload_file` callback -- no shell expansion on the remote side

Relates to #104

## Test plan

- [x] `bash -n` passes on all 28 changed `.sh` files
- [x] All 1500 CLI tests pass (`bun test`)
- [x] Verified correct upload/run callbacks for each cloud type (SSH-based, container, sprite, OVH, codespaces)