### PR TITLE
feat: Add Hostinger plandex support

### DIFF
--- a/hostinger/plandex.sh
+++ b/hostinger/plandex.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostinger/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostinger/lib/common.sh)"
+fi
+
+log_info "Plandex on Hostinger VPS"
+echo ""
+
+# 1. Resolve Hostinger API token
+ensure_hostinger_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${HOSTINGER_VPS_IP}"
+wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
+
+# 5. Install Plandex
+log_warn "Installing Plandex..."
+run_server "${HOSTINGER_VPS_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${HOSTINGER_VPS_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    log_error "The 'plandex' command is not available or not working properly on server ${HOSTINGER_VPS_IP}"
+    exit 1
+fi
+log_info "Plandex installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Hostinger VPS setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
+echo ""
+
+# 7. Start Plandex interactively
+log_warn "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && plandex"

--- a/manifest.json
+++ b/manifest.json
@@ -1137,7 +1137,7 @@
     "hostinger/cline": "missing",
     "hostinger/gptme": "missing",
     "hostinger/opencode": "implemented",
-    "hostinger/plandex": "missing",
+    "hostinger/plandex": "implemented",
     "hostinger/kilocode": "implemented",
     "hostinger/continue": "missing",
     "local/claude": "implemented",


### PR DESCRIPTION
## Summary
- Implements `hostinger/plandex.sh` using Hostinger VPS API
- Updates `manifest.json` to mark `hostinger/plandex` as implemented

## Implementation Details
- Uses `hostinger/lib/common.sh` cloud primitives for provisioning
- Follows standard pattern from `hetzner/plandex.sh`
- Installs Plandex via official installer
- Verifies installation with version check
- Injects `OPENROUTER_API_KEY` environment variable
- Launches interactive Plandex session

🤖 Generated with gap-filler-hostinger-4