### PR TITLE
fix: Improve CLI UX with better error messages and log levels

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/update-check.ts
+++ b/cli/src/update-check.ts
@@ -1,3 +1,4 @@
+import "./unicode-detect.js"; // Ensure TERM is set before using symbols
 import { execSync as nodeExecSync } from "child_process";
 import pc from "picocolors";
 import pkg from "../package.json" with { type: "json" };
@@ -13,6 +14,11 @@ export const executor = {
 // ── Constants ──────────────────────────────────────────────────────────────────
 
 const FETCH_TIMEOUT = 5000; // 5 seconds
+
+// Use ASCII-safe symbols when unicode is disabled (SSH, dumb terminals)
+const isAscii = process.env.TERM === "linux";
+const CHECK_MARK = isAscii ? "*" : "\u2713";
+const CROSS_MARK = isAscii ? "x" : "\u2717";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -78,7 +84,7 @@ function performAutoUpdate(latestVersion: string): void {
     });
 
     console.error();
-    console.error(pc.green(pc.bold("✓ Updated successfully!")));
+    console.error(pc.green(pc.bold(`${CHECK_MARK} Updated successfully!`)));
     console.error(pc.dim("  Restart your command to use the new version."));
     console.error();
 
@@ -86,7 +92,7 @@ function performAutoUpdate(latestVersion: string): void {
     process.exit(0);
   } catch (err) {
     console.error();
-    console.error(pc.red(pc.bold("✗ Auto-update failed")));
+    console.error(pc.red(pc.bold(`${CROSS_MARK} Auto-update failed`)));
     console.error(pc.dim("  Please update manually:"));
     console.error();
     console.error(pc.cyan(`  curl -fsSL ${RAW_BASE}/cli/install.sh | bash`));

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -302,11 +302,11 @@ get_model_id_interactive() {
     fi
 
     echo ""
-    log_warn "Browse models at: https://openrouter.ai/models"
+    log_info "Browse models at: https://openrouter.ai/models"
     if [[ -n "${agent_name}" ]]; then
-        log_warn "Which model would you like to use with ${agent_name}?"
+        log_info "Which model would you like to use with ${agent_name}?"
     else
-        log_warn "Which model would you like to use?"
+        log_info "Which model would you like to use?"
     fi
 
     local model_id=""
@@ -328,8 +328,8 @@ get_model_id_interactive() {
 # Manually prompt for API key
 get_openrouter_api_key_manual() {
     echo ""
-    log_warn "Manual API Key Entry"
-    printf '%b\n' "${YELLOW}Get your API key from: https://openrouter.ai/settings/keys${NC}"
+    log_info "Manual API Key Entry"
+    printf '%b\n' "${GREEN}Get your API key from: https://openrouter.ai/settings/keys${NC}"
     echo ""
 
     local api_key=""
@@ -487,7 +487,7 @@ wait_for_oauth_code() {
     local timeout="${2:-120}"
     local elapsed=0
 
-    log_warn "Waiting for authentication in browser (this usually takes 10-30 seconds, timeout: ${timeout}s)..."
+    log_info "Waiting for authentication in browser (this usually takes 10-30 seconds, timeout: ${timeout}s)..."
     while [[ ! -f "${code_file}" ]] && [[ ${elapsed} -lt ${timeout} ]]; do
         sleep "${POLL_INTERVAL}"
         elapsed=$((elapsed + POLL_INTERVAL))
@@ -624,7 +624,7 @@ _setup_oauth_server() {
     local port_file="${3}"
     local state_file="${4}"
 
-    log_warn "Starting local OAuth server (trying ports ${callback_port}-$((callback_port + 10)))..."
+    log_info "Starting local OAuth server (trying ports ${callback_port}-$((callback_port + 10)))..."
     local server_pid
     server_pid=$(start_oauth_server "${callback_port}" "${code_file}" "${port_file}" "${state_file}")
 
@@ -667,7 +667,7 @@ _generate_csrf_state() {
 try_oauth_flow() {
     local callback_port=${1:-5180}
 
-    log_warn "Attempting OAuth authentication..."
+    log_info "Attempting OAuth authentication..."
 
     # Check prerequisites
     if ! _check_oauth_prerequisites; then
@@ -700,7 +700,7 @@ try_oauth_flow() {
     # Open browser with CSRF state parameter
     local callback_url="http://localhost:${actual_port}/callback"
     local auth_url="https://openrouter.ai/auth?callback_url=${callback_url}&state=${csrf_state}"
-    log_warn "Opening browser to authenticate with OpenRouter..."
+    log_info "Opening browser to authenticate with OpenRouter..."
     open_browser "${auth_url}"
 
     # Wait for code
@@ -718,7 +718,7 @@ try_oauth_flow() {
     cleanup_oauth_session "${server_pid}" "${oauth_dir}"
 
     # Exchange code for API key
-    log_warn "Exchanging OAuth code for API key..."
+    log_info "Exchanging OAuth code for API key..."
     local api_key
     api_key=$(exchange_oauth_code "${oauth_code}") || return 1
 
@@ -741,9 +741,9 @@ get_openrouter_api_key_oauth() {
 
     # OAuth failed, offer manual entry
     echo ""
-    log_warn "OAuth authentication was not completed"
-    log_warn "You can enter your API key manually instead"
-    log_warn "Get a free key at: https://openrouter.ai/settings/keys"
+    log_warn "OAuth authentication was not completed."
+    log_info "You can enter your API key manually instead."
+    log_info "Get a free key at: https://openrouter.ai/settings/keys"
     echo ""
     local manual_choice
     manual_choice=$(safe_read "Would you like to enter your API key manually? (Y/n): ") || {


### PR DESCRIPTION
## Summary
- Fix auto-update unicode symbols (checkmark/cross) that bypassed unicode detection, causing garbled output in SSH sessions and dumb terminals
- Use `log_info` (green) instead of `log_warn` (yellow) for OAuth progress messages, so normal authentication flow doesn't look like warnings
- Add install path to `spawn version` output for easier debugging when multiple versions are installed
- Improve `--prompt-file` errors to distinguish file-not-found, permission denied, and is-a-directory with actionable guidance

## Test plan
- [x] All 3260 existing tests pass
- [x] `bash -n shared/common.sh` syntax check passes
- [ ] Verify `spawn version` now shows install path
- [ ] Verify `spawn --prompt-file nonexistent.txt` shows "Prompt file not found"
- [ ] Verify auto-update symbols render correctly in SSH sessions (TERM=linux)