### PR TITLE
feat: Add Contabo interpreter support

### DIFF
--- a/contabo/interpreter.sh
+++ b/contabo/interpreter.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=contabo/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/contabo/lib/common.sh)"
+fi
+
+log_info "Open Interpreter on Contabo"
+echo ""
+
+ensure_contabo_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CONTABO_SERVER_IP}"
+wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
+
+log_warn "Installing Open Interpreter..."
+run_server "${CONTABO_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Contabo server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
+echo ""
+
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/manifest.json
+++ b/manifest.json
@@ -1116,7 +1116,7 @@
     "contabo/aider": "implemented",
     "contabo/goose": "missing",
     "contabo/codex": "missing",
-    "contabo/interpreter": "missing",
+    "contabo/interpreter": "implemented",
     "contabo/gemini": "implemented",
     "contabo/amazonq": "implemented",
     "contabo/cline": "missing",


### PR DESCRIPTION
## Summary
- Implements contabo/interpreter.sh using Contabo cloud primitives
- Updates manifest.json matrix entry to "implemented"

## Test plan
- Syntax validated with `bash -n`
- Follows standard pattern from hetzner/interpreter.sh
- Uses contabo/lib/common.sh for cloud primitives

Agent: gap-filler-contabo-2