### PR TITLE
fix: Quote env values in generate_env_config to prevent shell injection

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -774,11 +774,17 @@ get_openrouter_api_key_oauth() {
 # Generate environment variable config content
 # Usage: generate_env_config KEY1=val1 KEY2=val2 ...
 # Outputs the env config to stdout
+# SECURITY: Values are single-quoted to prevent shell injection when sourced.
+# Single quotes prevent all interpretation of special characters ($, `, \, etc.)
 generate_env_config() {
     echo ""
     echo "# [spawn:env]"
     for env_pair in "$@"; do
-        echo "export ${env_pair}"
+        local key="${env_pair%%=*}"
+        local value="${env_pair#*=}"
+        # Escape any single quotes in the value: replace ' with '\''
+        local escaped_value="${value//\'/\'\\\'\'}"
+        echo "export ${key}='${escaped_value}'"
     done
 }
 


### PR DESCRIPTION
## Summary

- Fix shell injection vulnerability in `generate_env_config()` in `shared/common.sh`
- Values were written as `export KEY=VALUE` (unquoted), meaning shell metacharacters (`$`, backticks, spaces, etc.) would be interpreted when the config file is sourced
- Values are now single-quoted (`export KEY='VALUE'`), preventing all shell interpretation
- Single quotes within values are properly escaped using the standard `'\''` technique

## Security Impact

**Severity: HIGH** - When environment config files generated by `generate_env_config` are sourced by the remote server's shell (via `.zshrc`/`.bashrc`), unquoted values containing `$(...)`, backticks, or other shell metacharacters would be executed. While the primary values (API keys, URLs) are typically safe, this is a defense-in-depth fix that prevents exploitation if a value ever contains special characters.

## Test plan

- [x] `bash -n shared/common.sh` passes
- [x] All 3571 CLI tests pass (`bun test`)
- [x] All 75 shell tests pass (`bash test/run.sh`)
- [x] Verified that `$(whoami)` in a value is NOT interpreted when sourced
- [x] Verified single quotes in values are properly escaped
- [x] Verified normal API keys and URLs work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)