### PR TITLE
feat: Add Hostinger continue support

### DIFF
--- a/hostinger/continue.sh
+++ b/hostinger/continue.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostinger/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostinger/lib/common.sh)"
+fi
+
+log_info "Continue on Hostinger VPS"
+echo ""
+
+ensure_hostinger_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${HOSTINGER_VPS_IP}"
+wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
+
+log_warn "Installing Continue CLI..."
+run_server "${HOSTINGER_VPS_IP}" "npm install -g @continuedev/cli"
+log_info "Continue installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${HOSTINGER_VPS_IP}" \
+    "run_server ${HOSTINGER_VPS_IP}"
+
+echo ""
+log_info "Hostinger server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
+echo ""
+
+log_warn "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && cn"

--- a/manifest.json
+++ b/manifest.json
@@ -1139,7 +1139,7 @@
     "hostinger/opencode": "implemented",
     "hostinger/plandex": "missing",
     "hostinger/kilocode": "implemented",
-    "hostinger/continue": "missing",
+    "hostinger/continue": "implemented",
     "local/claude": "implemented",
     "local/openclaw": "implemented",
     "local/nanoclaw": "implemented",


### PR DESCRIPTION
## Summary
- Implements hostinger/continue matrix entry
- Uses Hostinger VPS API primitives from hostinger/lib/common.sh
- Follows same pattern as hetzner/continue.sh
- Installs Continue CLI via npm (@continuedev/cli)
- Configures OpenRouter integration with setup_continue_config
- Updates manifest.json matrix status to "implemented"

## Test plan
- [ ] Syntax validated with `bash -n`
- [ ] Follows Hostinger VPS provisioning pattern
- [ ] Injects required env vars (OPENROUTER_API_KEY)
- [ ] Creates Continue config with OpenRouter provider
- [ ] Launches interactive session with cn (Continue TUI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)