### PR TITLE
feat: Add Hostinger codex support

### DIFF
--- a/hostinger/codex.sh
+++ b/hostinger/codex.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostinger/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostinger/lib/common.sh)"
+fi
+
+log_info "Codex CLI on Hostinger VPS"
+echo ""
+
+ensure_hostinger_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${HOSTINGER_VPS_IP}"
+wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
+
+log_warn "Installing Codex CLI..."
+run_server "${HOSTINGER_VPS_IP}" "npm install -g @openai/codex"
+log_info "Codex CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Hostinger VPS setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
+echo ""
+
+log_warn "Starting Codex..."
+sleep 1
+clear
+interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && codex"

--- a/manifest.json
+++ b/manifest.json
@@ -1130,7 +1130,7 @@
     "hostinger/nanoclaw": "implemented",
     "hostinger/aider": "implemented",
     "hostinger/goose": "implemented",
-    "hostinger/codex": "missing",
+    "hostinger/codex": "implemented",
     "hostinger/interpreter": "missing",
     "hostinger/gemini": "missing",
     "hostinger/amazonq": "missing",


### PR DESCRIPTION
Implements hostinger/codex by combining Hostinger VPS primitives with Codex CLI setup.

## Changes
- Created `hostinger/codex.sh` with Codex CLI installation
- Updated manifest.json to mark hostinger/codex as implemented

## Pattern
- Uses Hostinger's lib/common.sh for VPS provisioning
- Installs Codex via npm
- Configures OpenRouter API key with OpenAI base URL override
- Launches interactive Codex session

Generated by gap-filler-hostinger-1 agent