### PR TITLE
refactor: deduplicate get_server_name across 18 cloud providers

### DIFF
--- a/binarylane/lib/common.sh
+++ b/binarylane/lib/common.sh
@@ -102,14 +102,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "BINARYLANE_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "BINARYLANE_SERVER_NAME" "Enter server name: "
 }
 
 # get_cloud_init_userdata is now defined in shared/common.sh

--- a/civo/lib/common.sh
+++ b/civo/lib/common.sh
@@ -93,14 +93,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "CIVO_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "CIVO_SERVER_NAME" "Enter server name: "
 }
 
 # Get the default network ID for the region

--- a/contabo/lib/common.sh
+++ b/contabo/lib/common.sh
@@ -143,14 +143,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "CONTABO_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "CONTABO_SERVER_NAME" "Enter server name: "
 }
 
 # Get all SSH secret IDs from Contabo

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -109,14 +109,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "DO_DROPLET_NAME" "Enter droplet name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "DO_DROPLET_NAME" "Enter droplet name: "
 }
 
 # get_cloud_init_userdata is now defined in shared/common.sh

--- a/exoscale/lib/common.sh
+++ b/exoscale/lib/common.sh
@@ -162,14 +162,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "EXOSCALE_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "EXOSCALE_SERVER_NAME" "Enter server name: "
 }
 
 # Wait for Exoscale instance to become running and get its IP

--- a/genesiscloud/lib/common.sh
+++ b/genesiscloud/lib/common.sh
@@ -101,14 +101,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "GENESIS_SERVER_NAME" "Enter instance name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "GENESIS_SERVER_NAME" "Enter instance name: "
 }
 
 # Get all SSH key IDs from Genesis Cloud

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -103,14 +103,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "HETZNER_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "HETZNER_SERVER_NAME" "Enter server name: "
 }
 
 # get_cloud_init_userdata is now defined in shared/common.sh

--- a/hostinger/lib/common.sh
+++ b/hostinger/lib/common.sh
@@ -106,14 +106,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "HOSTINGER_SERVER_NAME" "Enter VPS name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "HOSTINGER_SERVER_NAME" "Enter VPS name: "
 }
 
 # Fetch available VPS plans

--- a/ionos/lib/common.sh
+++ b/ionos/lib/common.sh
@@ -140,14 +140,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "IONOS_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "IONOS_SERVER_NAME" "Enter server name: "
 }
 
 # Try to find and use an existing IONOS datacenter

--- a/kamatera/lib/common.sh
+++ b/kamatera/lib/common.sh
@@ -110,14 +110,7 @@ ensure_kamatera_token() {
 }
 
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "KAMATERA_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "KAMATERA_SERVER_NAME" "Enter server name: "
 }
 
 # Extract a field from a Kamatera queue response (handles both list and dict responses)

--- a/latitude/lib/common.sh
+++ b/latitude/lib/common.sh
@@ -207,14 +207,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "LATITUDE_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "LATITUDE_SERVER_NAME" "Enter server name: "
 }
 
 # Create a Latitude.sh server

--- a/linode/lib/common.sh
+++ b/linode/lib/common.sh
@@ -101,14 +101,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "LINODE_SERVER_NAME" "Enter Linode label: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "LINODE_SERVER_NAME" "Enter Linode label: "
 }
 
 # get_cloud_init_userdata is now defined in shared/common.sh

--- a/netcup/lib/common.sh
+++ b/netcup/lib/common.sh
@@ -152,14 +152,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "NETCUP_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "NETCUP_SERVER_NAME" "Enter server name: "
 }
 
 # List available VPS products

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -217,14 +217,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "OVH_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "OVH_SERVER_NAME" "Enter server name: "
 }
 
 # Find OVH image ID for Ubuntu 24.04

--- a/ramnode/lib/common.sh
+++ b/ramnode/lib/common.sh
@@ -190,14 +190,7 @@ ensure_ssh_key() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "RAMNODE_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "RAMNODE_SERVER_NAME" "Enter server name: "
 }
 
 # List available flavors (instance types)

--- a/scaleway/lib/common.sh
+++ b/scaleway/lib/common.sh
@@ -192,14 +192,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "SCALEWAY_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "SCALEWAY_SERVER_NAME" "Enter server name: "
 }
 
 # Parse Scaleway server response to extract public IP address

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -314,6 +314,22 @@ get_resource_name() {
     fi
     echo "${name}"
 }
+
+# Get server name from environment or prompt, with validation
+# Usage: get_validated_server_name ENV_VAR_NAME PROMPT_TEXT
+# Returns: Validated server name via stdout
+# Example: get_validated_server_name "HETZNER_SERVER_NAME" "Enter server name: "
+get_validated_server_name() {
+    local server_name
+    server_name=$(get_resource_name "$1" "$2") || return 1
+
+    if ! validate_server_name "$server_name"; then
+        return 1
+    fi
+
+    echo "$server_name"
+}
+
 # Interactively prompt for model ID with validation
 # Usage: get_model_id_interactive [default_model] [agent_name]
 # Returns: Model ID via stdout

--- a/upcloud/lib/common.sh
+++ b/upcloud/lib/common.sh
@@ -63,14 +63,7 @@ ensure_upcloud_credentials() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "UPCLOUD_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "UPCLOUD_SERVER_NAME" "Enter server name: "
 }
 
 # Find Ubuntu 24.04 template UUID

--- a/vultr/lib/common.sh
+++ b/vultr/lib/common.sh
@@ -103,14 +103,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    local server_name
-    server_name=$(get_resource_name "VULTR_SERVER_NAME" "Enter server name: ") || return 1
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "VULTR_SERVER_NAME" "Enter server name: "
 }
 
 # get_cloud_init_userdata is now defined in shared/common.sh


### PR DESCRIPTION
## Summary
- Added `get_validated_server_name` helper to `shared/common.sh` that combines `get_resource_name` + `validate_server_name`
- Replaced 18 identical 7-line `get_server_name()` functions across cloud `lib/common.sh` files with one-line delegations
- Net reduction: **-110 lines** (34 added, 144 removed) across 19 files

## Affected clouds
binarylane, civo, contabo, digitalocean, exoscale, genesiscloud, hetzner, hostinger, ionos, kamatera, latitude, linode, netcup, ovh, ramnode, scaleway, upcloud, vultr

## Test plan
- [x] `bash -n` passes on all 19 modified scripts
- [x] `bun test` passes (5187 tests, 0 failures)
- [x] No behavioral change -- the shared helper has identical semantics to the replaced code

Agent: complexity-hunter

🤖 Generated with [Claude Code](https://claude.com/claude-code)