### PR TITLE
feat: store spawn history locally and repurpose spawn list

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cli-entry-edge-cases.test.ts
+++ b/cli/src/__tests__/cli-entry-edge-cases.test.ts
@@ -274,7 +274,14 @@ describe("command aliases", () => {
   it("should treat 'ls' as alias for 'list'", () => {
     const result = runCli(["ls"]);
     const out = output(result);
-    // 'ls' should produce list output with matrix
+    // 'ls' should produce spawn history output
+    expect(out).toMatch(/AGENT|No spawns recorded/);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should treat 'm' as alias for 'matrix'", () => {
+    const result = runCli(["m"]);
+    const out = output(result);
     expect(out).toContain("combinations implemented");
     expect(result.exitCode).toBe(0);
   });
@@ -386,15 +393,23 @@ describe("subcommand output format verification", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it("'list' should show the availability matrix", () => {
+  it("'list' should show spawn history", () => {
     const result = runCli(["list"]);
+    const out = output(result);
+    // list now shows spawn history (may be empty or have entries)
+    expect(out).toMatch(/AGENT|No spawns recorded/);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("'matrix' should show the availability matrix", () => {
+    const result = runCli(["matrix"]);
     const out = output(result);
     expect(out).toContain("combinations implemented");
     expect(result.exitCode).toBe(0);
   });
 
-  it("'list' should show usage hints at the bottom", () => {
-    const result = runCli(["list"]);
+  it("'matrix' should show usage hints at the bottom", () => {
+    const result = runCli(["matrix"]);
     const out = output(result);
     expect(out).toContain("spawn <agent>");
     expect(out).toContain("spawn <cloud>");
@@ -491,9 +506,9 @@ describe("extra positional argument warnings", () => {
   });
 
   it("should still work for subcommands with extra args (warning on stderr)", () => {
-    // "spawn list extra" runs successfully - the warning goes to stderr
+    // "spawn matrix extra" runs successfully - the warning goes to stderr
     // which isn't captured by execSync on success, but the command should still work
-    const result = runCli(["list", "extra"]);
+    const result = runCli(["matrix", "extra"]);
     const out = output(result);
     expect(out).toContain("combinations implemented");
     expect(result.exitCode).toBe(0);

--- a/cli/src/__tests__/cmd-interactive.test.ts
+++ b/cli/src/__tests__/cmd-interactive.test.ts
@@ -229,7 +229,7 @@ describe("cmdInteractive", () => {
       expect(errorCalls.some((msg: string) => msg.includes("Aider"))).toBe(true);
     });
 
-    it("should suggest 'spawn list' when no clouds available", async () => {
+    it("should suggest 'spawn matrix' when no clouds available", async () => {
       const noCloudManifest = {
         ...mockManifest,
         matrix: {
@@ -256,7 +256,7 @@ describe("cmdInteractive", () => {
       }
 
       const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
-      expect(infoCalls.some((msg: string) => msg.includes("spawn list"))).toBe(true);
+      expect(infoCalls.some((msg: string) => msg.includes("spawn matrix"))).toBe(true);
     });
   });
 

--- a/cli/src/__tests__/commands-compact-list.test.ts
+++ b/cli/src/__tests__/commands-compact-list.test.ts
@@ -177,7 +177,7 @@ mock.module("@clack/prompts", () => ({
 }));
 
 // Import commands after mock setup
-const { cmdList } = await import("../commands.js");
+const { cmdMatrix } = await import("../commands.js");
 
 describe("Compact List View", () => {
   let consoleMocks: ReturnType<typeof createConsoleMocks>;
@@ -222,7 +222,7 @@ describe("Compact List View", () => {
       // Force narrow terminal - compact view triggered
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // Compact view has "Agent", "Clouds", "Missing" header columns
       expect(output).toContain("Agent");
@@ -235,7 +235,7 @@ describe("Compact List View", () => {
       // Force wide terminal
       process.stdout.columns = 200;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // Grid view shows + and - symbols and cloud names in header
       expect(output).toContain("+");
@@ -250,7 +250,7 @@ describe("Compact List View", () => {
       // Simulate no tty (columns undefined)
       (process.stdout as any).columns = undefined;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // With 7 clouds at ~10+ chars each, the grid would be ~100+ chars
       // which exceeds the 80-column default, so compact view should trigger
@@ -266,7 +266,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       expect(output).toContain("Agent");
       expect(output).toContain("Clouds");
@@ -277,7 +277,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // The separator is a line of dashes (at least 20 chars: NAME_WIDTH + COUNT_WIDTH + 20)
       expect(output).toContain("----------");
@@ -291,7 +291,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // claude is implemented on all 7 clouds -> "7/7"
       expect(output).toContain("7/7");
@@ -301,7 +301,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // aider is implemented on sprite + linode = 2 out of 7
       expect(output).toContain("2/7");
@@ -311,7 +311,7 @@ describe("Compact List View", () => {
       await setManifest(allMissingManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       expect(output).toContain("0/7");
     });
@@ -320,7 +320,7 @@ describe("Compact List View", () => {
       await setManifest(allImplementedManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // Both agents should show 7/7
       // Check that "7/7" appears (for both claude and aider)
@@ -337,7 +337,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // claude is implemented everywhere -> "all clouds supported"
       expect(output).toContain("all clouds supported");
@@ -347,7 +347,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // aider is missing: hetzner, vultr, digitalocean, aws, gcp
       expect(output).toContain("Hetzner Cloud");
@@ -361,7 +361,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // Find the line containing "Aider" to isolate the aider row
       const lines = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" "));
@@ -380,7 +380,7 @@ describe("Compact List View", () => {
       await setManifest(allMissingManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // All cloud names should appear in the missing column
       expect(output).toContain("Sprite");
@@ -396,7 +396,7 @@ describe("Compact List View", () => {
       await setManifest(allImplementedManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       const allCloudsMatches = output.match(/all clouds supported/g);
       expect(allCloudsMatches).not.toBeNull();
@@ -412,7 +412,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       expect(output).toContain("Claude Code");
       expect(output).toContain("Aider");
@@ -426,7 +426,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       // claude: 7 implemented, aider: 2 implemented = 9 total out of 14
       expect(output).toContain("9/14");
@@ -436,7 +436,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       expect(output).toContain("implemented");
       // The +/- legend is grid-only, not shown in compact view
@@ -447,7 +447,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       expect(output).toContain("spawn <agent>");
       expect(output).toContain("spawn <cloud>");
@@ -474,7 +474,7 @@ describe("Compact List View", () => {
       await setManifest(singleAgent);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput();
       expect(output).toContain("Claude Code");
       expect(output).toContain("2/7");
@@ -490,7 +490,7 @@ describe("Compact List View", () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
-      await cmdList();
+      await cmdMatrix();
       const lines = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" "));
       const aiderLine = lines.find(
         (line: string) => line.includes("Aider") && line.includes("/7")

--- a/cli/src/__tests__/commands-display.test.ts
+++ b/cli/src/__tests__/commands-display.test.ts
@@ -123,7 +123,7 @@ mock.module("@clack/prompts", () => ({
 }));
 
 // Import commands after mock setup
-const { cmdAgentInfo, cmdList, cmdAgents, cmdClouds, cmdHelp, cmdUpdate } =
+const { cmdAgentInfo, cmdMatrix, cmdAgents, cmdClouds, cmdHelp, cmdUpdate } =
   await import("../commands.js");
 
 describe("Commands Display Output", () => {
@@ -234,9 +234,9 @@ describe("Commands Display Output", () => {
 
   // ── cmdList ────────────────────────────────────────────────────────
 
-  describe("cmdList", () => {
+  describe("cmdMatrix", () => {
     it("should display cloud names in header", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");
@@ -245,7 +245,7 @@ describe("Commands Display Output", () => {
     });
 
     it("should display agent names in rows", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");
@@ -254,7 +254,7 @@ describe("Commands Display Output", () => {
     });
 
     it("should show implemented count", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");
@@ -263,7 +263,7 @@ describe("Commands Display Output", () => {
     });
 
     it("should show legend for + and -", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");
@@ -272,7 +272,7 @@ describe("Commands Display Output", () => {
     });
 
     it("should show + for implemented and - for missing", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");
@@ -288,7 +288,7 @@ describe("Commands Display Output", () => {
       })) as any;
       await loadManifest(true);
 
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");
@@ -296,7 +296,7 @@ describe("Commands Display Output", () => {
     });
 
     it("should use spinner while loading manifest", async () => {
-      await cmdList();
+      await cmdMatrix();
       expect(mockSpinnerStart).toHaveBeenCalled();
       expect(mockSpinnerStop).toHaveBeenCalled();
     });
@@ -572,7 +572,7 @@ describe("Commands Display Output", () => {
       })) as any;
       await loadManifest(true);
 
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");
@@ -587,7 +587,7 @@ describe("Commands Display Output", () => {
       })) as any;
       await loadManifest(true);
 
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls
         .map((c: any[]) => c.join(" "))
         .join("\n");

--- a/cli/src/__tests__/commands-list-grid.test.ts
+++ b/cli/src/__tests__/commands-list-grid.test.ts
@@ -180,7 +180,7 @@ mock.module("@clack/prompts", () => ({
 }));
 
 // Import commands after mock setup
-const { cmdList, cmdClouds } = await import("../commands.js");
+const { cmdMatrix, cmdClouds } = await import("../commands.js");
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -203,7 +203,7 @@ function getLines(consoleMocks: ReturnType<typeof createConsoleMocks>): string[]
 
 // ── cmdList Grid View ────────────────────────────────────────────────────────
 
-describe("cmdList - grid view rendering", () => {
+describe("cmdMatrix - grid view rendering", () => {
   let consoleMocks: ReturnType<typeof createConsoleMocks>;
   let originalFetch: typeof global.fetch;
   let originalColumns: number | undefined;
@@ -232,7 +232,7 @@ describe("cmdList - grid view rendering", () => {
 
   describe("grid header", () => {
     it("should show cloud display names in the header row", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("Sprite");
       expect(output).toContain("Hetzner Cloud");
@@ -240,7 +240,7 @@ describe("cmdList - grid view rendering", () => {
 
     it("should show all cloud names when multiple types exist", async () => {
       await setManifest(multiTypeManifest);
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("Sprite");
       expect(output).toContain("Hetzner Cloud");
@@ -253,7 +253,7 @@ describe("cmdList - grid view rendering", () => {
 
   describe("grid separator", () => {
     it("should render a separator line with dashes", async () => {
-      await cmdList();
+      await cmdMatrix();
       const lines = getLines(consoleMocks);
       const separatorLine = lines.find((l: string) => l.includes("--") && !l.includes("Agent"));
       expect(separatorLine).toBeDefined();
@@ -264,13 +264,13 @@ describe("cmdList - grid view rendering", () => {
 
   describe("matrix rows", () => {
     it("should show '+' for implemented entries", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("+");
     });
 
     it("should show '-' for missing entries", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       // hetzner/aider is missing
       expect(output).toContain("-");
@@ -278,7 +278,7 @@ describe("cmdList - grid view rendering", () => {
 
     it("should show all '+' when everything is implemented", async () => {
       await setManifest(allImplManifest);
-      await cmdList();
+      await cmdMatrix();
       const lines = getLines(consoleMocks);
       // Find agent rows (contain agent display names)
       const agentRows = lines.filter(
@@ -291,7 +291,7 @@ describe("cmdList - grid view rendering", () => {
     });
 
     it("should show agent display names in rows", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("Claude Code");
       expect(output).toContain("Aider");
@@ -299,7 +299,7 @@ describe("cmdList - grid view rendering", () => {
 
     it("should render single agent grid correctly", async () => {
       await setManifest(singleAgentManifest);
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("Claude Code");
       expect(output).toContain("+");
@@ -308,7 +308,7 @@ describe("cmdList - grid view rendering", () => {
 
     it("should render single cloud grid correctly", async () => {
       await setManifest(singleCloudManifest);
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("Sprite");
       expect(output).toContain("Claude Code");
@@ -320,14 +320,14 @@ describe("cmdList - grid view rendering", () => {
 
   describe("grid legend", () => {
     it("should show legend with implemented and not-yet-available labels", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("implemented");
       expect(output).toContain("not yet available");
     });
 
     it("should show '+' symbol in legend", async () => {
-      await cmdList();
+      await cmdMatrix();
       const lines = getLines(consoleMocks);
       const legendLine = lines.find(
         (l: string) => l.includes("implemented") && l.includes("not yet available")
@@ -341,7 +341,7 @@ describe("cmdList - grid view rendering", () => {
 
   describe("grid footer", () => {
     it("should show correct implementation count for mixed matrix", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       // 3 implemented out of 4 total
       expect(output).toContain("3/4");
@@ -350,28 +350,28 @@ describe("cmdList - grid view rendering", () => {
 
     it("should show N/N for all-implemented matrix", async () => {
       await setManifest(allImplManifest);
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("4/4");
     });
 
     it("should show 0/N for all-missing matrix", async () => {
       await setManifest(allMissingManifest);
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("0/4");
     });
 
     it("should show correct count for multi-type manifest", async () => {
       await setManifest(multiTypeManifest);
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       // 6 implemented out of 8 total (2 agents x 4 clouds)
       expect(output).toContain("6/8");
     });
 
     it("should show usage hints with spawn <agent> and spawn <cloud>", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("spawn <agent>");
       expect(output).toContain("spawn <cloud>");
@@ -379,14 +379,14 @@ describe("cmdList - grid view rendering", () => {
 
     it("should show 1/2 for single agent with one implementation", async () => {
       await setManifest(singleAgentManifest);
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("1/2");
     });
 
     it("should show 1/2 for single cloud with one implementation", async () => {
       await setManifest(singleCloudManifest);
-      await cmdList();
+      await cmdMatrix();
       const output = getOutput(consoleMocks);
       expect(output).toContain("1/2");
     });

--- a/cli/src/__tests__/commands-output.test.ts
+++ b/cli/src/__tests__/commands-output.test.ts
@@ -38,7 +38,7 @@ mock.module("@clack/prompts", () => ({
 }));
 
 // Import commands after @clack/prompts mock is set up
-const { cmdList, cmdAgents, cmdClouds, cmdAgentInfo, cmdHelp } = await import("../commands.js");
+const { cmdMatrix, cmdAgents, cmdClouds, cmdAgentInfo, cmdHelp } = await import("../commands.js");
 
 describe("Command Output Functions", () => {
   let consoleMocks: ReturnType<typeof createConsoleMocks>;
@@ -70,42 +70,42 @@ describe("Command Output Functions", () => {
 
   // ── cmdList ─────────────────────────────────────────────────────────────
 
-  describe("cmdList", () => {
+  describe("cmdMatrix", () => {
     it("should load manifest and display matrix table", async () => {
-      await cmdList();
+      await cmdMatrix();
       expect(consoleMocks.log).toHaveBeenCalled();
     });
 
     it("should show agent names in the matrix", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
       expect(output).toContain("Claude Code");
       expect(output).toContain("Aider");
     });
 
     it("should show cloud names in the header", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
       expect(output).toContain("Sprite");
       expect(output).toContain("Hetzner Cloud");
     });
 
     it("should show implementation count", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
       // 3 implemented out of 4 total (2 agents x 2 clouds)
       expect(output).toContain("3/4");
     });
 
     it("should show legend with implemented and not-yet-available labels", async () => {
-      await cmdList();
+      await cmdMatrix();
       const output = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
       expect(output).toContain("implemented");
       expect(output).toContain("not yet available");
     });
 
     it("should use spinner while loading", async () => {
-      await cmdList();
+      await cmdMatrix();
       expect(mockSpinnerStart).toHaveBeenCalled();
       expect(mockSpinnerStop).toHaveBeenCalled();
     });

--- a/cli/src/__tests__/commands-resolve-run.test.ts
+++ b/cli/src/__tests__/commands-resolve-run.test.ts
@@ -428,7 +428,7 @@ describe("cmdRun - display name resolution", () => {
       expect(infoCalls.some((msg: string) => msg.includes("no implemented cloud providers"))).toBe(true);
     });
 
-    it("should suggest 'spawn list' when no clouds available", async () => {
+    it("should suggest 'spawn matrix' when no clouds available", async () => {
       await setManifestAndScript(noCloudManifest);
 
       try {
@@ -438,7 +438,7 @@ describe("cmdRun - display name resolution", () => {
       }
 
       const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
-      expect(infoCalls.some((msg: string) => msg.includes("spawn list"))).toBe(true);
+      expect(infoCalls.some((msg: string) => msg.includes("spawn matrix"))).toBe(true);
     });
   });
 

--- a/cli/src/__tests__/commands-update-download.test.ts
+++ b/cli/src/__tests__/commands-update-download.test.ts
@@ -471,7 +471,7 @@ describe("Script download and execution", () => {
 
     const allOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
     expect(allOutput).toContain("could not be found");
-    expect(allOutput).toContain("spawn list");
+    expect(allOutput).toContain("spawn matrix");
     expect(allOutput).toContain("Report the issue");
   });
 

--- a/cli/src/__tests__/commands.test.ts
+++ b/cli/src/__tests__/commands.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import {
   cmdRun,
-  cmdList,
+  cmdMatrix,
   cmdAgents,
   cmdClouds,
   cmdAgentInfo,

--- a/cli/src/__tests__/dispatch-extra-args.test.ts
+++ b/cli/src/__tests__/dispatch-extra-args.test.ts
@@ -38,7 +38,7 @@ const IMMEDIATE_COMMAND_KEYS = new Set([
 ]);
 
 const SUBCOMMAND_KEYS = new Set([
-  "list", "ls", "agents", "clouds", "update",
+  "list", "ls", "matrix", "m", "agents", "clouds", "update",
 ]);
 
 type DispatchResult =

--- a/cli/src/__tests__/download-and-failure.test.ts
+++ b/cli/src/__tests__/download-and-failure.test.ts
@@ -254,7 +254,7 @@ describe("Download and Failure Pipeline", () => {
       }
 
       const errorOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-      expect(errorOutput).toContain("spawn list");
+      expect(errorOutput).toContain("spawn matrix");
     });
 
     it("should suggest reporting the issue when both return 404", async () => {
@@ -369,7 +369,7 @@ describe("Download and Failure Pipeline", () => {
       }
 
       const errorOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-      expect(errorOutput).toContain("spawn list");
+      expect(errorOutput).toContain("spawn matrix");
     });
 
     it("should show the GitHub raw URL for manual access on network error", async () => {

--- a/cli/src/__tests__/validate-implementation-branches.test.ts
+++ b/cli/src/__tests__/validate-implementation-branches.test.ts
@@ -433,13 +433,13 @@ describe("validateImplementation branching", () => {
       expect(infos.some((msg: string) => msg.includes("no implemented cloud providers"))).toBe(true);
     });
 
-    it("should suggest 'spawn list' when agent has 0 clouds", async () => {
+    it("should suggest 'spawn matrix' when agent has 0 clouds", async () => {
       await setManifest(noCloudManifest);
 
       await expect(cmdRun("aider", "hetzner")).rejects.toThrow("process.exit");
 
       const infos = getInfoMessages();
-      expect(infos.some((msg: string) => msg.includes("spawn list"))).toBe(true);
+      expect(infos.some((msg: string) => msg.includes("spawn matrix"))).toBe(true);
     });
 
     it("should NOT show example spawn commands when agent has 0 clouds", async () => {
@@ -449,7 +449,7 @@ describe("validateImplementation branching", () => {
 
       const infos = getInfoMessages();
       // Should not have any "spawn aider <cloud>" examples
-      expect(infos.some((msg: string) => /spawn aider \w+/.test(msg) && !msg.includes("spawn list"))).toBe(false);
+      expect(infos.some((msg: string) => /spawn aider \w+/.test(msg) && !msg.includes("spawn matrix"))).toBe(false);
     });
 
     it("should show 'not yet implemented' error message", async () => {
@@ -630,7 +630,7 @@ describe("validateImplementation branching", () => {
       const infos = getInfoMessages();
       // aider has 0 implemented clouds in this manifest
       expect(infos.some((msg: string) => msg.includes("no implemented cloud providers"))).toBe(true);
-      expect(infos.some((msg: string) => msg.includes("spawn list"))).toBe(true);
+      expect(infos.some((msg: string) => msg.includes("spawn matrix"))).toBe(true);
     });
   });
 

--- a/cli/src/history.ts
+++ b/cli/src/history.ts
@@ -1,0 +1,56 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+export interface SpawnRecord {
+  agent: string;
+  cloud: string;
+  timestamp: string;
+  prompt?: string;
+}
+
+/** Returns the directory for spawn data, respecting SPAWN_HOME env var */
+export function getSpawnDir(): string {
+  return process.env.SPAWN_HOME || join(homedir(), ".spawn");
+}
+
+export function getHistoryPath(): string {
+  return join(getSpawnDir(), "history.json");
+}
+
+export function loadHistory(): SpawnRecord[] {
+  const path = getHistoryPath();
+  if (!existsSync(path)) return [];
+  try {
+    const data = JSON.parse(readFileSync(path, "utf-8"));
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveSpawnRecord(record: SpawnRecord): void {
+  const dir = getSpawnDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const history = loadHistory();
+  history.push(record);
+  writeFileSync(getHistoryPath(), JSON.stringify(history, null, 2) + "\n");
+}
+
+export function filterHistory(
+  agentFilter?: string,
+  cloudFilter?: string
+): SpawnRecord[] {
+  let records = loadHistory();
+  if (agentFilter) {
+    const lower = agentFilter.toLowerCase();
+    records = records.filter((r) => r.agent.toLowerCase() === lower);
+  }
+  if (cloudFilter) {
+    const lower = cloudFilter.toLowerCase();
+    records = records.filter((r) => r.cloud.toLowerCase() === lower);
+  }
+  return records;
+}


### PR DESCRIPTION
## Summary
- Renames `spawn list` to `spawn matrix` (alias: `m`) for the agent-cloud availability matrix
- Repurposes `spawn list` / `spawn ls` to show previously provisioned agents from `~/.spawn/history.json`
- Adds filtering support: `spawn list -a <agent>`, `spawn list -c <cloud>`
- Auto-records each spawn (agent, cloud, timestamp, prompt) before script execution
- History path respects `SPAWN_HOME` env var for testability
- Bumps CLI version to 0.2.44

## Test plan
- [x] All 4728 existing tests pass (0 failures)
- [x] Updated 13 test files to reflect `cmdList` -> `cmdMatrix` rename
- [x] New tests for `matrix` and `m` alias routing
- [x] `spawn list` shows history or "No spawns recorded" message
- [x] `spawn matrix` shows the availability grid as before

Fixes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)