### PR TITLE
fix: improve misleading 404 error in script download

### DIFF
--- a/cli/src/__tests__/commands-update-download.test.ts
+++ b/cli/src/__tests__/commands-update-download.test.ts
@@ -449,7 +449,7 @@ describe("Script download and execution", () => {
     ).toBe(true);
   });
 
-  it("should show 'not yet' message when both URLs 404", async () => {
+  it("should show script-not-found message when both URLs 404", async () => {
     global.fetch = mock(async (url: string) => {
       if (typeof url === "string" && url.includes("manifest.json")) {
         return {
@@ -470,7 +470,9 @@ describe("Script download and execution", () => {
     }
 
     const allOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-    expect(allOutput).toContain("doesn't exist yet");
+    expect(allOutput).toContain("could not be found");
+    expect(allOutput).toContain("spawn list");
+    expect(allOutput).toContain("Report the issue");
   });
 
   it("should show network error message when primary 500 and fallback 502", async () => {

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -397,13 +397,18 @@ function reportDownloadFailure(primaryUrl: string, fallbackUrl: string, primaryS
   console.error(`Fallback source (${fallbackUrl}): ${getStatusDescription(fallbackStatus)}`);
 
   if (primaryStatus === 404 && fallbackStatus === 404) {
-    console.error("\nThis agent + cloud combination doesn't exist yet.");
+    console.error("\nThe script file could not be found on either source.");
+    console.error("This usually means the script hasn't been published yet,");
+    console.error("even though it may appear in the matrix.");
     console.error(`\nWhat to do:`);
-    console.error(`  1. Check the matrix: ${pc.cyan("spawn list")}`);
-    console.error(`  2. Verify the combination is implemented (marked with +)`);
-    console.error(`  3. Check for typos in agent or cloud name`);
+    console.error(`  1. Verify the combination is implemented: ${pc.cyan("spawn list")}`);
+    console.error(`  2. Try again later (the script may be deploying)`);
+    console.error(`  3. Report the issue: ${pc.cyan(`https://github.com/${REPO}/issues`)}`);
   } else {
     console.error(`\nNetwork or server error - try again in a few moments.`);
+    if (primaryStatus >= 500 || fallbackStatus >= 500) {
+      console.error("The server may be experiencing temporary issues.");
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixed misleading error message in `reportDownloadFailure()` that told users "This agent + cloud combination doesn't exist yet" when getting a 404 during script download
- By the time this function runs, the agent/cloud combination has already been validated in the manifest, so a 404 means the script file is missing from the server, not that the combination is invalid
- New message explains the script couldn't be found on either source, suggests verifying the matrix, retrying later, or reporting an issue
- Added extra hint for 500-level server errors about temporary issues

## Test plan
- [x] Updated existing test to verify new error message text
- [x] All 4361 tests pass (0 failures)
- [x] Test verifies `"could not be found"`, `"spawn list"`, and `"Report the issue"` appear in output

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)