### PR TITLE
fix: improve CLI display for matrix, compact view, and list history

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/commands-compact-list.test.ts
+++ b/cli/src/__tests__/commands-compact-list.test.ts
@@ -227,7 +227,7 @@ describe("Compact List View", () => {
       // Compact view has "Agent", "Clouds", "Missing" header columns
       expect(output).toContain("Agent");
       expect(output).toContain("Clouds");
-      expect(output).toContain("Not available on");
+      expect(output).toContain("Missing");
     });
 
     it("should use grid view when terminal is wide enough for small manifest", async () => {
@@ -242,7 +242,7 @@ describe("Compact List View", () => {
       expect(output).toContain("Sprite");
       expect(output).toContain("Hetzner Cloud");
       // Grid view should NOT have the "Missing" header column
-      expect(output).not.toContain("Not available on");
+      expect(output).not.toContain("Missing");
     });
 
     it("should default to 80 columns when process.stdout.columns is undefined", async () => {
@@ -255,14 +255,14 @@ describe("Compact List View", () => {
       // With 7 clouds at ~10+ chars each, the grid would be ~100+ chars
       // which exceeds the 80-column default, so compact view should trigger
       expect(output).toContain("Agent");
-      expect(output).toContain("Not available on");
+      expect(output).toContain("Missing");
     });
   });
 
   // ── Compact view header and structure ─────────────────────────────
 
   describe("compact view header", () => {
-    it("should show three column headers: Agent, Clouds, Not available on", async () => {
+    it("should show three column headers: Agent, Clouds, Missing", async () => {
       await setManifest(wideManifest);
       process.stdout.columns = 60;
 
@@ -270,7 +270,7 @@ describe("Compact List View", () => {
       const output = getOutput();
       expect(output).toContain("Agent");
       expect(output).toContain("Clouds");
-      expect(output).toContain("Not available on");
+      expect(output).toContain("Missing");
     });
 
     it("should include a separator line with dashes", async () => {

--- a/cli/src/__tests__/list-filter-suggestions.test.ts
+++ b/cli/src/__tests__/list-filter-suggestions.test.ts
@@ -620,10 +620,10 @@ describe("cmdMatrix - compact vs grid view", () => {
       await cmdMatrix();
 
       const output = getOutput();
-      // Compact view shows "all clouds supported" or "Not available on" column
+      // Compact view shows "all clouds supported" or "Missing" column
       expect(output).toContain("Agent");
       expect(output).toContain("Clouds");
-      expect(output).toContain("Not available on");
+      expect(output).toContain("Missing");
     });
 
     it("should show green for fully-supported agents in compact view", async () => {


### PR DESCRIPTION
## Summary
- Add "Availability Matrix (N agents, M clouds)" title header to `spawn matrix` output so users immediately see the scope
- Shorten compact view column header from "Not available on" to "Missing" for better scannability
- Show display names (e.g. "Claude Code", "Hetzner Cloud") instead of raw keys (e.g. "claude", "hetzner") in `spawn list` output, matching the style of `spawn agents` and `spawn clouds`

## Test plan
- [x] All 5033 tests pass (1 pre-existing failure on main unrelated to these changes)
- [x] Updated 6 test assertions that referenced the old "Not available on" header
- [x] Version bumped to 0.2.52

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)