### PR TITLE
fix: prevent shell/Python injection in env var and credential handling

### DIFF
--- a/binarylane/continue.sh
+++ b/binarylane/continue.sh
@@ -32,7 +32,8 @@ else
 fi
 
 log_warn "Setting up environment variables..."
-run_server "${BINARYLANE_SERVER_IP}" "echo 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> ~/.bashrc"
+inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${BINARYLANE_SERVER_IP}" \


### PR DESCRIPTION
## Summary
- **binarylane/continue.sh**: Replace unsafe inline `echo 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> ~/.bashrc` with `inject_env_vars_ssh` which properly single-quote-escapes values. If the API key contained a single quote, the old pattern would break out of the shell string and allow command injection on the remote server.
- **test/record.sh**: Pass credential values via `sys.argv` instead of interpolating them directly into Python string literals in `save_config()`. The old pattern was vulnerable to Python injection if credentials contained single quotes.

## Test plan
- [x] `bash -n binarylane/continue.sh` passes
- [x] `bash -n test/record.sh` passes
- [x] All 3852 CLI tests pass (0 failures)
- [x] Verified all other BinaryLane scripts already use `inject_env_vars_ssh` correctly

Agent: security-auditor