### PR TITLE
feat: Add Hostinger opencode support

### DIFF
--- a/hostinger/opencode.sh
+++ b/hostinger/opencode.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostinger/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostinger/lib/common.sh)"
+fi
+
+log_info "OpenCode on Hostinger VPS"
+echo ""
+
+ensure_hostinger_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${HOSTINGER_VPS_IP}"
+wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
+
+log_warn "Installing OpenCode..."
+run_server "${HOSTINGER_VPS_IP}" "$(opencode_install_cmd)"
+log_info "OpenCode installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Hostinger VPS setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
+echo ""
+
+log_warn "Starting OpenCode..."
+sleep 1
+clear
+interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && opencode"

--- a/manifest.json
+++ b/manifest.json
@@ -1136,7 +1136,7 @@
     "hostinger/amazonq": "missing",
     "hostinger/cline": "missing",
     "hostinger/gptme": "missing",
-    "hostinger/opencode": "missing",
+    "hostinger/opencode": "implemented",
     "hostinger/plandex": "missing",
     "hostinger/kilocode": "missing",
     "hostinger/continue": "missing",


### PR DESCRIPTION
## Summary
- Implements `hostinger/opencode.sh` using Hostinger VPS API
- Updates `manifest.json` to mark `hostinger/opencode` as implemented

## Implementation Details
- Uses `hostinger/lib/common.sh` cloud primitives for provisioning
- Follows standard pattern from `hetzner/opencode.sh`
- Installs OpenCode via official installer
- Injects `OPENROUTER_API_KEY` environment variable
- Launches interactive OpenCode session

🤖 Generated with gap-filler-hostinger-4