### PR TITLE
fix: improve error message consistency and clarity across CLI

### DIFF
--- a/cli/src/__tests__/download-and-failure.test.ts
+++ b/cli/src/__tests__/download-and-failure.test.ts
@@ -446,9 +446,9 @@ describe("getScriptFailureGuidance - all exit codes", () => {
     expect(lines.some((l: string) => l.includes("still be running"))).toBe(true);
   });
 
-  it("should include cloud-specific command hint for 130", () => {
+  it("should include cloud provider dashboard hint for 130", () => {
     const lines = getScriptFailureGuidance(130, "hetzner");
-    expect(lines.some((l: string) => l.includes("spawn hetzner"))).toBe(true);
+    expect(lines.some((l: string) => l.includes("cloud provider dashboard"))).toBe(true);
   });
 
   it("should return OOM/timeout guidance for exit code 137", () => {

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -429,7 +429,7 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string)
       return [
         "Script was interrupted (Ctrl+C).",
         "Note: If a server was already created, it may still be running.",
-        `  Check your cloud provider dashboard or run ${pc.cyan(`spawn ${cloud}`)} for details.`,
+        "  Check your cloud provider dashboard to stop or delete any unused servers.",
       ];
     case 137:
       return ["Script was killed (likely by the system due to timeout or out of memory)."];
@@ -928,7 +928,7 @@ export async function cmdUpdate(): Promise<void> {
       console.log();
     }
   } catch (err) {
-    s.stop(pc.red(`Failed to check for updates ${pc.dim(`(current: v${VERSION})`)}`));
+    s.stop(pc.red("Failed to check for updates") + pc.dim(` (current: v${VERSION})`));
     console.error("Error:", getErrorMessage(err));
     console.error(`\nHow to fix:`);
     console.error(`  1. Check your internet connection`);

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -263,7 +263,7 @@ validated_read() {
             return 0
         fi
 
-        log_warn "Invalid input. Please try again."
+        log_warn "Please try again."
     done
 }
 
@@ -712,7 +712,7 @@ _await_oauth_callback() {
         log_warn "How to fix:"
         log_warn "  1. Re-run the command to try again"
         log_warn "  2. Set the key manually: export OPENROUTER_API_KEY=sk-or-..."
-        log_warn "     (get a key at https://openrouter.ai/keys)"
+        log_warn "     (get a key at https://openrouter.ai/settings/keys)"
         return 1
     fi
 
@@ -1572,6 +1572,8 @@ _validate_token_with_provider() {
 
     if ! "${test_func}"; then
         log_error "Authentication failed: Invalid ${provider_name} API token"
+        log_error "The token may be expired, revoked, or incorrectly copied."
+        log_error "Please re-run the command to enter a new token."
         unset "${env_var_name}"
         return 1
     fi
@@ -1796,6 +1798,8 @@ ensure_multi_credentials() {
         log_info "Testing ${provider_name} credentials..."
         if ! "${test_func}"; then
             log_error "Invalid ${provider_name} credentials"
+            log_error "The credentials may be expired, revoked, or incorrectly copied."
+            log_error "Please re-run the command to enter new credentials."
             local v
             for v in "${env_vars[@]}"; do
                 unset "${v}"


### PR DESCRIPTION
## Summary
- Style all CLI error messages with colored output (`pc.red` for errors, `pc.cyan` for commands/usage hints) for consistent visual hierarchy
- Fix inconsistent OpenRouter API key URL in OAuth timeout message (`/keys` -> `/settings/keys`)
- Improve Ctrl+C (exit code 130) guidance to suggest checking cloud provider dashboard instead of `spawn <cloud>` which only shows info
- Add actionable recovery hints ("token may be expired, re-run to enter a new one") to failed token/credential validation
- Remove redundant "Invalid input" prefix from `validated_read` since the validator already logs specific error details
- Fix nested `pc.red(pc.dim(...))` color codes in `cmdUpdate` failure spinner that don't render correctly
- Skip displaying "unknown path" in `spawn version` when binary path is unavailable

## Test plan
- [x] All tests pass (5 pre-existing failures on main unrelated to this change)
- [x] Updated test for exit code 130 guidance to match new message
- [x] `bash -n shared/common.sh` passes