### PR TITLE
fix: show runtime/platform in spawn version, clarify compact list legend

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/dispatch-extra-args.test.ts
+++ b/cli/src/__tests__/dispatch-extra-args.test.ts
@@ -368,9 +368,12 @@ describe("dispatchCommand routing", () => {
 describe("showVersion output format", () => {
   // Replica of the showVersion output structure
   function formatVersionOutput(version: string, binaryPath: string | undefined): string[] {
+    const runtime = process.versions.bun ? "bun" : "node";
+    const runtimeVersion = process.versions.bun ?? process.versions.node;
     return [
       `spawn v${version}`,
       `  ${binaryPath ?? "unknown path"}`,
+      `  ${runtime} ${runtimeVersion}  ${process.platform} ${process.arch}`,
       `  Run spawn update to check for updates.`,
     ];
   }
@@ -390,9 +393,15 @@ describe("showVersion output format", () => {
     expect(lines[1]).toContain("unknown path");
   });
 
+  it("should include runtime and platform info", () => {
+    const lines = formatVersionOutput("0.2.15", "/usr/local/bin/spawn");
+    expect(lines[2]).toContain(process.platform);
+    expect(lines[2]).toContain(process.arch);
+  });
+
   it("should suggest spawn update", () => {
     const lines = formatVersionOutput("0.2.15", "/usr/local/bin/spawn");
-    expect(lines[2]).toContain("spawn update");
+    expect(lines[3]).toContain("spawn update");
   });
 });
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -647,7 +647,7 @@ export async function cmdList(): Promise<void> {
   const total = agents.length * clouds.length;
   console.log();
   if (isCompact) {
-    console.log(`${pc.green("N/N")} all clouds  ${pc.yellow("N/N")} some missing`);
+    console.log(`Color: ${pc.green("green")} = all clouds  ${pc.yellow("yellow")} = some missing`);
   } else {
     console.log(`${pc.green("+")} implemented  ${pc.dim("-")} not yet available`);
   }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -250,6 +250,7 @@ async function handleNoCommand(prompt: string | undefined): Promise<void> {
 function showVersion(): void {
   console.log(`spawn v${VERSION}`);
   console.log(pc.dim(`  ${process.argv[1] ?? "unknown path"}`));
+  console.log(pc.dim(`  ${process.versions.bun ? "bun" : "node"} ${process.versions.bun ?? process.versions.node}  ${process.platform} ${process.arch}`));
   console.log(pc.dim(`  Run ${pc.cyan("spawn update")} to check for updates.`));
 }
 


### PR DESCRIPTION
## Summary
- **`spawn version` now shows diagnostic info** (runtime, version, platform, architecture) so users can include it in bug reports. Before: just version + path. After: version + path + `bun 1.3.7  linux x64`
- **Compact list legend clarified** from confusing literal `N/N all clouds  N/N some missing` to descriptive `Color: green = all clouds  yellow = some missing`

## Test plan
- [x] `bun test src/__tests__/dispatch-extra-args.test.ts` - all 55 tests pass (includes new test for runtime/platform line)
- [x] `bun test src/__tests__/commands-compact-list.test.ts` - all 20 tests pass
- [x] Full test suite: 4406 pass, 6 fail (all failures are pre-existing in `script-failure-guidance.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)