### PR TITLE
fix: use log_step for progress messages instead of log_warn

### DIFF
--- a/aws-lightsail/aider.sh
+++ b/aws-lightsail/aider.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${LIGHTSAIL_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -50,7 +50,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 8. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -61,7 +61,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 9. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/aws-lightsail/amazonq.sh
+++ b/aws-lightsail/amazonq.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${LIGHTSAIL_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -43,7 +43,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -56,7 +56,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 8. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/aws-lightsail/claude.sh
+++ b/aws-lightsail/claude.sh
@@ -30,9 +30,9 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${LIGHTSAIL_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${LIGHTSAIL_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -67,7 +67,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/aws-lightsail/cline.sh
+++ b/aws-lightsail/cline.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${LIGHTSAIL_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -43,7 +43,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -56,7 +56,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 8. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && cline"

--- a/aws-lightsail/codex.sh
+++ b/aws-lightsail/codex.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${LIGHTSAIL_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -43,7 +43,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -56,7 +56,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 8. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && codex"

--- a/aws-lightsail/continue.sh
+++ b/aws-lightsail/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${LIGHTSAIL_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Lightsail instance setup completed successfully!"
 log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && cn"

--- a/aws-lightsail/gemini.sh
+++ b/aws-lightsail/gemini.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${LIGHTSAIL_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -43,7 +43,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -57,7 +57,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 8. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/aws-lightsail/goose.sh
+++ b/aws-lightsail/goose.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${LIGHTSAIL_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -43,7 +43,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -54,7 +54,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 8. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && goose"

--- a/aws-lightsail/gptme.sh
+++ b/aws-lightsail/gptme.sh
@@ -27,7 +27,7 @@ verify_server_connectivity "$LIGHTSAIL_SERVER_IP"
 wait_for_cloud_init "$LIGHTSAIL_SERVER_IP"
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$LIGHTSAIL_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -47,7 +47,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 8. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -59,7 +59,7 @@ log_info "Instance: $SERVER_NAME (IP: $LIGHTSAIL_SERVER_IP)"
 echo ""
 
 # 9. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "$LIGHTSAIL_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/aws-lightsail/interpreter.sh
+++ b/aws-lightsail/interpreter.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${LIGHTSAIL_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -43,7 +43,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -56,7 +56,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 8. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/aws-lightsail/kilocode.sh
+++ b/aws-lightsail/kilocode.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Kilo Code
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${LIGHTSAIL_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -43,7 +43,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -56,7 +56,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 8. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/aws-lightsail/lib/common.sh
+++ b/aws-lightsail/lib/common.sh
@@ -95,7 +95,7 @@ _wait_for_lightsail_instance() {
     local max_attempts=${2:-60}
     local attempt=1
 
-    log_warn "Waiting for instance to become running..."
+    log_step "Waiting for instance to become running..."
     while [[ ${attempt} -le ${max_attempts} ]]; do
         local state
         state=$(aws lightsail get-instance --instance-name "${name}" \
@@ -128,7 +128,7 @@ create_server() {
     validate_resource_name "${bundle}" || { log_error "Invalid LIGHTSAIL_BUNDLE"; return 1; }
     validate_region_name "${region}" || { log_error "Invalid AWS_DEFAULT_REGION"; return 1; }
 
-    log_warn "Creating Lightsail instance '${name}' (bundle: ${bundle}, AZ: ${az})..."
+    log_step "Creating Lightsail instance '${name}' (bundle: ${bundle}, AZ: ${az})..."
 
     local userdata
     userdata=$(get_cloud_init_userdata)
@@ -173,7 +173,7 @@ wait_for_cloud_init() {
 
 destroy_server() {
     local name="${1}"
-    log_warn "Destroying Lightsail instance ${name}..."
+    log_step "Destroying Lightsail instance ${name}..."
     aws lightsail delete-instance --instance-name "${name}" >/dev/null
     log_info "Instance ${name} destroyed"
 }

--- a/aws-lightsail/nanoclaw.sh
+++ b/aws-lightsail/nanoclaw.sh
@@ -30,10 +30,10 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${LIGHTSAIL_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${LIGHTSAIL_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -54,7 +54,7 @@ inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 cat > "${DOTENV_TEMP}" << EOF
@@ -69,7 +69,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${LIGHTSAIL_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/aws-lightsail/openclaw.sh
+++ b/aws-lightsail/openclaw.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${LIGHTSAIL_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -46,7 +46,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 8. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LIGHTSAIL_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -63,7 +63,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 10. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/aws-lightsail/opencode.sh
+++ b/aws-lightsail/opencode.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${LIGHTSAIL_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -43,7 +43,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -54,7 +54,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 8. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/aws-lightsail/plandex.sh
+++ b/aws-lightsail/plandex.sh
@@ -30,7 +30,7 @@ verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${LIGHTSAIL_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -43,7 +43,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -54,7 +54,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LIGHTSAIL_SERVER_IP})"
 echo ""
 
 # 8. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${LIGHTSAIL_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/binarylane/aider.sh
+++ b/binarylane/aider.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${BINARYLANE_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 if ! run_server "${BINARYLANE_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
@@ -38,7 +38,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -47,7 +47,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/binarylane/amazonq.sh
+++ b/binarylane/amazonq.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${BINARYLANE_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/binarylane/claude.sh
+++ b/binarylane/claude.sh
@@ -20,9 +20,9 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${BINARYLANE_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${BINARYLANE_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -34,7 +34,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -52,7 +52,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/binarylane/cline.sh
+++ b/binarylane/cline.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${BINARYLANE_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && cline"

--- a/binarylane/codex.sh
+++ b/binarylane/codex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${BINARYLANE_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && codex"

--- a/binarylane/continue.sh
+++ b/binarylane/continue.sh
@@ -18,10 +18,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 
-log_warn "Setting up shell environment..."
+log_step "Setting up shell environment..."
 run_server "${BINARYLANE_SERVER_IP}" "curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/bashrc_additions.sh -o /tmp/bashrc_additions.sh && cat /tmp/bashrc_additions.sh >> ~/.bashrc && rm /tmp/bashrc_additions.sh"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${BINARYLANE_SERVER_IP}" "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash && export NVM_DIR=\"\$HOME/.nvm\" && [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\" && nvm install 20 && npm install -g @continuedev/cli"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -43,7 +43,7 @@ echo ""
 log_info "BinaryLane server setup completed successfully!"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "bash -c 'source ~/.bashrc && export NVM_DIR=\"\$HOME/.nvm\" && [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\" && cn'"

--- a/binarylane/gemini.sh
+++ b/binarylane/gemini.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${BINARYLANE_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -43,7 +43,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/binarylane/goose.sh
+++ b/binarylane/goose.sh
@@ -20,10 +20,10 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${BINARYLANE_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
-log_warn "Verifying Goose installation..."
+log_step "Verifying Goose installation..."
 if ! run_server "${BINARYLANE_SERVER_IP}" "command -v goose" >/dev/null 2>&1; then
     log_error "Goose installation failed"
     exit 1
@@ -37,7 +37,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && goose"

--- a/binarylane/gptme.sh
+++ b/binarylane/gptme.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "${BINARYLANE_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 if ! run_server "${BINARYLANE_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
@@ -38,7 +38,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -47,7 +47,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/binarylane/interpreter.sh
+++ b/binarylane/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${BINARYLANE_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/binarylane/kilocode.sh
+++ b/binarylane/kilocode.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing Kilo Code CLI..."
+log_step "Installing Kilo Code CLI..."
 run_server "${BINARYLANE_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -42,7 +42,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/binarylane/lib/common.sh
+++ b/binarylane/lib/common.sh
@@ -117,7 +117,7 @@ get_server_name() {
 # Poll the BinaryLane API until the server becomes active and has an IP
 # Sets BINARYLANE_SERVER_IP on success
 _binarylane_wait_for_active() {
-    log_warn "Waiting for server to become active..."
+    log_step "Waiting for server to become active..."
     local max_attempts=60
     local attempt=1
     while [[ "$attempt" -le "$max_attempts" ]]; do
@@ -204,7 +204,7 @@ create_server() {
     validate_region_name "$region" || { log_error "Invalid BINARYLANE_REGION"; return 1; }
     validate_resource_name "$image" || { log_error "Invalid BINARYLANE_IMAGE"; return 1; }
 
-    log_warn "Creating BinaryLane server '$name' (size: $size, region: $region, image: $image)..."
+    log_step "Creating BinaryLane server '$name' (size: $size, region: $region, image: $image)..."
 
     # Get all SSH key IDs
     local ssh_keys_response
@@ -233,7 +233,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 
 destroy_server() {
     local server_id="$1"
-    log_warn "Destroying server $server_id..."
+    log_step "Destroying server $server_id..."
     binarylane_api DELETE "/servers/$server_id"
     log_info "Server $server_id destroyed"
 }

--- a/binarylane/nanoclaw.sh
+++ b/binarylane/nanoclaw.sh
@@ -20,10 +20,10 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${BINARYLANE_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${BINARYLANE_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -34,13 +34,13 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
@@ -55,7 +55,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${BINARYLANE_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/binarylane/openclaw.sh
+++ b/binarylane/openclaw.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${BINARYLANE_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -34,7 +34,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -49,7 +49,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/binarylane/opencode.sh
+++ b/binarylane/opencode.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${BINARYLANE_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -40,7 +40,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/binarylane/plandex.sh
+++ b/binarylane/plandex.sh
@@ -20,10 +20,10 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${BINARYLANE_SERVER_IP}"
 wait_for_cloud_init "${BINARYLANE_SERVER_IP}" 60
 
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${BINARYLANE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
-log_warn "Verifying Plandex installation..."
+log_step "Verifying Plandex installation..."
 if ! run_server "${BINARYLANE_SERVER_IP}" "command -v plandex" >/dev/null 2>&1; then
     log_error "Plandex installation failed"
     exit 1
@@ -37,7 +37,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${BINARYLANE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -46,7 +46,7 @@ log_info "BinaryLane server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${BINARYLANE_SERVER_ID}, IP: ${BINARYLANE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${BINARYLANE_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/cherry/aider.sh
+++ b/cherry/aider.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${CHERRY_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 # Verify installation succeeded
@@ -50,7 +50,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -60,7 +60,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/cherry/amazonq.sh
+++ b/cherry/amazonq.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${CHERRY_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -40,7 +40,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/cherry/claude.sh
+++ b/cherry/claude.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Claude Code
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "${CHERRY_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -67,7 +67,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && claude"

--- a/cherry/cline.sh
+++ b/cherry/cline.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${CHERRY_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -40,7 +40,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && cline"

--- a/cherry/codex.sh
+++ b/cherry/codex.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${CHERRY_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -40,7 +40,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && codex"

--- a/cherry/continue.sh
+++ b/cherry/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${CHERRY_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Cherry Servers setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && cn"

--- a/cherry/gemini.sh
+++ b/cherry/gemini.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${CHERRY_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -40,7 +40,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -53,7 +53,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/cherry/goose.sh
+++ b/cherry/goose.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${CHERRY_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -58,7 +58,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && goose"

--- a/cherry/gptme.sh
+++ b/cherry/gptme.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "${CHERRY_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -50,7 +50,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -60,7 +60,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/cherry/interpreter.sh
+++ b/cherry/interpreter.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${CHERRY_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -40,7 +40,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/cherry/kilocode.sh
+++ b/cherry/kilocode.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Kilo Code
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${CHERRY_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -40,7 +40,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -52,7 +52,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/cherry/nanoclaw.sh
+++ b/cherry/nanoclaw.sh
@@ -28,10 +28,10 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${CHERRY_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${CHERRY_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -43,14 +43,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 7. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -67,7 +67,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 8. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${CHERRY_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/cherry/openclaw.sh
+++ b/cherry/openclaw.sh
@@ -28,11 +28,11 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install dependencies (Node.js + Bun)
-log_warn "Installing Node.js and Bun..."
+log_step "Installing Node.js and Bun..."
 run_server "${CHERRY_SERVER_IP}" "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs && curl -fsSL https://bun.sh/install | bash"
 
 # 6. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${CHERRY_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -47,7 +47,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -64,7 +64,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 9. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${CHERRY_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/cherry/opencode.sh
+++ b/cherry/opencode.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${CHERRY_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -40,7 +40,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -50,7 +50,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/cherry/plandex.sh
+++ b/cherry/plandex.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CHERRY_SERVER_IP}"
 wait_for_cloud_init "${CHERRY_SERVER_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${CHERRY_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CHERRY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -57,7 +57,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CHERRY_SERVER_ID}, IP: ${CHERRY_SERVER_I
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${CHERRY_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/civo/aider.sh
+++ b/civo/aider.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${CIVO_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -35,7 +35,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -44,7 +44,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/civo/amazonq.sh
+++ b/civo/amazonq.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${CIVO_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/civo/claude.sh
+++ b/civo/claude.sh
@@ -19,13 +19,13 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 # Civo uses init scripts, wait for completion marker
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${CIVO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${CIVO_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -37,7 +37,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -55,7 +55,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/civo/cline.sh
+++ b/civo/cline.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${CIVO_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && cline"

--- a/civo/codex.sh
+++ b/civo/codex.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${CIVO_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && codex"

--- a/civo/continue.sh
+++ b/civo/continue.sh
@@ -18,7 +18,7 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${CIVO_SERVER_IP}" "curl -fsSL https://bun.sh/install | bash"
 run_server "${CIVO_SERVER_IP}" "export PATH=\"\$HOME/.bun/bin:\$PATH\" && bun install -g @continuedev/cli"
 
@@ -29,7 +29,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 run_server "${CIVO_SERVER_IP}" "cat >> ~/.bashrc << 'ENV_EOF'
 export PATH=\"\$HOME/.bun/bin:\$PATH\"
 export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
@@ -48,7 +48,7 @@ echo ""
 log_info "Server setup completed successfully!"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && cn"

--- a/civo/gemini.sh
+++ b/civo/gemini.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${CIVO_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/civo/goose.sh
+++ b/civo/goose.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${CIVO_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 if ! run_server "${CIVO_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
@@ -39,7 +39,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -49,7 +49,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && goose"

--- a/civo/gptme.sh
+++ b/civo/gptme.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "${CIVO_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -43,7 +43,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -52,7 +52,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/civo/interpreter.sh
+++ b/civo/interpreter.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${CIVO_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/civo/kilocode.sh
+++ b/civo/kilocode.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${CIVO_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -44,7 +44,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/civo/lib/common.sh
+++ b/civo/lib/common.sh
@@ -269,7 +269,7 @@ create_server() {
     validate_resource_name "$size" || { log_error "Invalid CIVO_SIZE"; return 1; }
     validate_region_name "$region" || { log_error "Invalid CIVO_REGION"; return 1; }
 
-    log_warn "Creating Civo instance '$name' (size: $size, region: $region)..."
+    log_step "Creating Civo instance '$name' (size: $size, region: $region)..."
 
     # Gather required resource IDs
     local network_id template_id ssh_key_id
@@ -308,7 +308,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 destroy_server() {
     local server_id="$1"
     local region="${CIVO_REGION:-lon1}"
-    log_warn "Destroying instance $server_id..."
+    log_step "Destroying instance $server_id..."
     civo_api DELETE "/instances/$server_id?region=$region"
     log_info "Instance $server_id destroyed"
 }

--- a/civo/nanoclaw.sh
+++ b/civo/nanoclaw.sh
@@ -19,13 +19,13 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${CIVO_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${CIVO_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -36,13 +36,13 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -58,7 +58,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${CIVO_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/civo/openclaw.sh
+++ b/civo/openclaw.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${CIVO_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -35,7 +35,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${CIVO_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/civo/opencode.sh
+++ b/civo/opencode.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${CIVO_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/civo/plandex.sh
+++ b/civo/plandex.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${CIVO_SERVER_IP}"
 
-log_warn "Waiting for cloud-init to complete..."
+log_step "Waiting for cloud-init to complete..."
 generic_ssh_wait "root" "${CIVO_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "cloud-init" 60 5
 
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${CIVO_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Civo instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CIVO_SERVER_ID}, IP: ${CIVO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${CIVO_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/contabo/aider.sh
+++ b/contabo/aider.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
 # 5. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${CONTABO_SERVER_IP}" "pip install aider-chat"
 
 # 6. Get OpenRouter API key
@@ -45,7 +45,7 @@ printf "Enter model ID [openrouter/auto]: "
 MODEL_ID=$(safe_read) || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -55,7 +55,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SE
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider with model: ${MODEL_ID}..."
+log_step "Starting Aider with model: ${MODEL_ID}..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && aider --model ${MODEL_ID}"

--- a/contabo/amazonq.sh
+++ b/contabo/amazonq.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${CONTABO_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Contabo server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.bashrc && q chat"

--- a/contabo/claude.sh
+++ b/contabo/claude.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${CONTABO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${CONTABO_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
@@ -50,7 +50,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -70,7 +70,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SE
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/contabo/cline.sh
+++ b/contabo/cline.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${CONTABO_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Contabo server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && cline"

--- a/contabo/codex.sh
+++ b/contabo/codex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${CONTABO_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Contabo server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && codex"

--- a/contabo/continue.sh
+++ b/contabo/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${CONTABO_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Contabo server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && cn"

--- a/contabo/gemini.sh
+++ b/contabo/gemini.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
 # 5. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 if ! run_server "${CONTABO_SERVER_IP}" "command -v gemini" >/dev/null 2>&1; then
     run_server "${CONTABO_SERVER_IP}" "npm install -g @google/gemini-cli"
 fi
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -62,7 +62,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERV
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/contabo/goose.sh
+++ b/contabo/goose.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
 # 5. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${CONTABO_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -58,7 +58,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERV
 echo ""
 
 # 8. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && goose"

--- a/contabo/gptme.sh
+++ b/contabo/gptme.sh
@@ -27,7 +27,7 @@ verify_server_connectivity "$CONTABO_SERVER_IP"
 wait_for_cloud_init "$CONTABO_SERVER_IP"
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$CONTABO_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -49,7 +49,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "$CONTABO_SERVER_IP" upload_file run_server \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
 
@@ -59,7 +59,7 @@ log_info "Server: $SERVER_NAME (ID: $CONTABO_INSTANCE_ID, IP: $CONTABO_SERVER_IP
 echo ""
 
 # 9. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "$CONTABO_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/contabo/interpreter.sh
+++ b/contabo/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${CONTABO_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Contabo server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/contabo/kilocode.sh
+++ b/contabo/kilocode.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${CONTABO_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Contabo server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.bashrc && kilocode"

--- a/contabo/lib/common.sh
+++ b/contabo/lib/common.sh
@@ -219,7 +219,7 @@ create_server() {
         return 1
     fi
 
-    log_warn "Creating Contabo instance '$name' (product: $product_id, region: $region)..."
+    log_step "Creating Contabo instance '$name' (product: $product_id, region: $region)..."
 
     local ssh_secret_ids
     ssh_secret_ids=$(_contabo_get_ssh_secret_ids)
@@ -264,7 +264,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 destroy_server() {
     local instance_id="$1"
 
-    log_warn "Destroying instance $instance_id..."
+    log_step "Destroying instance $instance_id..."
     local response
     response=$(contabo_api DELETE "/compute/instances/$instance_id")
 

--- a/contabo/nanoclaw.sh
+++ b/contabo/nanoclaw.sh
@@ -28,10 +28,10 @@ verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
 # 5. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${CONTABO_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${CONTABO_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -43,14 +43,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -67,7 +67,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERV
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${CONTABO_SERVER_IP}" "cd ~/nanoclaw && source ~/.bashrc && npm run dev"

--- a/contabo/openclaw.sh
+++ b/contabo/openclaw.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
 # 5. Install OpenClaw
-log_warn "Installing OpenClaw..."
+log_step "Installing OpenClaw..."
 run_server "${CONTABO_SERVER_IP}" "bun install -g openclaw"
 
 # 6. Get OpenRouter API key
@@ -45,7 +45,7 @@ printf "Enter model ID [openrouter/auto]: "
 MODEL_ID=$(safe_read) || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ sleep 2
 
 echo ""
 # 8. Start OpenClaw TUI interactively
-log_warn "Starting OpenClaw TUI..."
+log_step "Starting OpenClaw TUI..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/contabo/opencode.sh
+++ b/contabo/opencode.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${CONTABO_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -40,7 +40,7 @@ log_info "Contabo server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/contabo/plandex.sh
+++ b/contabo/plandex.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${CONTABO_SERVER_IP}"
 wait_for_cloud_init "${CONTABO_SERVER_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${CONTABO_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -57,7 +57,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERV
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${CONTABO_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/daytona/aider.sh
+++ b/daytona/aider.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -46,7 +46,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -57,7 +57,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/daytona/amazonq.sh
+++ b/daytona/amazonq.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 7. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && q chat"

--- a/daytona/claude.sh
+++ b/daytona/claude.sh
@@ -26,9 +26,9 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -42,7 +42,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -63,7 +63,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/daytona/cline.sh
+++ b/daytona/cline.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "npm install -g cline"
 log_info "Cline installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cline"

--- a/daytona/codex.sh
+++ b/daytona/codex.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 7. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && codex"

--- a/daytona/continue.sh
+++ b/daytona/continue.sh
@@ -18,7 +18,7 @@ SANDBOX_NAME=$(get_server_name)
 create_server "${SANDBOX_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "npm install -g @continuedev/cli"
 
 echo ""
@@ -28,7 +28,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
 run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
 
@@ -38,7 +38,7 @@ echo ""
 log_info "Sandbox setup completed successfully!"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && cn"

--- a/daytona/gemini.sh
+++ b/daytona/gemini.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -53,7 +53,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && gemini"

--- a/daytona/goose.sh
+++ b/daytona/goose.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
@@ -51,7 +51,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 7. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && goose"

--- a/daytona/gptme.sh
+++ b/daytona/gptme.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -46,7 +46,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -57,7 +57,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/daytona/interpreter.sh
+++ b/daytona/interpreter.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 7. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && interpreter"

--- a/daytona/kilocode.sh
+++ b/daytona/kilocode.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Kilo Code
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 7. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && kilocode"

--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -27,7 +27,7 @@ fi
 
 ensure_daytona_cli() {
     if ! command -v daytona &>/dev/null; then
-        log_warn "Installing Daytona CLI..."
+        log_step "Installing Daytona CLI..."
         if command -v brew &>/dev/null; then
             brew install daytonaio/cli/daytona 2>/dev/null || {
                 log_error "Failed to install Daytona CLI via Homebrew"
@@ -105,7 +105,7 @@ create_server() {
     if [[ ! "${memory}" =~ ^[0-9]+$ ]]; then log_error "Invalid DAYTONA_MEMORY: must be numeric"; return 1; fi
     if [[ ! "${disk}" =~ ^[0-9]+$ ]]; then log_error "Invalid DAYTONA_DISK: must be numeric"; return 1; fi
 
-    log_warn "Creating Daytona sandbox '${name}' (${cpu} vCPU / ${memory}MB RAM / ${disk}GB disk)..."
+    log_step "Creating Daytona sandbox '${name}' (${cpu} vCPU / ${memory}MB RAM / ${disk}GB disk)..."
 
     # Create sandbox with resource flags and auto-stop disabled
     local output
@@ -143,7 +143,7 @@ create_server() {
 }
 
 wait_for_cloud_init() {
-    log_warn "Installing base tools in sandbox..."
+    log_step "Installing base tools in sandbox..."
     run_server "apt-get update -y && apt-get install -y curl unzip git zsh" >/dev/null 2>&1 || true
     run_server "curl -fsSL https://bun.sh/install | bash" >/dev/null 2>&1 || true
     run_server "curl -fsSL https://claude.ai/install.sh | bash" >/dev/null 2>&1 || true
@@ -199,7 +199,7 @@ destroy_server() {
         log_warn "No sandbox ID to destroy"
         return 0
     fi
-    log_warn "Destroying sandbox ${sandbox_id}..."
+    log_step "Destroying sandbox ${sandbox_id}..."
     daytona delete "${sandbox_id}" 2>/dev/null || true
     log_info "Sandbox destroyed"
 }

--- a/daytona/nanoclaw.sh
+++ b/daytona/nanoclaw.sh
@@ -26,10 +26,10 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -42,7 +42,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ inject_env_vars_local upload_file run_server \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 7. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -66,7 +66,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 8. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/daytona/openclaw.sh
+++ b/daytona/openclaw.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -42,7 +42,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 9. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "source ~/.zshrc && openclaw tui"

--- a/daytona/opencode.sh
+++ b/daytona/opencode.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -50,7 +50,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 7. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && opencode"

--- a/daytona/plandex.sh
+++ b/daytona/plandex.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -50,7 +50,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${DAYTONA_SANDBOX_ID})"
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && plandex"

--- a/digitalocean/aider.sh
+++ b/digitalocean/aider.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
 # 5. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${DO_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 # Verify installation succeeded
@@ -50,7 +50,7 @@ fi
 # 7. Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -60,7 +60,7 @@ log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
 # 9. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/digitalocean/amazonq.sh
+++ b/digitalocean/amazonq.sh
@@ -22,7 +22,7 @@ create_server "${DROPLET_NAME}"
 verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${DO_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "DigitalOcean droplet setup completed successfully!"
 log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/digitalocean/cline.sh
+++ b/digitalocean/cline.sh
@@ -22,7 +22,7 @@ create_server "${DROPLET_NAME}"
 verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${DO_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "DigitalOcean droplet setup completed successfully!"
 log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && cline"

--- a/digitalocean/codex.sh
+++ b/digitalocean/codex.sh
@@ -20,7 +20,7 @@ create_server "${DROPLET_NAME}"
 verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${DO_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "DigitalOcean droplet setup completed successfully!"
 log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && codex"

--- a/digitalocean/continue.sh
+++ b/digitalocean/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${DO_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "DigitalOcean droplet setup completed successfully!"
 log_info "Droplet: ${SERVER_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && cn"

--- a/digitalocean/gemini.sh
+++ b/digitalocean/gemini.sh
@@ -22,7 +22,7 @@ create_server "${DROPLET_NAME}"
 verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${DO_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -46,7 +46,7 @@ log_info "DigitalOcean droplet setup completed successfully!"
 log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/digitalocean/goose.sh
+++ b/digitalocean/goose.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
 # 5. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${DO_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -40,7 +40,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -51,7 +51,7 @@ log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
 # 8. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && goose"

--- a/digitalocean/gptme.sh
+++ b/digitalocean/gptme.sh
@@ -27,7 +27,7 @@ verify_server_connectivity "$DO_SERVER_IP"
 wait_for_cloud_init "$DO_SERVER_IP"
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$DO_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -49,7 +49,7 @@ fi
 # 7. Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "$DO_SERVER_IP" upload_file run_server \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
 
@@ -59,7 +59,7 @@ log_info "Droplet: $DROPLET_NAME (ID: $DO_DROPLET_ID, IP: $DO_SERVER_IP)"
 echo ""
 
 # 9. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "$DO_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/digitalocean/interpreter.sh
+++ b/digitalocean/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${DROPLET_NAME}"
 verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${DO_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "DigitalOcean droplet setup completed successfully!"
 log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/digitalocean/kilocode.sh
+++ b/digitalocean/kilocode.sh
@@ -22,7 +22,7 @@ create_server "${DROPLET_NAME}"
 verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${DO_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "DigitalOcean droplet setup completed successfully!"
 log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/digitalocean/nanoclaw.sh
+++ b/digitalocean/nanoclaw.sh
@@ -28,10 +28,10 @@ verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
 # 5. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${DO_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${DO_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -43,14 +43,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -67,7 +67,7 @@ log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${DO_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/digitalocean/openclaw.sh
+++ b/digitalocean/openclaw.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${DO_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -43,7 +43,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
 # 10. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${DO_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/digitalocean/opencode.sh
+++ b/digitalocean/opencode.sh
@@ -31,7 +31,7 @@ verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
 # 5. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${DO_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -44,7 +44,7 @@ else
 fi
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -54,7 +54,7 @@ log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
 # 8. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/digitalocean/plandex.sh
+++ b/digitalocean/plandex.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${DO_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${DO_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -57,7 +57,7 @@ log_info "Droplet: ${DROPLET_NAME} (ID: ${DO_DROPLET_ID}, IP: ${DO_SERVER_IP})"
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${DO_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/e2b/aider.sh
+++ b/e2b/aider.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -46,7 +46,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -57,7 +57,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/e2b/amazonq.sh
+++ b/e2b/amazonq.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 7. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && q chat"

--- a/e2b/claude.sh
+++ b/e2b/claude.sh
@@ -26,9 +26,9 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -42,7 +42,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -63,7 +63,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/e2b/cline.sh
+++ b/e2b/cline.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "npm install -g cline"
 log_info "Cline installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cline"

--- a/e2b/codex.sh
+++ b/e2b/codex.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 7. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && codex"

--- a/e2b/continue.sh
+++ b/e2b/continue.sh
@@ -21,7 +21,7 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -32,7 +32,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
 run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
 
@@ -43,7 +43,7 @@ log_info "E2B sandbox setup completed successfully!"
 log_info "Sandbox ID: ${E2B_SANDBOX_ID}"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cn"

--- a/e2b/gemini.sh
+++ b/e2b/gemini.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -53,7 +53,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && gemini"

--- a/e2b/goose.sh
+++ b/e2b/goose.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
@@ -51,7 +51,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 7. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && goose"

--- a/e2b/gptme.sh
+++ b/e2b/gptme.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -44,7 +44,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -55,7 +55,7 @@ log_info "Sandbox: $SERVER_NAME (ID: $E2B_SANDBOX_ID)"
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/e2b/interpreter.sh
+++ b/e2b/interpreter.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 7. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && interpreter"

--- a/e2b/kilocode.sh
+++ b/e2b/kilocode.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Kilo Code
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 7. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && kilocode"

--- a/e2b/lib/common.sh
+++ b/e2b/lib/common.sh
@@ -27,7 +27,7 @@ fi
 
 ensure_e2b_cli() {
     if ! command -v e2b &>/dev/null; then
-        log_warn "Installing E2B CLI..."
+        log_step "Installing E2B CLI..."
         npm install -g @e2b/cli 2>/dev/null || {
             log_error "Failed to install E2B CLI. Install manually: npm install -g @e2b/cli"
             return 1
@@ -72,7 +72,7 @@ create_server() {
     local name="${1}"
     local template="${E2B_TEMPLATE:-base}"
 
-    log_warn "Creating E2B sandbox '${name}' (template: ${template})..."
+    log_step "Creating E2B sandbox '${name}' (template: ${template})..."
 
     # Create sandbox and capture ID
     local output
@@ -94,7 +94,7 @@ create_server() {
 }
 
 wait_for_cloud_init() {
-    log_warn "Installing base tools in sandbox..."
+    log_step "Installing base tools in sandbox..."
     run_server "apt-get update -y && apt-get install -y curl unzip git zsh" >/dev/null 2>&1 || true
     run_server "curl -fsSL https://bun.sh/install | bash" >/dev/null 2>&1 || true
     run_server "curl -fsSL https://claude.ai/install.sh | bash" >/dev/null 2>&1 || true
@@ -138,7 +138,7 @@ interactive_session() {
 
 destroy_server() {
     local sandbox_id="${1:-${E2B_SANDBOX_ID}}"
-    log_warn "Destroying sandbox ${sandbox_id}..."
+    log_step "Destroying sandbox ${sandbox_id}..."
     e2b sandbox kill "${sandbox_id}" 2>/dev/null || true
     log_info "Sandbox destroyed"
 }

--- a/e2b/nanoclaw.sh
+++ b/e2b/nanoclaw.sh
@@ -26,10 +26,10 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -42,7 +42,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ inject_env_vars_local upload_file run_server \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 7. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -66,7 +66,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 8. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/e2b/openclaw.sh
+++ b/e2b/openclaw.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -42,7 +42,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 9. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "source ~/.zshrc && openclaw tui"

--- a/e2b/opencode.sh
+++ b/e2b/opencode.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -50,7 +50,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 7. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && opencode"

--- a/e2b/plandex.sh
+++ b/e2b/plandex.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -39,7 +39,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -50,7 +50,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${E2B_SANDBOX_ID})"
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && plandex"

--- a/exoscale/aider.sh
+++ b/exoscale/aider.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${EXOSCALE_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -33,7 +33,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Exoscale instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/exoscale/amazonq.sh
+++ b/exoscale/amazonq.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${EXOSCALE_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Exoscale server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/exoscale/claude.sh
+++ b/exoscale/claude.sh
@@ -20,9 +20,9 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${EXOSCALE_SERVER_IP}" "command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${EXOSCALE_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -34,7 +34,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -52,7 +52,7 @@ log_info "Exoscale instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && claude"

--- a/exoscale/cline.sh
+++ b/exoscale/cline.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${EXOSCALE_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Exoscale server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && cline"

--- a/exoscale/codex.sh
+++ b/exoscale/codex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${EXOSCALE_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Exoscale server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && codex"

--- a/exoscale/continue.sh
+++ b/exoscale/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${EXOSCALE_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Exoscale server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && cn"

--- a/exoscale/gemini.sh
+++ b/exoscale/gemini.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${EXOSCALE_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -46,7 +46,7 @@ log_info "Exoscale server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/exoscale/goose.sh
+++ b/exoscale/goose.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${EXOSCALE_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -41,7 +41,7 @@ log_info "Exoscale instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && goose"

--- a/exoscale/gptme.sh
+++ b/exoscale/gptme.sh
@@ -27,7 +27,7 @@ verify_server_connectivity "$EXOSCALE_SERVER_IP"
 wait_for_cloud_init "$EXOSCALE_SERVER_IP"
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$EXOSCALE_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -49,7 +49,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "$EXOSCALE_SERVER_IP" upload_file run_server \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
 
@@ -59,7 +59,7 @@ log_info "Server: $SERVER_NAME (ID: $EXOSCALE_SERVER_ID, IP: $EXOSCALE_SERVER_IP
 echo ""
 
 # 9. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "$EXOSCALE_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/exoscale/interpreter.sh
+++ b/exoscale/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${EXOSCALE_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Exoscale server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/exoscale/kilocode.sh
+++ b/exoscale/kilocode.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${EXOSCALE_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Exoscale server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/exoscale/lib/common.sh
+++ b/exoscale/lib/common.sh
@@ -34,7 +34,7 @@ ensure_exo_cli() {
         return 0
     fi
 
-    log_warn "exo CLI not found, installing..."
+    log_step "exo CLI not found, installing..."
 
     # Detect OS and architecture
     local os arch exo_url
@@ -56,7 +56,7 @@ ensure_exo_cli() {
     local version="1.90.1"
     exo_url="https://github.com/exoscale/cli/releases/download/v${version}/exoscale-cli_${version}_${os}_${arch}.tar.gz"
 
-    log_warn "Downloading exo CLI from GitHub..."
+    log_step "Downloading exo CLI from GitHub..."
     local temp_dir
     temp_dir=$(mktemp -d)
     if ! curl -fsSL "$exo_url" -o "${temp_dir}/exo.tar.gz"; then
@@ -143,7 +143,7 @@ exoscale_register_ssh_key() {
     local key_name="$1"
     local pub_path="$2"
 
-    log_warn "Registering SSH key '$key_name' with Exoscale..."
+    log_step "Registering SSH key '$key_name' with Exoscale..."
     if exo compute ssh-key register "$key_name" "$pub_path"; then
         log_info "SSH key registered successfully"
         return 0
@@ -180,7 +180,7 @@ _wait_for_exoscale_instance() {
     local max_attempts=${2:-60}
     local attempt=1
 
-    log_warn "Waiting for instance to become running..."
+    log_step "Waiting for instance to become running..."
     while [[ "$attempt" -le "$max_attempts" ]]; do
         local status_json
         status_json=$(exo compute instance show "$instance_id" -O json 2>/dev/null || echo '{}')
@@ -240,7 +240,7 @@ create_server() {
     validate_resource_name "$instance_type" || { log_error "Invalid EXOSCALE_INSTANCE_TYPE"; return 1; }
     validate_region_name "$zone" || { log_error "Invalid EXOSCALE_ZONE"; return 1; }
 
-    log_warn "Creating Exoscale instance '$name' (type: $instance_type, zone: $zone)..."
+    log_step "Creating Exoscale instance '$name' (type: $instance_type, zone: $zone)..."
 
     local ssh_key_name="spawn-${USER}-$(hostname)"
 
@@ -281,7 +281,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 
 destroy_server() {
     local server_id="$1"
-    log_warn "Destroying instance $server_id..."
+    log_step "Destroying instance $server_id..."
     exo compute instance delete "$server_id" --force
     log_info "Instance $server_id destroyed"
 }

--- a/exoscale/nanoclaw.sh
+++ b/exoscale/nanoclaw.sh
@@ -28,10 +28,10 @@ verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
 # 5. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${EXOSCALE_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${EXOSCALE_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -43,14 +43,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -67,7 +67,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERV
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${EXOSCALE_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/exoscale/openclaw.sh
+++ b/exoscale/openclaw.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${EXOSCALE_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -43,7 +43,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERV
 echo ""
 
 # 10. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/exoscale/opencode.sh
+++ b/exoscale/opencode.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${EXOSCALE_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -40,7 +40,7 @@ log_info "Exoscale server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/exoscale/plandex.sh
+++ b/exoscale/plandex.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${EXOSCALE_SERVER_IP}"
 wait_for_cloud_init "${EXOSCALE_SERVER_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${EXOSCALE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${EXOSCALE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -57,7 +57,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${EXOSCALE_SERVER_ID}, IP: ${EXOSCALE_SERV
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${EXOSCALE_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/fly/aider.sh
+++ b/fly/aider.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -40,7 +40,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && aider --model openrouter/${MODEL_ID}"

--- a/fly/amazonq.sh
+++ b/fly/amazonq.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.bashrc and ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -51,7 +51,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 7. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && q chat"

--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Claude Code
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -55,7 +55,7 @@ inject_env_vars_fly \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
 # 7. Configure Claude Code settings
-log_warn "Configuring Claude Code..."
+log_step "Configuring Claude Code..."
 
 run_server "mkdir -p ~/.claude"
 
@@ -103,7 +103,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "export PATH=\$HOME/.local/bin:\$PATH && source ~/.bashrc && claude"

--- a/fly/cline.sh
+++ b/fly/cline.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "npm install -g cline"
 log_info "Cline installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.bashrc and ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -51,7 +51,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && cline"

--- a/fly/codex.sh
+++ b/fly/codex.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -51,7 +51,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 7. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && codex"

--- a/fly/continue.sh
+++ b/fly/continue.sh
@@ -18,7 +18,7 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "npm install -g @continuedev/cli"
 
 echo ""
@@ -28,7 +28,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -38,7 +38,7 @@ echo ""
 log_info "Fly.io setup completed successfully!"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cn"

--- a/fly/gemini.sh
+++ b/fly/gemini.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.bashrc and ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && gemini"

--- a/fly/goose.sh
+++ b/fly/goose.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "GOOSE_PROVIDER=openrouter" \
@@ -56,7 +56,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 7. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && goose"

--- a/fly/gptme.sh
+++ b/fly/gptme.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -40,7 +40,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
 # 7. Inject environment variables into ~/.bashrc and ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && gptme -m openrouter/${MODEL_ID}"

--- a/fly/interpreter.sh
+++ b/fly/interpreter.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -51,7 +51,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 7. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && interpreter"

--- a/fly/kilocode.sh
+++ b/fly/kilocode.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Kilo Code
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.bashrc and ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 7. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && kilocode"

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -47,7 +47,7 @@ ensure_fly_cli() {
         return 0
     fi
 
-    log_warn "Installing flyctl CLI..."
+    log_step "Installing flyctl CLI..."
     curl -L https://fly.io/install.sh | sh 2>/dev/null || {
         log_error "Failed to install flyctl CLI"
         log_error "Install manually: curl -L https://fly.io/install.sh | sh"
@@ -170,7 +170,7 @@ _fly_create_app() {
         return 1
     fi
 
-    log_warn "Creating Fly.io app '$name'..."
+    log_step "Creating Fly.io app '$name'..."
     # SECURITY: Use json_escape to prevent JSON injection
     local app_body
     app_body=$(printf '{"app_name":%s,"org_slug":%s}' "$(json_escape "$name")" "$(json_escape "$org")")
@@ -203,7 +203,7 @@ _fly_create_machine() {
     local region="$2"
     local vm_memory="$3"
 
-    log_warn "Creating Fly.io machine (region: $region, memory: ${vm_memory}MB)..."
+    log_step "Creating Fly.io machine (region: $region, memory: ${vm_memory}MB)..."
 
     # SECURITY: Pass values via environment variables to prevent Python injection
     local machine_body
@@ -257,7 +257,7 @@ _fly_wait_for_machine_start() {
     local max_attempts="${3:-30}"
     local attempt=1
 
-    log_warn "Waiting for machine to start..."
+    log_step "Waiting for machine to start..."
     while [[ "$attempt" -le "$max_attempts" ]]; do
         local status_response
         status_response=$(fly_api GET "/apps/$name/machines/$machine_id")
@@ -297,7 +297,7 @@ create_server() {
 
 # Wait for base tools to be installed (Fly.io uses bare Ubuntu image)
 wait_for_cloud_init() {
-    log_warn "Installing base tools on Fly.io machine..."
+    log_step "Installing base tools on Fly.io machine..."
     run_server "apt-get update -y && apt-get install -y curl unzip git zsh python3 pip" >/dev/null 2>&1 || true
     run_server "curl -fsSL https://bun.sh/install | bash" >/dev/null 2>&1 || true
     run_server 'echo "export PATH=\"\$HOME/.bun/bin:\$PATH\"" >> ~/.bashrc' >/dev/null 2>&1 || true
@@ -349,7 +349,7 @@ interactive_session() {
 destroy_server() {
     local app_name="${1:-$FLY_APP_NAME}"
 
-    log_warn "Destroying Fly.io app and machines for '$app_name'..."
+    log_step "Destroying Fly.io app and machines for '$app_name'..."
 
     # List and destroy all machines in the app
     local machines=$(fly_api GET "/apps/$app_name/machines")
@@ -362,10 +362,10 @@ if isinstance(data, list):
 " 2>/dev/null || true)
 
     for mid in $machine_ids; do
-        log_warn "Stopping machine $mid..."
+        log_step "Stopping machine $mid..."
         fly_api POST "/apps/$app_name/machines/$mid/stop" '{}' >/dev/null 2>&1 || true
         sleep 2
-        log_warn "Destroying machine $mid..."
+        log_step "Destroying machine $mid..."
         fly_api DELETE "/apps/$app_name/machines/$mid?force=true" >/dev/null 2>&1 || true
     done
 

--- a/fly/nanoclaw.sh
+++ b/fly/nanoclaw.sh
@@ -24,10 +24,10 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install tsx and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -40,7 +40,7 @@ else
 fi
 
 # 6. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -49,7 +49,7 @@ inject_env_vars_fly \
     "PATH=\$HOME/.bun/bin:\$PATH"
 
 # 7. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 chmod 600 "$DOTENV_TEMP"
@@ -66,7 +66,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 8. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/fly/openclaw.sh
+++ b/fly/openclaw.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -40,7 +40,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 6. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -49,7 +49,7 @@ inject_env_vars_fly \
     "PATH=\$HOME/.bun/bin:\$PATH"
 
 # 7. Configure openclaw
-log_warn "Configuring openclaw..."
+log_step "Configuring openclaw..."
 
 run_server "rm -rf ~/.openclaw && mkdir -p ~/.openclaw"
 
@@ -69,7 +69,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 8. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "source ~/.zshrc && openclaw tui"

--- a/fly/opencode.sh
+++ b/fly/opencode.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -48,7 +48,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 7. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && opencode"

--- a/fly/plandex.sh
+++ b/fly/plandex.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_fly \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -49,7 +49,7 @@ log_info "App: $SERVER_NAME (Machine ID: $FLY_MACHINE_ID)"
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && plandex"

--- a/gcp/aider.sh
+++ b/gcp/aider.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${GCP_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -53,7 +53,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 8. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -64,7 +64,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 9. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/gcp/amazonq.sh
+++ b/gcp/amazonq.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${GCP_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 8. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -33,9 +33,9 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${GCP_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${GCP_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -49,7 +49,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -70,7 +70,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/gcp/cline.sh
+++ b/gcp/cline.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${GCP_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 8. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && cline"

--- a/gcp/codex.sh
+++ b/gcp/codex.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${GCP_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 8. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && codex"

--- a/gcp/continue.sh
+++ b/gcp/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${GCP_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "GCP instance setup completed successfully!"
 log_info "Instance: ${SERVER_NAME} (IP: ${GCP_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && cn"

--- a/gcp/gemini.sh
+++ b/gcp/gemini.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${GCP_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 8. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/gcp/goose.sh
+++ b/gcp/goose.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${GCP_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
@@ -58,7 +58,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 8. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && goose"

--- a/gcp/gptme.sh
+++ b/gcp/gptme.sh
@@ -27,7 +27,7 @@ verify_server_connectivity "$GCP_SERVER_IP"
 wait_for_cloud_init "$GCP_SERVER_IP"
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$GCP_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -47,7 +47,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 8. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -59,7 +59,7 @@ log_info "Instance: $GCP_INSTANCE_NAME_ACTUAL (Zone: $GCP_ZONE, IP: $GCP_SERVER_
 echo ""
 
 # 9. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "$GCP_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/gcp/interpreter.sh
+++ b/gcp/interpreter.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${GCP_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 8. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/gcp/kilocode.sh
+++ b/gcp/kilocode.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Kilo Code
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${GCP_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 8. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -90,7 +90,7 @@ create_server() {
     validate_resource_name "${machine_type}" || { log_error "Invalid GCP_MACHINE_TYPE"; return 1; }
     validate_region_name "${zone}" || { log_error "Invalid GCP_ZONE"; return 1; }
 
-    log_warn "Creating GCP instance '${name}' (type: ${machine_type}, zone: ${zone})..."
+    log_step "Creating GCP instance '${name}' (type: ${machine_type}, zone: ${zone})..."
 
     local userdata
     userdata=$(get_cloud_init_userdata)
@@ -165,7 +165,7 @@ interactive_session() {
 destroy_server() {
     local name="${1}"
     local zone="${GCP_ZONE:-us-central1-a}"
-    log_warn "Destroying GCP instance ${name}..."
+    log_step "Destroying GCP instance ${name}..."
     gcloud compute instances delete "${name}" --zone="${zone}" --project="${GCP_PROJECT}" --quiet >/dev/null 2>&1
     log_info "Instance ${name} destroyed"
 }

--- a/gcp/nanoclaw.sh
+++ b/gcp/nanoclaw.sh
@@ -33,10 +33,10 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${GCP_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${GCP_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -49,7 +49,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -57,7 +57,7 @@ inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 cat > "${DOTENV_TEMP}" << EOF
@@ -72,7 +72,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${GCP_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/gcp/openclaw.sh
+++ b/gcp/openclaw.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${GCP_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -49,7 +49,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 8. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -66,7 +66,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 10. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${GCP_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/gcp/opencode.sh
+++ b/gcp/opencode.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${GCP_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -57,7 +57,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 8. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/gcp/plandex.sh
+++ b/gcp/plandex.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${GCP_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -57,7 +57,7 @@ log_info "Instance: ${GCP_INSTANCE_NAME_ACTUAL} (Zone: ${GCP_ZONE}, IP: ${GCP_SE
 echo ""
 
 # 8. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${GCP_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/genesiscloud/claude.sh
+++ b/genesiscloud/claude.sh
@@ -20,9 +20,9 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${GENESIS_SERVER_IP}"
 wait_for_cloud_init "${GENESIS_SERVER_IP}" 60
 
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${GENESIS_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${GENESIS_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -34,7 +34,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${GENESIS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -52,7 +52,7 @@ log_info "Genesis Cloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${GENESIS_SERVER_ID}, IP: ${GENESIS_SERVER_IP})"
 echo ""
 
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${GENESIS_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/genesiscloud/lib/common.sh
+++ b/genesiscloud/lib/common.sh
@@ -168,7 +168,7 @@ create_server() {
     # Image names may contain spaces (e.g. "Ubuntu 24.04") but must not contain quotes or shell metacharacters
     if [[ "$image" =~ [\'\"\`\$\;\\] ]]; then log_error "Invalid GENESIS_IMAGE: contains unsafe characters"; return 1; fi
 
-    log_warn "Creating Genesis Cloud instance '$name' (type: $instance_type, region: $region)..."
+    log_step "Creating Genesis Cloud instance '$name' (type: $instance_type, region: $region)..."
 
     local ssh_key_ids
     ssh_key_ids=$(_genesis_get_ssh_key_ids)
@@ -207,7 +207,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 
 destroy_server() {
     local server_id="$1"
-    log_warn "Destroying instance $server_id..."
+    log_step "Destroying instance $server_id..."
     genesis_api DELETE "/instances/$server_id"
     log_info "Instance $server_id destroyed"
 }

--- a/github-codespaces/aider.sh
+++ b/github-codespaces/aider.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -63,7 +63,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/amazonq.sh
+++ b/github-codespaces/amazonq.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install amazon q
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -62,7 +62,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 7. Start amazon q interactively
-log_warn "Starting Amazon Q CLI..."
+log_step "Starting Amazon Q CLI..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/claude.sh
+++ b/github-codespaces/claude.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install Claude Code
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation

--- a/github-codespaces/cline.sh
+++ b/github-codespaces/cline.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install cline
-log_warn "Installing cline..."
+log_step "Installing cline..."
 run_server "npm install -g cline"
 log_info "cline installed"
 
@@ -62,7 +62,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 7. Start cline interactively
-log_warn "Starting cline..."
+log_step "Starting cline..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/codex.sh
+++ b/github-codespaces/codex.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install codex
-log_warn "Installing codex..."
+log_step "Installing codex..."
 run_server "npm install -g @openai/codex"
 log_info "codex installed"
 
@@ -62,7 +62,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 7. Start codex interactively
-log_warn "Starting codex..."
+log_step "Starting codex..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/continue.sh
+++ b/github-codespaces/continue.sh
@@ -26,7 +26,7 @@ export CODESPACE_NAME
 
 wait_for_codespace "${CODESPACE_NAME}"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_in_codespace "${CODESPACE_NAME}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -37,7 +37,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
 run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
 
@@ -48,7 +48,7 @@ log_info "Codespace setup completed successfully!"
 log_info "Codespace: ${CODESPACE_NAME}"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 gh codespace ssh --codespace "${CODESPACE_NAME}" -- "source ~/.zshrc && cn"

--- a/github-codespaces/gemini.sh
+++ b/github-codespaces/gemini.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install gemini
-log_warn "Installing gemini..."
+log_step "Installing gemini..."
 run_server "npm install -g @google/gemini-cli"
 log_info "gemini installed"
 
@@ -63,7 +63,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 7. Start gemini interactively
-log_warn "Starting gemini..."
+log_step "Starting gemini..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/goose.sh
+++ b/github-codespaces/goose.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install goose
-log_warn "Installing goose..."
+log_step "Installing goose..."
 run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "goose installed"
 
@@ -61,7 +61,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 7. Start goose interactively
-log_warn "Starting goose..."
+log_step "Starting goose..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/gptme.sh
+++ b/github-codespaces/gptme.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -63,7 +63,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/interpreter.sh
+++ b/github-codespaces/interpreter.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install open-interpreter
-log_warn "Installing open-interpreter..."
+log_step "Installing open-interpreter..."
 run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "open-interpreter installed"
 
@@ -62,7 +62,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 7. Start interpreter interactively
-log_warn "Starting open-interpreter..."
+log_step "Starting open-interpreter..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/kilocode.sh
+++ b/github-codespaces/kilocode.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install kilocode
-log_warn "Installing kilocode..."
+log_step "Installing kilocode..."
 run_server "npm install -g @kilocode/cli"
 log_info "kilocode installed"
 
@@ -62,7 +62,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 7. Start kilocode interactively
-log_warn "Starting kilocode..."
+log_step "Starting kilocode..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/lib/common.sh
+++ b/github-codespaces/lib/common.sh
@@ -30,7 +30,7 @@ ensure_gh_cli() {
         return 0
     fi
 
-    log_warn "Installing GitHub CLI (gh)..."
+    log_step "Installing GitHub CLI (gh)..."
 
     # Detect OS and install accordingly
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/github-codespaces/nanoclaw.sh
+++ b/github-codespaces/nanoclaw.sh
@@ -38,11 +38,11 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install dependencies and nanoclaw
-log_warn "Installing Node.js dependencies..."
+log_step "Installing Node.js dependencies..."
 run_server "npm install -g tsx"
 log_info "tsx installed"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "nanoclaw installed"
 
@@ -61,7 +61,7 @@ inject_env_vars \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 7. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 chmod 600 "${DOTENV_TEMP}"
 track_temp_file "${DOTENV_TEMP}"
@@ -79,7 +79,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 8. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""

--- a/github-codespaces/openclaw.sh
+++ b/github-codespaces/openclaw.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install bun and openclaw
-log_warn "Installing bun..."
+log_step "Installing bun..."
 run_server "curl -fsSL https://bun.sh/install | bash && export BUN_INSTALL=\$HOME/.bun && export PATH=\$BUN_INSTALL/bin:\$PATH && bun install -g openclaw"
 log_info "openclaw installed"
 
@@ -60,7 +60,7 @@ inject_env_vars \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Setup openclaw config
-log_warn "Configuring openclaw..."
+log_step "Configuring openclaw..."
 CONFIG_TEMP=$(mktemp)
 chmod 600 "${CONFIG_TEMP}"
 track_temp_file "${CONFIG_TEMP}"
@@ -81,7 +81,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 9. Start openclaw gateway in background, then TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/opencode.sh
+++ b/github-codespaces/opencode.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install opencode
-log_warn "Installing opencode..."
+log_step "Installing opencode..."
 run_server "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
 log_info "opencode installed"
 
@@ -60,7 +60,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 7. Start opencode interactively
-log_warn "Starting opencode..."
+log_step "Starting opencode..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/github-codespaces/plandex.sh
+++ b/github-codespaces/plandex.sh
@@ -38,7 +38,7 @@ CODESPACE_NAME="$CODESPACE"
 wait_for_codespace "$CODESPACE"
 
 # 4. Install plandex
-log_warn "Installing plandex..."
+log_step "Installing plandex..."
 run_server "curl -sL https://plandex.ai/install.sh | bash"
 log_info "plandex installed"
 
@@ -60,7 +60,7 @@ log_info "Codespace: $CODESPACE"
 echo ""
 
 # 7. Start plandex interactively
-log_warn "Starting plandex..."
+log_step "Starting plandex..."
 log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1

--- a/hetzner/aider.sh
+++ b/hetzner/aider.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
 # 5. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${HETZNER_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 # Verify installation succeeded
@@ -50,7 +50,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -60,7 +60,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER
 echo ""
 
 # 9. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/hetzner/amazonq.sh
+++ b/hetzner/amazonq.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${HETZNER_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Hetzner server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/hetzner/cline.sh
+++ b/hetzner/cline.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${HETZNER_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Hetzner server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && cline"

--- a/hetzner/codex.sh
+++ b/hetzner/codex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${HETZNER_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Hetzner server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && codex"

--- a/hetzner/continue.sh
+++ b/hetzner/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${HETZNER_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Hetzner server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && cn"

--- a/hetzner/gemini.sh
+++ b/hetzner/gemini.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${HETZNER_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -46,7 +46,7 @@ log_info "Hetzner server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/hetzner/goose.sh
+++ b/hetzner/goose.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
 # 5. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${HETZNER_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -58,7 +58,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER
 echo ""
 
 # 8. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && goose"

--- a/hetzner/gptme.sh
+++ b/hetzner/gptme.sh
@@ -27,7 +27,7 @@ verify_server_connectivity "$HETZNER_SERVER_IP"
 wait_for_cloud_init "$HETZNER_SERVER_IP"
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$HETZNER_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -49,7 +49,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "$HETZNER_SERVER_IP" upload_file run_server \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
 
@@ -59,7 +59,7 @@ log_info "Server: $SERVER_NAME (ID: $HETZNER_SERVER_ID, IP: $HETZNER_SERVER_IP)"
 echo ""
 
 # 9. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "$HETZNER_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/hetzner/interpreter.sh
+++ b/hetzner/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${HETZNER_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Hetzner server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/hetzner/kilocode.sh
+++ b/hetzner/kilocode.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${HETZNER_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Hetzner server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/hetzner/nanoclaw.sh
+++ b/hetzner/nanoclaw.sh
@@ -28,10 +28,10 @@ verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
 # 5. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${HETZNER_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${HETZNER_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -43,14 +43,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -67,7 +67,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${HETZNER_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/hetzner/openclaw.sh
+++ b/hetzner/openclaw.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${HETZNER_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -43,7 +43,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER
 echo ""
 
 # 10. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${HETZNER_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/hetzner/opencode.sh
+++ b/hetzner/opencode.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${HETZNER_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -40,7 +40,7 @@ log_info "Hetzner server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/hetzner/plandex.sh
+++ b/hetzner/plandex.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${HETZNER_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -57,7 +57,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/hostinger/aider.sh
+++ b/hostinger/aider.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
 # 5. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${HOSTINGER_VPS_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 # Verify installation succeeded
@@ -50,7 +50,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -60,7 +60,7 @@ log_info "VPS: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})
 echo ""
 
 # 9. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/hostinger/amazonq.sh
+++ b/hostinger/amazonq.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${HOSTINGER_VPS_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Hostinger VPS setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && q chat"

--- a/hostinger/claude.sh
+++ b/hostinger/claude.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${HOSTINGER_VPS_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${HOSTINGER_VPS_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
@@ -50,7 +50,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -70,7 +70,7 @@ log_info "VPS: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/hostinger/cline.sh
+++ b/hostinger/cline.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${HOSTINGER_VPS_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Hostinger VPS setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && cline"

--- a/hostinger/codex.sh
+++ b/hostinger/codex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${HOSTINGER_VPS_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Hostinger VPS setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && codex"

--- a/hostinger/continue.sh
+++ b/hostinger/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${HOSTINGER_VPS_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Hostinger server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && cn"

--- a/hostinger/gemini.sh
+++ b/hostinger/gemini.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${HOSTINGER_VPS_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -46,7 +46,7 @@ log_info "Hostinger VPS setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && gemini"

--- a/hostinger/goose.sh
+++ b/hostinger/goose.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${HOSTINGER_VPS_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -41,7 +41,7 @@ log_info "Hostinger VPS setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
 echo ""
 
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && goose"

--- a/hostinger/gptme.sh
+++ b/hostinger/gptme.sh
@@ -27,7 +27,7 @@ verify_server_connectivity "$HOSTINGER_VPS_IP"
 wait_for_cloud_init "$HOSTINGER_VPS_IP"
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$HOSTINGER_VPS_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -49,7 +49,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "$HOSTINGER_VPS_IP" upload_file run_server \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
 
@@ -59,7 +59,7 @@ log_info "Server: $SERVER_NAME (ID: $HOSTINGER_VPS_ID, IP: $HOSTINGER_VPS_IP)"
 echo ""
 
 # 9. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "$HOSTINGER_VPS_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/hostinger/interpreter.sh
+++ b/hostinger/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${HOSTINGER_VPS_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Hostinger VPS setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && interpreter"

--- a/hostinger/kilocode.sh
+++ b/hostinger/kilocode.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${HOSTINGER_VPS_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Hostinger server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && kilocode"

--- a/hostinger/lib/common.sh
+++ b/hostinger/lib/common.sh
@@ -233,7 +233,7 @@ create_server() {
     validate_region_name "$location" || { log_error "Invalid HOSTINGER_LOCATION"; return 1; }
     validate_resource_name "$os_template" || { log_error "Invalid HOSTINGER_OS_TEMPLATE"; return 1; }
 
-    log_warn "Creating Hostinger VPS '$name' (plan: $plan, location: $location)..."
+    log_step "Creating Hostinger VPS '$name' (plan: $plan, location: $location)..."
 
     # Get all SSH key IDs
     local ssh_keys_response
@@ -269,7 +269,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 destroy_server() {
     local vps_id="$1"
 
-    log_warn "Destroying VPS $vps_id..."
+    log_step "Destroying VPS $vps_id..."
     local response
     response=$(hostinger_api DELETE "/virtual-machines/$vps_id")
 

--- a/hostinger/nanoclaw.sh
+++ b/hostinger/nanoclaw.sh
@@ -28,10 +28,10 @@ verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
 # 5. Install Node.js and clone nanoclaw
-log_warn "Installing Node.js dependencies..."
+log_step "Installing Node.js dependencies..."
 run_server "${HOSTINGER_VPS_IP}" "bun install -g tsx"
 
-log_warn "Cloning nanoclaw..."
+log_step "Cloning nanoclaw..."
 run_server "${HOSTINGER_VPS_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 
 # 6. Get OpenRouter API key
@@ -42,14 +42,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 7. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
@@ -66,7 +66,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_I
 echo ""
 
 # 8. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 sleep 1

--- a/hostinger/openclaw.sh
+++ b/hostinger/openclaw.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${HOSTINGER_VPS_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -43,7 +43,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "VPS: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})
 echo ""
 
 # 10. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${HOSTINGER_VPS_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && openclaw tui"

--- a/hostinger/opencode.sh
+++ b/hostinger/opencode.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${HOSTINGER_VPS_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -40,7 +40,7 @@ log_info "Hostinger VPS setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && opencode"

--- a/hostinger/plandex.sh
+++ b/hostinger/plandex.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${HOSTINGER_VPS_IP}"
 wait_for_cloud_init "${HOSTINGER_VPS_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${HOSTINGER_VPS_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HOSTINGER_VPS_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -57,7 +57,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${HOSTINGER_VPS_ID}, IP: ${HOSTINGER_VPS_I
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${HOSTINGER_VPS_IP}" "source ~/.zshrc && plandex"

--- a/hyperstack/claude.sh
+++ b/hyperstack/claude.sh
@@ -30,7 +30,7 @@ create_vm "${VM_NAME}" "${ENVIRONMENT}"
 verify_server_connectivity "${HYPERSTACK_VM_IP}"
 
 # 6. Install Claude Code
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "${HYPERSTACK_VM_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${HYPERSTACK_VM_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -69,7 +69,7 @@ log_info "VM: ${VM_NAME} (ID: ${HYPERSTACK_VM_ID}, IP: ${HYPERSTACK_VM_IP})"
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${HYPERSTACK_VM_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/ionos/aider.sh
+++ b/ionos/aider.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Verify Aider is installed (fallback to manual install)
-log_warn "Verifying Aider installation..."
+log_step "Verifying Aider installation..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v aider" >/dev/null 2>&1; then
-    log_warn "Aider not found, installing manually..."
+    log_step "Aider not found, installing manually..."
     run_server "${IONOS_SERVER_IP}" "pip install aider-chat"
 fi
 
@@ -58,7 +58,7 @@ log_info "Examples: openrouter/auto, openrouter/anthropic/claude-3-5-sonnet"
 echo ""
 MODEL_ID=$(get_interactive_value "MODEL_ID" "Enter model ID" "openrouter/auto") || return 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "MODEL_ID=${MODEL_ID}"
@@ -69,7 +69,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && aider --model \${MODEL_ID}"

--- a/ionos/amazonq.sh
+++ b/ionos/amazonq.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v q" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 fi
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -61,7 +61,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 7. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/ionos/claude.sh
+++ b/ionos/claude.sh
@@ -30,9 +30,9 @@ verify_server_connectivity "${LAMBDA_SERVER_IP}"
 wait_for_cloud_init "${LAMBDA_SERVER_IP}"
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${LAMBDA_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${LAMBDA_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LAMBDA_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -67,7 +67,7 @@ log_info "Instance: ${SERVER_NAME} (IP: ${LAMBDA_SERVER_IP})"
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${LAMBDA_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/ionos/cline.sh
+++ b/ionos/cline.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v cline" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "npm install -g cline"
 fi
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -61,7 +61,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && cline"

--- a/ionos/codex.sh
+++ b/ionos/codex.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v codex" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "npm install -g @openai/codex"
 fi
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -61,7 +61,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 7. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && codex"

--- a/ionos/continue.sh
+++ b/ionos/continue.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install Continue CLI
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v cn" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "npm install -g @continuedev/cli"
 fi
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -64,7 +64,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 8. Start Continue CLI in TUI mode
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && cn"

--- a/ionos/gemini.sh
+++ b/ionos/gemini.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v gemini" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "npm install -g @google/gemini-cli"
 fi
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -62,7 +62,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/ionos/goose.sh
+++ b/ionos/goose.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Verify Goose is installed (fallback to manual install)
-log_warn "Verifying Goose installation..."
+log_step "Verifying Goose installation..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v goose" >/dev/null 2>&1; then
-    log_warn "Goose not found, installing manually..."
+    log_step "Goose not found, installing manually..."
     run_server "${IONOS_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 fi
 
@@ -50,7 +50,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5182)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GOOSE_PROVIDER=openrouter"
@@ -61,7 +61,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 7. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && goose"

--- a/ionos/gptme.sh
+++ b/ionos/gptme.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v gptme" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 fi
@@ -52,7 +52,7 @@ fi
 # 7. Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -62,7 +62,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/ionos/interpreter.sh
+++ b/ionos/interpreter.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v interpreter" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 fi
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -61,7 +61,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 7. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/ionos/kilocode.sh
+++ b/ionos/kilocode.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install Kilo Code CLI
-log_warn "Installing Kilo Code CLI..."
+log_step "Installing Kilo Code CLI..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v kilocode" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "npm install -g @kilocode/cli"
 fi
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -61,7 +61,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 7. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/ionos/lib/common.sh
+++ b/ionos/lib/common.sh
@@ -207,7 +207,7 @@ ensure_datacenter() {
         return 1
     fi
 
-    log_warn "Checking for existing IONOS datacenter..."
+    log_step "Checking for existing IONOS datacenter..."
     local response
     response=$(ionos_api GET "/datacenters?depth=1")
 
@@ -271,7 +271,7 @@ _ionos_wait_for_volume() {
     local volume_id="$1"
     local max_wait="${2:-120}"
 
-    log_warn "Waiting for volume provisioning..."
+    log_step "Waiting for volume provisioning..."
     local waited=0
     while [[ $waited -lt $max_wait ]]; do
         local vol_status
@@ -297,7 +297,7 @@ _ionos_create_boot_volume() {
     local disk_size="$2"
     local image_id="$3"
 
-    log_warn "Creating boot volume..."
+    log_step "Creating boot volume..."
     local volume_body
     volume_body=$(_ionos_build_volume_body "$name" "$disk_size" "$image_id")
 
@@ -320,7 +320,7 @@ _ionos_create_boot_volume() {
 # Poll the IONOS API until the server has an IP address
 # Sets IONOS_SERVER_IP on success
 _ionos_wait_for_server_ip() {
-    log_warn "Waiting for server to get IP address..."
+    log_step "Waiting for server to get IP address..."
     local max_wait=180
     local waited=0
     while [[ $waited -lt $max_wait ]]; do
@@ -379,7 +379,7 @@ print(json.dumps(body))
 _ionos_launch_and_attach() {
     local volume_id="$1" name="$2" cores="$3" ram="$4"
 
-    log_warn "Creating server instance..."
+    log_step "Creating server instance..."
     local server_body
     server_body=$(_ionos_build_server_body "$name" "$cores" "$ram")
 
@@ -421,7 +421,7 @@ create_server() {
         return 1
     fi
 
-    log_warn "Creating IONOS server '$name' (cores: $cores, ram: ${ram}MB, disk: ${disk_size}GB)..."
+    log_step "Creating IONOS server '$name' (cores: $cores, ram: ${ram}MB, disk: ${disk_size}GB)..."
 
     # Ensure we have a datacenter
     ensure_datacenter || return 1
@@ -440,7 +440,7 @@ create_server() {
     volume_id=$(_ionos_create_boot_volume "$name" "$disk_size" "$image_id") || return 1
 
     # Register SSH key with datacenter
-    log_warn "Registering SSH key..."
+    log_step "Registering SSH key..."
     local key_path="$HOME/.ssh/spawn_ed25519"
     local pub_path="${key_path}.pub"
     ionos_register_ssh_key "spawn-key-$(date +%s)" "$pub_path" "${IONOS_DATACENTER_ID}" || log_warn "SSH key registration failed, continuing anyway..."
@@ -465,7 +465,7 @@ destroy_server() {
     local datacenter_id="$1"
     local server_id="$2"
 
-    log_warn "Destroying server $server_id in datacenter $datacenter_id..."
+    log_step "Destroying server $server_id in datacenter $datacenter_id..."
     local response
     response=$(ionos_api DELETE "/datacenters/${datacenter_id}/servers/${server_id}")
 

--- a/ionos/nanoclaw.sh
+++ b/ionos/nanoclaw.sh
@@ -28,10 +28,10 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install Node.js and clone nanoclaw
-log_warn "Installing Node.js dependencies..."
+log_step "Installing Node.js dependencies..."
 run_server "${IONOS_SERVER_IP}" "bun install -g tsx"
 
-log_warn "Cloning nanoclaw..."
+log_step "Cloning nanoclaw..."
 run_server "${IONOS_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 
 # 6. Get OpenRouter API key
@@ -42,14 +42,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 7. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
@@ -66,7 +66,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 8. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 sleep 1

--- a/ionos/openclaw.sh
+++ b/ionos/openclaw.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install openclaw using bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v openclaw" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "bun install -g openclaw"
 fi
@@ -52,7 +52,7 @@ fi
 # 7. Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -69,11 +69,11 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 9. Start openclaw interactively
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 log_info "First starting openclaw gateway in background..."
 run_server "${IONOS_SERVER_IP}" "nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
-log_warn "Starting openclaw tui..."
+log_step "Starting openclaw tui..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/ionos/opencode.sh
+++ b/ionos/opencode.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${IONOS_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -40,7 +40,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -50,7 +50,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 7. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/ionos/plandex.sh
+++ b/ionos/plandex.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${IONOS_SERVER_IP}"
 wait_for_cloud_init "${IONOS_SERVER_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 if ! run_server "${IONOS_SERVER_IP}" "command -v plandex" >/dev/null 2>&1; then
     run_server "${IONOS_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 fi
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${IONOS_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -59,7 +59,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${IONOS_SERVER_ID}, IP: ${IONOS_SERVER_IP}
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${IONOS_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/kamatera/aider.sh
+++ b/kamatera/aider.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${KAMATERA_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -35,7 +35,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -44,7 +44,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/kamatera/amazonq.sh
+++ b/kamatera/amazonq.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${KAMATERA_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/kamatera/claude.sh
+++ b/kamatera/claude.sh
@@ -19,12 +19,12 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${KAMATERA_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${KAMATERA_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -36,7 +36,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -54,7 +54,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/kamatera/cline.sh
+++ b/kamatera/cline.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${KAMATERA_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && cline"

--- a/kamatera/codex.sh
+++ b/kamatera/codex.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${KAMATERA_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && codex"

--- a/kamatera/continue.sh
+++ b/kamatera/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 wait_for_cloud_init "${KAMATERA_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${KAMATERA_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && cn"

--- a/kamatera/gemini.sh
+++ b/kamatera/gemini.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${KAMATERA_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/kamatera/goose.sh
+++ b/kamatera/goose.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${KAMATERA_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -43,7 +43,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && goose"

--- a/kamatera/gptme.sh
+++ b/kamatera/gptme.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "${KAMATERA_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -35,7 +35,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -44,7 +44,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/kamatera/interpreter.sh
+++ b/kamatera/interpreter.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${KAMATERA_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/kamatera/kilocode.sh
+++ b/kamatera/kilocode.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing Kilo Code CLI..."
+log_step "Installing Kilo Code CLI..."
 run_server "${KAMATERA_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -44,7 +44,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/kamatera/lib/common.sh
+++ b/kamatera/lib/common.sh
@@ -145,7 +145,7 @@ wait_for_command() {
     local timeout="${2:-$KAMATERA_COMMAND_TIMEOUT}"
 
     local elapsed=0
-    log_warn "Waiting for Kamatera command to complete (timeout: ${timeout}s)..."
+    log_step "Waiting for Kamatera command to complete (timeout: ${timeout}s)..."
 
     while [[ "$elapsed" -lt "$timeout" ]]; do
         local queue_response
@@ -245,7 +245,7 @@ get_kamatera_server_ip() {
             return 0
         fi
 
-        log_warn "Waiting for server IP... (attempt $attempt/$max_attempts)"
+        log_step "Waiting for server IP... (attempt $attempt/$max_attempts)"
         sleep "$INSTANCE_STATUS_POLL_DELAY"
         attempt=$((attempt + 1))
     done
@@ -373,7 +373,7 @@ create_server() {
 
     validate_kamatera_params "$datacenter" "$cpu" "$ram" "$disk" "$image" "$billing" || return 1
 
-    log_warn "Creating Kamatera server '$name' (datacenter: $datacenter, cpu: $cpu, ram: ${ram}MB)..."
+    log_step "Creating Kamatera server '$name' (datacenter: $datacenter, cpu: $cpu, ram: ${ram}MB)..."
 
     local password ssh_key script_content body
     password=$(generate_server_password)

--- a/kamatera/nanoclaw.sh
+++ b/kamatera/nanoclaw.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing NanoClaw..."
+log_step "Installing NanoClaw..."
 run_server "${KAMATERA_SERVER_IP}" "source ~/.bashrc && npm install -g tsx && git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -47,7 +47,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting NanoClaw..."
+log_step "Starting NanoClaw..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && cd ~/nanoclaw && npm run dev"

--- a/kamatera/openclaw.sh
+++ b/kamatera/openclaw.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${KAMATERA_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -35,7 +35,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${KAMATERA_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/kamatera/opencode.sh
+++ b/kamatera/opencode.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${KAMATERA_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/kamatera/plandex.sh
+++ b/kamatera/plandex.sh
@@ -19,10 +19,10 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${KAMATERA_SERVER_IP}"
 
-log_warn "Waiting for init script to complete..."
+log_step "Waiting for init script to complete..."
 generic_ssh_wait "root" "${KAMATERA_SERVER_IP}" "${SSH_OPTS} -o ConnectTimeout=5" "test -f /root/.cloud-init-complete" "init script" 60 5
 
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${KAMATERA_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 if ! run_server "${KAMATERA_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
@@ -38,7 +38,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -47,7 +47,7 @@ log_info "Kamatera server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (IP: ${KAMATERA_SERVER_IP})"
 echo ""
 
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${KAMATERA_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/koyeb/aider.sh
+++ b/koyeb/aider.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -40,7 +40,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && aider --model openrouter/${MODEL_ID}"

--- a/koyeb/amazonq.sh
+++ b/koyeb/amazonq.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 7. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && q chat"

--- a/koyeb/claude.sh
+++ b/koyeb/claude.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Claude Code
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -55,7 +55,7 @@ inject_env_vars \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
 # 7. Configure Claude Code settings
-log_warn "Configuring Claude Code..."
+log_step "Configuring Claude Code..."
 
 run_server "mkdir -p /root/.claude"
 
@@ -103,7 +103,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "export PATH=\$HOME/.local/bin:\$PATH && source /root/.bashrc && claude"

--- a/koyeb/cline.sh
+++ b/koyeb/cline.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Node.js and Cline
-log_warn "Installing Node.js and Cline..."
+log_step "Installing Node.js and Cline..."
 run_server "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs && npm install -g cline"
 log_info "Cline installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && cline"

--- a/koyeb/codex.sh
+++ b/koyeb/codex.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Node.js and Codex
-log_warn "Installing Node.js and Codex CLI..."
+log_step "Installing Node.js and Codex CLI..."
 run_server "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs && npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 7. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && codex"

--- a/koyeb/continue.sh
+++ b/koyeb/continue.sh
@@ -20,7 +20,7 @@ ensure_koyeb_token
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_koyeb "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Koyeb service setup completed successfully!"
 log_info "Service: ${SERVER_NAME} (App: ${KOYEB_APP_NAME})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cn"

--- a/koyeb/gemini.sh
+++ b/koyeb/gemini.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Node.js and Gemini CLI
-log_warn "Installing Node.js and Gemini CLI..."
+log_step "Installing Node.js and Gemini CLI..."
 run_server "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs && npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -51,7 +51,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && gemini"

--- a/koyeb/goose.sh
+++ b/koyeb/goose.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "GOOSE_PROVIDER=openrouter" \
@@ -49,7 +49,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 7. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && goose"

--- a/koyeb/gptme.sh
+++ b/koyeb/gptme.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -40,7 +40,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && gptme -m openrouter/${MODEL_ID}"

--- a/koyeb/interpreter.sh
+++ b/koyeb/interpreter.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -51,7 +51,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 7. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && interpreter"

--- a/koyeb/kilocode.sh
+++ b/koyeb/kilocode.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Node.js and Kilo Code CLI
-log_warn "Installing Node.js and Kilo Code CLI..."
+log_step "Installing Node.js and Kilo Code CLI..."
 run_server "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs && npm install -g @kilocode/cli"
 log_info "Kilo Code CLI installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 7. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && kilocode"

--- a/koyeb/lib/common.sh
+++ b/koyeb/lib/common.sh
@@ -30,7 +30,7 @@ ensure_koyeb_cli() {
         return 0
     fi
 
-    log_warn "Installing Koyeb CLI..."
+    log_step "Installing Koyeb CLI..."
 
     # Detect OS and architecture
     local os=""
@@ -97,7 +97,7 @@ get_server_name() {
 # Usage: _koyeb_create_app APP_NAME
 _koyeb_create_app() {
     local app_name="$1"
-    log_warn "Creating Koyeb app: $app_name"
+    log_step "Creating Koyeb app: $app_name"
     if ! koyeb app create "$app_name" >/dev/null 2>&1; then
         log_error "Failed to create Koyeb app"
         return 1
@@ -111,7 +111,7 @@ _koyeb_create_service() {
     local app_name="$1"
     local service_name="$2"
 
-    log_warn "Creating Koyeb service: $service_name"
+    log_step "Creating Koyeb service: $service_name"
 
     local create_output
     create_output=$(koyeb service create "$service_name" \
@@ -147,7 +147,7 @@ _koyeb_wait_for_service() {
     local max_attempts=${2:-60}
     local attempt=0
 
-    log_warn "Waiting for service to deploy..."
+    log_step "Waiting for service to deploy..."
     while [[ $attempt -lt $max_attempts ]]; do
         local status
         status=$(koyeb service get "$service_id" 2>/dev/null | grep "Status:" | awk '{print $2}')
@@ -241,7 +241,7 @@ upload_file() {
 
 # Wait for cloud-init or basic system readiness
 wait_for_cloud_init() {
-    log_warn "Installing base tools..."
+    log_step "Installing base tools..."
 
     # Update package lists and install essentials
     run_server "apt-get update -qq && apt-get install -y -qq curl wget git python3 python3-pip build-essential ca-certificates" || {

--- a/koyeb/nanoclaw.sh
+++ b/koyeb/nanoclaw.sh
@@ -24,12 +24,12 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Node.js and tsx
-log_warn "Installing Node.js and tsx..."
+log_step "Installing Node.js and tsx..."
 run_server "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs && npm install -g tsx"
 log_info "Node.js and tsx installed"
 
 # 5. Clone and build NanoClaw
-log_warn "Cloning and building NanoClaw..."
+log_step "Cloning and building NanoClaw..."
 run_server "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -42,7 +42,7 @@ else
 fi
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ inject_env_vars \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create NanoClaw .env file
-log_warn "Configuring NanoClaw..."
+log_step "Configuring NanoClaw..."
 run_server "cat > ~/nanoclaw/.env << 'EOF'
 ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
 EOF"
@@ -61,7 +61,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 9. Start NanoClaw interactively
-log_warn "Starting NanoClaw..."
+log_step "Starting NanoClaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 sleep 1

--- a/koyeb/openclaw.sh
+++ b/koyeb/openclaw.sh
@@ -24,13 +24,13 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install bun first (required for openclaw)
-log_warn "Installing bun..."
+log_step "Installing bun..."
 run_server "curl -fsSL https://bun.sh/install | bash"
 run_server "export PATH=\"\$HOME/.bun/bin:\$PATH\""
 log_info "Bun installed"
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "source /root/.bashrc && export PATH=\"\$HOME/.bun/bin:\$PATH\" && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -46,7 +46,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 7. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -55,7 +55,7 @@ inject_env_vars \
     "PATH=\$HOME/.bun/bin:\$PATH"
 
 # 8. Configure openclaw
-log_warn "Configuring openclaw..."
+log_step "Configuring openclaw..."
 
 run_server "rm -rf /root/.openclaw && mkdir -p /root/.openclaw"
 
@@ -75,7 +75,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 9. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "source /root/.bashrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "source /root/.bashrc && openclaw tui"

--- a/koyeb/opencode.sh
+++ b/koyeb/opencode.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -48,7 +48,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 7. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && opencode"

--- a/koyeb/plandex.sh
+++ b/koyeb/plandex.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -48,7 +48,7 @@ log_info "Service: $KOYEB_SERVICE_NAME (Instance: $KOYEB_INSTANCE_ID)"
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && plandex"

--- a/latitude/aider.sh
+++ b/latitude/aider.sh
@@ -31,7 +31,7 @@ verify_server_connectivity "${LATITUDE_SERVER_IP}"
 # 6. Install base tools and Aider
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${LATITUDE_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 # Verify installation succeeded
@@ -53,7 +53,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -63,7 +63,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERV
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/latitude/amazonq.sh
+++ b/latitude/amazonq.sh
@@ -20,7 +20,7 @@ wait_for_server_ready "${LATITUDE_SERVER_ID}" 60
 verify_server_connectivity "${LATITUDE_SERVER_IP}"
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${LATITUDE_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Latitude.sh server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/latitude/claude.sh
+++ b/latitude/claude.sh
@@ -31,7 +31,7 @@ verify_server_connectivity "${LATITUDE_SERVER_IP}"
 # 6. Install base tools and Claude Code
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "${LATITUDE_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -50,7 +50,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -70,7 +70,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERV
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/latitude/cline.sh
+++ b/latitude/cline.sh
@@ -20,7 +20,7 @@ wait_for_server_ready "${LATITUDE_SERVER_ID}" 60
 verify_server_connectivity "${LATITUDE_SERVER_IP}"
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${LATITUDE_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Latitude.sh server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && cline"

--- a/latitude/codex.sh
+++ b/latitude/codex.sh
@@ -20,7 +20,7 @@ wait_for_server_ready "${LATITUDE_SERVER_ID}" 60
 verify_server_connectivity "${LATITUDE_SERVER_IP}"
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${LATITUDE_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Latitude.sh server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && codex"

--- a/latitude/continue.sh
+++ b/latitude/continue.sh
@@ -21,7 +21,7 @@ verify_server_connectivity "$LATITUDE_SERVER_IP"
 
 install_base_tools "$LATITUDE_SERVER_IP"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "$LATITUDE_SERVER_IP" "npm install -g @continuedev/cli"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.bashrc"
 run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.zshrc"
 
@@ -43,7 +43,7 @@ echo ""
 log_info "Latitude.sh setup completed successfully!"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "$LATITUDE_SERVER_IP" "zsh -c 'source ~/.zshrc && cn'"

--- a/latitude/gemini.sh
+++ b/latitude/gemini.sh
@@ -20,7 +20,7 @@ wait_for_server_ready "${LATITUDE_SERVER_ID}" 60
 verify_server_connectivity "${LATITUDE_SERVER_IP}"
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${LATITUDE_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -43,7 +43,7 @@ log_info "Latitude.sh server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/latitude/goose.sh
+++ b/latitude/goose.sh
@@ -31,7 +31,7 @@ verify_server_connectivity "${LATITUDE_SERVER_IP}"
 # 6. Install base tools and Goose
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${LATITUDE_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation succeeded
@@ -50,7 +50,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -61,7 +61,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERV
 echo ""
 
 # 8. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && goose"

--- a/latitude/gptme.sh
+++ b/latitude/gptme.sh
@@ -31,7 +31,7 @@ verify_server_connectivity "${LATITUDE_SERVER_IP}"
 # 6. Install base tools and gptme
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "${LATITUDE_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -53,7 +53,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -63,7 +63,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERV
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/latitude/interpreter.sh
+++ b/latitude/interpreter.sh
@@ -20,7 +20,7 @@ wait_for_server_ready "${LATITUDE_SERVER_ID}" 60
 verify_server_connectivity "${LATITUDE_SERVER_IP}"
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${LATITUDE_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Latitude.sh server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/latitude/kilocode.sh
+++ b/latitude/kilocode.sh
@@ -20,7 +20,7 @@ wait_for_server_ready "${LATITUDE_SERVER_ID}" 60
 verify_server_connectivity "${LATITUDE_SERVER_IP}"
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Kilo Code CLI..."
+log_step "Installing Kilo Code CLI..."
 run_server "${LATITUDE_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -42,7 +42,7 @@ log_info "Latitude.sh server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/latitude/lib/common.sh
+++ b/latitude/lib/common.sh
@@ -229,7 +229,7 @@ create_server() {
     validate_region_name "$site" || { log_error "Invalid LATITUDE_SITE"; return 1; }
     validate_resource_name "$os" || { log_error "Invalid LATITUDE_OS"; return 1; }
 
-    log_warn "Creating Latitude.sh server '$hostname' (plan: $plan, site: $site)..."
+    log_step "Creating Latitude.sh server '$hostname' (plan: $plan, site: $site)..."
 
     # Get project ID
     local project_id
@@ -266,7 +266,7 @@ create_server() {
     export LATITUDE_SERVER_ID
 
     log_info "Server created: ID=$LATITUDE_SERVER_ID"
-    log_warn "Waiting for server provisioning (this may take a few minutes for bare metal)..."
+    log_step "Waiting for server provisioning (this may take a few minutes for bare metal)..."
 }
 
 # Extract the IPv4 address from a Latitude.sh server API response
@@ -313,7 +313,7 @@ wait_for_server_ready() {
     local max_attempts=${2:-60}
     local attempt=1
 
-    log_warn "Waiting for server $server_id to become active..."
+    log_step "Waiting for server $server_id to become active..."
     while [[ "$attempt" -le "$max_attempts" ]]; do
         local response
         response=$(latitude_api GET "/servers/$server_id")
@@ -357,7 +357,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 destroy_server() {
     local server_id="$1"
 
-    log_warn "Destroying server $server_id..."
+    log_step "Destroying server $server_id..."
     local response
     response=$(latitude_api DELETE "/servers/$server_id")
 
@@ -397,9 +397,9 @@ for s in servers:
 # Install basic tools on the server (cloud-init equivalent for Latitude.sh)
 install_base_tools() {
     local ip="$1"
-    log_warn "Installing base tools..."
+    log_step "Installing base tools..."
     run_server "$ip" "apt-get update -qq && apt-get install -y -qq curl unzip git zsh > /dev/null 2>&1"
-    log_warn "Installing Bun..."
+    log_step "Installing Bun..."
     run_server "$ip" "curl -fsSL https://bun.sh/install | bash"
     run_server "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.bun/bin:\${PATH}\"' >> /root/.bashrc"
     run_server "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.bun/bin:\${PATH}\"' >> /root/.zshrc"

--- a/latitude/nanoclaw.sh
+++ b/latitude/nanoclaw.sh
@@ -31,10 +31,10 @@ verify_server_connectivity "${LATITUDE_SERVER_IP}"
 # 6. Install base tools and nanoclaw
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${LATITUDE_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${LATITUDE_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -46,14 +46,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 track_temp_file "${DOTENV_TEMP}"
@@ -70,7 +70,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERV
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${LATITUDE_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/latitude/openclaw.sh
+++ b/latitude/openclaw.sh
@@ -31,7 +31,7 @@ verify_server_connectivity "${LATITUDE_SERVER_IP}"
 # 6. Install base tools and openclaw
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${LATITUDE_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -46,7 +46,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -63,7 +63,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERV
 echo ""
 
 # 9. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${LATITUDE_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/latitude/opencode.sh
+++ b/latitude/opencode.sh
@@ -20,7 +20,7 @@ wait_for_server_ready "${LATITUDE_SERVER_ID}" 60
 verify_server_connectivity "${LATITUDE_SERVER_IP}"
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${LATITUDE_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -40,7 +40,7 @@ log_info "Latitude.sh server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/latitude/plandex.sh
+++ b/latitude/plandex.sh
@@ -31,7 +31,7 @@ verify_server_connectivity "${LATITUDE_SERVER_IP}"
 # 6. Install base tools and Plandex
 install_base_tools "${LATITUDE_SERVER_IP}"
 
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${LATITUDE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -50,7 +50,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -60,7 +60,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${LATITUDE_SERVER_ID}, IP: ${LATITUDE_SERV
 echo ""
 
 # 8. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${LATITUDE_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/linode/aider.sh
+++ b/linode/aider.sh
@@ -12,20 +12,20 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${LINODE_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/linode/amazonq.sh
+++ b/linode/amazonq.sh
@@ -14,13 +14,13 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${LINODE_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -29,7 +29,7 @@ inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/linode/claude.sh
+++ b/linode/claude.sh
@@ -12,16 +12,16 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${LINODE_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${LINODE_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -36,7 +36,7 @@ echo ""
 log_info "Linode setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LINODE_SERVER_ID}, IP: ${LINODE_SERVER_IP})"
 echo ""
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/linode/cline.sh
+++ b/linode/cline.sh
@@ -14,13 +14,13 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${LINODE_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -29,7 +29,7 @@ inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && cline"

--- a/linode/codex.sh
+++ b/linode/codex.sh
@@ -12,13 +12,13 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${LINODE_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -26,7 +26,7 @@ inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && codex"

--- a/linode/continue.sh
+++ b/linode/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${LINODE_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Linode setup completed successfully!"
 log_info "Linode: ${SERVER_NAME} (ID: ${LINODE_SERVER_ID}, IP: ${LINODE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && cn"

--- a/linode/gemini.sh
+++ b/linode/gemini.sh
@@ -14,13 +14,13 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${LINODE_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -30,7 +30,7 @@ inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/linode/goose.sh
+++ b/linode/goose.sh
@@ -12,20 +12,20 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${LINODE_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && goose"

--- a/linode/gptme.sh
+++ b/linode/gptme.sh
@@ -11,20 +11,20 @@ SERVER_NAME=$(get_server_name)
 create_server "$SERVER_NAME"
 verify_server_connectivity "$LINODE_SERVER_IP"
 wait_for_cloud_init "$LINODE_SERVER_IP"
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$LINODE_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "$LINODE_SERVER_IP" upload_file run_server \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "$LINODE_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/linode/interpreter.sh
+++ b/linode/interpreter.sh
@@ -12,13 +12,13 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${LINODE_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -26,7 +26,7 @@ inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/linode/kilocode.sh
+++ b/linode/kilocode.sh
@@ -14,13 +14,13 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${LINODE_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -29,7 +29,7 @@ inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/linode/lib/common.sh
+++ b/linode/lib/common.sh
@@ -173,7 +173,7 @@ create_server() {
     validate_resource_name "$type" || { log_error "Invalid LINODE_TYPE"; return 1; }
     validate_region_name "$region" || { log_error "Invalid LINODE_REGION"; return 1; }
 
-    log_warn "Creating Linode '$name' (type: $type, region: $region)..."
+    log_step "Creating Linode '$name' (type: $type, region: $region)..."
 
     local authorized_keys
     authorized_keys=$(_linode_fetch_ssh_keys)
@@ -220,7 +220,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 
 destroy_server() {
     local server_id="$1"
-    log_warn "Destroying Linode $server_id..."
+    log_step "Destroying Linode $server_id..."
     linode_api DELETE "/linode/instances/$server_id"
     log_info "Linode $server_id destroyed"
 }

--- a/linode/nanoclaw.sh
+++ b/linode/nanoclaw.sh
@@ -12,20 +12,20 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${LINODE_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${LINODE_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
@@ -36,7 +36,7 @@ upload_file "${LINODE_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${LINODE_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/linode/openclaw.sh
+++ b/linode/openclaw.sh
@@ -12,14 +12,14 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${LINODE_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -31,7 +31,7 @@ echo ""
 log_info "Linode setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LINODE_SERVER_ID}, IP: ${LINODE_SERVER_IP})"
 echo ""
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${LINODE_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/linode/opencode.sh
+++ b/linode/opencode.sh
@@ -12,20 +12,20 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${LINODE_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 echo ""
 log_info "Linode setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${LINODE_SERVER_ID}, IP: ${LINODE_SERVER_IP})"
 echo ""
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/linode/plandex.sh
+++ b/linode/plandex.sh
@@ -12,7 +12,7 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${LINODE_SERVER_IP}"
 wait_for_cloud_init "${LINODE_SERVER_IP}" 60
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${LINODE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 if ! run_server "${LINODE_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
     log_error "Plandex installation verification failed"
@@ -22,13 +22,13 @@ log_info "Plandex installed"
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then log_info "Using OpenRouter API key from environment"
 else OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180); fi
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${LINODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 echo ""
 log_info "Linode setup completed successfully!"
 echo ""
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${LINODE_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/local/claude.sh
+++ b/local/claude.sh
@@ -19,7 +19,7 @@ ensure_local_ready
 if command -v claude &>/dev/null; then
     log_info "Claude Code already installed"
 else
-    log_warn "Installing Claude Code..."
+    log_step "Installing Claude Code..."
     curl -fsSL https://claude.ai/install.sh | bash
     export PATH="${HOME}/.local/bin:${PATH}"
 fi
@@ -62,12 +62,12 @@ echo ""
 
 # 6. Start Claude Code
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
-    log_warn "Executing Claude Code with prompt..."
+    log_step "Executing Claude Code with prompt..."
     export PATH="${HOME}/.local/bin:${PATH}"
     source ~/.zshrc 2>/dev/null || true
     claude -p "${SPAWN_PROMPT}"
 else
-    log_warn "Starting Claude Code..."
+    log_step "Starting Claude Code..."
     sleep 1
     clear 2>/dev/null || true
     export PATH="${HOME}/.local/bin:${PATH}"

--- a/local/codex.sh
+++ b/local/codex.sh
@@ -26,7 +26,7 @@ fi
 if command -v codex &>/dev/null; then
     log_info "Codex already installed"
 else
-    log_warn "Installing Codex..."
+    log_step "Installing Codex..."
     npm install -g @openai/codex
 fi
 
@@ -60,11 +60,11 @@ echo ""
 
 # 6. Start Codex
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
-    log_warn "Executing Codex with prompt..."
+    log_step "Executing Codex with prompt..."
     source ~/.zshrc 2>/dev/null || true
     codex -m "${SPAWN_PROMPT}"
 else
-    log_warn "Starting Codex..."
+    log_step "Starting Codex..."
     sleep 1
     clear 2>/dev/null || true
     source ~/.zshrc 2>/dev/null || true

--- a/local/continue.sh
+++ b/local/continue.sh
@@ -26,7 +26,7 @@ fi
 if command -v cn &>/dev/null; then
     log_info "Continue already installed"
 else
-    log_warn "Installing Continue..."
+    log_step "Installing Continue..."
     npm install -g @continuedev/cli
 fi
 
@@ -53,7 +53,7 @@ inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 # 6. Configure Continue
-log_warn "Configuring Continue..."
+log_step "Configuring Continue..."
 CONTINUE_CONFIG_DIR="${HOME}/.continue"
 mkdir -p "${CONTINUE_CONFIG_DIR}"
 
@@ -77,11 +77,11 @@ echo ""
 
 # 7. Start Continue
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
-    log_warn "Executing Continue with prompt..."
+    log_step "Executing Continue with prompt..."
     source ~/.zshrc 2>/dev/null || true
     cn -p "${SPAWN_PROMPT}"
 else
-    log_warn "Starting Continue..."
+    log_step "Starting Continue..."
     sleep 1
     clear 2>/dev/null || true
     source ~/.zshrc 2>/dev/null || true

--- a/local/goose.sh
+++ b/local/goose.sh
@@ -19,7 +19,7 @@ ensure_local_ready
 if command -v goose &>/dev/null; then
     log_info "Goose already installed"
 else
-    log_warn "Installing Goose..."
+    log_step "Installing Goose..."
     CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash
 fi
 
@@ -52,12 +52,12 @@ echo ""
 
 # 5. Start Goose
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
-    log_warn "Executing Goose with prompt..."
+    log_step "Executing Goose with prompt..."
     export PATH="${HOME}/.local/bin:${PATH}"
     source ~/.zshrc 2>/dev/null || true
     goose -m "${SPAWN_PROMPT}"
 else
-    log_warn "Starting Goose..."
+    log_step "Starting Goose..."
     sleep 1
     clear 2>/dev/null || true
     export PATH="${HOME}/.local/bin:${PATH}"

--- a/local/nanoclaw.sh
+++ b/local/nanoclaw.sh
@@ -20,14 +20,14 @@ if ! command -v npm &>/dev/null; then
     if command -v bun &>/dev/null; then
         log_info "Using bun as package manager"
     else
-        log_warn "Installing bun..."
+        log_step "Installing bun..."
         curl -fsSL https://bun.sh/install | bash
         export PATH="${HOME}/.bun/bin:${PATH}"
     fi
 fi
 
 # 3. Install tsx dependency
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 if command -v bun &>/dev/null; then
     bun install -g tsx
 elif command -v npm &>/dev/null; then
@@ -38,7 +38,7 @@ fi
 if [[ -d "${HOME}/nanoclaw" ]]; then
     log_info "NanoClaw already cloned"
 else
-    log_warn "Cloning nanoclaw..."
+    log_step "Cloning nanoclaw..."
     git clone https://github.com/gavrielc/nanoclaw.git "${HOME}/nanoclaw"
     cd "${HOME}/nanoclaw" && npm install && npm run build
 fi
@@ -59,7 +59,7 @@ inject_env_vars_local upload_file run_server \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 7. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 chmod 600 "${DOTENV_TEMP}"
 track_temp_file "${DOTENV_TEMP}"
@@ -71,7 +71,7 @@ log_info "Local setup completed successfully!"
 echo ""
 
 # 8. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 source ~/.zshrc 2>/dev/null || true

--- a/local/openclaw.sh
+++ b/local/openclaw.sh
@@ -17,7 +17,7 @@ ensure_local_ready
 
 # 2. Install bun if not available
 if ! command -v bun &>/dev/null; then
-    log_warn "Installing bun..."
+    log_step "Installing bun..."
     curl -fsSL https://bun.sh/install | bash
     export PATH="${HOME}/.bun/bin:${PATH}"
 fi
@@ -26,7 +26,7 @@ fi
 if command -v openclaw &>/dev/null; then
     log_info "OpenClaw already installed"
 else
-    log_warn "Installing openclaw..."
+    log_step "Installing openclaw..."
     bun install -g openclaw
 fi
 
@@ -58,7 +58,7 @@ log_info "Local setup completed successfully!"
 echo ""
 
 # 8. Start openclaw gateway and TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 source ~/.zshrc 2>/dev/null || true
 nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &
 sleep 2

--- a/modal/aider.sh
+++ b/modal/aider.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -52,7 +52,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -62,7 +62,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/modal/amazonq.sh
+++ b/modal/amazonq.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -57,7 +57,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 7. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && q chat"

--- a/modal/claude.sh
+++ b/modal/claude.sh
@@ -32,9 +32,9 @@ fi
 wait_for_cloud_init
 
 # 4. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -48,7 +48,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -68,7 +68,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/modal/cline.sh
+++ b/modal/cline.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "npm install -g cline"
 log_info "Cline installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -58,7 +58,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cline"

--- a/modal/codex.sh
+++ b/modal/codex.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -58,7 +58,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 7. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && codex"

--- a/modal/continue.sh
+++ b/modal/continue.sh
@@ -20,7 +20,7 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
 run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
 
@@ -42,7 +42,7 @@ log_info "Modal sandbox setup completed successfully!"
 log_info "Sandbox ID: ${MODAL_SANDBOX_ID}"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cn"

--- a/modal/gemini.sh
+++ b/modal/gemini.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && gemini"

--- a/modal/goose.sh
+++ b/modal/goose.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
@@ -57,7 +57,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 7. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && goose"

--- a/modal/gptme.sh
+++ b/modal/gptme.sh
@@ -23,7 +23,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -43,7 +43,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -54,7 +54,7 @@ log_info "Sandbox: $SERVER_NAME (ID: $MODAL_SANDBOX_ID)"
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/modal/interpreter.sh
+++ b/modal/interpreter.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -58,7 +58,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 7. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && interpreter"

--- a/modal/kilocode.sh
+++ b/modal/kilocode.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install Kilo Code
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -58,7 +58,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 7. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && kilocode"

--- a/modal/lib/common.sh
+++ b/modal/lib/common.sh
@@ -30,7 +30,7 @@ ensure_modal_cli() {
     check_python_available || return 1
 
     if ! command -v modal &>/dev/null; then
-        log_warn "Installing Modal CLI..."
+        log_step "Installing Modal CLI..."
         if ! pip install modal 2>/dev/null && ! pip3 install modal 2>/dev/null; then
             log_error "Failed to install Modal CLI"
             log_error ""
@@ -126,7 +126,7 @@ create_server() {
 
     _validate_modal_params "${name}" "${image}" || return 1
 
-    log_warn "Creating Modal sandbox '${name}'..."
+    log_step "Creating Modal sandbox '${name}'..."
 
     local create_output create_exitcode
     create_output=$(_invoke_modal_create "${name}" "${image}")
@@ -145,7 +145,7 @@ create_server() {
 }
 
 wait_for_cloud_init() {
-    log_warn "Installing tools in sandbox..."
+    log_step "Installing tools in sandbox..."
     run_server "curl -fsSL https://bun.sh/install | bash" >/dev/null 2>&1 || true
     run_server "curl -fsSL https://claude.ai/install.sh | bash" >/dev/null 2>&1 || true
     run_server 'echo "export PATH=\"${HOME}/.claude/local/bin:${HOME}/.bun/bin:${PATH}\"" >> ~/.bashrc' >/dev/null 2>&1 || true

--- a/modal/nanoclaw.sh
+++ b/modal/nanoclaw.sh
@@ -32,10 +32,10 @@ fi
 wait_for_cloud_init
 
 # 4. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -48,7 +48,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -56,7 +56,7 @@ inject_env_vars_local upload_file run_server \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 7. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -72,7 +72,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 8. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/modal/openclaw.sh
+++ b/modal/openclaw.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -48,7 +48,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -66,7 +66,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 9. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "source ~/.zshrc && openclaw tui"

--- a/modal/opencode.sh
+++ b/modal/opencode.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -55,7 +55,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 7. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && opencode"

--- a/modal/plandex.sh
+++ b/modal/plandex.sh
@@ -32,7 +32,7 @@ fi
 wait_for_cloud_init
 
 # 4. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -55,7 +55,7 @@ log_info "Sandbox: ${SERVER_NAME} (ID: ${MODAL_SANDBOX_ID})"
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && plandex"

--- a/netcup/amazonq.sh
+++ b/netcup/amazonq.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${NETCUP_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Netcup server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/netcup/claude.sh
+++ b/netcup/claude.sh
@@ -30,7 +30,7 @@ wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 # 5. Verify Claude Code is installed (fallback to manual install)
 log_step "Verifying Claude Code installation..."
 if ! run_server "${NETCUP_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${NETCUP_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 

--- a/netcup/cline.sh
+++ b/netcup/cline.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${NETCUP_SERVER_IP}"
 wait_for_cloud_init "${NETCUP_SERVER_IP}" 60
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${NETCUP_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Netcup server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && cline"

--- a/netcup/lib/common.sh
+++ b/netcup/lib/common.sh
@@ -313,7 +313,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 destroy_server() {
     local server_id="$1"
 
-    log_warn "Destroying VPS $server_id..."
+    log_step "Destroying VPS $server_id..."
     local response
     response=$(netcup_api "deleteVServer" "{\"vserverid\": \"$server_id\"}")
 

--- a/netcup/opencode.sh
+++ b/netcup/opencode.sh
@@ -19,7 +19,7 @@ SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${NETCUP_SERVER_IP}"
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${NETCUP_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${NETCUP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -39,7 +39,7 @@ log_info "Netcup server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${NETCUP_SERVER_ID}, IP: ${NETCUP_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${NETCUP_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/northflank/aider.sh
+++ b/northflank/aider.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -46,7 +46,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 7. Inject environment variables into shell configs
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -57,7 +57,7 @@ log_info "Service: ${SERVER_NAME} (Project: ${NORTHFLANK_PROJECT_NAME})"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && aider --model openrouter/${MODEL_ID}"

--- a/northflank/amazonq.sh
+++ b/northflank/amazonq.sh
@@ -21,7 +21,7 @@ PROJECT_NAME=$(get_project_name)
 create_server "${SERVICE_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ echo ""
 log_info "Northflank service setup completed successfully!"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && q chat"

--- a/northflank/claude.sh
+++ b/northflank/claude.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install Claude Code
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
@@ -45,7 +45,7 @@ else
 fi
 
 # 6. Inject environment variables into shell configs
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -66,7 +66,7 @@ log_info "Service: ${SERVER_NAME} (Project: ${NORTHFLANK_PROJECT_NAME})"
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "export PATH=\$HOME/.local/bin:\$PATH && source ~/.bashrc && claude"

--- a/northflank/cline.sh
+++ b/northflank/cline.sh
@@ -21,7 +21,7 @@ PROJECT_NAME=$(get_project_name)
 create_server "${SERVICE_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "npm install -g cline"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ echo ""
 log_info "Northflank service setup completed successfully!"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && cline"

--- a/northflank/codex.sh
+++ b/northflank/codex.sh
@@ -20,7 +20,7 @@ NORTHFLANK_PROJECT_NAME=$(get_project_name)
 create_server "${NORTHFLANK_SERVICE_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "npm install -g @openai/codex"
 
 echo ""
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -40,7 +40,7 @@ echo ""
 log_info "Northflank setup completed successfully!"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && codex"

--- a/northflank/continue.sh
+++ b/northflank/continue.sh
@@ -20,7 +20,7 @@ ensure_northflank_token
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_northflank "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Northflank service setup completed successfully!"
 log_info "Service: ${NORTHFLANK_SERVICE_ID} (Project: ${NORTHFLANK_PROJECT_ID})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cn"

--- a/northflank/gemini.sh
+++ b/northflank/gemini.sh
@@ -20,7 +20,7 @@ PROJECT_NAME=$(get_project_name)
 create_server "${SERVICE_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "export PATH=\"\$HOME/.bun/bin:\$PATH\" && npm install -g @google/gemini-cli"
 
 echo ""
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ echo ""
 log_info "Northflank setup completed successfully!"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && gemini"

--- a/northflank/goose.sh
+++ b/northflank/goose.sh
@@ -24,7 +24,7 @@ create_server "${SERVICE_NAME}"
 wait_for_cloud_init
 
 # Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation succeeded
@@ -43,7 +43,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -53,7 +53,7 @@ log_info "Northflank setup completed successfully!"
 echo ""
 
 # Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && goose"

--- a/northflank/gptme.sh
+++ b/northflank/gptme.sh
@@ -21,7 +21,7 @@ PROJECT_NAME=$(get_project_name)
 create_server "${SERVICE_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation
@@ -42,7 +42,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -50,7 +50,7 @@ echo ""
 log_info "Northflank service setup completed successfully!"
 echo ""
 
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && gptme -m openrouter/${MODEL_ID}"

--- a/northflank/interpreter.sh
+++ b/northflank/interpreter.sh
@@ -20,7 +20,7 @@ PROJECT_NAME=$(get_project_name)
 create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 
 echo ""
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -40,7 +40,7 @@ echo ""
 log_info "Northflank setup completed successfully!"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && interpreter"

--- a/northflank/kilocode.sh
+++ b/northflank/kilocode.sh
@@ -21,7 +21,7 @@ PROJECT_NAME=$(get_project_name)
 create_server "${SERVICE_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "curl -fsSL https://bun.sh/install | bash && export PATH=\"\$HOME/.bun/bin:\$PATH\" && bun install -g @kilocode/cli"
 
 # Verify installation
@@ -39,7 +39,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "KILO_PROVIDER_TYPE=openrouter" \
     "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -49,7 +49,7 @@ echo ""
 log_info "Northflank service setup completed successfully!"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && kilocode"

--- a/northflank/lib/common.sh
+++ b/northflank/lib/common.sh
@@ -27,7 +27,7 @@ fi
 
 ensure_northflank_cli() {
     if ! command -v northflank &>/dev/null; then
-        log_warn "Installing Northflank CLI..."
+        log_step "Installing Northflank CLI..."
         npm install -g @northflank/cli 2>/dev/null || {
             log_error "Failed to install Northflank CLI. Install manually: npm install -g @northflank/cli"
             return 1
@@ -75,7 +75,7 @@ _northflank_wait_for_service() {
     local max_attempts="${3:-60}"
     local attempt=1
 
-    log_warn "Waiting for service to start..."
+    log_step "Waiting for service to start..."
     while [[ "${attempt}" -le "${max_attempts}" ]]; do
         local status
         status=$(northflank get service --name "${name}" --project "${project_name}" 2>/dev/null | grep -i "status" || true)
@@ -84,7 +84,7 @@ _northflank_wait_for_service() {
             return 0
         fi
 
-        log_warn "Waiting for service to start (${attempt}/${max_attempts})..."
+        log_step "Waiting for service to start (${attempt}/${max_attempts})..."
         sleep 3
         attempt=$((attempt + 1))
     done
@@ -98,7 +98,7 @@ create_server() {
     local image="${NORTHFLANK_IMAGE:-ubuntu:24.04}"
     local project_name="${NORTHFLANK_PROJECT_NAME:-spawn-project}"
 
-    log_warn "Creating Northflank project '${project_name}'..."
+    log_step "Creating Northflank project '${project_name}'..."
 
     # Create project (idempotent - won't fail if exists)
     northflank create project \
@@ -108,7 +108,7 @@ create_server() {
     log_info "Project '${project_name}' ready"
     export NORTHFLANK_PROJECT_NAME="${project_name}"
 
-    log_warn "Creating service '${name}' with image: ${image}"
+    log_step "Creating service '${name}' with image: ${image}"
 
     # Create deployment service with Docker image
     local service_output
@@ -132,7 +132,7 @@ create_server() {
 }
 
 wait_for_cloud_init() {
-    log_warn "Installing base tools in container..."
+    log_step "Installing base tools in container..."
 
     # Update package lists and install essentials
     run_server "apt-get update -y && apt-get install -y curl git unzip python3 pip" >/dev/null 2>&1 || true
@@ -202,7 +202,7 @@ destroy_server() {
     local service_name="${1:-${NORTHFLANK_SERVICE_NAME}}"
     local project_name="${NORTHFLANK_PROJECT_NAME}"
 
-    log_warn "Destroying service '${service_name}'..."
+    log_step "Destroying service '${service_name}'..."
 
     northflank delete service \
         --name "${service_name}" \

--- a/northflank/nanoclaw.sh
+++ b/northflank/nanoclaw.sh
@@ -28,11 +28,11 @@ create_server "${SERVER_NAME}"
 # Wait for container to be ready and install base tools
 wait_for_cloud_init
 
-log_warn "Installing Node.js dependencies..."
+log_step "Installing Node.js dependencies..."
 run_server "export PATH=\"\$HOME/.bun/bin:\$PATH\" && bun install -g tsx" >/dev/null 2>&1 || true
 
 # Clone nanoclaw
-log_warn "Cloning nanoclaw..."
+log_step "Cloning nanoclaw..."
 run_server "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 
 # Get OpenRouter API key
@@ -43,14 +43,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 chmod 600 "${DOTENV_TEMP}"
@@ -68,7 +68,7 @@ log_info "Northflank setup completed successfully!"
 echo ""
 
 # Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "cd ~/nanoclaw && source ~/.bashrc && npm run dev"

--- a/northflank/openclaw.sh
+++ b/northflank/openclaw.sh
@@ -26,7 +26,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # 4. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -42,7 +42,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 7. Inject environment variables into shell configs
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Service: ${SERVER_NAME} (Project: ${NORTHFLANK_PROJECT_NAME})"
 echo ""
 
 # 9. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "source ~/.bashrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "source ~/.bashrc && openclaw tui"

--- a/northflank/opencode.sh
+++ b/northflank/opencode.sh
@@ -21,7 +21,7 @@ PROJECT_NAME=$(get_project_name)
 create_server "${SERVICE_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
 
 # Verify installation
@@ -39,7 +39,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -47,7 +47,7 @@ echo ""
 log_info "Northflank service setup completed successfully!"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && opencode"

--- a/northflank/plandex.sh
+++ b/northflank/plandex.sh
@@ -21,7 +21,7 @@ PROJECT_NAME=$(get_project_name)
 create_server "${SERVICE_NAME}"
 wait_for_cloud_init
 
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation
@@ -39,7 +39,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_northflank \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -47,7 +47,7 @@ echo ""
 log_info "Northflank service setup completed successfully!"
 echo ""
 
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && plandex"

--- a/oracle/aider.sh
+++ b/oracle/aider.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${OCI_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -53,7 +53,7 @@ MODEL_ID=$(safe_read "Enter model ID [openrouter/auto]: ") || MODEL_ID=""
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 8. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -64,7 +64,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 9. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/oracle/amazonq.sh
+++ b/oracle/amazonq.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${OCI_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 8. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/oracle/claude.sh
+++ b/oracle/claude.sh
@@ -33,9 +33,9 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${OCI_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${OCI_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -49,7 +49,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -70,7 +70,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/oracle/cline.sh
+++ b/oracle/cline.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${OCI_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 8. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && cline"

--- a/oracle/codex.sh
+++ b/oracle/codex.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${OCI_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -58,7 +58,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 8. Start Codex
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && codex"

--- a/oracle/continue.sh
+++ b/oracle/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${OCI_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Oracle Cloud instance setup completed successfully!"
 log_info "Instance: ${SERVER_NAME} (ID: ${OCI_SERVER_ID}, IP: ${OCI_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && cn"

--- a/oracle/gemini.sh
+++ b/oracle/gemini.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${OCI_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 8. Start Gemini CLI interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/oracle/goose.sh
+++ b/oracle/goose.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${OCI_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
@@ -58,7 +58,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 8. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && goose"

--- a/oracle/gptme.sh
+++ b/oracle/gptme.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "${OCI_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -56,7 +56,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
 # 8. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -67,7 +67,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 9. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/oracle/interpreter.sh
+++ b/oracle/interpreter.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${OCI_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -46,7 +46,7 @@ else
 fi
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -58,7 +58,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 8. Start Open Interpreter
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/oracle/kilocode.sh
+++ b/oracle/kilocode.sh
@@ -32,7 +32,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Kilo Code
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${OCI_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -57,7 +57,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 8. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/oracle/lib/common.sh
+++ b/oracle/lib/common.sh
@@ -271,7 +271,7 @@ _get_subnet_id() {
     fi
 
     # No public subnet found - create VCN with networking and subnet
-    log_warn "No public subnet found. Creating VCN and subnet..."
+    log_step "No public subnet found. Creating VCN and subnet..."
 
     local vcn_id
     vcn_id=$(_create_vcn "${compartment}") || return 1
@@ -355,7 +355,7 @@ create_server() {
     local name="${1}"
     local shape="${OCI_SHAPE:-VM.Standard.E2.1.Micro}"
 
-    log_warn "Creating OCI instance '${name}' (shape: ${shape})..."
+    log_step "Creating OCI instance '${name}' (shape: ${shape})..."
 
     local image_id
     image_id=$(_get_ubuntu_image_id "${shape}") || return 1
@@ -410,7 +410,7 @@ destroy_server() {
         log_error "No instance ID provided. Usage: destroy_server INSTANCE_OCID"
         return 1
     fi
-    log_warn "Terminating OCI instance ${instance_id}..."
+    log_step "Terminating OCI instance ${instance_id}..."
     oci compute instance terminate \
         --instance-id "${instance_id}" \
         --preserve-boot-volume false \

--- a/oracle/nanoclaw.sh
+++ b/oracle/nanoclaw.sh
@@ -33,10 +33,10 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${OCI_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${OCI_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -49,14 +49,14 @@ else
 fi
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -73,7 +73,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${OCI_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/oracle/openclaw.sh
+++ b/oracle/openclaw.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${OCI_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -49,7 +49,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 8. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -66,7 +66,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 10. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${OCI_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/oracle/opencode.sh
+++ b/oracle/opencode.sh
@@ -32,7 +32,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${OCI_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -45,7 +45,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -55,7 +55,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 8. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/oracle/plandex.sh
+++ b/oracle/plandex.sh
@@ -32,7 +32,7 @@ verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
 # 5. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${OCI_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -52,7 +52,7 @@ else
 fi
 
 # 7. Inject environment variables into ~/.zshrc
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${OCI_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -62,7 +62,7 @@ log_info "Instance: ${OCI_INSTANCE_NAME_ACTUAL} (IP: ${OCI_SERVER_IP})"
 echo ""
 
 # 8. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${OCI_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/ovh/aider.sh
+++ b/ovh/aider.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_ovh "${OVH_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 # Verify installation succeeded
@@ -55,7 +55,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -65,7 +65,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 9. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/ovh/amazonq.sh
+++ b/ovh/amazonq.sh
@@ -23,7 +23,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 # Install base dependencies
 install_base_deps "${OVH_SERVER_IP}"
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_ovh "${OVH_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -34,7 +34,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "OVHcloud instance setup completed successfully!"
 log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q CLI..."
+log_step "Starting Amazon Q CLI..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/ovh/claude.sh
+++ b/ovh/claude.sh
@@ -33,9 +33,9 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_ovh "${OVH_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_ovh "${OVH_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
@@ -55,7 +55,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -75,7 +75,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 10. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/ovh/cline.sh
+++ b/ovh/cline.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_ovh "${OVH_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -45,7 +45,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -57,7 +57,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 9. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && cline"

--- a/ovh/codex.sh
+++ b/ovh/codex.sh
@@ -23,7 +23,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 # Install base dependencies
 install_base_deps "${OVH_SERVER_IP}"
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_ovh "${OVH_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -34,7 +34,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "OVHcloud instance setup completed successfully!"
 log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && codex"

--- a/ovh/continue.sh
+++ b/ovh/continue.sh
@@ -19,10 +19,10 @@ create_ovh_instance "${SERVER_NAME}"
 wait_for_ovh_instance "${OVH_INSTANCE_ID}"
 verify_server_connectivity "${OVH_SERVER_IP}"
 
-log_warn "Installing base dependencies..."
+log_step "Installing base dependencies..."
 install_base_deps "${OVH_SERVER_IP}"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_ovh "${OVH_SERVER_IP}" "npm install -g @continuedev/cli"
 
 echo ""
@@ -32,7 +32,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -44,7 +44,7 @@ echo ""
 log_info "OVHcloud instance setup completed successfully!"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "zsh -c 'source ~/.zshrc && cn'"

--- a/ovh/gemini.sh
+++ b/ovh/gemini.sh
@@ -23,7 +23,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 # Install base dependencies
 install_base_deps "${OVH_SERVER_IP}"
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_ovh "${OVH_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -34,7 +34,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -46,7 +46,7 @@ log_info "OVHcloud instance setup completed successfully!"
 log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini CLI..."
+log_step "Starting Gemini CLI..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/ovh/goose.sh
+++ b/ovh/goose.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_ovh "${OVH_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation succeeded
@@ -52,7 +52,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -63,7 +63,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 9. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && goose"

--- a/ovh/gptme.sh
+++ b/ovh/gptme.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_ovh "${OVH_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -55,7 +55,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -65,7 +65,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 9. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/ovh/interpreter.sh
+++ b/ovh/interpreter.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_ovh "${OVH_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -45,7 +45,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -57,7 +57,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 9. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/ovh/kilocode.sh
+++ b/ovh/kilocode.sh
@@ -23,7 +23,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 # Install base dependencies
 install_base_deps "${OVH_SERVER_IP}"
 
-log_warn "Installing Kilo Code CLI..."
+log_step "Installing Kilo Code CLI..."
 run_ovh "${OVH_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code CLI installed"
 
@@ -34,7 +34,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -45,7 +45,7 @@ log_info "OVHcloud instance setup completed successfully!"
 log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -352,7 +352,7 @@ create_ovh_instance() {
     validate_resource_name "$flavor" || { log_error "Invalid OVH_FLAVOR"; return 1; }
     validate_region_name "$region" || { log_error "Invalid OVH_REGION"; return 1; }
 
-    log_warn "Creating OVHcloud instance '$name' (flavor: $flavor, region: $region)..."
+    log_step "Creating OVHcloud instance '$name' (flavor: $flavor, region: $region)..."
 
     # Resolve image, flavor, and SSH key IDs
     local resources
@@ -420,7 +420,7 @@ wait_for_ovh_instance() {
     local interval=5
     local max_interval=15
 
-    log_warn "Waiting for OVHcloud instance to become active..."
+    log_step "Waiting for OVHcloud instance to become active..."
     while [[ "${attempt}" -le "${max_attempts}" ]]; do
         local response
         response=$(ovh_api_call GET "/cloud/project/${OVH_PROJECT_ID}/instance/${instance_id}")
@@ -457,7 +457,7 @@ wait_for_ovh_instance() {
 destroy_ovh_instance() {
     local instance_id="$1"
 
-    log_warn "Destroying OVHcloud instance $instance_id..."
+    log_step "Destroying OVHcloud instance $instance_id..."
     local response
     response=$(ovh_api_call DELETE "/cloud/project/${OVH_PROJECT_ID}/instance/${instance_id}")
 
@@ -482,7 +482,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 install_base_deps() {
     local ip="$1"
 
-    log_warn "Installing base dependencies..."
+    log_step "Installing base dependencies..."
 
     # Use sudo if not root
     local sudo_prefix=""

--- a/ovh/nanoclaw.sh
+++ b/ovh/nanoclaw.sh
@@ -33,10 +33,10 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Install Node.js deps and clone nanoclaw
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_ovh "${OVH_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_ovh "${OVH_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -48,14 +48,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 9. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -72,7 +72,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 10. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${OVH_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/ovh/openclaw.sh
+++ b/ovh/openclaw.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_ovh "${OVH_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -48,7 +48,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -65,7 +65,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 10. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_ovh "${OVH_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/ovh/opencode.sh
+++ b/ovh/opencode.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_ovh "${OVH_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -45,7 +45,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -55,7 +55,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 9. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/ovh/plandex.sh
+++ b/ovh/plandex.sh
@@ -33,7 +33,7 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 install_base_deps "${OVH_SERVER_IP}"
 
 # 7. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_ovh "${OVH_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -52,7 +52,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ovh "${OVH_SERVER_IP}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -62,7 +62,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${OVH_INSTANCE_ID}, IP: ${OVH_SERVER_IP}
 echo ""
 
 # 9. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${OVH_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/railway/aider.sh
+++ b/railway/aider.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -40,7 +40,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Service: $RAILWAY_SERVICE_NAME"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && aider --model openrouter/${MODEL_ID}"

--- a/railway/amazonq.sh
+++ b/railway/amazonq.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ log_info "Service: $RAILWAY_SERVICE_NAME"
 echo ""
 
 # 7. Start Amazon Q interactively
-log_warn "Starting Amazon Q CLI..."
+log_step "Starting Amazon Q CLI..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && q chat"

--- a/railway/claude.sh
+++ b/railway/claude.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Claude Code
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -55,7 +55,7 @@ inject_env_vars \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
 # 7. Configure Claude Code settings
-log_warn "Configuring Claude Code..."
+log_step "Configuring Claude Code..."
 
 run_server "mkdir -p /root/.claude"
 
@@ -103,7 +103,7 @@ log_info "Service: $RAILWAY_SERVICE_NAME"
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "export PATH=\$HOME/.local/bin:\$PATH && source ~/.bashrc && claude"

--- a/railway/cline.sh
+++ b/railway/cline.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "npm install -g cline"
 log_info "Cline installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -50,7 +50,7 @@ log_info "Service: $RAILWAY_SERVICE_NAME"
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && cline"

--- a/railway/codex.sh
+++ b/railway/codex.sh
@@ -22,11 +22,11 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # Install Node.js and npm if needed
-log_warn "Installing Node.js and npm..."
+log_step "Installing Node.js and npm..."
 run_server "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs"
 
 # Install Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "npm install -g @openai/codex"
 
 # Get OpenRouter API key via OAuth
@@ -48,7 +48,7 @@ log_info "Railway service setup completed successfully!"
 echo ""
 
 # Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "bash -c 'source ~/.bashrc && codex'"

--- a/railway/continue.sh
+++ b/railway/continue.sh
@@ -20,7 +20,7 @@ ensure_railway_token
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_railway "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Railway service setup completed successfully!"
 log_info "Project: ${SERVER_NAME}"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cn"

--- a/railway/gemini.sh
+++ b/railway/gemini.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -51,7 +51,7 @@ log_info "Service: $RAILWAY_SERVICE_NAME"
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini CLI..."
+log_step "Starting Gemini CLI..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && gemini"

--- a/railway/goose.sh
+++ b/railway/goose.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation succeeded
@@ -51,7 +51,7 @@ log_info "Railway service setup completed successfully!"
 echo ""
 
 # Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "bash -c 'source ~/.bashrc && goose'"

--- a/railway/gptme.sh
+++ b/railway/gptme.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -40,7 +40,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
 # 7. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -52,7 +52,7 @@ log_info "Project: $SERVER_NAME"
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && gptme -m openrouter/${MODEL_ID}"

--- a/railway/interpreter.sh
+++ b/railway/interpreter.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 wait_for_cloud_init
 
 # Install Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 
 # Get OpenRouter API key via OAuth
@@ -44,7 +44,7 @@ log_info "Railway service setup completed successfully!"
 echo ""
 
 # Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "bash -c 'source ~/.bashrc && interpreter'"

--- a/railway/kilocode.sh
+++ b/railway/kilocode.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install kilocode
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "curl -fsSL https://bun.sh/install | bash && export PATH=\"\$HOME/.bun/bin:\$PATH\" && bun install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -51,7 +51,7 @@ log_info "Project: $SERVER_NAME"
 echo ""
 
 # 7. Start kilocode interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && kilocode"

--- a/railway/lib/common.sh
+++ b/railway/lib/common.sh
@@ -30,7 +30,7 @@ ensure_railway_cli() {
         return 0
     fi
 
-    log_warn "Installing Railway CLI..."
+    log_step "Installing Railway CLI..."
 
     # Railway CLI is installed via npm
     if ! command -v npm &>/dev/null; then
@@ -77,7 +77,7 @@ get_server_name() {
 _railway_create_project() {
     local name="$1"
 
-    log_warn "Creating Railway project: $name"
+    log_step "Creating Railway project: $name"
 
     local project_output
     project_output=$(railway init -n "$name" 2>&1)
@@ -99,7 +99,7 @@ _railway_create_project() {
 # Deploy an Ubuntu container to the linked Railway project
 # Usage: _railway_deploy_container
 _railway_deploy_container() {
-    log_warn "Deploying service..."
+    log_step "Deploying service..."
 
     local temp_dir=$(mktemp -d)
     cat > "$temp_dir/Dockerfile" <<'EOF'
@@ -125,7 +125,7 @@ _railway_wait_for_deployment() {
     local max_attempts="${1:-60}"
     local attempt=0
 
-    log_warn "Waiting for service to deploy..."
+    log_step "Waiting for service to deploy..."
 
     while [[ $attempt -lt $max_attempts ]]; do
         local status
@@ -199,7 +199,7 @@ upload_file() {
 
 # Wait for system readiness (Railway containers start with Ubuntu base)
 wait_for_cloud_init() {
-    log_warn "Verifying system packages..."
+    log_step "Verifying system packages..."
 
     # Update package lists if needed
     run_server "apt-get update -qq >/dev/null 2>&1 || true" || {
@@ -212,7 +212,7 @@ wait_for_cloud_init() {
 # Inject environment variables into shell config
 # Writes to a temp file and uploads to avoid shell interpolation of values
 inject_env_vars() {
-    log_warn "Injecting environment variables..."
+    log_step "Injecting environment variables..."
 
     local env_temp
     env_temp=$(mktemp)
@@ -241,7 +241,7 @@ interactive_session() {
 # Cleanup: delete the project
 cleanup_server() {
     if [[ -n "${RAILWAY_SERVICE_NAME:-}" ]]; then
-        log_warn "Deleting Railway project: $RAILWAY_SERVICE_NAME"
+        log_step "Deleting Railway project: $RAILWAY_SERVICE_NAME"
         railway delete --yes >/dev/null 2>&1 || true
     fi
 }

--- a/railway/nanoclaw.sh
+++ b/railway/nanoclaw.sh
@@ -24,12 +24,12 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install tsx dependency
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "curl -fsSL https://bun.sh/install | bash && export PATH=\"\$HOME/.bun/bin:\$PATH\" && bun install -g tsx"
 log_info "tsx installed"
 
 # 5. Clone and build nanoclaw
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "git clone https://github.com/gavrielc/nanoclaw.git /root/nanoclaw && cd /root/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -42,7 +42,7 @@ else
 fi
 
 # 7. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -51,7 +51,7 @@ inject_env_vars \
     "PATH=\$HOME/.bun/bin:\$PATH"
 
 # 8. Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -68,7 +68,7 @@ log_info "Service: $RAILWAY_SERVICE_NAME"
 echo ""
 
 # 9. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "cd /root/nanoclaw && source /root/.bashrc && npm run dev"

--- a/railway/openclaw.sh
+++ b/railway/openclaw.sh
@@ -24,13 +24,13 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install bun first (required for openclaw)
-log_warn "Installing bun..."
+log_step "Installing bun..."
 run_server "curl -fsSL https://bun.sh/install | bash"
 run_server "export PATH=\"\$HOME/.bun/bin:\$PATH\""
 log_info "Bun installed"
 
 # 5. Install openclaw via bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "source /root/.bashrc && export PATH=\"\$HOME/.bun/bin:\$PATH\" && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -46,7 +46,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 7. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -55,7 +55,7 @@ inject_env_vars \
     "PATH=\$HOME/.bun/bin:\$PATH"
 
 # 8. Configure openclaw
-log_warn "Configuring openclaw..."
+log_step "Configuring openclaw..."
 
 run_server "rm -rf /root/.openclaw && mkdir -p /root/.openclaw"
 
@@ -75,7 +75,7 @@ log_info "Service: $RAILWAY_SERVICE_NAME"
 echo ""
 
 # 9. Start openclaw gateway in background and launch TUI
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "source /root/.bashrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "source /root/.bashrc && openclaw tui"

--- a/railway/opencode.sh
+++ b/railway/opencode.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install opencode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
 log_info "OpenCode installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -49,7 +49,7 @@ log_info "Project: $SERVER_NAME"
 echo ""
 
 # 7. Start opencode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && opencode"

--- a/railway/plandex.sh
+++ b/railway/plandex.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -37,7 +37,7 @@ else
 fi
 
 # 6. Inject environment variables into shell config
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -49,7 +49,7 @@ log_info "Project: $SERVER_NAME"
 echo ""
 
 # 7. Start plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "source ~/.bashrc && plandex"

--- a/ramnode/aider.sh
+++ b/ramnode/aider.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${RAMNODE_SERVER_IP}"
 wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
 
 # 5. Verify Aider is installed (fallback to manual install)
-log_warn "Verifying Aider installation..."
+log_step "Verifying Aider installation..."
 if ! run_server "${RAMNODE_SERVER_IP}" "command -v aider" >/dev/null 2>&1; then
-    log_warn "Aider not found, installing manually..."
+    log_step "Aider not found, installing manually..."
     run_server "${RAMNODE_SERVER_IP}" "pip install aider-chat"
 fi
 
@@ -53,7 +53,7 @@ fi
 echo ""
 MODEL_ID=$(get_model_id "openrouter/auto")
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -64,7 +64,7 @@ log_info "Model: ${MODEL_ID}"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/ramnode/claude.sh
+++ b/ramnode/claude.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${RAMNODE_SERVER_IP}"
 wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${RAMNODE_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${RAMNODE_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 
@@ -50,7 +50,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -70,7 +70,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${RAMNODE_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/ramnode/cline.sh
+++ b/ramnode/cline.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${RAMNODE_SERVER_IP}"
 wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
 
 # 5. Verify Cline is installed (fallback to manual install)
-log_warn "Verifying Cline installation..."
+log_step "Verifying Cline installation..."
 if ! run_server "${RAMNODE_SERVER_IP}" "command -v cline" >/dev/null 2>&1; then
-    log_warn "Cline not found, installing manually..."
+    log_step "Cline not found, installing manually..."
     run_server "${RAMNODE_SERVER_IP}" "npm install -g cline"
 fi
 
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -61,7 +61,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && cline"

--- a/ramnode/continue.sh
+++ b/ramnode/continue.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${RAMNODE_SERVER_IP}"
 wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
 
 # 5. Verify Continue is installed (fallback to manual install)
-log_warn "Verifying Continue installation..."
+log_step "Verifying Continue installation..."
 if ! run_server "${RAMNODE_SERVER_IP}" "command -v cn" >/dev/null 2>&1; then
-    log_warn "Continue not found, installing manually..."
+    log_step "Continue not found, installing manually..."
     run_server "${RAMNODE_SERVER_IP}" "npm install -g @continuedev/cli"
 fi
 
@@ -49,12 +49,12 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 # 7. Configure Continue config.json
-log_warn "Configuring Continue..."
+log_step "Configuring Continue..."
 CONFIG_CONTENT=$(python3 -c "
 import json, sys
 config = {
@@ -80,7 +80,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER
 echo ""
 
 # 8. Start Continue interactively
-log_warn "Starting Continue..."
+log_step "Starting Continue..."
 sleep 1
 clear
 interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && cn"

--- a/ramnode/goose.sh
+++ b/ramnode/goose.sh
@@ -28,9 +28,9 @@ verify_server_connectivity "${RAMNODE_SERVER_IP}"
 wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
 
 # 5. Verify Goose is installed (fallback to manual install)
-log_warn "Verifying Goose installation..."
+log_step "Verifying Goose installation..."
 if ! run_server "${RAMNODE_SERVER_IP}" "command -v goose" >/dev/null 2>&1; then
-    log_warn "Goose not found, installing manually..."
+    log_step "Goose not found, installing manually..."
     run_server "${RAMNODE_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 fi
 
@@ -49,7 +49,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -60,7 +60,7 @@ log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER
 echo ""
 
 # 7. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && goose"

--- a/ramnode/interpreter.sh
+++ b/ramnode/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${RAMNODE_SERVER_IP}"
 wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${RAMNODE_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "RamNode server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/ramnode/lib/common.sh
+++ b/ramnode/lib/common.sh
@@ -404,7 +404,7 @@ create_server() {
     local userdata
     userdata=$(get_cloud_init_userdata | base64 -w 0 || get_cloud_init_userdata | base64)
 
-    log_warn "Creating RamNode instance '$name' (flavor: $flavor)..."
+    log_step "Creating RamNode instance '$name' (flavor: $flavor)..."
 
     local body
     body=$(_ramnode_build_server_body "$name" "$flavor" "$image_id" "$key_name" "$userdata" "${network_id:-}")
@@ -428,7 +428,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 destroy_server() {
     local server_id="$1"
 
-    log_warn "Destroying server $server_id..."
+    log_step "Destroying server $server_id..."
     local response
     response=$(ramnode_compute_api DELETE "/servers/$server_id")
 

--- a/render/aider.sh
+++ b/render/aider.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "pip install aider-chat"
 
 # Verify installation
@@ -48,7 +48,7 @@ MODEL_ID=$(safe_read "Enter model ID (default: openrouter/auto): ")
 MODEL_ID="${MODEL_ID:-openrouter/auto}"
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -60,7 +60,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 8. Start Aider interactively
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && aider --model openrouter/\${MODEL_ID}"

--- a/render/amazonq.sh
+++ b/render/amazonq.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Amazon Q CLI
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -57,7 +57,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 7. Start Amazon Q interactively
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && q chat"

--- a/render/claude.sh
+++ b/render/claude.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Claude Code
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -63,7 +63,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && claude"

--- a/render/cline.sh
+++ b/render/cline.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Cline
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "npm install -g cline"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -57,7 +57,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 7. Start Cline interactively
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && cline"

--- a/render/codex.sh
+++ b/render/codex.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Node.js and Codex CLI
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs"
 run_server "npm install -g @openai/codex"
 
@@ -44,7 +44,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -58,7 +58,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 7. Start Codex interactively
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && codex"

--- a/render/continue.sh
+++ b/render/continue.sh
@@ -20,7 +20,7 @@ ensure_render_api_key
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_render "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Render service setup completed successfully!"
 log_info "Service: ${SERVER_NAME} (ID: ${RENDER_SERVICE_ID})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "source ~/.zshrc && cn"

--- a/render/gemini.sh
+++ b/render/gemini.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Node.js and Gemini CLI
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs"
 run_server "npm install -g @google/gemini-cli"
 
@@ -44,7 +44,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 7. Start Gemini interactively
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && gemini"

--- a/render/goose.sh
+++ b/render/goose.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "GOOSE_PROVIDER=openrouter" \
@@ -55,7 +55,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 7. Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && goose"

--- a/render/gptme.sh
+++ b/render/gptme.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation
@@ -46,7 +46,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -58,7 +58,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 8. Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && gptme -m openrouter/${MODEL_ID}"

--- a/render/interpreter.sh
+++ b/render/interpreter.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Python and Open Interpreter
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "apt-get update && apt-get install -y python3 python3-pip"
 run_server "pip3 install open-interpreter"
 
@@ -44,7 +44,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -57,7 +57,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 7. Start Open Interpreter interactively
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && interpreter"

--- a/render/kilocode.sh
+++ b/render/kilocode.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Kilo Code CLI
-log_warn "Installing Kilo Code CLI..."
+log_step "Installing Kilo Code CLI..."
 run_server "npm install -g @kilocode/cli"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -57,7 +57,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 7. Start Kilo Code interactively
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && kilocode"

--- a/render/lib/common.sh
+++ b/render/lib/common.sh
@@ -30,7 +30,7 @@ ensure_render_cli() {
         return 0
     fi
 
-    log_warn "Installing Render CLI..."
+    log_step "Installing Render CLI..."
 
     # Render CLI installation via npm
     local node_runtime
@@ -90,7 +90,7 @@ get_server_name() {
 # Sets: RENDER_SERVICE_ID
 _render_create_service() {
     local service_name="$1"
-    log_warn "Creating Render web service: $service_name"
+    log_step "Creating Render web service: $service_name"
 
     # Build JSON body safely via Python to prevent injection
     local body
@@ -146,7 +146,7 @@ _render_wait_for_service() {
     local max_attempts=${2:-60}
     local attempt=0
 
-    log_warn "Waiting for service to be live..."
+    log_step "Waiting for service to be live..."
     while [[ $attempt -lt $max_attempts ]]; do
         local status
         status=$(curl -s "https://api.render.com/v1/services/${service_id}" \

--- a/render/nanoclaw.sh
+++ b/render/nanoclaw.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Node.js and dependencies
-log_warn "Installing Node.js..."
+log_step "Installing Node.js..."
 run_server "curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs"
 
 # Verify Node.js installation
@@ -35,11 +35,11 @@ fi
 log_info "Node.js installed"
 
 # 5. Install tsx globally
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "npm install -g tsx"
 
 # 6. Clone and build nanoclaw
-log_warn "Cloning nanoclaw..."
+log_step "Cloning nanoclaw..."
 run_server "git clone https://github.com/gavrielc/nanoclaw.git /root/nanoclaw && cd /root/nanoclaw && npm install && npm run build"
 
 # 7. Get OpenRouter API key
@@ -51,7 +51,7 @@ else
 fi
 
 # 8. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -59,7 +59,7 @@ inject_env_vars \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # 9. Create nanoclaw .env file safely via temp file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 chmod 600 "$DOTENV_TEMP"
@@ -74,7 +74,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 10. Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 sleep 1
 clear

--- a/render/openclaw.sh
+++ b/render/openclaw.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Bun
-log_warn "Installing Bun..."
+log_step "Installing Bun..."
 run_server "curl -fsSL https://bun.sh/install | bash"
 
 # Verify Bun installation
@@ -35,7 +35,7 @@ fi
 log_info "Bun installed"
 
 # 5. Install openclaw using Bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "/root/.bun/bin/bun install -g openclaw"
 
 # 6. Get OpenRouter API key
@@ -50,7 +50,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 8. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -67,7 +67,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 10. Start openclaw
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 log_info "Starting gateway in background, then launching TUI..."
 sleep 1
 clear

--- a/render/opencode.sh
+++ b/render/opencode.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install OpenCode
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "$(opencode_install_cmd)"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -55,7 +55,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 7. Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && opencode"

--- a/render/plandex.sh
+++ b/render/plandex.sh
@@ -24,7 +24,7 @@ create_server "$SERVER_NAME"
 wait_for_cloud_init
 
 # 4. Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -55,7 +55,7 @@ log_info "Service: $RENDER_SERVICE_NAME (ID: $RENDER_SERVICE_ID)"
 echo ""
 
 # 7. Start Plandex interactively
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && plandex"

--- a/runpod/claude.sh
+++ b/runpod/claude.sh
@@ -29,9 +29,9 @@ verify_server_connectivity
 install_base_tools
 
 # 5. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${RUNPOD_POD_ID}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${RUNPOD_POD_ID}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -45,7 +45,7 @@ else
 fi
 
 # 7. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${RUNPOD_POD_ID}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -65,7 +65,7 @@ log_info "Pod: ${SERVER_NAME} (ID: ${RUNPOD_POD_ID})"
 echo ""
 
 # 9. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${RUNPOD_POD_ID}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/scaleway/aider.sh
+++ b/scaleway/aider.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${SCALEWAY_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -33,7 +33,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/scaleway/amazonq.sh
+++ b/scaleway/amazonq.sh
@@ -21,7 +21,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${SCALEWAY_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -32,7 +32,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -43,7 +43,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/scaleway/claude.sh
+++ b/scaleway/claude.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "${SCALEWAY_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 log_info "Claude Code installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -49,7 +49,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/scaleway/cline.sh
+++ b/scaleway/cline.sh
@@ -21,7 +21,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${SCALEWAY_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -32,7 +32,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -43,7 +43,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && cline"

--- a/scaleway/codex.sh
+++ b/scaleway/codex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${SCALEWAY_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && codex"

--- a/scaleway/continue.sh
+++ b/scaleway/continue.sh
@@ -17,13 +17,13 @@ ensure_ssh_key
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 
-log_warn "Waiting for SSH connectivity..."
+log_step "Waiting for SSH connectivity..."
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 wait_for_server_ready "${SCALEWAY_SERVER_IP}"
 
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${SCALEWAY_SERVER_IP}" "npm install -g @continuedev/cli"
 
 echo ""
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.bashrc"
 run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.zshrc"
 
@@ -45,7 +45,7 @@ echo ""
 log_info "Scaleway setup completed successfully!"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "zsh -c 'source ~/.zshrc && cn'"

--- a/scaleway/gemini.sh
+++ b/scaleway/gemini.sh
@@ -21,7 +21,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${SCALEWAY_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -32,7 +32,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -44,7 +44,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/scaleway/goose.sh
+++ b/scaleway/goose.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${SCALEWAY_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -41,7 +41,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && goose"

--- a/scaleway/gptme.sh
+++ b/scaleway/gptme.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "${SCALEWAY_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -33,7 +33,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/scaleway/interpreter.sh
+++ b/scaleway/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${SCALEWAY_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/scaleway/kilocode.sh
+++ b/scaleway/kilocode.sh
@@ -21,7 +21,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${SCALEWAY_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -32,7 +32,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -43,7 +43,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/scaleway/lib/common.sh
+++ b/scaleway/lib/common.sh
@@ -119,7 +119,7 @@ if images:
 
 # Get Ubuntu image ID for the current zone
 get_ubuntu_image_id() {
-    log_warn "Looking up Ubuntu image for zone ${SCALEWAY_ZONE}..."
+    log_step "Looking up Ubuntu image for zone ${SCALEWAY_ZONE}..."
 
     # Try specific 24.04 search first, then broader Ubuntu search
     local image_id="" query
@@ -235,7 +235,7 @@ _scaleway_power_on_and_wait() {
         log_warn "Power on may have failed, checking status..."
     fi
 
-    log_warn "Waiting for instance to become active..."
+    log_step "Waiting for instance to become active..."
     local max_attempts=60
     local attempt=1
     while [[ "$attempt" -le "$max_attempts" ]]; do
@@ -271,7 +271,7 @@ create_server() {
     validate_resource_name "$commercial_type" || { log_error "Invalid SCALEWAY_TYPE"; return 1; }
     validate_region_name "$zone" || { log_error "Invalid SCALEWAY_ZONE"; return 1; }
 
-    log_warn "Creating Scaleway instance '$name' (type: $commercial_type, zone: $zone)..."
+    log_step "Creating Scaleway instance '$name' (type: $commercial_type, zone: $zone)..."
 
     local project_id
     project_id=$(get_scaleway_project_id) || return 1
@@ -322,17 +322,17 @@ wait_for_server_ready() {
     local ip="$1"
     local max_attempts=${2:-60}
     # Scaleway doesn't use cloud-init by default, so we wait for basic tools
-    log_warn "Waiting for server to be ready..."
+    log_step "Waiting for server to be ready..."
     generic_ssh_wait "root" "$ip" "$SSH_OPTS -o ConnectTimeout=5" "command -v curl" "server readiness" "$max_attempts" 5
 }
 
 install_base_packages() {
     local ip="$1"
-    log_warn "Installing base packages..."
+    log_step "Installing base packages..."
     run_server "$ip" "apt-get update -qq && apt-get install -y -qq curl unzip git zsh >/dev/null 2>&1"
-    log_warn "Installing Bun..."
+    log_step "Installing Bun..."
     run_server "$ip" "curl -fsSL https://bun.sh/install | bash"
-    log_warn "Installing Node.js..."
+    log_step "Installing Node.js..."
     run_server "$ip" "curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y -qq nodejs >/dev/null 2>&1"
     # Set up PATH in shell configs
     run_server "$ip" "printf 'export PATH=\"\${HOME}/.claude/local/bin:\${HOME}/.bun/bin:\${PATH}\"\n' >> /root/.bashrc"
@@ -347,7 +347,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 
 destroy_server() {
     local server_id="$1"
-    log_warn "Destroying instance $server_id..."
+    log_step "Destroying instance $server_id..."
 
     # Scaleway requires powering off before deleting
     scaleway_instance_api POST "/servers/$server_id/action" '{"action":"poweroff"}' >/dev/null 2>&1 || true

--- a/scaleway/nanoclaw.sh
+++ b/scaleway/nanoclaw.sh
@@ -20,9 +20,9 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${SCALEWAY_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${SCALEWAY_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -33,13 +33,13 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
@@ -53,7 +53,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${SCALEWAY_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/scaleway/openclaw.sh
+++ b/scaleway/openclaw.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${SCALEWAY_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -33,7 +33,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -48,7 +48,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/scaleway/opencode.sh
+++ b/scaleway/opencode.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${SCALEWAY_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -40,7 +40,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/scaleway/plandex.sh
+++ b/scaleway/plandex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${SCALEWAY_SERVER_IP}"
 install_base_packages "${SCALEWAY_SERVER_IP}"
 
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${SCALEWAY_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 log_info "Plandex installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -40,7 +40,7 @@ log_info "Scaleway instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${SCALEWAY_SERVER_ID}, IP: ${SCALEWAY_SERVER_IP})"
 echo ""
 
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${SCALEWAY_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/sprite/aider.sh
+++ b/sprite/aider.sh
@@ -20,13 +20,13 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 
 # Configure shell environment
 setup_shell_environment "${SPRITE_NAME}"
 
 # Install Aider
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_sprite "${SPRITE_NAME}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 # Verify installation succeeded
@@ -48,7 +48,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -59,7 +59,7 @@ echo ""
 # Check if running in non-interactive mode
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     # Non-interactive mode: execute prompt and exit
-    log_warn "Executing Aider with prompt..."
+    log_step "Executing Aider with prompt..."
 
     # Escape prompt for safe shell execution
     escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
@@ -68,7 +68,7 @@ if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     sprite exec -s "${SPRITE_NAME}" -- zsh -c "source ~/.zshrc && aider --model openrouter/${MODEL_ID} -m ${escaped_prompt}"
 else
     # Interactive mode: start Aider normally
-    log_warn "Starting Aider..."
+    log_step "Starting Aider..."
     sleep 1
     clear
     sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/sprite/amazonq.sh
+++ b/sprite/amazonq.sh
@@ -18,10 +18,10 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 setup_shell_environment "${SPRITE_NAME}"
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_sprite "${SPRITE_NAME}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ echo ""
 log_info "Sprite setup completed successfully!"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && q chat"

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -20,13 +20,13 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 
 # Configure shell environment
 setup_shell_environment "${SPRITE_NAME}"
 
 # Install Claude Code
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_sprite "${SPRITE_NAME}" "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -45,7 +45,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -60,13 +60,13 @@ setup_claude_code_config "${OPENROUTER_API_KEY}" \
     "run_sprite ${SPRITE_NAME}"
 
 echo ""
-log_info "✅ Sprite setup completed successfully!"
+log_info "Sprite setup completed successfully!"
 echo ""
 
 # Check if running in non-interactive mode
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     # Non-interactive mode: execute prompt and exit
-    log_warn "Executing Claude Code with prompt..."
+    log_step "Executing Claude Code with prompt..."
 
     # Escape prompt for safe shell execution
     escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
@@ -75,7 +75,7 @@ if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     sprite exec -s "${SPRITE_NAME}" -- zsh -c "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude -p ${escaped_prompt}"
 else
     # Interactive mode: start Claude Code normally
-    log_warn "Starting Claude Code..."
+    log_step "Starting Claude Code..."
     sleep 1
     clear 2>/dev/null || true
     sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/sprite/cline.sh
+++ b/sprite/cline.sh
@@ -18,10 +18,10 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 setup_shell_environment "${SPRITE_NAME}"
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_sprite "${SPRITE_NAME}" "npm install -g cline"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ echo ""
 log_info "Sprite setup completed successfully!"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && cline"

--- a/sprite/codex.sh
+++ b/sprite/codex.sh
@@ -18,10 +18,10 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 setup_shell_environment "${SPRITE_NAME}"
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_sprite "${SPRITE_NAME}" "npm install -g @openai/codex"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ echo ""
 log_info "Sprite setup completed successfully!"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && codex"

--- a/sprite/continue.sh
+++ b/sprite/continue.sh
@@ -18,10 +18,10 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}" 5
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 setup_shell_environment "${SPRITE_NAME}"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_sprite "${SPRITE_NAME}" "npm install -g @continuedev/cli"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -43,7 +43,7 @@ echo ""
 log_info "Sprite setup completed successfully!"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && cn"

--- a/sprite/gemini.sh
+++ b/sprite/gemini.sh
@@ -18,10 +18,10 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 setup_shell_environment "${SPRITE_NAME}"
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_sprite "${SPRITE_NAME}" "npm install -g @google/gemini-cli"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ echo ""
 log_info "Sprite setup completed successfully!"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && gemini"

--- a/sprite/goose.sh
+++ b/sprite/goose.sh
@@ -20,13 +20,13 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 
 # Configure shell environment
 setup_shell_environment "${SPRITE_NAME}"
 
 # Install Goose
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_sprite "${SPRITE_NAME}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 # Verify installation succeeded
@@ -45,7 +45,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -55,7 +55,7 @@ log_info "Sprite setup completed successfully!"
 echo ""
 
 # Start Goose interactively
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && goose"

--- a/sprite/gptme.sh
+++ b/sprite/gptme.sh
@@ -20,13 +20,13 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "$SPRITE_NAME"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 
 # Configure shell environment
 setup_shell_environment "$SPRITE_NAME"
 
 # Install gptme
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_sprite "$SPRITE_NAME" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
@@ -48,7 +48,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "$SPRITE_NAME" \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
 
@@ -57,7 +57,7 @@ log_info "Sprite setup completed successfully!"
 echo ""
 
 # Start gptme interactively
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 sprite exec -s "$SPRITE_NAME" -tty -- zsh -c "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/sprite/interpreter.sh
+++ b/sprite/interpreter.sh
@@ -18,10 +18,10 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 setup_shell_environment "${SPRITE_NAME}"
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_sprite "${SPRITE_NAME}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ echo ""
 log_info "Sprite setup completed successfully!"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && interpreter"

--- a/sprite/kilocode.sh
+++ b/sprite/kilocode.sh
@@ -18,10 +18,10 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 setup_shell_environment "${SPRITE_NAME}"
 
-log_warn "Installing Kilo Code CLI..."
+log_step "Installing Kilo Code CLI..."
 run_sprite "${SPRITE_NAME}" "npm install -g @kilocode/cli"
 
 echo ""
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -41,7 +41,7 @@ echo ""
 log_info "Sprite setup completed successfully!"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && kilocode"

--- a/sprite/nanoclaw.sh
+++ b/sprite/nanoclaw.sh
@@ -20,17 +20,17 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 
 # Configure shell environment
 setup_shell_environment "${SPRITE_NAME}"
 
 # Install Node.js dependencies
-log_warn "Installing Node.js..."
+log_step "Installing Node.js..."
 run_sprite "${SPRITE_NAME}" "/.sprite/languages/bun/bin/bun install -g tsx"
 
 # Clone nanoclaw
-log_warn "Cloning nanoclaw..."
+log_step "Cloning nanoclaw..."
 run_sprite "${SPRITE_NAME}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 
 # Get OpenRouter API key
@@ -41,14 +41,14 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
 # Create nanoclaw .env file
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
@@ -60,11 +60,11 @@ EOF
 sprite exec -s "${SPRITE_NAME}" -file "${DOTENV_TEMP}:/tmp/nanoclaw_env" -- bash -c "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
-log_info "✅ Sprite setup completed successfully!"
+log_info "Sprite setup completed successfully!"
 echo ""
 
 # Start nanoclaw
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/sprite/openclaw.sh
+++ b/sprite/openclaw.sh
@@ -19,13 +19,13 @@ ensure_sprite_authenticated
 SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 
 # Configure shell environment
 setup_shell_environment "${SPRITE_NAME}"
 
 # Install openclaw using bun
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_sprite "${SPRITE_NAME}" "/.sprite/languages/bun/bin/bun install -g openclaw"
 
 # Get OpenRouter API key
@@ -39,7 +39,7 @@ fi
 # Get model preference
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -51,11 +51,11 @@ setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" \
     "run_sprite ${SPRITE_NAME}"
 
 echo ""
-log_info "✅ Sprite setup completed successfully!"
+log_info "Sprite setup completed successfully!"
 echo ""
 
 # Start openclaw gateway in background and run openclaw tui
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 sprite exec -s "${SPRITE_NAME}" -- zsh -c "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && openclaw tui"

--- a/sprite/opencode.sh
+++ b/sprite/opencode.sh
@@ -20,10 +20,10 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 setup_shell_environment "${SPRITE_NAME}"
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_sprite "${SPRITE_NAME}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -35,7 +35,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -44,7 +44,7 @@ log_info "Sprite setup completed successfully!"
 echo ""
 
 # Start OpenCode interactively
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && opencode"

--- a/sprite/plandex.sh
+++ b/sprite/plandex.sh
@@ -20,13 +20,13 @@ SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"
 
-log_warn "Setting up sprite environment..."
+log_step "Setting up sprite environment..."
 
 # Configure shell environment
 setup_shell_environment "${SPRITE_NAME}"
 
 # Install Plandex
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_sprite "${SPRITE_NAME}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -45,7 +45,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_sprite "${SPRITE_NAME}" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -56,7 +56,7 @@ echo ""
 # Check if running in non-interactive mode
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     # Non-interactive mode: execute prompt and exit
-    log_warn "Executing Plandex with prompt..."
+    log_step "Executing Plandex with prompt..."
 
     # Escape prompt for safe shell execution
     escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
@@ -65,7 +65,7 @@ if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     sprite exec -s "${SPRITE_NAME}" -- zsh -c "source ~/.zshrc && plandex new && plandex tell ${escaped_prompt}"
 else
     # Interactive mode: start Plandex normally
-    log_warn "Starting Plandex..."
+    log_step "Starting Plandex..."
     sleep 1
     clear
     sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "source ~/.zshrc && plandex"

--- a/upcloud/aider.sh
+++ b/upcloud/aider.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${UPCLOUD_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 if ! run_server "${UPCLOUD_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
@@ -37,7 +37,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -46,7 +46,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/upcloud/amazonq.sh
+++ b/upcloud/amazonq.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${UPCLOUD_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/upcloud/claude.sh
+++ b/upcloud/claude.sh
@@ -28,7 +28,7 @@ verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 # 5. Install base tools and Claude Code
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Claude Code..."
+log_step "Installing Claude Code..."
 run_server "${UPCLOUD_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation succeeded
@@ -47,7 +47,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -67,7 +67,7 @@ log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SE
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/upcloud/cline.sh
+++ b/upcloud/cline.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${UPCLOUD_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && cline"

--- a/upcloud/codex.sh
+++ b/upcloud/codex.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${UPCLOUD_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && codex"

--- a/upcloud/continue.sh
+++ b/upcloud/continue.sh
@@ -20,7 +20,7 @@ verify_server_connectivity "$UPCLOUD_SERVER_IP"
 
 install_base_tools "$UPCLOUD_SERVER_IP"
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "$UPCLOUD_SERVER_IP" "npm install -g @continuedev/cli"
 
 echo ""
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.bashrc"
 run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.zshrc"
 
@@ -42,7 +42,7 @@ echo ""
 log_info "UpCloud server setup completed successfully!"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "$UPCLOUD_SERVER_IP" "source ~/.zshrc && cn"

--- a/upcloud/gemini.sh
+++ b/upcloud/gemini.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${UPCLOUD_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/upcloud/goose.sh
+++ b/upcloud/goose.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${UPCLOUD_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 if ! run_server "${UPCLOUD_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
@@ -35,7 +35,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -45,7 +45,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && goose"

--- a/upcloud/gptme.sh
+++ b/upcloud/gptme.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "${UPCLOUD_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 if ! run_server "${UPCLOUD_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
@@ -37,7 +37,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -46,7 +46,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/upcloud/interpreter.sh
+++ b/upcloud/interpreter.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${UPCLOUD_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -41,7 +41,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/upcloud/kilocode.sh
+++ b/upcloud/kilocode.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Kilo Code CLI..."
+log_step "Installing Kilo Code CLI..."
 run_server "${UPCLOUD_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code CLI installed"
 
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
@@ -41,7 +41,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/upcloud/lib/common.sh
+++ b/upcloud/lib/common.sh
@@ -188,7 +188,7 @@ create_server() {
     validate_resource_name "$plan" || { log_error "Invalid UPCLOUD_PLAN"; return 1; }
     validate_region_name "$zone" || { log_error "Invalid UPCLOUD_ZONE"; return 1; }
 
-    log_warn "Creating UpCloud server '$name' (plan: $plan, zone: $zone)..."
+    log_step "Creating UpCloud server '$name' (plan: $plan, zone: $zone)..."
 
     # Find Ubuntu template
     local template_uuid
@@ -229,7 +229,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 destroy_server() {
     local server_uuid="$1"
 
-    log_warn "Stopping server $server_uuid..."
+    log_step "Stopping server $server_uuid..."
     upcloud_api POST "/server/$server_uuid/stop" '{"stop_server":{"stop_type":"soft","timeout":"60"}}' >/dev/null 2>&1 || true
 
     # Wait for server to stop
@@ -247,7 +247,7 @@ destroy_server() {
         attempt=$((attempt + 1))
     done
 
-    log_warn "Destroying server $server_uuid..."
+    log_step "Destroying server $server_uuid..."
     local response
     response=$(upcloud_api DELETE "/server/$server_uuid?storages=1")
 
@@ -286,13 +286,13 @@ for s in servers:
 install_base_tools() {
     local ip="$1"
 
-    log_warn "Installing base tools..."
+    log_step "Installing base tools..."
     run_server "$ip" "apt-get update -qq && apt-get install -y -qq curl unzip git zsh python3 > /dev/null 2>&1"
 
-    log_warn "Installing Bun..."
+    log_step "Installing Bun..."
     run_server "$ip" "curl -fsSL https://bun.sh/install | bash"
 
-    log_warn "Installing Node.js..."
+    log_step "Installing Node.js..."
     run_server "$ip" "curl -fsSL https://deb.nodesource.com/setup_22.x | bash - > /dev/null 2>&1 && apt-get install -y -qq nodejs > /dev/null 2>&1"
 
     # Configure PATH

--- a/upcloud/nanoclaw.sh
+++ b/upcloud/nanoclaw.sh
@@ -19,10 +19,10 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${UPCLOUD_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
 
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${UPCLOUD_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -33,13 +33,13 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
@@ -54,7 +54,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${UPCLOUD_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/upcloud/openclaw.sh
+++ b/upcloud/openclaw.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${UPCLOUD_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -32,7 +32,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -47,7 +47,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/upcloud/opencode.sh
+++ b/upcloud/opencode.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${UPCLOUD_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -30,7 +30,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -39,7 +39,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/upcloud/plandex.sh
+++ b/upcloud/plandex.sh
@@ -19,7 +19,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${UPCLOUD_SERVER_IP}"
 install_base_tools "${UPCLOUD_SERVER_IP}"
 
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${UPCLOUD_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 if ! run_server "${UPCLOUD_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
@@ -35,7 +35,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -44,7 +44,7 @@ log_info "UpCloud server setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (UUID: ${UPCLOUD_SERVER_UUID}, IP: ${UPCLOUD_SERVER_IP})"
 echo ""
 
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${UPCLOUD_SERVER_IP}" "source ~/.zshrc && plandex"

--- a/vastai/claude.sh
+++ b/vastai/claude.sh
@@ -27,9 +27,9 @@ verify_server_connectivity
 install_base_tools
 
 # 4. Verify Claude Code is installed (fallback to manual install)
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${VASTAI_INSTANCE_ID}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${VASTAI_INSTANCE_ID}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -43,7 +43,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VASTAI_INSTANCE_ID}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -63,7 +63,7 @@ log_info "Instance: ${SERVER_NAME} (ID: ${VASTAI_INSTANCE_ID})"
 echo ""
 
 # 8. Start Claude Code interactively
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${VASTAI_INSTANCE_ID}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/vultr/aider.sh
+++ b/vultr/aider.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Aider..."
+log_step "Installing Aider..."
 run_server "${VULTR_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 log_info "Aider installed"
 
@@ -33,7 +33,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -42,7 +42,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Aider..."
+log_step "Starting Aider..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/vultr/amazonq.sh
+++ b/vultr/amazonq.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Amazon Q CLI..."
+log_step "Installing Amazon Q CLI..."
 run_server "${VULTR_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
 log_info "Amazon Q CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Amazon Q..."
+log_step "Starting Amazon Q..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/vultr/claude.sh
+++ b/vultr/claude.sh
@@ -20,9 +20,9 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Verifying Claude Code installation..."
+log_step "Verifying Claude Code installation..."
 if ! run_server "${VULTR_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_warn "Claude Code not found, installing manually..."
+    log_step "Claude Code not found, installing manually..."
     run_server "${VULTR_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
 fi
 log_info "Claude Code is installed"
@@ -34,7 +34,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
@@ -52,7 +52,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Claude Code..."
+log_step "Starting Claude Code..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/vultr/cline.sh
+++ b/vultr/cline.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Cline..."
+log_step "Installing Cline..."
 run_server "${VULTR_SERVER_IP}" "npm install -g cline"
 log_info "Cline installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Cline..."
+log_step "Starting Cline..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && cline"

--- a/vultr/codex.sh
+++ b/vultr/codex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Codex CLI..."
+log_step "Installing Codex CLI..."
 run_server "${VULTR_SERVER_IP}" "npm install -g @openai/codex"
 log_info "Codex CLI installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Codex..."
+log_step "Starting Codex..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && codex"

--- a/vultr/continue.sh
+++ b/vultr/continue.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Continue CLI..."
+log_step "Installing Continue CLI..."
 run_server "${VULTR_SERVER_IP}" "npm install -g @continuedev/cli"
 log_info "Continue installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -47,7 +47,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Instance: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Continue CLI in TUI mode..."
+log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && cn"

--- a/vultr/gemini.sh
+++ b/vultr/gemini.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Gemini CLI..."
+log_step "Installing Gemini CLI..."
 run_server "${VULTR_SERVER_IP}" "npm install -g @google/gemini-cli"
 log_info "Gemini CLI installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -46,7 +46,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Gemini..."
+log_step "Starting Gemini..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/vultr/goose.sh
+++ b/vultr/goose.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Goose..."
+log_step "Installing Goose..."
 run_server "${VULTR_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 log_info "Goose installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
@@ -41,7 +41,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Goose..."
+log_step "Starting Goose..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && goose"

--- a/vultr/gptme.sh
+++ b/vultr/gptme.sh
@@ -19,7 +19,7 @@ create_server "$SERVER_NAME"
 verify_server_connectivity "$VULTR_SERVER_IP"
 wait_for_cloud_init "$VULTR_SERVER_IP"
 
-log_warn "Installing gptme..."
+log_step "Installing gptme..."
 run_server "$VULTR_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 log_info "gptme installed"
 
@@ -32,7 +32,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "$VULTR_SERVER_IP" upload_file run_server \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
 
@@ -41,7 +41,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: $SERVER_NAME (ID: $VULTR_SERVER_ID, IP: $VULTR_SERVER_IP)"
 echo ""
 
-log_warn "Starting gptme..."
+log_step "Starting gptme..."
 sleep 1
 clear
 interactive_session "$VULTR_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/vultr/interpreter.sh
+++ b/vultr/interpreter.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Open Interpreter..."
+log_step "Installing Open Interpreter..."
 run_server "${VULTR_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
 log_info "Open Interpreter installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
@@ -42,7 +42,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Open Interpreter..."
+log_step "Starting Open Interpreter..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/vultr/kilocode.sh
+++ b/vultr/kilocode.sh
@@ -22,7 +22,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Kilo Code..."
+log_step "Installing Kilo Code..."
 run_server "${VULTR_SERVER_IP}" "npm install -g @kilocode/cli"
 log_info "Kilo Code installed"
 
@@ -33,7 +33,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
@@ -45,7 +45,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Kilo Code..."
+log_step "Starting Kilo Code..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/vultr/lib/common.sh
+++ b/vultr/lib/common.sh
@@ -160,7 +160,7 @@ create_server() {
     validate_region_name "$region" || { log_error "Invalid VULTR_REGION"; return 1; }
     if [[ ! "$os_id" =~ ^[0-9]+$ ]]; then log_error "Invalid VULTR_OS_ID: must be numeric"; return 1; fi
 
-    log_warn "Creating Vultr instance '$name' (plan: $plan, region: $region)..."
+    log_step "Creating Vultr instance '$name' (plan: $plan, region: $region)..."
 
     # Get all SSH key IDs
     local ssh_keys_response
@@ -208,7 +208,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 
 destroy_server() {
     local server_id="$1"
-    log_warn "Destroying instance $server_id..."
+    log_step "Destroying instance $server_id..."
     vultr_api DELETE "/instances/$server_id"
     log_info "Instance $server_id destroyed"
 }

--- a/vultr/nanoclaw.sh
+++ b/vultr/nanoclaw.sh
@@ -20,9 +20,9 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing tsx..."
+log_step "Installing tsx..."
 run_server "${VULTR_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
-log_warn "Cloning and building nanoclaw..."
+log_step "Cloning and building nanoclaw..."
 run_server "${VULTR_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
@@ -33,13 +33,13 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-log_warn "Configuring nanoclaw..."
+log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
@@ -53,7 +53,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting nanoclaw..."
+log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
 echo ""
 interactive_session "${VULTR_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/vultr/openclaw.sh
+++ b/vultr/openclaw.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing openclaw..."
+log_step "Installing openclaw..."
 run_server "${VULTR_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
 log_info "OpenClaw installed"
 
@@ -33,7 +33,7 @@ fi
 
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
@@ -48,7 +48,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting openclaw..."
+log_step "Starting openclaw..."
 run_server "${VULTR_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/vultr/opencode.sh
+++ b/vultr/opencode.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing OpenCode..."
+log_step "Installing OpenCode..."
 run_server "${VULTR_SERVER_IP}" "$(opencode_install_cmd)"
 log_info "OpenCode installed"
 
@@ -31,7 +31,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -40,7 +40,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting OpenCode..."
+log_step "Starting OpenCode..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/vultr/plandex.sh
+++ b/vultr/plandex.sh
@@ -20,7 +20,7 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${VULTR_SERVER_IP}"
 wait_for_cloud_init "${VULTR_SERVER_IP}" 60
 
-log_warn "Installing Plandex..."
+log_step "Installing Plandex..."
 run_server "${VULTR_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 if ! run_server "${VULTR_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
@@ -36,7 +36,7 @@ else
     OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
 fi
 
-log_warn "Setting up environment variables..."
+log_step "Setting up environment variables..."
 inject_env_vars_ssh "${VULTR_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
@@ -45,7 +45,7 @@ log_info "Vultr instance setup completed successfully!"
 log_info "Server: ${SERVER_NAME} (ID: ${VULTR_SERVER_ID}, IP: ${VULTR_SERVER_IP})"
 echo ""
 
-log_warn "Starting Plandex..."
+log_step "Starting Plandex..."
 sleep 1
 clear
 interactive_session "${VULTR_SERVER_IP}" "source ~/.zshrc && plandex"


### PR DESCRIPTION
## Summary
- Replace ~1500 `log_warn` (yellow) calls with `log_step` (cyan) for progress/status messages across 481 shell script files
- Normal operations like "Installing...", "Setting up...", "Creating server..." were displayed in yellow warning color, making users think something was wrong
- `log_warn` is now reserved for actual warnings (error remediation, deprecation notices, etc.)
- Remove emoji from 3 sprite completion messages for consistency

## Test plan
- [x] `bash -n` syntax check passes on all 481 modified files
- [x] No test file changes needed (only log function name changed, not behavior)
- [x] Verified remaining `log_warn` calls are genuinely for warnings/errors

Agent: ux-engineer