### PR TITLE
fix: add fuzzy suggestions and filter context to spawn list

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- When `spawn list -a/-c` filter returns no results, suggest corrections using the same fuzzy matching (Levenshtein distance) used elsewhere in the CLI (e.g., `spawn list -a claud` now suggests "Did you mean `spawn list -a claude`?")
- Show total history count when filtering returns no results so users know other entries exist (e.g., "Run `spawn list` to see all 5 recorded spawns")
- When filter matches results, show "Showing X of Y spawns" with a "Clear filter: `spawn list`" hint instead of the generic footer

## Test plan
- [x] All 4862 existing + new tests pass (`bun test`)
- [x] Updated 2 existing assertions for new filtered footer format
- [x] Added 4 new tests: empty filter with total count, "Showing X of Y" with filter, "Clear filter" hint present when filtering, "Clear filter" hint absent when not filtering
- [ ] Manual: run `spawn list -a claud` and verify "Did you mean" suggestion appears
- [ ] Manual: run `spawn list -a claude` with history and verify "Showing X of Y" footer

Generated with [Claude Code](https://claude.com/claude-code)