### PR TITLE
fix: use log_step for progress messages in netcup scripts

### DIFF
--- a/netcup/aider.sh
+++ b/netcup/aider.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
 # 5. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${NETCUP_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 # Verify installation succeeded
@@ -50,7 +50,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -60,7 +60,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_I
 echo ""
 
 # 9. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/netcup/claude.sh
+++ b/netcup/claude.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${NETCUP_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
     log_warn "Claude Code not found, installing manually..."
     run_server "${NETCUP_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
@@ -50,7 +50,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -70,7 +70,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_I
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/netcup/codex.sh
+++ b/netcup/codex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${NETCUP_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Netcup server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && codex"

--- a/netcup/continue.sh
+++ b/netcup/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${NETCUP_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Netcup server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && cn"

--- a/netcup/gemini.sh
+++ b/netcup/gemini.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${NETCUP_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -46,7 +46,7 @@ log_info "Netcup server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/netcup/goose.sh
+++ b/netcup/goose.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
 # 5. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${NETCUP_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -58,7 +58,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_I
 echo ""
 
 # 8. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && goose"

--- a/netcup/interpreter.sh
+++ b/netcup/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${NETCUP_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Netcup server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/netcup/lib/common.sh
+++ b/netcup/lib/common.sh
@@ -366,7 +366,7 @@ create_server() {
 
     local image="ubuntu-24.04"
 
-    log_warn "Creating Netcup VPS '$name' (product: $product, datacenter: $datacenter)..."
+    log_step "Creating Netcup VPS '$name' (product: $product, datacenter: $datacenter)..."
 
     # Get cloud-init userdata and build request body
     local param

--- a/netcup/nanoclaw.sh
+++ b/netcup/nanoclaw.sh
@@ -28,10 +28,10 @@ verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
 # 5. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${NETCUP_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${NETCUP_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -43,14 +43,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -67,7 +67,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_I
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
-log_warn "You will need to scan a WhatsApp QR code to authenticate."
+log_step "Starting nanoclaw..."
+log_info "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${NETCUP_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/netcup/openclaw.sh
+++ b/netcup/openclaw.sh
@@ -28,11 +28,11 @@ verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
 # 5. Install bun
-log_warn "Installing bun..."
+log_step "Installing bun..."
 run_server "${NETCUP_SERVER_IP}" "curl -fsSL https://bun.sh/install | bash"
 
 # 6. Install openclaw
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${NETCUP_SERVER_IP}" "export PATH=\$HOME/.bun/bin:\$PATH && bun install -g openclaw"
 
 # 7. Get OpenRouter API key
@@ -46,7 +46,7 @@ fi
 # 8. Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -63,7 +63,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_I
 echo ""
 
 # 10. Start openclaw gateway in background and run openclaw tui
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${NETCUP_SERVER_IP}" "export PATH=\$HOME/.bun/bin:\$PATH && source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${NETCUP_SERVER_IP}" "export PATH=\$HOME/.bun/bin:\$PATH && source ~/.zshrc && openclaw tui"


### PR DESCRIPTION
## Summary
- Replace `log_warn` (yellow) with `log_step` (cyan) for progress messages in all 9 netcup agent scripts and `netcup/lib/common.sh`
- Affected messages: "Installing...", "Setting up environment variables...", "Starting...", "Verifying...", "Configuring...", "Cloning...", "Creating VPS..."
- Keeps `log_warn` for actual warnings: invalid user choices, fallback defaults, destructive operations (destroying VPS)
- Changes nanoclaw WhatsApp QR code notice from `log_warn` to `log_info` (it's informational, not a warning)

## Context
PR #440 added `log_step` (cyan) for progress/status messages to distinguish them from `log_warn` (yellow) which should be reserved for actual warnings. The netcup scripts were added after that convention was established but used the old `log_warn` pattern.

## Test plan
- [x] All 10 modified `.sh` files pass `bash -n` syntax check
- [x] All 3841 CLI tests pass (`bun test`)