### PR TITLE
feat: Add Hostinger cline support

### DIFF
--- a/hostinger/cline.sh
+++ b/hostinger/cline.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostinger/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostinger/lib/common.sh)"
+fi
+
+log_info "Cline on Hostinger VPS"
+echo ""
+
+ensure_hostinger_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${HOSTINGER_VPS_IP}"
+wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
+
+log_warn "Installing Cline..."
+run_server "${HOSTINGER_VPS_IP}" "npm install -g cline"
+log_info "Cline installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Hostinger VPS setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
+echo ""
+
+log_warn "Starting Cline..."
+sleep 1
+clear
+interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && cline"

--- a/manifest.json
+++ b/manifest.json
@@ -690,7 +690,7 @@
         "location": "eu-central",
         "os_template": "ubuntu-24.04"
       },
-      "notes": "Budget VPS provider with cloud-init pre-installed. Starting at $4.95/mo. Requires HOSTINGER_API_KEY from hPanel → Profile → Account Information → API. API docs at developers.hostinger.com"
+      "notes": "Budget VPS provider with cloud-init pre-installed. Starting at $4.95/mo. Requires HOSTINGER_API_KEY from hPanel \u2192 Profile \u2192 Account Information \u2192 API. API docs at developers.hostinger.com"
     },
     "local": {
       "name": "Local Machine",
@@ -1134,7 +1134,7 @@
     "hostinger/interpreter": "missing",
     "hostinger/gemini": "missing",
     "hostinger/amazonq": "missing",
-    "hostinger/cline": "missing",
+    "hostinger/cline": "implemented",
     "hostinger/gptme": "missing",
     "hostinger/opencode": "missing",
     "hostinger/plandex": "missing",


### PR DESCRIPTION
Implements the missing `hostinger/cline` matrix entry.

## Implementation

- Created `hostinger/cline.sh` using the Hostinger VPS provisioning primitives
- Installs Cline via npm
- Injects OpenRouter credentials via OPENAI_BASE_URL override
- Marked matrix entry as `implemented`

Related to matrix gap-filling for Hostinger.