### PR TITLE
fix: improve spawn list and clouds UX

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/commands-error-paths.test.ts
+++ b/cli/src/__tests__/commands-error-paths.test.ts
@@ -359,8 +359,8 @@ describe("Commands Error Paths", () => {
       await expect(cmdRun("sprite", "claude")).rejects.toThrow("process.exit");
       expect(processExitSpy).toHaveBeenCalledWith(1);
 
-      const warnCalls = mockLogWarn.mock.calls.map((c: any[]) => c.join(" "));
-      expect(warnCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
+      const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
     });
 
     it("should suggest the correct argument order when swapped", async () => {
@@ -373,8 +373,8 @@ describe("Commands Error Paths", () => {
     it("should suggest correct order for hetzner/aider swap", async () => {
       await expect(cmdRun("hetzner", "aider")).rejects.toThrow("process.exit");
 
-      const warnCalls = mockLogWarn.mock.calls.map((c: any[]) => c.join(" "));
-      expect(warnCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
+      const infoCalls2 = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls2.some((msg: string) => msg.includes("swapped"))).toBe(true);
 
       const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("spawn aider hetzner"))).toBe(true);

--- a/cli/src/__tests__/commands-swap-resolve.test.ts
+++ b/cli/src/__tests__/commands-swap-resolve.test.ts
@@ -113,10 +113,8 @@ describe("detectAndFixSwappedArgs via cmdRun", () => {
         // May throw from script execution
       }
 
-      const warnCalls = mockLogWarn.mock.calls.map((c: any[]) => c.join(" "));
-      expect(warnCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
-
       const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
       expect(infoCalls.some((msg: string) => msg.includes("spawn claude sprite"))).toBe(true);
     });
 
@@ -221,8 +219,8 @@ describe("detectAndFixSwappedArgs via cmdRun", () => {
       }
 
       // Should detect the swap
-      const warnCalls = mockLogWarn.mock.calls.map((c: any[]) => c.join(" "));
-      expect(warnCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
+      const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
 
       // Should then fail at implementation check
       const errorCalls = mockLogError.mock.calls.map((c: any[]) => c.join(" "));
@@ -552,8 +550,8 @@ describe("prompt handling with swapped args", () => {
     }
 
     // Should detect swap
-    const warnCalls = mockLogWarn.mock.calls.map((c: any[]) => c.join(" "));
-    expect(warnCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
+    const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+    expect(infoCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
 
     // Should show launch message with prompt
     const stepCalls = mockLogStep.mock.calls.map((c: any[]) => c.join(" "));


### PR DESCRIPTION
## Summary
- Show prompt preview in `spawn list` history so users can distinguish interactive vs automated runs
- Include the prompt in the rerun hint when the most recent spawn used `--prompt`
- Show auth requirements (e.g. `auth: HCLOUD_TOKEN`) in `spawn clouds` listing so users know what credentials are needed at a glance
- Change swap detection message from `warn` (yellow) to `info` -- auto-correcting swapped args is helpful, not a warning
- Update `spawn clouds` footer to say "for setup instructions" instead of "for details"

## Test plan
- [x] All 4762 existing tests pass
- [x] Updated 5 tests that checked `mockLogWarn` for swap detection to use `mockLogInfo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)