### PR TITLE
feat: Add Contabo opencode support

### DIFF
--- a/contabo/opencode.sh
+++ b/contabo/opencode.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=contabo/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/contabo/lib/common.sh)"
+fi
+
+log_info "OpenCode on Contabo"
+echo ""
+
+ensure_contabo_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CONTABO_SERVER_IP}"
+wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
+
+log_warn "Installing OpenCode..."
+run_server "${CONTABO_SERVER_IP}" "$(opencode_install_cmd)"
+log_info "OpenCode installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Contabo server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
+echo ""
+
+log_warn "Starting OpenCode..."
+sleep 1
+clear
+interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/manifest.json
+++ b/manifest.json
@@ -1121,7 +1121,7 @@
     "contabo/amazonq": "implemented",
     "contabo/cline": "implemented",
     "contabo/gptme": "implemented",
-    "contabo/opencode": "missing",
+    "contabo/opencode": "implemented",
     "contabo/plandex": "implemented",
     "contabo/kilocode": "implemented",
     "contabo/continue": "implemented",


### PR DESCRIPTION
Implements contabo/opencode.sh

## Changes
- Created contabo/opencode.sh using Contabo cloud primitives
- Updated manifest.json matrix entry to "implemented"

## Implementation
- Sources contabo/lib/common.sh for cloud-specific functions
- Follows the same pattern as hetzner/opencode.sh
- Installs opencode via official install script
- Injects OPENROUTER_API_KEY into environment
- Launches opencode in interactive mode

Agent: gap-filler-contabo-3