### PR TITLE
fix: use log_step for progress messages in recent scripts

### DIFF
--- a/local/aider.sh
+++ b/local/aider.sh
@@ -19,7 +19,7 @@ ensure_local_ready
 if command -v aider &>/dev/null; then
     log_info "Aider already installed"
 else
-    log_warn "Installing Aider..."
+    log_step "Installing Aider..."
     pip install aider-chat 2>/dev/null || pip3 install aider-chat
 fi
 
@@ -44,7 +44,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
 # 5. Inject environment variables
-log_warn "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -54,12 +54,12 @@ echo ""
 
 # 6. Start Aider
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
-    log_warn "Executing Aider with prompt..."
+    log_step "Executing Aider with prompt..."
     source ~/.zshrc 2>/dev/null || true
     escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
     aider --model "openrouter/${MODEL_ID}" -m "${escaped_prompt}"
 else
-    log_warn "Starting Aider..."
+    log_step "Starting Aider..."
     sleep 1
     clear 2>/dev/null || true
     source ~/.zshrc 2>/dev/null || true

--- a/local/gptme.sh
+++ b/local/gptme.sh
@@ -19,7 +19,7 @@ ensure_local_ready
 if command -v gptme &>/dev/null; then
     log_info "gptme already installed"
 else
-    log_warn "Installing gptme..."
+    log_step "Installing gptme..."
     pip install gptme 2>/dev/null || pip3 install gptme
 fi
 
@@ -44,7 +44,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
 # 4. Inject environment variables
-log_warn "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -54,12 +54,12 @@ echo ""
 
 # 5. Start gptme
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
-    log_warn "Executing gptme with prompt..."
+    log_step "Executing gptme with prompt..."
     export PATH="${HOME}/.local/bin:${PATH}"
     source ~/.zshrc 2>/dev/null || true
     gptme -m "openrouter/${MODEL_ID}" "${SPAWN_PROMPT}"
 else
-    log_warn "Starting gptme..."
+    log_step "Starting gptme..."
     sleep 1
     clear 2>/dev/null || true
     export PATH="${HOME}/.local/bin:${PATH}"

--- a/netcup/gptme.sh
+++ b/netcup/gptme.sh
@@ -62,5 +62,5 @@ echo ""
 # 7. Start gptme interactively
 log_step "Starting gptme..."
 sleep 1
-clear
+clear 2>/dev/null || true
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/ramnode/gptme.sh
+++ b/ramnode/gptme.sh
@@ -27,7 +27,7 @@ verify_server_connectivity "$RAMNODE_SERVER_IP"
 wait_for_cloud_init "$RAMNODE_SERVER_IP"
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$RAMNODE_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -49,7 +49,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "$RAMNODE_SERVER_IP" upload_file run_server \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
 
@@ -59,7 +59,7 @@ log_info "Server: $SERVER_NAME (ID: $RAMNODE_SERVER_ID, IP: $RAMNODE_SERVER_IP)"
 echo ""
 
 # 7. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
-clear
+clear 2>/dev/null || true
 interactive_session "$RAMNODE_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/ramnode/openclaw.sh
+++ b/ramnode/openclaw.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${RAMNODE_SERVER_IP}"
 wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${RAMNODE_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -43,7 +43,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER
 echo ""
 
 # 10. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${RAMNODE_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && openclaw tui"


### PR DESCRIPTION
## Summary
- Replace `log_warn` (yellow) with `log_step` (cyan) for progress messages in 5 recently-added scripts: `local/gptme.sh`, `local/aider.sh`, `ramnode/openclaw.sh`, `ramnode/gptme.sh`, `netcup/gptme.sh`
- Fix bare `clear` calls to use `clear 2>/dev/null || true` for robustness on minimal terminals (`ramnode/gptme.sh`, `netcup/gptme.sh`)
- Improve misleading "Appending environment variables to ~/.zshrc..." message to standard "Setting up environment variables..." in local scripts

## Context
`log_warn` (yellow) should be reserved for actual warnings. Progress messages like "Installing...", "Setting up environment variables...", and "Starting..." should use `log_step` (cyan) to match the convention established in PR #440. The `netcup/gptme.sh` script already partially followed this convention but had a bare `clear` that could fail on minimal terminals.

## Test plan
- [x] `bash -n` passes on all 5 modified scripts
- [ ] Verify progress messages appear in cyan (not yellow) during execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)