### PR TITLE
fix: show specific auth env vars in script failure errors

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -292,6 +292,66 @@ describe("getScriptFailureGuidance", () => {
     });
   });
 
+  // ── Auth hint parameter ──────────────────────────────────────────────────
+
+  describe("auth hint parameter", () => {
+    it("should show specific env var name for exit code 1 when authHint is provided", () => {
+      const lines = getScriptFailureGuidance(1, "hetzner", "HCLOUD_TOKEN");
+      const joined = lines.join("\n");
+      expect(joined).toContain("HCLOUD_TOKEN");
+      expect(joined).toContain("OPENROUTER_API_KEY");
+    });
+
+    it("should show generic setup hint for exit code 1 when no authHint", () => {
+      const lines = getScriptFailureGuidance(1, "hetzner");
+      const joined = lines.join("\n");
+      expect(joined).toContain("spawn hetzner");
+      expect(joined).not.toContain("HCLOUD_TOKEN");
+    });
+
+    it("should show specific env var name for default case when authHint is provided", () => {
+      const lines = getScriptFailureGuidance(42, "digitalocean", "DO_API_TOKEN");
+      const joined = lines.join("\n");
+      expect(joined).toContain("DO_API_TOKEN");
+      expect(joined).toContain("OPENROUTER_API_KEY");
+    });
+
+    it("should show generic setup hint for default case when no authHint", () => {
+      const lines = getScriptFailureGuidance(42, "digitalocean");
+      const joined = lines.join("\n");
+      expect(joined).toContain("spawn digitalocean");
+      expect(joined).not.toContain("DO_API_TOKEN");
+    });
+
+    it("should handle multi-credential auth hint", () => {
+      const lines = getScriptFailureGuidance(1, "contabo", "CONTABO_CLIENT_ID + CONTABO_CLIENT_SECRET");
+      const joined = lines.join("\n");
+      expect(joined).toContain("CONTABO_CLIENT_ID + CONTABO_CLIENT_SECRET");
+    });
+
+    it("should not affect non-credential exit codes (130, 137, etc.)", () => {
+      const lines130 = getScriptFailureGuidance(130, "hetzner", "HCLOUD_TOKEN");
+      const joined130 = lines130.join("\n");
+      expect(joined130).not.toContain("HCLOUD_TOKEN");
+      expect(joined130).toContain("Ctrl+C");
+
+      const lines255 = getScriptFailureGuidance(255, "hetzner", "HCLOUD_TOKEN");
+      const joined255 = lines255.join("\n");
+      expect(joined255).not.toContain("HCLOUD_TOKEN");
+      expect(joined255).toContain("SSH");
+    });
+
+    it("should preserve line count for exit code 1 with authHint", () => {
+      const lines = getScriptFailureGuidance(1, "hetzner", "HCLOUD_TOKEN");
+      expect(lines).toHaveLength(4);
+    });
+
+    it("should preserve line count for default case with authHint", () => {
+      const lines = getScriptFailureGuidance(42, "hetzner", "HCLOUD_TOKEN");
+      expect(lines).toHaveLength(4);
+    });
+  });
+
   // ── Edge cases ────────────────────────────────────────────────────────────
 
   describe("edge cases", () => {


### PR DESCRIPTION
## Summary
- When a spawn script fails (exit code 1 or unknown), error messages now show the specific environment variables needed for the cloud provider (e.g., `HCLOUD_TOKEN + OPENROUTER_API_KEY`) instead of the generic "run `spawn <cloud>` for setup"
- Adds a `Retry: spawn <agent> <cloud>` hint at the end of all script failure error messages so users can quickly rerun
- Adds 8 new tests for the auth hint parameter in `getScriptFailureGuidance`

## Before
```
Common causes:
  - Missing or invalid credentials (run spawn hetzner for setup)
  - Cloud provider API error (quota, rate limit, or region issue)
```

## After
```
Common causes:
  - Missing or invalid credentials (need HCLOUD_TOKEN + OPENROUTER_API_KEY)
  - Cloud provider API error (quota, rate limit, or region issue)

Retry: spawn claude hetzner
```

## Test plan
- [x] All 5128 existing tests pass
- [x] 8 new tests for auth hint in script-failure-guidance.test.ts
- [x] Auth hint is only shown for credential-related exit codes (1, default), not for SSH/interrupt/permission errors
- [x] When auth info is not available (e.g., `auth: "none"`), falls back to generic "run spawn <cloud> for setup" message

Agent: ux-engineer