### PR TITLE
fix: add timeout to script downloads and validate list filter flags

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -417,7 +417,9 @@ async function downloadScriptWithFallback(primaryUrl: string, fallbackUrl: strin
   s.start("Downloading spawn script...");
 
   try {
-    const res = await fetch(primaryUrl);
+    const res = await fetch(primaryUrl, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT),
+    });
     if (res.ok) {
       s.stop("Script downloaded");
       return res.text();
@@ -425,7 +427,9 @@ async function downloadScriptWithFallback(primaryUrl: string, fallbackUrl: strin
 
     // Fallback to GitHub raw
     s.message("Trying fallback source...");
-    const ghRes = await fetch(fallbackUrl);
+    const ghRes = await fetch(fallbackUrl, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT),
+    });
     if (!ghRes.ok) {
       s.stop(pc.red("Download failed"));
       reportDownloadFailure(primaryUrl, fallbackUrl, res.status, ghRes.status);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -304,10 +304,20 @@ function parseListFilters(args: string[]): { agentFilter?: string; cloudFilter?:
   let agentFilter: string | undefined;
   let cloudFilter: string | undefined;
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "-a" && args[i + 1] && !args[i + 1].startsWith("-")) {
+    if (args[i] === "-a") {
+      if (!args[i + 1] || args[i + 1].startsWith("-")) {
+        console.error(pc.red(`Error: ${pc.bold("-a")} requires an agent name`));
+        console.error(`\nUsage: ${pc.cyan("spawn list -a <agent>")}`);
+        process.exit(1);
+      }
       agentFilter = args[i + 1];
       i++;
-    } else if (args[i] === "-c" && args[i + 1] && !args[i + 1].startsWith("-")) {
+    } else if (args[i] === "-c") {
+      if (!args[i + 1] || args[i + 1].startsWith("-")) {
+        console.error(pc.red(`Error: ${pc.bold("-c")} requires a cloud name`));
+        console.error(`\nUsage: ${pc.cyan("spawn list -c <cloud>")}`);
+        process.exit(1);
+      }
       cloudFilter = args[i + 1];
       i++;
     }


### PR DESCRIPTION
## Summary
- Add `FETCH_TIMEOUT` (10s) to script download fetches in `downloadScriptWithFallback`, preventing indefinite hangs when the server is unresponsive. The timeout constant already existed but was only used in `cmdUpdate`, not in the main script download path.
- Show an actionable error when `spawn list -a` or `spawn list -c` is used without a value, instead of silently showing unfiltered results.
- Bump CLI version to 0.2.48.

## Test plan
- [x] All 4827 existing tests pass
- [ ] Manual test: `spawn list -a` shows error with usage hint
- [ ] Manual test: `spawn list -c` shows error with usage hint
- [ ] Manual test: `spawn list -a claude` still works correctly

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)