### PR TITLE
fix: improve UX with version hints, non-TTY message, and retry bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Launch any AI agent on any cloud with a single command. Coding agents, research agents, self-hosted AI tools — Spawn deploys them all. All models powered by [OpenRouter](https://openrouter.ai). (ALPHA software, use at your own risk!)
 
-**15 agents. 32 clouds. 444 combinations. Zero config.**
+**15 agents. 32 clouds. 445 combinations. Zero config.**
 
 ## Install
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -244,8 +244,8 @@ async function main(): Promise<void> {
       if (isInteractiveTTY()) {
         await cmdInteractive();
       } else {
-        console.error(pc.yellow("Non-interactive terminal detected (no TTY). Showing help instead of interactive picker."));
-        console.error(pc.dim("To launch directly, use: spawn <agent> <cloud>\n"));
+        console.error(pc.yellow("No interactive terminal detected."));
+        console.error(pc.dim(`To launch directly: ${pc.cyan("spawn <agent> <cloud>")}\n`));
         cmdHelp();
       }
       return;
@@ -255,6 +255,7 @@ async function main(): Promise<void> {
     const showVersion = () => {
       console.log(`spawn v${VERSION}`);
       console.log(pc.dim(`  ${process.argv[1] ?? "unknown path"}`));
+      console.log(pc.dim(`  Run ${pc.cyan("spawn update")} to check for updates.`));
     };
     const immediateCommands: Record<string, () => void> = {
       "help": cmdHelp, "--help": cmdHelp, "-h": cmdHelp,

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1023,7 +1023,7 @@ _api_handle_transient_http_error() {
         error_msg="service unavailable"
     fi
 
-    if ! _api_should_retry_on_error "http_${http_code}" "${attempt}" "${max_retries}" "${interval}" "${max_interval}" "Cloud API returned ${error_msg} (HTTP ${http_code})"; then
+    if ! _api_should_retry_on_error "${attempt}" "${max_retries}" "${interval}" "${max_interval}" "Cloud API returned ${error_msg} (HTTP ${http_code})"; then
         log_error "Cloud API returned HTTP ${http_code} after ${max_retries} attempts"
         return 1
     fi


### PR DESCRIPTION
## Summary

- **Version output now hints about updates**: `spawn version` shows `Run spawn update to check for updates` so users discover the update command
- **Clearer non-TTY message**: Simplified from "Non-interactive terminal detected (no TTY). Showing help instead of interactive picker." to just "No interactive terminal detected." with a highlighted direct-launch hint
- **Fix retry logic bug**: `_api_handle_transient_http_error` was passing `"http_429"` as the attempt number to `_api_should_retry_on_error` instead of the actual attempt count, causing incorrect retry behavior and misleading retry messages
- **Sync README count**: 444 -> 445 combinations to match current manifest

## Test plan
- [x] All 3595 CLI tests pass (0 failures)
- [x] `bash -n shared/common.sh` passes
- [x] Version bump to 0.2.32

Agent: ux-engineer