### PR TITLE
feat: add --dry-run flag to preview provisioning details

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cli-entry-edge-cases.test.ts
+++ b/cli/src/__tests__/cli-entry-edge-cases.test.ts
@@ -158,12 +158,12 @@ describe("unknown flags with subcommands", () => {
     expect(result.exitCode).not.toBe(0);
   });
 
-  it("should reject --dry-run with valid agent and cloud", () => {
+  it("should handle --dry-run with valid agent and cloud", () => {
     const result = runCli(["claude", "sprite", "--dry-run"]);
     const out = output(result);
-    expect(out).toContain("Unknown flag");
-    expect(out).toContain("--dry-run");
-    expect(result.exitCode).not.toBe(0);
+    expect(out).toContain("Dry run");
+    expect(out).toContain("no resources");
+    expect(result.exitCode).toBe(0);
   });
 
   it("should show supported flags list in unknown flag error", () => {

--- a/cli/src/__tests__/unknown-flags.test.ts
+++ b/cli/src/__tests__/unknown-flags.test.ts
@@ -11,6 +11,7 @@ const KNOWN_FLAGS = new Set([
   "--help", "-h",
   "--version", "-v", "-V",
   "--prompt", "-p", "--prompt-file", "-f",
+  "--dry-run", "-n",
 ]);
 
 /** Replicated from index.ts for testability - returns the first unknown flag or null */
@@ -44,8 +45,8 @@ describe("Unknown Flag Detection", () => {
       expect(findUnknownFlag(["agents", "--output", "json"])).toBe("--output");
     });
 
-    it("should detect --dry-run as unknown", () => {
-      expect(findUnknownFlag(["claude", "sprite", "--dry-run"])).toBe("--dry-run");
+    it("should detect --verbose as unknown", () => {
+      expect(findUnknownFlag(["claude", "sprite", "--verbose"])).toBe("--verbose");
     });
 
     it("should detect unknown flag at the beginning", () => {
@@ -92,6 +93,14 @@ describe("Unknown Flag Detection", () => {
 
     it("should allow -f (short form of --prompt-file)", () => {
       expect(findUnknownFlag(["-f"])).toBeNull();
+    });
+
+    it("should allow --dry-run", () => {
+      expect(findUnknownFlag(["claude", "sprite", "--dry-run"])).toBeNull();
+    });
+
+    it("should allow -n (short form of --dry-run)", () => {
+      expect(findUnknownFlag(["claude", "sprite", "-n"])).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `--dry-run` / `-n` flag to the spawn CLI
- Shows agent info, cloud info, server defaults, script URL, and env vars without provisioning
- Includes proper error when `--dry-run` is used without a cloud argument
- Bumps CLI version to 0.2.41

## Test plan
- [x] `bun test` passes (4658 tests, 0 failures)
- [x] Updated existing tests that expected `--dry-run` to be unknown
- [x] Added new tests for `--dry-run` and `-n` flag recognition

Fixes #474

Agent: issue-fixer
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>