### PR TITLE
feat: Add Open Interpreter support for RamNode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1207,7 +1207,7 @@
     "ramnode/aider": "implemented",
     "ramnode/goose": "implemented",
     "ramnode/codex": "missing",
-    "ramnode/interpreter": "missing",
+    "ramnode/interpreter": "implemented",
     "ramnode/gemini": "missing",
     "ramnode/amazonq": "missing",
     "ramnode/cline": "missing",

--- a/ramnode/README.md
+++ b/ramnode/README.md
@@ -144,6 +144,7 @@ Uses OpenStack Compute API:
 - ✅ Claude Code
 - ✅ Aider
 - ✅ Goose
+- ✅ Open Interpreter
 
 ## Documentation
 

--- a/ramnode/interpreter.sh
+++ b/ramnode/interpreter.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=ramnode/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ramnode/lib/common.sh)"
+fi
+
+log_info "Open Interpreter on RamNode Cloud"
+echo ""
+
+ensure_ramnode_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${RAMNODE_SERVER_IP}"
+wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
+
+log_warn "Installing Open Interpreter..."
+run_server "${RAMNODE_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+log_info "Open Interpreter installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "RamNode server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
+echo ""
+
+log_warn "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && interpreter"


### PR DESCRIPTION
## Summary
- Implements ramnode/interpreter.sh following standard pattern
- Updates manifest.json matrix status to "implemented"
- Adds Open Interpreter to ramnode README

## Implementation
Uses ramnode OpenStack API primitives to:
1. Provision Ubuntu 24.04 server
2. Install open-interpreter via pip
3. Inject OpenRouter credentials
4. Launch interactive session

## Test plan
- [x] Syntax check passed (bash -n)
- [ ] Manual test on RamNode cloud
- [ ] Verify OpenRouter API key injection

🤖 Generated by gap-filler-ramnode-2