### PR TITLE
fix: show spawn history newest-first with rerun hint

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.44",
+  "version": "0.2.45",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -770,6 +770,11 @@ export async function cmdList(agentFilter?: string, cloudFilter?: string): Promi
   }
 
   console.log();
+
+  // Show rerun hint for the most recent spawn (first record since list is newest-first)
+  const latest = records[0];
+  console.log(`Rerun last: ${pc.cyan(`spawn ${latest.agent} ${latest.cloud}`)}`);
+
   console.log(pc.dim(`${records.length} spawn${records.length !== 1 ? "s" : ""} recorded`));
   console.log(pc.dim(`Filter: ${pc.cyan("spawn list -a <agent>")}  or  ${pc.cyan("spawn list -c <cloud>")}`));
   console.log();

--- a/cli/src/history.ts
+++ b/cli/src/history.ts
@@ -52,5 +52,7 @@ export function filterHistory(
     const lower = cloudFilter.toLowerCase();
     records = records.filter((r) => r.cloud.toLowerCase() === lower);
   }
+  // Show newest first (reverse chronological order)
+  records.reverse();
   return records;
 }


### PR DESCRIPTION
## Summary
- `spawn list` now shows records in reverse chronological order (newest first), matching the convention of `git log`, shell `history`, and `docker ps`
- Adds a "Rerun last: spawn <agent> <cloud>" hint at the bottom of history output for quick re-execution

## Test plan
- [x] All 4728 existing tests pass
- [x] Verify `spawn list` shows newest spawns at the top
- [x] Verify "Rerun last" hint appears with correct agent/cloud from most recent spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)