### PR TITLE
fix: improve user-facing messages and error text

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cmd-interactive.test.ts
+++ b/cli/src/__tests__/cmd-interactive.test.ts
@@ -118,7 +118,7 @@ describe("cmdInteractive", () => {
       expect(processExitSpy).toHaveBeenCalledWith(0);
     });
 
-    it("should print 'Operation cancelled' when user cancels agent selection", async () => {
+    it("should show cancelled message when user cancels agent selection", async () => {
       selectReturnValues = [CANCEL_SYMBOL, "sprite"];
       isCancelValues = new Set([CANCEL_SYMBOL]);
 
@@ -128,8 +128,8 @@ describe("cmdInteractive", () => {
         // Expected
       }
 
-      const errorOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-      expect(errorOutput).toContain("cancelled");
+      const outroOutput = mockOutro.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+      expect(outroOutput.toLowerCase()).toContain("cancelled");
     });
 
     it("should exit with code 0 when user cancels cloud selection", async () => {
@@ -140,7 +140,7 @@ describe("cmdInteractive", () => {
       expect(processExitSpy).toHaveBeenCalledWith(0);
     });
 
-    it("should print 'Operation cancelled' when user cancels cloud selection", async () => {
+    it("should show cancelled message when user cancels cloud selection", async () => {
       selectReturnValues = ["claude", CANCEL_SYMBOL];
       isCancelValues = new Set([CANCEL_SYMBOL]);
 
@@ -150,8 +150,8 @@ describe("cmdInteractive", () => {
         // Expected
       }
 
-      const errorOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-      expect(errorOutput).toContain("cancelled");
+      const outroOutput = mockOutro.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+      expect(outroOutput.toLowerCase()).toContain("cancelled");
     });
 
     it("should not show launch message when user cancels", async () => {

--- a/cli/src/__tests__/commands-compact-list.test.ts
+++ b/cli/src/__tests__/commands-compact-list.test.ts
@@ -400,8 +400,8 @@ describe("Compact List View", () => {
       const output = getOutput();
       const allCloudsMatches = output.match(/all clouds supported/g);
       expect(allCloudsMatches).not.toBeNull();
-      // Both agents fully implemented -> 2 "all clouds supported"
-      expect(allCloudsMatches!.length).toBe(2);
+      // Both agents fully implemented -> 2 "all clouds supported" + 1 in legend
+      expect(allCloudsMatches!.length).toBe(3);
     });
   });
 
@@ -440,7 +440,7 @@ describe("Compact List View", () => {
       const output = getOutput();
       expect(output).toContain("implemented");
       // The +/- legend is grid-only, not shown in compact view
-      expect(output).not.toContain("not yet available");
+      expect(output).not.toContain("+ implemented");
     });
 
     it("should show usage hints", async () => {

--- a/cli/src/__tests__/commands-update-download.test.ts
+++ b/cli/src/__tests__/commands-update-download.test.ts
@@ -258,7 +258,7 @@ describe("Script download and execution", () => {
 
     // Should show 404-specific error messaging
     const errorOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-    expect(errorOutput).toContain("not found");
+    expect(errorOutput).toContain("could not be found");
   });
 
   it("should exit when both primary and fallback URLs return server errors", async () => {

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -190,15 +190,21 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("interrupted");
     });
 
-    it("should reassure no server was left running", () => {
+    it("should warn server may still be running", () => {
       const lines = getScriptFailureGuidance(130, "sprite");
       const joined = lines.join("\n");
-      expect(joined).toContain("No server was left running");
+      expect(joined).toContain("may still be running");
     });
 
-    it("should return exactly 1 guidance line", () => {
+    it("should suggest checking cloud provider dashboard", () => {
       const lines = getScriptFailureGuidance(130, "sprite");
-      expect(lines).toHaveLength(1);
+      const joined = lines.join("\n");
+      expect(joined).toContain("cloud provider dashboard");
+    });
+
+    it("should return exactly 3 guidance lines", () => {
+      const lines = getScriptFailureGuidance(130, "sprite");
+      expect(lines).toHaveLength(3);
     });
   });
 

--- a/cli/src/__tests__/shared-common-validators.test.ts
+++ b/cli/src/__tests__/shared-common-validators.test.ts
@@ -278,7 +278,7 @@ describe("validate_api_token", () => {
       it(`should reject token with ${desc}`, () => {
         const result = runValidator("validate_api_token", input);
         expect(result.exitCode).not.toBe(0);
-        expect(result.stderr).toContain("metacharacters");
+        expect(result.stderr).toContain("special characters");
       });
     }
   });

--- a/cli/src/update-check.ts
+++ b/cli/src/update-check.ts
@@ -85,7 +85,7 @@ function performAutoUpdate(latestVersion: string): void {
 
     console.error();
     console.error(pc.green(pc.bold(`${CHECK_MARK} Updated successfully!`)));
-    console.error(pc.dim("  Restart your command to use the new version."));
+    console.error(pc.dim("  Run your spawn command again to use the new version."));
     console.error();
 
     // Exit cleanly after update

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -195,9 +195,9 @@ validate_api_token() {
 
     # Block shell metacharacters that could enable command injection
     if [[ "${token}" =~ [\;\'\"\<\>\|\&\$\`\\\(\)] ]]; then
-        log_error "Invalid token format: contains shell metacharacters"
-        log_error "Tokens should not contain: ; ' \" < > | & \$ \` \\ ( )"
-        log_error "Copy the token directly from your provider's dashboard"
+        log_error "Invalid token format: contains special characters"
+        log_error "API tokens should only contain letters, numbers, dashes, and underscores."
+        log_error "Copy the token directly from your provider's dashboard without extra characters."
         return 1
     fi
 
@@ -764,7 +764,8 @@ get_openrouter_api_key_oauth() {
 
     # OAuth failed, offer manual entry
     echo ""
-    log_warn "Browser-based OAuth login was not completed (timed out or browser not available)."
+    log_warn "Browser-based OAuth login was not completed."
+    log_warn "This is normal on remote servers, SSH sessions, or headless environments."
     log_info "You can paste an API key instead. Create one at: https://openrouter.ai/settings/keys"
     echo ""
     local manual_choice
@@ -1905,7 +1906,7 @@ interactive_pick() {
     if [[ "${choice}" -ge 1 && "${choice}" -le "${#ids[@]}" ]] 2>/dev/null; then
         echo "${ids[$((choice - 1))]}"
     else
-        log_warn "Invalid choice, using default: ${default_value}"
+        log_warn "Invalid selection '${choice}' (enter a number between 1 and ${#ids[@]}). Using default: ${default_value}"
         echo "${default_value}"
     fi
 }


### PR DESCRIPTION
## Summary
- **Cancel handling**: Use `p.outro` with dim text instead of red error text for user cancellation (Ctrl+C is normal, not an error)
- **Exit code 130 (Ctrl+C)**: Warn that a server may still be running instead of falsely claiming "No server was left running"
- **Download errors**: Hide internal primary/fallback URLs from user, show friendly "could not be found" message
- **Compact list legend**: Use "not yet available" consistently instead of developer jargon "missing"
- **Update messages**: Say "Run your spawn command again" instead of vague "Restart your command"
- **API token validation**: Show friendly "special characters" error instead of listing individual forbidden characters
- **OAuth fallback**: Explain that failed browser auth is normal on remote servers, SSH sessions, or headless environments
- **Interactive picker**: Show what was entered and the valid range on invalid selection

## Test plan
- [x] All 4439 CLI tests pass (0 failures)
- [x] `bash -n shared/common.sh` passes
- [x] Updated 5 test files to match new message text