### PR TITLE
feat: Add Hostinger amazonq support

### DIFF
--- a/hostinger/amazonq.sh
+++ b/hostinger/amazonq.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostinger/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostinger/lib/common.sh)"
+fi
+
+log_info "Amazon Q on Hostinger VPS"
+echo ""
+
+ensure_hostinger_token
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${HOSTINGER_VPS_IP}"
+wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
+
+log_warn "Installing Amazon Q CLI..."
+run_server "${HOSTINGER_VPS_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Hostinger VPS setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
+echo ""
+
+log_warn "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && q chat"

--- a/manifest.json
+++ b/manifest.json
@@ -1133,7 +1133,7 @@
     "hostinger/codex": "implemented",
     "hostinger/interpreter": "missing",
     "hostinger/gemini": "implemented",
-    "hostinger/amazonq": "missing",
+    "hostinger/amazonq": "implemented",
     "hostinger/cline": "implemented",
     "hostinger/gptme": "missing",
     "hostinger/opencode": "implemented",


### PR DESCRIPTION
## Summary
- Implement hostinger/amazonq.sh using Hostinger VPS primitives
- Update manifest.json matrix entry to "implemented"
- Uses OpenRouter API for Amazon Q CLI

## Test plan
- [ ] bash -n hostinger/amazonq.sh passes
- [ ] Script follows curl|bash pattern with local-or-remote fallback
- [ ] OpenRouter injection is mandatory and correctly configured
- [ ] Script matches pattern from hetzner/amazonq.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)