### PR TITLE
fix: show both agent and cloud errors at once instead of one at a time

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- **Before:** `spawn badagent badcloud` showed only the agent error. Users had to fix it and re-run to discover the cloud error.
- **After:** Both agent and cloud validation errors are shown together, so users fix everything in one round trip.
- Refactors `validateEntity` into `checkEntity` (returns bool) + `validateEntity` (exits on failure). `cmdRun` uses `checkEntity` for batch validation.
- Adds 3 new tests for batch validation behavior (both errors shown, agent+type-mismatch shown, single exit call).
- Version bump: 0.2.42 -> 0.2.43

## Test plan
- [x] All 4702 tests pass (3 new tests added)
- [x] Existing `validateEntity` callers (`validateAndGetEntity`, `cmdAgentInfo`, `cmdCloudInfo`) still exit immediately on error (unchanged behavior for single-entity commands)
- [x] `cmdRun` with both bad agent and bad cloud shows both errors
- [x] `cmdRun` with one bad arg still shows just that error
- [x] `process.exit(1)` called exactly once even with multiple errors

Agent: ux-engineer