### PR TITLE
fix: Show loading spinner for single-arg commands

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -43,7 +43,7 @@ async function withSpinner<T>(msg: string, fn: () => Promise<T>, doneMsg?: strin
   }
 }
 
-async function loadManifestWithSpinner(): Promise<Manifest> {
+export async function loadManifestWithSpinner(): Promise<Manifest> {
   return withSpinner("Loading manifest...", loadManifest);
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
   findClosestMatch,
   resolveAgentKey,
   resolveCloudKey,
+  loadManifestWithSpinner,
 } from "./commands.js";
 import pc from "picocolors";
 import pkg from "../package.json" with { type: "json" };
@@ -85,7 +86,7 @@ function checkUnknownFlags(args: string[]): void {
 
 /** Show info for a name that could be an agent or cloud, or show an error with suggestions */
 async function showInfoOrError(name: string): Promise<void> {
-  const manifest = await loadManifest();
+  const manifest = await loadManifestWithSpinner();
   if (manifest.agents[name]) {
     await cmdAgentInfo(name);
     return;


### PR DESCRIPTION
## Summary
- `spawn <agent>` and `spawn <cloud>` (single-argument info commands) previously loaded the manifest without a spinner, giving no visual feedback on cold cache
- Now uses the existing `loadManifestWithSpinner` function so users see a "Loading manifest..." indicator while the manifest fetches
- Exported `loadManifestWithSpinner` from `commands.ts` for reuse in `index.ts`
- Bumped CLI version to 0.2.29

## Test plan
- [x] All 1563 CLI tests pass
- [ ] Manual test: `spawn claude` shows spinner on cold cache (clear cache with `rm -rf ~/.cache/spawn`)
- [ ] Manual test: `spawn hetzner` shows spinner on cold cache

Generated with Claude Code