### PR TITLE
fix: add 'spawn history' alias for spawn list

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.56",
+  "version": "0.2.57",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1256,9 +1256,10 @@ ${pc.bold("USAGE")}
                                      Execute agent with prompt from file
   spawn <agent>                      Show available clouds for agent
   spawn <cloud>                      Show available agents for cloud
-  spawn list                         Browse and rerun previous spawns (alias: ls)
+  spawn list                         Browse and rerun previous spawns
   spawn list -a <agent>              Filter spawn history by agent
   spawn list -c <cloud>              Filter spawn history by cloud
+                                     Aliases: ls, history
   spawn matrix                       Full availability matrix (alias: m)
   spawn agents                       List all agents with descriptions
   spawn clouds                       List all cloud providers

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -276,8 +276,8 @@ const SUBCOMMANDS: Record<string, () => Promise<void>> = {
   "update": cmdUpdate,
 };
 
-// list/ls handled separately for -a/-c flag parsing
-const LIST_COMMANDS = new Set(["list", "ls"]);
+// list/ls/history handled separately for -a/-c flag parsing
+const LIST_COMMANDS = new Set(["list", "ls", "history"]);
 
 // Common verb prefixes that users naturally try (e.g. "spawn run claude sprite")
 // These are not real subcommands -- we strip them and forward to the default handler


### PR DESCRIPTION
## Summary
- Add `spawn history` as a command alias for `spawn list` / `spawn ls`, making the history feature more discoverable
- Update help text to document all three aliases (list, ls, history) clearly
- Bump CLI version to 0.2.57

## Motivation
The word "list" is ambiguous in a CLI that also has `spawn agents` and `spawn clouds`. Users naturally expect `spawn list` to list resources, not show spawn history. Adding `spawn history` makes the history command intuitive and self-documenting.

## Test plan
- [x] All 5225 existing tests pass (2 pre-existing flaky failures in cmdlist-integration unrelated to this change)
- [x] Help content tests pass -- "ls" and "history" both appear in help text
- [x] Index parsing and verb alias tests pass
- [x] `spawn history`, `spawn list`, and `spawn ls` all route to the same handler

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)