### PR TITLE
feat: Add Hostinger gptme support

### DIFF
--- a/hostinger/gptme.sh
+++ b/hostinger/gptme.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostinger/lib/common.sh)"
+fi
+
+log_info "gptme on Hostinger VPS"
+echo ""
+
+# 1. Resolve Hostinger API token
+ensure_hostinger_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "$SERVER_NAME"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "$HOSTINGER_VPS_IP"
+wait_for_cloud_init "$HOSTINGER_VPS_IP"
+
+# 5. Install gptme
+log_warn "Installing gptme..."
+run_server "$HOSTINGER_VPS_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
+
+# Verify installation succeeded
+if ! run_server "$HOSTINGER_VPS_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
+    log_error "gptme installation verification failed"
+    log_error "The 'gptme' command is not available or not working properly on server $HOSTINGER_VPS_IP"
+    exit 1
+fi
+log_info "gptme installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "$HOSTINGER_VPS_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
+
+echo ""
+log_info "Hostinger VPS setup completed successfully!"
+log_info "Server: $SERVER_NAME (ID: $HOSTINGER_VPS_ID, IP: $HOSTINGER_VPS_IP)"
+echo ""
+
+# 9. Start gptme interactively
+log_warn "Starting gptme..."
+sleep 1
+clear
+interactive_session "$HOSTINGER_VPS_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/manifest.json
+++ b/manifest.json
@@ -1135,7 +1135,7 @@
     "hostinger/gemini": "implemented",
     "hostinger/amazonq": "missing",
     "hostinger/cline": "implemented",
-    "hostinger/gptme": "missing",
+    "hostinger/gptme": "implemented",
     "hostinger/opencode": "implemented",
     "hostinger/plandex": "missing",
     "hostinger/kilocode": "implemented",


### PR DESCRIPTION
Implements the missing `hostinger/gptme` matrix entry.

## Implementation

- Created `hostinger/gptme.sh` using the Hostinger VPS provisioning primitives
- Installs gptme via pip
- Injects OpenRouter API key
- Supports interactive model selection
- Marked matrix entry as `implemented`

Related to matrix gap-filling for Hostinger.