### PR TITLE
fix: add log_step for progress messages, fix misleading prompt error

### DIFF
--- a/cli/src/__tests__/security.test.ts
+++ b/cli/src/__tests__/security.test.ts
@@ -182,8 +182,8 @@ wget http://example.com/install.sh | sh
         validatePrompt("Run $(echo test)");
         throw new Error("Expected validatePrompt to throw");
       } catch (e: any) {
-        expect(e.message).toContain("prompt-file");
-        expect(e.message).toContain("spawn");
+        expect(e.message).toContain("false positive");
+        expect(e.message).toContain("rephrasing");
       }
     });
 

--- a/cli/src/security.ts
+++ b/cli/src/security.ts
@@ -108,9 +108,8 @@ export function validatePrompt(prompt: string): void {
       throw new Error(
         `Prompt blocked: contains potentially dangerous pattern (${description}).\n` +
         `\n` +
-        `If this is a false positive, use --prompt-file instead:\n` +
-        `  echo "your prompt" > prompt.txt\n` +
-        `  spawn <agent> <cloud> --prompt-file prompt.txt`
+        `If this is a false positive, try rephrasing to avoid shell-like syntax\n` +
+        `(e.g., describe the command instead of writing it literally).`
       );
     }
   }

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -31,9 +31,9 @@ verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${DO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${DO_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
@@ -54,7 +54,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -74,7 +74,7 @@ log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -166,7 +166,7 @@ create_server() {
     validate_resource_name "$size" || { log_error "Invalid DO_DROPLET_SIZE"; return 1; }
     validate_region_name "$region" || { log_error "Invalid DO_REGION"; return 1; }
 
-    log_warn "Creating DigitalOcean droplet '$name' (size: $size, region: $region)..."
+    log_step "Creating DigitalOcean droplet '$name' (size: $size, region: $region)..."
 
     # Get all SSH key IDs
     local ssh_keys_response
@@ -219,7 +219,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 destroy_server() {
     local droplet_id="$1"
 
-    log_warn "Destroying droplet $droplet_id..."
+    log_step "Destroying droplet $droplet_id..."
     local response
     response=$(do_api DELETE "/droplets/$droplet_id")
 

--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${HETZNER_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${HETZNER_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
@@ -50,7 +50,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -70,7 +70,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -244,7 +244,7 @@ create_server() {
     validate_resource_name "$server_type" || { log_error "Invalid HETZNER_SERVER_TYPE"; return 1; }
     validate_region_name "$location" || { log_error "Invalid HETZNER_LOCATION"; return 1; }
 
-    log_warn "Creating Hetzner server '$name' (type: $server_type, location: $location)..."
+    log_step "Creating Hetzner server '$name' (type: $server_type, location: $location)..."
 
     # Get all SSH key IDs
     local ssh_keys_response
@@ -280,7 +280,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 destroy_server() {
     local server_id="$1"
 
-    log_warn "Destroying server $server_id..."
+    log_step "Destroying server $server_id..."
     local response
     response=$(hetzner_api DELETE "/servers/$server_id")
 

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -53,7 +53,7 @@ ensure_sprite_installed() {
     done
 
     # sprite not found, install it
-    log_warn "Installing sprite CLI..."
+    log_step "Installing sprite CLI..."
     if ! curl -fsSL https://sprites.dev/install.sh | bash; then
         log_error "Failed to install sprite CLI"
         log_error ""
@@ -80,7 +80,7 @@ ensure_sprite_installed() {
 # Check if already authenticated with sprite
 ensure_sprite_authenticated() {
     if ! sprite org list &> /dev/null; then
-        log_warn "Logging in to sprite..."
+        log_step "Logging in to sprite..."
         sprite login || true
     fi
 }
@@ -107,10 +107,10 @@ ensure_sprite_exists() {
         return 0
     fi
 
-    log_warn "Creating sprite '${sprite_name}'..."
+    log_step "Creating sprite '${sprite_name}'..."
     sprite create -skip-console "${sprite_name}" || true
 
-    log_warn "Waiting for sprite to be provisioned..."
+    log_step "Waiting for sprite to be provisioned..."
     local elapsed=0
     while [[ "${elapsed}" -lt "${max_wait}" ]]; do
         if sprite list 2>/dev/null | grep -qE "^${sprite_name}( |$)"; then
@@ -131,13 +131,13 @@ verify_sprite_connectivity() {
     local max_attempts=${2:-6}
     local attempt=1
 
-    log_warn "Verifying sprite connectivity..."
+    log_step "Verifying sprite connectivity..."
     while [[ "${attempt}" -le "${max_attempts}" ]]; do
         if sprite exec -s "${sprite_name}" -- echo "ok" >/dev/null 2>&1; then
             log_info "Sprite '${sprite_name}' is ready"
             return 0
         fi
-        log_warn "Sprite not ready, retrying (${attempt}/${max_attempts})..."
+        log_step "Sprite not ready, retrying (${attempt}/${max_attempts})..."
         sleep "${SPRITE_CONNECTIVITY_POLL_DELAY}"
         ((attempt++))
     done
@@ -166,7 +166,7 @@ run_sprite() {
 # Configure shell environment (PATH, zsh setup)
 setup_shell_environment() {
     local sprite_name=${1}
-    log_warn "Configuring shell environment..."
+    log_step "Configuring shell environment..."
 
     # Create temp file with path config
     local path_temp


### PR DESCRIPTION
## Summary

- **Add `log_step()` function** (cyan colored) to `shared/common.sh` for progress/status messages, distinct from `log_warn` (yellow) which should be reserved for actual warnings
- **Convert misused `log_warn` to `log_step`** in `shared/common.sh` (14 instances: SSH key generation, agent verification, waiting/polling, configuring agents, API token prompts, SSH key registration)
- **Convert representative cloud scripts** (hetzner, digitalocean, sprite) to demonstrate the pattern for other clouds
- **Fix misleading `validatePrompt` error message** that suggested `--prompt-file` as a workaround, when `--prompt-file` goes through the same validation and would produce the same error

## Why

The codebase had ~1600 instances of `log_warn` (yellow warning color) being used for normal progress messages like "Verifying installation...", "Setting up environment variables...", and "Starting Claude Code...". This made the output look alarming when nothing was wrong. The new `log_step` function provides a proper semantic distinction:
- `log_info` (green) = success/completion
- `log_step` (cyan) = progress/status
- `log_warn` (yellow) = actual warnings
- `log_error` (red) = errors

## Test plan
- [x] `bash -n` passes on all modified `.sh` files
- [x] `bun test` passes (3815 tests, 0 failures)
- [ ] Visual check: progress messages appear in cyan instead of yellow

Agent: ux-engineer