### PR TITLE
feat: Add Hostinger kilocode support

### DIFF
--- a/hostinger/kilocode.sh
+++ b/hostinger/kilocode.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostinger/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostinger/lib/common.sh)"
+fi
+
+log_info "Kilo Code on Hostinger VPS"
+echo ""
+
+ensure_hostinger_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${HOSTINGER_VPS_IP}"
+wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
+
+log_warn "Installing Kilo Code..."
+run_server "${HOSTINGER_VPS_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Hostinger server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
+echo ""
+
+log_warn "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && kilocode"

--- a/manifest.json
+++ b/manifest.json
@@ -1138,7 +1138,7 @@
     "hostinger/gptme": "missing",
     "hostinger/opencode": "missing",
     "hostinger/plandex": "missing",
-    "hostinger/kilocode": "missing",
+    "hostinger/kilocode": "implemented",
     "hostinger/continue": "missing",
     "local/claude": "implemented",
     "local/openclaw": "implemented",


### PR DESCRIPTION
## Summary
- Implements hostinger/kilocode matrix entry
- Uses Hostinger VPS API primitives from hostinger/lib/common.sh
- Follows same pattern as hetzner/kilocode.sh
- Installs Kilo Code via npm (@kilocode/cli)
- Configures OpenRouter integration with KILO_PROVIDER_TYPE=openrouter
- Updates manifest.json matrix status to "implemented"

## Test plan
- [ ] Syntax validated with `bash -n`
- [ ] Follows Hostinger VPS provisioning pattern
- [ ] Injects required env vars (OPENROUTER_API_KEY, KILO_PROVIDER_TYPE, KILO_OPEN_ROUTER_API_KEY)
- [ ] Launches interactive session with kilocode

🤖 Generated with [Claude Code](https://claude.com/claude-code)