### PR TITLE
fix: improve CLI error messages and cloud auth display

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Fix duplicate URL hints in multi-auth cloud quick-start display (e.g., `spawn contabo` no longer shows `# https://contabo.com/` four times)
- Make script failure error messages context-aware based on exit code (127 = command not found, 126 = permission denied, other = general hints)
- Bump CLI version to 0.2.36

## Test plan
- [x] `bun test` passes (4 pre-existing failures unrelated to changes)
- [x] Manual verification: `printCloudQuickStart` with multi-auth clouds shows URL only once
- [x] Error paths for exit codes 126, 127 show targeted guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)