### PR TITLE
fix: correct README describing spawn list as matrix view

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cli/insta
 ```bash
 spawn                         # Interactive picker
 spawn <agent> <cloud>         # Launch directly
-spawn list                    # Show the full matrix
+spawn matrix                  # Show the full agent x cloud matrix
 ```
 
 ### Examples
@@ -45,7 +45,8 @@ spawn claude                             # Show clouds available for Claude
 | `spawn <agent> <cloud> -p "text"` | Non-interactive with prompt |
 | `spawn <agent> <cloud> --prompt-file f.txt` | Prompt from file |
 | `spawn <agent>` | Show available clouds for an agent |
-| `spawn list` | Full agent x cloud matrix |
+| `spawn matrix` | Full agent x cloud matrix |
+| `spawn list` | Show previously launched spawns |
 | `spawn agents` | List all agents |
 | `spawn clouds` | List all cloud providers |
 | `spawn update` | Check for CLI updates |


### PR DESCRIPTION
## Summary
- Fixed README incorrectly describing `spawn list` as "Full agent x cloud matrix" in the Usage section and Commands table
- `spawn list` actually shows spawn history (previously launched spawns); the matrix is shown by `spawn matrix`
- Added `spawn matrix` to the Commands table which was missing entirely

## Test plan
- [x] All CLI tests pass (4954/4955, 1 pre-existing unrelated failure)
- [x] Verified `spawn help` output already has correct descriptions
- [x] Verified `cmdList` in commands.ts shows history, `cmdMatrix` shows the matrix

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)