### PR TITLE
refactor: reduce complexity in IONOS and Scaleway provider libraries

### DIFF
--- a/ionos/lib/common.sh
+++ b/ionos/lib/common.sh
@@ -30,24 +30,9 @@ ionos_api() {
     local endpoint="$2"
     local body="${3:-}"
 
-    # IONOS API uses Basic Auth
-    local auth_header="Authorization: Basic $(printf '%s:%s' "${IONOS_USERNAME}" "${IONOS_PASSWORD}" | base64)"
-
-    local response
-    if [[ "$method" == "GET" || "$method" == "DELETE" ]]; then
-        response=$(curl -s -X "$method" \
-            -H "$auth_header" \
-            -H "Content-Type: application/json" \
-            "${IONOS_API_BASE}${endpoint}")
-    else
-        response=$(curl -s -X "$method" \
-            -H "$auth_header" \
-            -H "Content-Type: application/json" \
-            -d "$body" \
-            "${IONOS_API_BASE}${endpoint}")
-    fi
-
-    echo "$response"
+    # IONOS API uses Basic Auth — delegate to generic wrapper for retry logic
+    generic_cloud_api_custom_auth "$IONOS_API_BASE" "$method" "$endpoint" "$body" 3 \
+        -H "Authorization: Basic $(printf '%s:%s' "${IONOS_USERNAME}" "${IONOS_PASSWORD}" | base64)"
 }
 
 # Parse error message from an IONOS API error response


### PR DESCRIPTION
## Summary
- **IONOS**: Replace hand-rolled duplicated curl calls in `ionos_api()` with `generic_cloud_api_custom_auth`, removing the unnecessary GET/DELETE vs POST branch and adding automatic retry logic with exponential backoff (consistent with all other providers)
- **Scaleway**: Extract duplicated Python image-lookup code into `_scaleway_pick_ubuntu_image()` helper and consolidate the two-pass search in `get_ubuntu_image_id()` into a loop (47 lines -> 18 lines)

Net reduction: 26 lines (-55, +29)

## Test plan
- [ ] `bash -n ionos/lib/common.sh` passes (verified)
- [ ] `bash -n scaleway/lib/common.sh` passes (verified)
- [ ] IONOS API calls work with Basic Auth through generic wrapper
- [ ] Scaleway image lookup still finds Ubuntu 24.04 images

Agent: complexity-hunter