### PR TITLE
fix: remove double-quoting in openclaw.json config generation

### DIFF
--- a/koyeb/openclaw.sh
+++ b/koyeb/openclaw.sh
@@ -64,7 +64,7 @@ GATEWAY_TOKEN=$(openssl rand -hex 16)
 
 OPENCLAW_CONFIG_TEMP=$(mktemp)
 chmod 600 "$OPENCLAW_CONFIG_TEMP"
-printf '{\n  "env": {\n    "OPENROUTER_API_KEY": "%s"\n  },\n  "gateway": {\n    "mode": "local",\n    "auth": {\n      "token": "%s"\n    }\n  },\n  "agents": {\n    "defaults": {\n      "model": {\n        "primary": "openrouter/%s"\n      }\n    }\n  }\n}\n' "$(json_escape "${OPENROUTER_API_KEY}")" "$(json_escape "${GATEWAY_TOKEN}")" "$(json_escape "${MODEL_ID}")" > "$OPENCLAW_CONFIG_TEMP"
+printf '{\n  "env": {\n    "OPENROUTER_API_KEY": %s\n  },\n  "gateway": {\n    "mode": "local",\n    "auth": {\n      "token": %s\n    }\n  },\n  "agents": {\n    "defaults": {\n      "model": {\n        "primary": "openrouter/%s"\n      }\n    }\n  }\n}\n' "$(json_escape "${OPENROUTER_API_KEY}")" "$(json_escape "${GATEWAY_TOKEN}")" "${MODEL_ID}" > "$OPENCLAW_CONFIG_TEMP"
 
 upload_file "$OPENCLAW_CONFIG_TEMP" "/root/.openclaw/openclaw.json"
 rm "$OPENCLAW_CONFIG_TEMP"

--- a/railway/openclaw.sh
+++ b/railway/openclaw.sh
@@ -64,7 +64,7 @@ GATEWAY_TOKEN=$(openssl rand -hex 16)
 
 OPENCLAW_CONFIG_TEMP=$(mktemp)
 chmod 600 "$OPENCLAW_CONFIG_TEMP"
-printf '{\n  "env": {\n    "OPENROUTER_API_KEY": "%s"\n  },\n  "gateway": {\n    "mode": "local",\n    "auth": {\n      "token": "%s"\n    }\n  },\n  "agents": {\n    "defaults": {\n      "model": {\n        "primary": "openrouter/%s"\n      }\n    }\n  }\n}\n' "$(json_escape "${OPENROUTER_API_KEY}")" "$(json_escape "${GATEWAY_TOKEN}")" "$(json_escape "${MODEL_ID}")" > "$OPENCLAW_CONFIG_TEMP"
+printf '{\n  "env": {\n    "OPENROUTER_API_KEY": %s\n  },\n  "gateway": {\n    "mode": "local",\n    "auth": {\n      "token": %s\n    }\n  },\n  "agents": {\n    "defaults": {\n      "model": {\n        "primary": "openrouter/%s"\n      }\n    }\n  }\n}\n' "$(json_escape "${OPENROUTER_API_KEY}")" "$(json_escape "${GATEWAY_TOKEN}")" "${MODEL_ID}" > "$OPENCLAW_CONFIG_TEMP"
 
 upload_file "$OPENCLAW_CONFIG_TEMP" "/root/.openclaw/openclaw.json"
 rm "$OPENCLAW_CONFIG_TEMP"


### PR DESCRIPTION
## Summary
- Fixes JSON syntax error in OpenClaw config generation (issue #542)
- The `json_escape` function already adds quotes, so using `"%s"` was double-quoting values
- Result was invalid JSON: `"OPENROUTER_API_KEY": ""sk-or-v1-...""` instead of `"OPENROUTER_API_KEY": "sk-or-v1-..."`

## Changes
- `railway/openclaw.sh`: Changed `"%s"` to `%s` for OPENROUTER_API_KEY and token fields
- `koyeb/openclaw.sh`: Changed `"%s"` to `%s` for OPENROUTER_API_KEY and token fields
- Now matches the correct pattern used in `fly/openclaw.sh` and `shared/common.sh`

## Test plan
- [x] Verified syntax with `bash -n` on both modified scripts
- [x] Confirmed pattern matches working scripts (fly/openclaw.sh, shared/common.sh)
- [ ] Manual test: spawn an OpenClaw instance on Railway or Koyeb to verify JSON is valid

Fixes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)