### PR TITLE
refactor: simplify BinaryLane wait loop and use log_step for progress messages

### DIFF
--- a/aws-lightsail/lib/common.sh
+++ b/aws-lightsail/lib/common.sh
@@ -108,7 +108,7 @@ _wait_for_lightsail_instance() {
             log_info "Instance running: IP=${LIGHTSAIL_SERVER_IP}"
             return 0
         fi
-        log_warn "Instance state: ${state} (${attempt}/${max_attempts})"
+        log_step "Instance state: ${state} (${attempt}/${max_attempts})"
         sleep "${INSTANCE_STATUS_POLL_DELAY}"
         attempt=$((attempt + 1))
     done

--- a/binarylane/lib/common.sh
+++ b/binarylane/lib/common.sh
@@ -110,29 +110,10 @@ get_server_name() {
 # Poll the BinaryLane API until the server becomes active and has an IP
 # Sets BINARYLANE_SERVER_IP on success
 _binarylane_wait_for_active() {
-    log_step "Waiting for server to become active..."
-    local max_attempts=60
-    local attempt=1
-    while [[ "$attempt" -le "$max_attempts" ]]; do
-        local status_response
-        status_response=$(binarylane_api GET "/servers/$BINARYLANE_SERVER_ID")
-        local status
-        status=$(echo "$status_response" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['server']['status'])")
-
-        if [[ "$status" == "active" ]]; then
-            BINARYLANE_SERVER_IP=$(echo "$status_response" | python3 -c "import json,sys; networks = json.loads(sys.stdin.read())['server']['networks']['v4']; print([n['ip_address'] for n in networks if n['type'] == 'public'][0])")
-            export BINARYLANE_SERVER_IP
-            log_info "Server active: IP=$BINARYLANE_SERVER_IP"
-            return 0
-        fi
-
-        log_warn "Server status: $status ($attempt/$max_attempts)"
-        sleep "${INSTANCE_STATUS_POLL_DELAY}"
-        attempt=$((attempt + 1))
-    done
-
-    log_error "Server did not become active in time"
-    return 1
+    generic_wait_for_instance binarylane_api "/servers/$BINARYLANE_SERVER_ID" \
+        "active" "d['server']['status']" \
+        "next(n['ip_address'] for n in d['server']['networks']['v4'] if n['type']=='public')" \
+        BINARYLANE_SERVER_IP "Server" 60
 }
 
 # Build JSON request body for BinaryLane server creation

--- a/exoscale/lib/common.sh
+++ b/exoscale/lib/common.sh
@@ -190,7 +190,7 @@ _wait_for_exoscale_instance() {
             fi
         fi
 
-        log_warn "Instance status: $status ($attempt/$max_attempts)"
+        log_step "Instance status: $status ($attempt/$max_attempts)"
         sleep "${INSTANCE_STATUS_POLL_DELAY}"
         attempt=$((attempt + 1))
     done

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -269,7 +269,7 @@ _fly_wait_for_machine_start() {
             return 0
         fi
 
-        log_warn "Machine state: $state ($attempt/$max_attempts)"
+        log_step "Machine state: $state ($attempt/$max_attempts)"
         sleep 3
         attempt=$((attempt + 1))
     done

--- a/kamatera/lib/common.sh
+++ b/kamatera/lib/common.sh
@@ -158,7 +158,7 @@ wait_for_command() {
             return 1
         fi
 
-        log_warn "Command status: ${status:-pending} (elapsed: ${elapsed}s)"
+        log_step "Command status: ${status:-pending} (elapsed: ${elapsed}s)"
         sleep "$INSTANCE_STATUS_POLL_DELAY"
         elapsed=$((elapsed + INSTANCE_STATUS_POLL_DELAY))
     done

--- a/latitude/lib/common.sh
+++ b/latitude/lib/common.sh
@@ -327,9 +327,9 @@ print(attrs.get('status', 'unknown'))
                 log_info "Server active: IP=$LATITUDE_SERVER_IP"
                 return 0
             fi
-            log_warn "Server active but IP not yet assigned... (attempt $attempt/$max_attempts)"
+            log_step "Server active but IP not yet assigned... (attempt $attempt/$max_attempts)"
         else
-            log_warn "Server status: $status (attempt $attempt/$max_attempts)"
+            log_step "Server status: $status (attempt $attempt/$max_attempts)"
         fi
 
         sleep 10

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -432,7 +432,7 @@ wait_for_ovh_instance() {
 
         local jitter
         jitter=$(calculate_retry_backoff "${interval}" "${max_interval}")
-        log_warn "Instance status: ${status:-unknown} (attempt ${attempt}/${max_attempts}, retry in ${jitter}s)"
+        log_step "Instance status: ${status:-unknown} (attempt ${attempt}/${max_attempts}, retry in ${jitter}s)"
         sleep "${jitter}"
 
         interval=$((interval * 2))

--- a/scaleway/lib/common.sh
+++ b/scaleway/lib/common.sh
@@ -246,7 +246,7 @@ _scaleway_power_on_and_wait() {
             fi
         fi
 
-        log_warn "Instance state: $state ($attempt/$max_attempts)"
+        log_step "Instance state: $state ($attempt/$max_attempts)"
         sleep "${INSTANCE_STATUS_POLL_DELAY}"
         attempt=$((attempt + 1))
     done


### PR DESCRIPTION
## Summary

- **BinaryLane**: Replace 25-line custom `_binarylane_wait_for_active` polling loop with a 4-line `generic_wait_for_instance` call, matching the pattern already used by 7 other clouds (DigitalOcean, Vultr, Linode, Contabo, Civo, Genesis Cloud, UpCloud)
- **7 clouds**: Change `log_warn` to `log_step` for status/progress messages in polling loops (aws-lightsail, exoscale, fly, kamatera, latitude, ovh, scaleway) — these are normal status updates during provisioning, not warnings

## Files changed

- `binarylane/lib/common.sh` — replaced custom wait loop with `generic_wait_for_instance`
- `aws-lightsail/lib/common.sh` — `log_warn` -> `log_step` for instance state polling
- `exoscale/lib/common.sh` — `log_warn` -> `log_step` for instance status polling
- `fly/lib/common.sh` — `log_warn` -> `log_step` for machine state polling
- `kamatera/lib/common.sh` — `log_warn` -> `log_step` for command status polling
- `latitude/lib/common.sh` — `log_warn` -> `log_step` for server status polling
- `ovh/lib/common.sh` — `log_warn` -> `log_step` for instance status polling
- `scaleway/lib/common.sh` — `log_warn` -> `log_step` for instance state polling

## Test plan

- [x] `bash -n` syntax check on all 8 changed files
- [x] `bun test` — 5187 tests pass, 0 failures