### PR TITLE
feat: Add Contabo gptme support

### DIFF
--- a/contabo/gptme.sh
+++ b/contabo/gptme.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/contabo/lib/common.sh)"
+fi
+
+log_info "gptme on Contabo"
+echo ""
+
+# 1. Resolve Contabo API credentials
+ensure_contabo_credentials
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$CONTABO_SERVER_IP"
+wait_for_cloud_init "$CONTABO_SERVER_IP"
+
+# 5. Install gptme
+log_warn "Installing gptme..."
+run_server "$CONTABO_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
+
+# Verify installation succeeded
+if ! run_server "$CONTABO_SERVER_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
+    log_error "gptme installation verification failed"
+    log_error "The 'gptme' command is not available or not working properly on server $CONTABO_SERVER_IP"
+    exit 1
+fi
+log_info "gptme installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "$CONTABO_SERVER_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
+
+echo ""
+log_info "Contabo server setup completed successfully!"
+log_info "Server: $SERVER_NAME (ID: $CONTABO_INSTANCE_ID, IP: $CONTABO_SERVER_IP)"
+echo ""
+
+# 9. Start gptme interactively
+log_warn "Starting gptme..."
+sleep 1
+clear
+interactive_session "$CONTABO_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/manifest.json
+++ b/manifest.json
@@ -1120,7 +1120,7 @@
     "contabo/gemini": "implemented",
     "contabo/amazonq": "implemented",
     "contabo/cline": "missing",
-    "contabo/gptme": "missing",
+    "contabo/gptme": "implemented",
     "contabo/opencode": "missing",
     "contabo/plandex": "missing",
     "contabo/kilocode": "implemented",


### PR DESCRIPTION
Implements contabo/gptme.sh

## Changes
- Created contabo/gptme.sh using Contabo cloud primitives
- Updated manifest.json matrix entry to "implemented"

## Implementation
- Sources contabo/lib/common.sh for cloud-specific functions
- Follows the same pattern as hetzner/gptme.sh
- Installs gptme via pip
- Injects OPENROUTER_API_KEY into environment
- Launches gptme with OpenRouter model selection

Agent: gap-filler-contabo-3