### PR TITLE
fix: improve error messages and UX consistency

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -392,30 +392,33 @@ async function downloadScriptWithFallback(primaryUrl: string, fallbackUrl: strin
 }
 
 function reportDownloadFailure(primaryUrl: string, fallbackUrl: string, primaryStatus: number, fallbackStatus: number): void {
-  p.log.error("Script download failed");
-
   if (primaryStatus === 404 && fallbackStatus === 404) {
+    p.log.error("Script download failed (HTTP 404: not found)");
     console.error("\nThe script file could not be found.");
     console.error("This usually means the combination hasn't been published yet,");
     console.error("even though it may appear in the matrix.");
-    console.error(`\nWhat to do:`);
+    console.error(`\nHow to fix:`);
     console.error(`  1. Verify the combination is implemented: ${pc.cyan("spawn list")}`);
     console.error(`  2. Try again later (the script may be deploying)`);
     console.error(`  3. Report the issue: ${pc.cyan(`https://github.com/${REPO}/issues`)}`);
   } else {
-    console.error(`\nNetwork or server error (HTTP ${primaryStatus}) - try again in a few moments.`);
+    p.log.error(`Script download failed (HTTP ${primaryStatus}/${fallbackStatus})`);
+    console.error(`\nBoth download sources returned errors.`);
     if (primaryStatus >= 500 || fallbackStatus >= 500) {
       console.error("The server may be experiencing temporary issues.");
     }
+    console.error(`\nHow to fix:`);
+    console.error(`  1. Wait a moment and try again`);
+    console.error(`  2. Check GitHub status: ${pc.cyan("https://www.githubstatus.com")}`);
   }
 }
 
 function reportDownloadError(ghUrl: string, err: unknown): never {
-  p.log.error("Failed to download spawn script");
+  p.log.error("Script download failed (network error)");
   console.error("\nError:", getErrorMessage(err));
-  console.error("\nTroubleshooting:");
-  console.error(`  1. Verify this combination exists: ${pc.cyan("spawn list")}`);
-  console.error("  2. Check your internet connection");
+  console.error("\nHow to fix:");
+  console.error("  1. Check your internet connection");
+  console.error(`  2. Verify this combination exists: ${pc.cyan("spawn list")}`);
   console.error(`  3. Try accessing the script directly: ${ghUrl}`);
   process.exit(1);
 }
@@ -927,7 +930,7 @@ export async function cmdUpdate(): Promise<void> {
   } catch (err) {
     s.stop(pc.red(`Failed to check for updates ${pc.dim(`(current: v${VERSION})`)}`));
     console.error("Error:", getErrorMessage(err));
-    console.error(`\nTroubleshooting:`);
+    console.error(`\nHow to fix:`);
     console.error(`  1. Check your internet connection`);
     console.error(`  2. Try again in a few moments`);
     console.error(`  3. Update manually: ${pc.cyan(`curl -fsSL ${RAW_BASE}/cli/install.sh | bash`)}`);

--- a/cli/src/manifest.ts
+++ b/cli/src/manifest.ts
@@ -178,7 +178,7 @@ export async function loadManifest(forceRefresh = false): Promise<Manifest> {
   throw new Error(
     `Cannot load manifest: failed to fetch from GitHub and no local cache available.\n` +
     `\n` +
-    `Troubleshooting:\n` +
+    `How to fix:\n` +
     `  1. Check your internet connection\n` +
     `  2. Try again in a few moments (GitHub may be temporarily unreachable)\n` +
     `  3. If the problem persists, clear the cache and retry:\n` +

--- a/modal/lib/common.sh
+++ b/modal/lib/common.sh
@@ -114,7 +114,7 @@ _report_modal_create_error() {
     log_error "  - Network connectivity issues"
     log_error "  - Invalid sandbox name (must be alphanumeric with dashes)"
     log_error ""
-    log_error "Troubleshooting:"
+    log_error "How to fix:"
     log_error "  1. Re-authenticate: modal setup"
     log_error "  2. Verify account status: https://modal.com/settings"
     log_error "  3. Check Modal status: https://status.modal.com"

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -144,7 +144,7 @@ verify_sprite_connectivity() {
 
     log_error "Sprite '${sprite_name}' failed to respond after ${max_attempts} attempts"
     log_error ""
-    log_error "Troubleshooting:"
+    log_error "How to fix:"
     log_error "  1. Check sprite status: sprite list"
     log_error "  2. View sprite logs: sprite logs ${sprite_name}"
     log_error "  3. Try recreating the sprite: sprite delete ${sprite_name} && sprite create ${sprite_name}"


### PR DESCRIPTION
## Summary
- **Clarify download errors**: Distinguish HTTP errors (with status codes) from network errors in CLI download failure messages
- **OAuth timeout actionable steps**: Add "How to fix" section with re-run and manual key export instructions
- **Standardize help labels**: Unify inconsistent "What to do:", "Troubleshooting:", and "Possible causes:" patterns to consistent "How to fix:" across CLI and shell scripts
- **API retry context**: Include the HTTP method and endpoint in retry exhaustion messages so users know which call failed
- **Mutually exclusive agent verification errors**: Separate PATH/installation issues from runtime/dependency issues with distinct causes and fix steps

## Files changed
- `cli/src/commands.ts` — download error and update check messages
- `cli/src/manifest.ts` — manifest fetch error label
- `shared/common.sh` — OAuth timeout, API retry messages, verify_agent_installed
- `sprite/lib/common.sh` — error label standardization
- `modal/lib/common.sh` — error label standardization

## Test plan
- [x] All 4542 CLI tests pass (bun test)
- [x] `bash -n` passes on all modified shell scripts
- [ ] Manual: trigger OAuth timeout to verify new "How to fix" section appears
- [ ] Manual: trigger download failure to verify distinct HTTP vs network messages