### PR TITLE
fix: improve error messages with actionable guidance

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/exec-script-errors.test.ts
+++ b/cli/src/__tests__/exec-script-errors.test.ts
@@ -211,8 +211,36 @@ describe("execScript bash execution error handling", () => {
       expect(errors).toContain("Common causes");
     });
 
-    it("should mention missing credentials for generic failures", async () => {
+    it("should mention missing credentials for exit code 1", async () => {
       mockFetchWithScript("exit 1");
+      await loadManifest(true);
+
+      try {
+        await cmdRun("claude", "sprite");
+      } catch {
+        // Expected
+      }
+
+      const errors = getErrorOutput();
+      expect(errors).toContain("credentials");
+    });
+
+    it("should mention API errors for exit code 1", async () => {
+      mockFetchWithScript("exit 1");
+      await loadManifest(true);
+
+      try {
+        await cmdRun("claude", "sprite");
+      } catch {
+        // Expected
+      }
+
+      const errors = getErrorOutput();
+      expect(errors).toContain("API error");
+    });
+
+    it("should mention local dependencies for other exit codes", async () => {
+      mockFetchWithScript("exit 2");
       await loadManifest(true);
 
       try {
@@ -223,34 +251,6 @@ describe("execScript bash execution error handling", () => {
 
       const errors = getErrorOutput();
       expect(errors).toContain("Missing credentials");
-    });
-
-    it("should mention rate limits for generic failures", async () => {
-      mockFetchWithScript("exit 1");
-      await loadManifest(true);
-
-      try {
-        await cmdRun("claude", "sprite");
-      } catch {
-        // Expected
-      }
-
-      const errors = getErrorOutput();
-      expect(errors).toContain("rate limit");
-    });
-
-    it("should mention local dependencies for generic failures", async () => {
-      mockFetchWithScript("exit 1");
-      await loadManifest(true);
-
-      try {
-        await cmdRun("claude", "sprite");
-      } catch {
-        // Expected
-      }
-
-      const errors = getErrorOutput();
-      expect(errors).toContain("SSH");
       expect(errors).toContain("curl");
       expect(errors).toContain("jq");
     });

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -445,6 +445,11 @@ async function execScript(cloud: string, agent: string, prompt?: string): Promis
       console.error(`  - Cloud-specific CLI tools (run ${pc.cyan(`spawn ${cloud}`)} for details)`);
     } else if (exitCode === 126) {
       console.error("\nA command was found but could not be executed (permission denied).");
+    } else if (exitCode === 1) {
+      console.error("\nCommon causes:");
+      console.error(`  - Missing or invalid credentials (run ${pc.cyan(`spawn ${cloud}`)} for setup)`);
+      console.error("  - Cloud provider API error (quota, rate limit, or region issue)");
+      console.error("  - Server provisioning failed (try again or pick a different region)");
     } else {
       console.error("\nCommon causes:");
       console.error(`  - Missing credentials (run ${pc.cyan(`spawn ${cloud}`)} for setup instructions)`);
@@ -601,7 +606,9 @@ export async function cmdList(): Promise<void> {
   const impl = countImplemented(manifest);
   const total = agents.length * clouds.length;
   console.log();
-  if (!isCompact) {
+  if (isCompact) {
+    console.log(`${pc.green("N/N")} all clouds  ${pc.yellow("N/N")} some missing`);
+  } else {
     console.log(`${pc.green("+")} implemented  ${pc.dim("-")} not yet available`);
   }
   console.log(pc.green(`${impl}/${total} combinations implemented`));
@@ -876,7 +883,7 @@ export async function cmdUpdate(): Promise<void> {
       console.log();
     }
   } catch (err) {
-    s.stop(pc.red("Failed to check for updates"));
+    s.stop(pc.red(`Failed to check for updates ${pc.dim(`(current: v${VERSION})`)}`));
     console.error("Error:", getErrorMessage(err));
     console.error(`\nTroubleshooting:`);
     console.error(`  1. Check your internet connection`);

--- a/cli/src/security.ts
+++ b/cli/src/security.ts
@@ -71,7 +71,11 @@ export function validateScriptContent(script: string): void {
 
   // Ensure script starts with shebang
   if (!script.trim().startsWith("#!")) {
-    throw new Error("Script must start with a valid shebang (e.g., #!/bin/bash)");
+    throw new Error(
+      "Script must start with a valid shebang (e.g., #!/bin/bash).\n" +
+      "This usually means the download returned an error page instead of a script.\n" +
+      "Try again, or check your internet connection."
+    );
   }
 }
 
@@ -90,7 +94,10 @@ export function validatePrompt(prompt: string): void {
   // Check length constraints (10KB max to prevent DoS)
   const MAX_PROMPT_LENGTH = 10 * 1024;
   if (prompt.length > MAX_PROMPT_LENGTH) {
-    throw new Error(`Prompt exceeds maximum length of ${MAX_PROMPT_LENGTH} characters`);
+    throw new Error(
+      `Prompt exceeds maximum length of ${MAX_PROMPT_LENGTH} characters (${prompt.length} given).\n` +
+      `For longer prompts, use --prompt-file to read from a file instead.`
+    );
   }
 
   // Check for obvious command injection patterns


### PR DESCRIPTION
## Summary
- **Prompt too long**: `validatePrompt` max-length error now shows actual length and suggests `--prompt-file` as an alternative
- **Bad script download**: `validateScriptContent` shebang error now explains this is likely a download issue (error page returned instead of script)
- **Compact list legend**: Compact view (`spawn list`) now shows a color legend explaining green (all clouds) vs yellow (some missing), matching the grid view's legend
- **Exit code 1 guidance**: Most common failure (exit code 1) now gets specific, targeted troubleshooting advice (credentials, API errors, provisioning) instead of the generic catch-all
- **Update error context**: `spawn update` network failure now shows the current version so users know where they stand

## Test plan
- [x] All 3876 tests pass (3865 pass, 11 skip, 0 fail)
- [x] Updated `exec-script-errors.test.ts` to match new exit code 1 messaging
- [x] No shell script changes, so no `bash -n` needed