### PR TITLE
feat: Add Contabo goose support

### DIFF
--- a/contabo/goose.sh
+++ b/contabo/goose.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=contabo/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/contabo/lib/common.sh)"
+fi
+
+log_info "Goose on Contabo"
+echo ""
+
+# 1. Resolve Contabo credentials
+ensure_contabo_credentials
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${CONTABO_SERVER_IP}"
+wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
+
+# 5. Install Goose
+log_warn "Installing Goose..."
+run_server "${CONTABO_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${CONTABO_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
+    log_error "Goose installation verification failed"
+    log_error "The 'goose' command is not available or not working properly on server ${CONTABO_SERVER_IP}"
+    exit 1
+fi
+log_info "Goose installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
+    "GOOSE_PROVIDER=openrouter" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Contabo server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
+echo ""
+
+# 8. Start Goose interactively
+log_warn "Starting Goose..."
+sleep 1
+clear
+interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && goose"

--- a/manifest.json
+++ b/manifest.json
@@ -690,7 +690,7 @@
         "location": "eu-central",
         "os_template": "ubuntu-24.04"
       },
-      "notes": "Budget VPS provider with cloud-init pre-installed. Starting at $4.95/mo. Requires HOSTINGER_API_KEY from hPanel → Profile → Account Information → API. API docs at developers.hostinger.com"
+      "notes": "Budget VPS provider with cloud-init pre-installed. Starting at $4.95/mo. Requires HOSTINGER_API_KEY from hPanel \u2192 Profile \u2192 Account Information \u2192 API. API docs at developers.hostinger.com"
     },
     "local": {
       "name": "Local Machine",
@@ -1114,7 +1114,7 @@
     "contabo/openclaw": "implemented",
     "contabo/nanoclaw": "implemented",
     "contabo/aider": "implemented",
-    "contabo/goose": "missing",
+    "contabo/goose": "implemented",
     "contabo/codex": "missing",
     "contabo/interpreter": "missing",
     "contabo/gemini": "implemented",


### PR DESCRIPTION
## Summary
- Implements contabo/goose.sh using Contabo cloud primitives
- Updates manifest.json matrix entry to "implemented"
- Script uses standard pattern: provision server, install Goose, inject OpenRouter env vars

## Test plan
- [x] Bash syntax validation passed
- [ ] Manual testing on Contabo infrastructure

🤖 Generated by gap-filler-contabo-1