### PR TITLE
feat: Add Continue agent for Netcup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -706,7 +706,7 @@
         "datacenter": "Nuremberg",
         "image": "ubuntu-24.04"
       },
-      "notes": "German budget VPS provider starting at €3.86/mo. Session-based REST API launched Oct 2025. Requires NETCUP_CUSTOMER_NUMBER, NETCUP_API_KEY, and NETCUP_API_PASSWORD from https://ccp.netcup.net/ → Settings → API"
+      "notes": "German budget VPS provider starting at \u20ac3.86/mo. Session-based REST API launched Oct 2025. Requires NETCUP_CUSTOMER_NUMBER, NETCUP_API_KEY, and NETCUP_API_PASSWORD from https://ccp.netcup.net/ \u2192 Settings \u2192 API"
     },
     "local": {
       "name": "Local Machine",
@@ -732,7 +732,7 @@
         "flavor": "1GB",
         "image": "Ubuntu 24.04"
       },
-      "notes": "Budget VPS provider with OpenStack API. Hourly billing starting at $0.006/hr (~$4.38/mo). Full OpenStack compatibility. Get credentials from https://manage.ramnode.com/ → Cloud → API Users. Requires RAMNODE_USERNAME, RAMNODE_PASSWORD, and RAMNODE_PROJECT_ID."
+      "notes": "Budget VPS provider with OpenStack API. Hourly billing starting at $0.006/hr (~$4.38/mo). Full OpenStack compatibility. Get credentials from https://manage.ramnode.com/ \u2192 Cloud \u2192 API Users. Requires RAMNODE_USERNAME, RAMNODE_PASSWORD, and RAMNODE_PROJECT_ID."
     }
   },
   "matrix": {
@@ -1185,7 +1185,7 @@
     "netcup/opencode": "missing",
     "netcup/plandex": "missing",
     "netcup/kilocode": "missing",
-    "netcup/continue": "missing",
+    "netcup/continue": "implemented",
     "local/claude": "implemented",
     "local/openclaw": "implemented",
     "local/nanoclaw": "implemented",

--- a/netcup/continue.sh
+++ b/netcup/continue.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=netcup/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/netcup/lib/common.sh)"
+fi
+
+log_info "Continue on Netcup"
+echo ""
+
+ensure_netcup_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${NETCUP_SERVER_IP}"
+wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
+
+log_warn "Installing Continue CLI..."
+run_server "${NETCUP_SERVER_IP}" "npm install -g @continuedev/cli"
+log_info "Continue installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${NETCUP_SERVER_IP}" \
+    "run_server ${NETCUP_SERVER_IP}"
+
+echo ""
+log_info "Netcup server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_IP})"
+echo ""
+
+log_warn "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && cn"


### PR DESCRIPTION
Implements netcup/continue.sh by combining Netcup cloud primitives with Continue agent setup.