### PR TITLE
refactor: simplify API retry logic and dispatchCommand

### DIFF
--- a/cli/src/__tests__/shared-common-oauth-retry.test.ts
+++ b/cli/src/__tests__/shared-common-oauth-retry.test.ts
@@ -3,14 +3,13 @@ import { execSync } from "child_process";
 import { resolve } from "path";
 
 /**
- * Tests for untested bash functions in shared/common.sh:
+ * Tests for bash functions in shared/common.sh:
  * - validate_oauth_port: OAuth port validation (security-critical)
  * - generate_env_config: shell export statement generation (injection risk)
  * - calculate_retry_backoff: exponential backoff with jitter
  * - _update_retry_interval: indirect variable update via printf -v
  * - _parse_api_response: HTTP response code extraction
  *
- * These functions had zero test coverage despite being security-relevant.
  * Each test sources shared/common.sh and calls the function in a real
  * bash subprocess to catch actual shell behavior.
  *
@@ -452,34 +451,6 @@ describe("_parse_api_response", () => {
     `);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("429");
-  });
-});
-
-// ── _api_handle_transient_http_error ─────────────────────────────────────
-
-describe("_api_handle_transient_http_error", () => {
-  it("should return 1 (fail) when max retries exhausted", () => {
-    const result = runBash(`
-      _api_handle_transient_http_error 429 5 5 10 60
-      echo "exit=$?"
-    `);
-    // The function calls _api_should_retry_on_error which returns 1 when
-    // attempt >= max_retries, and then _api_handle_transient_http_error returns 1
-    expect(result.stdout).toContain("exit=1");
-  });
-
-  it("should log HTTP 429 in error message when retries exhausted", () => {
-    const result = runBash(`
-      _api_handle_transient_http_error 429 5 5 10 60 2>&1
-    `);
-    expect(result.stdout).toContain("HTTP 429");
-  });
-
-  it("should log HTTP 503 in error message when retries exhausted", () => {
-    const result = runBash(`
-      _api_handle_transient_http_error 503 5 5 10 60 2>&1
-    `);
-    expect(result.stdout).toContain("HTTP 503");
   });
 });
 


### PR DESCRIPTION
## Summary
- Remove 2 unnecessary indirection layers (`_handle_api_transient_error` and `_api_handle_transient_http_error`) from the cloud API retry infrastructure in `shared/common.sh`, collapsing a 3-layer call chain into direct inline logic in `_cloud_api_retry_loop`
- Fix a bug where `_handle_api_transient_error` passed the string `"network"` as the numeric `attempt` parameter to `_api_should_retry_on_error`, causing incorrect retry behavior on network failures
- Extract duplicated help-flag checking in `dispatchCommand` (`cli/src/index.ts`) into a `hasTrailingHelpFlag` helper, reducing nesting depth and removing repeated code

Net: -72 lines, 2 fewer functions, 1 bug fix.

## Test plan
- [x] `bash -n shared/common.sh` passes
- [x] All 5160 tests pass (`bun test`)
- [x] Retry tests in `shared-common-oauth-retry.test.ts` pass (removed tests for deleted function)

Agent: complexity-hunter