### PR TITLE
fix: show error when --dry-run used without agent and cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ spawn claude                             # Show clouds available for Claude
 |---------|-------------|
 | `spawn` | Interactive agent + cloud picker |
 | `spawn <agent> <cloud>` | Launch agent on cloud directly |
+| `spawn <agent> <cloud> --dry-run` | Preview without provisioning |
 | `spawn <agent> <cloud> -p "text"` | Non-interactive with prompt |
 | `spawn <agent> <cloud> --prompt-file f.txt` | Prompt from file |
 | `spawn <agent>` | Show available clouds for an agent |

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -234,7 +234,12 @@ async function resolvePrompt(args: string[]): Promise<[string | undefined, strin
 }
 
 /** Handle the case when no command is given (interactive mode or help) */
-async function handleNoCommand(prompt: string | undefined): Promise<void> {
+async function handleNoCommand(prompt: string | undefined, dryRun?: boolean): Promise<void> {
+  if (dryRun) {
+    console.error(pc.red("Error: --dry-run requires both <agent> and <cloud>"));
+    console.error(`\nUsage: ${pc.cyan("spawn <agent> <cloud> --dry-run")}`);
+    process.exit(1);
+  }
   if (prompt) {
     console.error(pc.red("Error: --prompt requires both <agent> and <cloud>"));
     console.error(`\nUsage: ${pc.cyan('spawn <agent> <cloud> --prompt "your prompt here"')}`);
@@ -330,7 +335,7 @@ async function main(): Promise<void> {
 
   try {
     if (!cmd) {
-      await handleNoCommand(prompt);
+      await handleNoCommand(prompt, dryRun);
     } else {
       await dispatchCommand(cmd, filteredArgs, prompt, dryRun);
     }


### PR DESCRIPTION
## Summary
- `spawn --dry-run` (no agent/cloud args) silently entered interactive mode, ignoring the `--dry-run` flag. Now shows an actionable error: "Error: --dry-run requires both <agent> and <cloud>", matching the existing `--prompt` behavior.
- Adds `--dry-run` to the README commands table, which was missing even though the flag is documented in `spawn help`.
- Patch version bump (0.2.41 -> 0.2.42).

## Test plan
- [x] `bun test` passes for all argument parsing / routing tests
- [x] Verified `spawn <agent> --dry-run` already showed the correct error (existing behavior)
- [x] No shell scripts modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)