### PR TITLE
feat: Add Cline support for Netcup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1180,7 +1180,7 @@
     "netcup/interpreter": "implemented",
     "netcup/gemini": "implemented",
     "netcup/amazonq": "implemented",
-    "netcup/cline": "missing",
+    "netcup/cline": "implemented",
     "netcup/gptme": "missing",
     "netcup/opencode": "missing",
     "netcup/plandex": "missing",

--- a/netcup/cline.sh
+++ b/netcup/cline.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=netcup/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/netcup/lib/common.sh)"
+fi
+
+log_info "Cline on Netcup Cloud"
+echo ""
+
+ensure_netcup_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${NETCUP_SERVER_IP}"
+wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
+
+log_warn "Installing Cline..."
+run_server "${NETCUP_SERVER_IP}" "npm install -g cline"
+log_info "Cline installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_warn "Setting up environment variables..."
+
+inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Netcup server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_IP})"
+echo ""
+
+log_warn "Starting Cline..."
+sleep 1
+clear
+interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && cline"


### PR DESCRIPTION
## Summary
- Implements netcup/cline script using Netcup cloud primitives
- Updates manifest.json to mark netcup/cline as implemented

## Implementation
- Sources netcup/lib/common.sh for cloud-specific functions
- Installs Cline via npm
- Injects OpenRouter env vars (OPENROUTER_API_KEY, OPENAI_API_KEY, OPENAI_BASE_URL)
- Launches interactive Cline session

Generated with [Claude Code](https://claude.com/claude-code)