### PR TITLE
test: fix 6 broken tests, add exit code branch coverage

### DIFF
--- a/cli/src/__tests__/exec-script-errors.test.ts
+++ b/cli/src/__tests__/exec-script-errors.test.ts
@@ -239,7 +239,7 @@ describe("execScript bash execution error handling", () => {
       expect(errors).toContain("API error");
     });
 
-    it("should mention local dependencies for other exit codes", async () => {
+    it("should show shell syntax error guidance for exit code 2", async () => {
       mockFetchWithScript("exit 2");
       await loadManifest(true);
 
@@ -250,9 +250,8 @@ describe("execScript bash execution error handling", () => {
       }
 
       const errors = getErrorOutput();
-      expect(errors).toContain("Missing credentials");
-      expect(errors).toContain("curl");
-      expect(errors).toContain("jq");
+      expect(errors).toContain("Shell syntax or argument error");
+      expect(errors).toContain("bug in the script");
     });
 
     it("should suggest spawn <cloud> for setup instructions", async () => {
@@ -358,7 +357,7 @@ describe("execScript bash execution error handling", () => {
       expect(errors).toContain("command was not found");
     });
 
-    it("should give generic guidance for exit code 2", async () => {
+    it("should give shell syntax guidance for exit code 2", async () => {
       mockFetchWithScript("exit 2");
       await loadManifest(true);
 
@@ -369,7 +368,7 @@ describe("execScript bash execution error handling", () => {
       }
 
       const errors = getErrorOutput();
-      expect(errors).toContain("Common causes");
+      expect(errors).toContain("Shell syntax or argument error");
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix 6 broken test assertions in `script-failure-guidance.test.ts` and `exec-script-errors.test.ts` that were written before exit codes 130, 137, 255, and 2 got dedicated handlers in `getScriptFailureGuidance()` (PRs #449, #450)
- Add 16 new tests covering the specific guidance for each newly handled exit code: 130 (Ctrl+C interrupt), 137 (OOM/killed), 255 (SSH failure), 2 (shell syntax error)
- Full suite: 4423 pass, 0 fail (was 6 fail before this fix)

## Test plan
- [x] All 47 tests in `script-failure-guidance.test.ts` pass (was 31 pass / 4 fail)
- [x] All 21 tests in `exec-script-errors.test.ts` pass (was 19 pass / 2 fail)
- [x] Full suite: `bun test` passes with 0 failures across 52 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)