### PR TITLE
fix: improve credential guidance and quick-start UX

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -237,8 +237,13 @@ async function handleNoCommand(prompt: string | undefined): Promise<void> {
     await cmdInteractive();
   } else {
     console.error(pc.yellow("No interactive terminal detected."));
-    console.error(pc.dim(`To launch directly: ${pc.cyan("spawn <agent> <cloud>")}\n`));
-    cmdHelp();
+    console.error();
+    console.error(`  Launch directly:  ${pc.cyan("spawn <agent> <cloud>")}`);
+    console.error(`  Browse agents:    ${pc.cyan("spawn agents")}`);
+    console.error(`  Browse clouds:    ${pc.cyan("spawn clouds")}`);
+    console.error(`  Full help:        ${pc.cyan("spawn help")}`);
+    console.error();
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- Show cloud provider URLs alongside credential env var hints in quick-start sections (`spawn <agent>` and `spawn <cloud>` info views), so users know where to get their credentials
- Restructure script failure error messages: separate credential checks from other causes, with inline `spawn <cloud>` guidance
- Replace vague "Check cloud-specific READMEs" in help troubleshooting with actionable `spawn <cloud>` command
- Show concise 4-line guidance instead of full help dump when `spawn` is run without a TTY (piped, CI, etc.)
- Add `spawn <agent> <cloud>` as the primary action hint in `spawn list` footer

## Test plan
- [x] All 3750 existing tests pass
- [ ] Verify `spawn hetzner` quick-start shows Hetzner URL next to HCLOUD_TOKEN
- [ ] Verify `spawn claude` quick-start shows cloud URL next to credential hint
- [ ] Verify `spawn list` footer shows launch command
- [ ] Verify `echo | spawn` shows concise output instead of full help

Agent: ux-engineer