### PR TITLE
test: fix non-TTY test expectations to match CLI behavior

### DIFF
--- a/cli/src/__tests__/cli-entry-edge-cases.test.ts
+++ b/cli/src/__tests__/cli-entry-edge-cases.test.ts
@@ -247,24 +247,24 @@ describe("version flag edge cases", () => {
 // ── Non-TTY behavior ──────────────────────────────────────────────────────
 
 describe("non-TTY behavior", () => {
-  it("should show help output when no args in non-TTY (subprocess) mode", () => {
+  it("should show non-TTY hint when no args in non-TTY (subprocess) mode", () => {
     // Subprocesses don't have TTY stdin, so isInteractiveTTY returns false
     const result = runCli([]);
     const out = output(result);
-    expect(out).toContain("USAGE");
-    expect(result.exitCode).toBe(0);
+    expect(out).toContain("No interactive terminal detected");
+    expect(result.exitCode).toBe(1);
   });
 
-  it("should include EXAMPLES section in non-TTY help", () => {
+  it("should include launch hint in non-TTY output", () => {
     const result = runCli([]);
     const out = output(result);
-    expect(out).toContain("EXAMPLES");
+    expect(out).toContain("spawn <agent> <cloud>");
   });
 
-  it("should include AUTHENTICATION section in non-TTY help", () => {
+  it("should include help hint in non-TTY output", () => {
     const result = runCli([]);
     const out = output(result);
-    expect(out).toContain("AUTHENTICATION");
+    expect(out).toContain("spawn help");
   });
 });
 

--- a/cli/src/__tests__/index-main-routing.test.ts
+++ b/cli/src/__tests__/index-main-routing.test.ts
@@ -174,12 +174,11 @@ describe("index.ts main() routing", () => {
   // ── non-TTY mode with no args ──────────────────────────────────────
 
   describe("non-TTY mode", () => {
-    it("should show help when run without args in non-TTY mode", () => {
-      // When stdin is not a TTY (piped), and no args, it shows help
+    it("should show non-TTY hint when run without args in non-TTY mode", () => {
+      // When stdin is not a TTY (piped), and no args, it shows the non-TTY hint
       const result = runCli([]);
       const output = result.stdout + result.stderr;
-      // In non-TTY mode (subprocess), it should show help output
-      expect(output).toContain("USAGE");
+      expect(output).toContain("No interactive terminal detected");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fix 4 failing tests in `cli-entry-edge-cases.test.ts` and `index-main-routing.test.ts`
- Tests expected help output (USAGE/EXAMPLES/AUTHENTICATION) in non-TTY mode
- CLI actually shows "No interactive terminal detected" hint with exit code 1
- Updated test expectations to match actual behavior

## Test plan
- [ ] `bun test` passes (these 4 tests were the pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)