### PR TITLE
fix: improve fuzzy matching to check display names

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cli-entry-edge-cases.test.ts
+++ b/cli/src/__tests__/cli-entry-edge-cases.test.ts
@@ -435,7 +435,7 @@ describe("fuzzy matching edge cases in showInfoOrError", () => {
     const out = output(result);
     // Should suggest sprite as a cloud
     expect(out).toContain("sprite");
-    expect(out).toContain("(cloud)");
+    expect(out).toContain("(cloud:");
   });
 });
 

--- a/cli/src/__tests__/commands-name-suggestions.test.ts
+++ b/cli/src/__tests__/commands-name-suggestions.test.ts
@@ -231,10 +231,9 @@ describe("Display Name Suggestions in Validation Errors", () => {
       await expect(cmdRun("claud", "sprite")).rejects.toThrow("process.exit");
 
       const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
-      // Should suggest via key match, not display name match
+      // Should suggest via key match and always show display name for clarity
       expect(infoCalls.some((msg: string) => msg.includes("claude"))).toBe(true);
-      // Should NOT show display name in parentheses (that's the name suggestion format)
-      expect(infoCalls.some((msg: string) => msg.includes("Claude Code"))).toBe(false);
+      expect(infoCalls.some((msg: string) => msg.includes("Claude Code"))).toBe(true);
     });
   });
 
@@ -285,8 +284,8 @@ describe("Display Name Suggestions in Validation Errors", () => {
 
       const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("sprite"))).toBe(true);
-      // Should be plain suggestion, not display name format with parentheses
-      expect(infoCalls.some((msg: string) => msg.includes("Sprite"))).toBe(false);
+      // Should always show display name for clarity
+      expect(infoCalls.some((msg: string) => msg.includes("Sprite"))).toBe(true);
     });
   });
 

--- a/cli/src/__tests__/show-info-or-error.test.ts
+++ b/cli/src/__tests__/show-info-or-error.test.ts
@@ -193,8 +193,8 @@ describe("showInfoOrError - single argument routing", () => {
       // "aidr" should match "aider" (an agent)
       const result = runCli(["aidr"]);
       const output = result.stdout + result.stderr;
-      // showInfoOrError labels suggestions as "(agent)" or "(cloud)"
-      expect(output).toMatch(/\(agent\)|\(cloud\)/);
+      // showInfoOrError labels suggestions as "(agent: Name)" or "(cloud: Name)"
+      expect(output).toMatch(/\(agent:|\(cloud:/);
     });
   });
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,7 +9,7 @@ import {
   cmdCloudInfo,
   cmdUpdate,
   cmdHelp,
-  findClosestMatch,
+  findClosestKeyByNameOrKey,
   resolveAgentKey,
   resolveCloudKey,
   loadManifestWithSpinner,
@@ -108,18 +108,20 @@ async function showInfoOrError(name: string): Promise<void> {
     return;
   }
 
-  // Fall back to fuzzy matching suggestions
-  const agentMatch = findClosestMatch(name, agentKeys(manifest));
-  const cloudMatch = findClosestMatch(name, cloudKeys(manifest));
+  // Fall back to fuzzy matching suggestions (checks both keys and display names)
+  const agentMatch = findClosestKeyByNameOrKey(name, agentKeys(manifest), (k) => manifest.agents[k].name);
+  const cloudMatch = findClosestKeyByNameOrKey(name, cloudKeys(manifest), (k) => manifest.clouds[k].name);
 
   console.error(pc.red(`Unknown command: ${pc.bold(name)}`));
   console.error();
+  const fmtAgent = agentMatch ? `${pc.cyan(agentMatch)} (agent: ${manifest.agents[agentMatch].name})` : "";
+  const fmtCloud = cloudMatch ? `${pc.cyan(cloudMatch)} (cloud: ${manifest.clouds[cloudMatch].name})` : "";
   if (agentMatch && cloudMatch) {
-    console.error(`  Did you mean ${pc.cyan(agentMatch)} (agent) or ${pc.cyan(cloudMatch)} (cloud)?`);
+    console.error(`  Did you mean ${fmtAgent} or ${fmtCloud}?`);
   } else if (agentMatch) {
-    console.error(`  Did you mean ${pc.cyan(agentMatch)} (agent)?`);
+    console.error(`  Did you mean ${fmtAgent}?`);
   } else if (cloudMatch) {
-    console.error(`  Did you mean ${pc.cyan(cloudMatch)} (cloud)?`);
+    console.error(`  Did you mean ${fmtCloud}?`);
   }
   console.error();
   console.error(`  Run ${pc.cyan("spawn agents")} to see available agents.`);


### PR DESCRIPTION
## Summary
- Added `findClosestKeyByNameOrKey()` that fuzzy-matches user input against both manifest keys (e.g. `claude`) and display names (e.g. `Claude Code`), returning the best match
- Updated `validateAgent`, `validateCloud`, and `showInfoOrError` to use unified fuzzy matching, replacing the previous dual-call pattern
- Suggestions now always show the display name for clarity: `Did you mean claude (Claude Code)?` instead of just `Did you mean claude?`
- Bumped CLI version to 0.2.31

## Before
```
$ spawn Hetzne
Unknown command: Hetzne
  (no suggestion - "Hetzne" is too far from key "hetzner" but close to display name "Hetzner")
```

## After
```
$ spawn Hetzne
Unknown command: Hetzne
  Did you mean hetzner (cloud: Hetzner)?
```

## Test plan
- [x] All 3571 existing tests pass (0 failures)
- [x] Updated 3 test files to match new suggestion format
- [x] Verified fuzzy matching works for both key typos and display name typos

🤖 Generated with [Claude Code](https://claude.com/claude-code)