### PR TITLE
feat: make spawn list interactive with rerun support

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.54",
+  "version": "0.2.55",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- `spawn list` / `spawn ls` now shows an interactive picker in TTY mode, allowing users to navigate past spawns and press Enter to rerun one directly
- Non-TTY environments (piped output, scripts) continue to show the static table
- Updated help text to reflect the new interactive behavior

Fixes #492

## Test plan
- [x] All 5160 existing tests pass (0 failures)
- [x] All 261 list-related tests pass unchanged (non-TTY test env uses static table path)
- [ ] Manual: run `spawn ls` in terminal, verify interactive picker appears
- [ ] Manual: select a past spawn, verify it reruns correctly
- [ ] Manual: press Ctrl+C in picker, verify clean exit
- [ ] Manual: pipe `spawn list | cat`, verify static table output

🤖 Generated with [Claude Code](https://claude.com/claude-code)