### PR TITLE
fix: add ENVIRONMENT VARIABLES section to spawn help

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.49",
+  "version": "0.2.50",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cmd-help-content.test.ts
+++ b/cli/src/__tests__/cmd-help-content.test.ts
@@ -208,6 +208,39 @@ describe("cmdHelp - content completeness", () => {
     });
   });
 
+  // ── Environment variables section ──────────────────────────────────
+
+  describe("environment variables section", () => {
+    it("should have an ENVIRONMENT VARIABLES section", () => {
+      expect(getHelpOutput()).toContain("ENVIRONMENT VARIABLES");
+    });
+
+    it("should document OPENROUTER_API_KEY", () => {
+      const output = getHelpOutput();
+      expect(output).toContain("OPENROUTER_API_KEY");
+    });
+
+    it("should document SPAWN_NO_UPDATE_CHECK", () => {
+      const output = getHelpOutput();
+      expect(output).toContain("SPAWN_NO_UPDATE_CHECK");
+    });
+
+    it("should document SPAWN_NO_UNICODE", () => {
+      const output = getHelpOutput();
+      expect(output).toContain("SPAWN_NO_UNICODE");
+    });
+
+    it("should document SPAWN_HOME", () => {
+      const output = getHelpOutput();
+      expect(output).toContain("SPAWN_HOME");
+    });
+
+    it("should document SPAWN_DEBUG", () => {
+      const output = getHelpOutput();
+      expect(output).toContain("SPAWN_DEBUG");
+    });
+  });
+
   // ── Links ──────────────────────────────────────────────────────────
 
   describe("repository links", () => {

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1155,6 +1155,13 @@ ${pc.bold("TROUBLESHOOTING")}
   ${pc.dim("*")} Garbled unicode: Set ${pc.cyan("SPAWN_NO_UNICODE=1")} for ASCII-only output
   ${pc.dim("*")} Slow startup: Set ${pc.cyan("SPAWN_NO_UPDATE_CHECK=1")} to skip auto-update
 
+${pc.bold("ENVIRONMENT VARIABLES")}
+  ${pc.cyan("OPENROUTER_API_KEY")}        OpenRouter API key (all agents require this)
+  ${pc.cyan("SPAWN_NO_UPDATE_CHECK=1")}   Skip auto-update check on startup
+  ${pc.cyan("SPAWN_NO_UNICODE=1")}        Force ASCII output (no unicode symbols)
+  ${pc.cyan("SPAWN_HOME")}                Override spawn data directory (default: ~/.spawn)
+  ${pc.cyan("SPAWN_DEBUG=1")}             Show debug output (unicode detection, etc.)
+
 ${pc.bold("MORE INFO")}
   Repository:  https://github.com/${REPO}
   OpenRouter:  https://openrouter.ai


### PR DESCRIPTION
## Summary
- Adds a new **ENVIRONMENT VARIABLES** section to `spawn help` output, documenting all `SPAWN_*` env vars (`OPENROUTER_API_KEY`, `SPAWN_NO_UPDATE_CHECK`, `SPAWN_NO_UNICODE`, `SPAWN_HOME`, `SPAWN_DEBUG`)
- Users previously had no way to discover `SPAWN_HOME`, `SPAWN_DEBUG`, or `SPAWN_UNICODE` without reading source code
- Adds 5 tests verifying the new section content

## Test plan
- [x] All 37 cmd-help-content tests pass (including 5 new)
- [x] Full test suite passes (4907/4908 — 1 pre-existing failure on main unrelated to this change)
- [x] Version bumped to 0.2.50

Agent: ux-engineer