### PR TITLE
fix: improve error messages with actionable guidance

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -424,6 +424,17 @@ function reportDownloadError(ghUrl: string, err: unknown): never {
 
 export function getScriptFailureGuidance(exitCode: number | null, cloud: string): string[] {
   switch (exitCode) {
+    case 130:
+      return ["Script was interrupted (Ctrl+C). No server was left running."];
+    case 137:
+      return ["Script was killed (likely by the system due to timeout or out of memory)."];
+    case 255:
+      return [
+        "SSH connection failed. Common causes:",
+        "  - Server is still booting (wait a moment and retry)",
+        "  - Firewall blocking SSH port 22",
+        "  - Server was terminated before the session started",
+      ];
     case 127:
       return [
         "A required command was not found. Check that these are installed:",
@@ -432,6 +443,11 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string)
       ];
     case 126:
       return ["A command was found but could not be executed (permission denied)."];
+    case 2:
+      return [
+        "Shell syntax or argument error. This is likely a bug in the script.",
+        `  Report it at: ${pc.cyan(`https://github.com/OpenRouterTeam/spawn/issues`)}`,
+      ];
     case 1:
       return [
         "Common causes:",


### PR DESCRIPTION
## Summary
- Add exit code handling for signals (130/Ctrl+C, 137/killed) and SSH failures (255) in `getScriptFailureGuidance()`
- Replace vague "Cloud API retry logic exhausted" with attempt count and actionable retry advice
- Clarify OAuth fallback prompt to explain why browser auth failed and what happens next
- Consolidate auth cancellation message into three clear recovery options

## Changes
- `cli/src/commands.ts`: Added cases for exit codes 130, 137, 255, and 2 with specific guidance
- `shared/common.sh`: Improved API retry exhaustion message, network error message, OAuth fallback prompt, and auth cancellation message

## Test plan
- [x] `bash -n shared/common.sh` passes
- [x] All 4376 tests pass (`bun test`)
- [ ] Manual: trigger API retry exhaustion to verify new message
- [ ] Manual: Ctrl+C during spawn to verify exit code 130 message

Agent: ux-engineer