### PR TITLE
fix: secure upload_file against command injection in 5 clouds

### DIFF
--- a/e2b/lib/common.sh
+++ b/e2b/lib/common.sh
@@ -115,15 +115,18 @@ run_server() {
 upload_file() {
     local local_path="${1}"
     local remote_path="${2}"
-    # Upload via base64 encoding through exec
+
+    # SECURITY: Validate remote_path to prevent command injection via single-quote breakout
+    if [[ "$remote_path" == *"'"* || "$remote_path" == *'$'* || "$remote_path" == *'`'* || "$remote_path" == *$'\n'* ]]; then
+        log_error "Invalid remote path (contains unsafe characters): $remote_path"
+        return 1
+    fi
+
+    # base64 output is safe (alphanumeric + /+=) so no injection risk
     local content
     content=$(base64 -w0 "${local_path}" 2>/dev/null || base64 "${local_path}")
-    # SECURITY: Properly escape the remote path
-    local escaped_path
-    escaped_path=$(printf '%q' "${remote_path}")
-    local escaped_content
-    escaped_content=$(printf '%q' "${content}")
-    e2b sandbox exec "${E2B_SANDBOX_ID}" -- bash -c "echo ${escaped_content} | base64 -d > ${escaped_path}"
+
+    e2b sandbox exec "${E2B_SANDBOX_ID}" -- bash -c "printf '%s' '${content}' | base64 -d > '${remote_path}'"
 }
 
 interactive_session() {

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -311,13 +311,18 @@ run_server() {
 upload_file() {
     local local_path="$1"
     local remote_path="$2"
-    local content=$(base64 -w0 "$local_path" 2>/dev/null || base64 "$local_path")
-    # SECURITY: Properly escape paths and content to prevent injection
-    local escaped_path
-    escaped_path=$(printf '%q' "$remote_path")
-    local escaped_content
-    escaped_content=$(printf '%q' "$content")
-    run_server "echo $escaped_content | base64 -d > $escaped_path"
+
+    # SECURITY: Validate remote_path to prevent command injection via single-quote breakout
+    if [[ "$remote_path" == *"'"* || "$remote_path" == *'$'* || "$remote_path" == *'`'* || "$remote_path" == *$'\n'* ]]; then
+        log_error "Invalid remote path (contains unsafe characters): $remote_path"
+        return 1
+    fi
+
+    # base64 output is safe (alphanumeric + /+=) so no injection risk
+    local content
+    content=$(base64 -w0 "$local_path" 2>/dev/null || base64 "$local_path")
+
+    run_server "printf '%s' '${content}' | base64 -d > '${remote_path}'"
 }
 
 # Start an interactive SSH session on the Fly.io machine

--- a/koyeb/lib/common.sh
+++ b/koyeb/lib/common.sh
@@ -222,16 +222,18 @@ upload_file() {
         return 1
     fi
 
+    # SECURITY: Validate remote_path to prevent command injection via single-quote breakout
+    if [[ "$remote_path" == *"'"* || "$remote_path" == *'$'* || "$remote_path" == *'`'* || "$remote_path" == *$'\n'* ]]; then
+        log_error "Invalid remote path (contains unsafe characters): $remote_path"
+        return 1
+    fi
+
     # SECURITY: base64 -w0 produces single-line output (no newline injection)
+    # base64 output is safe (alphanumeric + /+=) so no injection risk
     local content
     content=$(base64 -w0 "$local_path" 2>/dev/null || base64 "$local_path")
 
-    # SECURITY: Properly escape remote_path to prevent injection
-    local escaped_path
-    escaped_path=$(printf '%q' "$remote_path")
-
-    # base64 output is safe (alphanumeric + /+=) so no injection risk
-    run_server "printf '%s' '$content' | base64 -d > $escaped_path"
+    run_server "printf '%s' '${content}' | base64 -d > '${remote_path}'"
 }
 
 # Wait for cloud-init or basic system readiness


### PR DESCRIPTION
## Summary
- Fix command injection vulnerability in `upload_file()` functions across 5 cloud providers: **fly**, **northflank**, **daytona**, **e2b**, **koyeb**
- Previous code used `printf '%q'`-escaped variables without proper quoting in command strings passed to `bash -c` or `run_server`, allowing potential injection via crafted filenames
- Replace with validated single-quoted embedding pattern (matching render, modal, railway implementations)

## Changes per file
- **fly/lib/common.sh**: Remove double `printf '%q'` escaping, add path validation, single-quote vars
- **northflank/lib/common.sh**: Same fix pattern
- **daytona/lib/common.sh**: Same fix pattern (direct `daytona exec` call)
- **e2b/lib/common.sh**: Same fix pattern (direct `e2b sandbox exec` call)
- **koyeb/lib/common.sh**: Add path validation, single-quote the previously unquoted `$escaped_path`

## Test plan
- [x] `bash -n` syntax check passes on all 5 modified files
- [x] Fix pattern matches correctly-implemented clouds (render, modal, railway)
- [x] Path validation rejects `'`, `$`, `` ` ``, and newline characters

Agent: security-auditor