### PR TITLE
fix: improve spawn list UX with positional filters and long flags

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1257,8 +1257,9 @@ ${pc.bold("USAGE")}
   spawn <agent>                      Show available clouds for agent
   spawn <cloud>                      Show available agents for cloud
   spawn list                         Browse and rerun previous spawns
-  spawn list -a <agent>              Filter spawn history by agent
-  spawn list -c <cloud>              Filter spawn history by cloud
+  spawn list <filter>                Filter history by agent or cloud name
+  spawn list -a <agent>              Filter spawn history by agent (or --agent)
+  spawn list -c <cloud>              Filter spawn history by cloud (or --cloud)
                                      Aliases: ls, history
   spawn matrix                       Full availability matrix (alias: m)
   spawn agents                       List all agents with descriptions
@@ -1280,6 +1281,7 @@ ${pc.bold("EXAMPLES")}
   spawn claude                       ${pc.dim("# Show which clouds support Claude")}
   spawn hetzner                      ${pc.dim("# Show which agents run on Hetzner")}
   spawn list                         ${pc.dim("# Browse history and pick one to rerun")}
+  spawn list claude                  ${pc.dim("# Filter history by agent name")}
   spawn matrix                       ${pc.dim("# See the full agent x cloud matrix")}
 
 ${pc.bold("AUTHENTICATION")}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -63,7 +63,7 @@ const KNOWN_FLAGS = new Set([
   "--version", "-v", "-V",
   "--prompt", "-p", "--prompt-file", "-f",
   "--dry-run", "-n",
-  "-a", "-c",
+  "-a", "-c", "--agent", "--cloud",
 ]);
 
 /** Check for unknown flags and show an actionable error */
@@ -293,29 +293,39 @@ function warnExtraArgs(filteredArgs: string[], maxExpected: number): void {
   }
 }
 
-/** Parse -a <agent> and -c <cloud> filter flags from args */
+/** Parse -a/--agent <agent> and -c/--cloud <cloud> filter flags from args.
+ *  Also accepts a bare positional arg as a filter (e.g. "spawn list claude"). */
 function parseListFilters(args: string[]): { agentFilter?: string; cloudFilter?: string } {
   let agentFilter: string | undefined;
   let cloudFilter: string | undefined;
+  const positional: string[] = [];
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "-a") {
+    if (args[i] === "-a" || args[i] === "--agent") {
       if (!args[i + 1] || args[i + 1].startsWith("-")) {
-        console.error(pc.red(`Error: ${pc.bold("-a")} requires an agent name`));
+        console.error(pc.red(`Error: ${pc.bold(args[i])} requires an agent name`));
         console.error(`\nUsage: ${pc.cyan("spawn list -a <agent>")}`);
         process.exit(1);
       }
       agentFilter = args[i + 1];
       i++;
-    } else if (args[i] === "-c") {
+    } else if (args[i] === "-c" || args[i] === "--cloud") {
       if (!args[i + 1] || args[i + 1].startsWith("-")) {
-        console.error(pc.red(`Error: ${pc.bold("-c")} requires a cloud name`));
+        console.error(pc.red(`Error: ${pc.bold(args[i])} requires a cloud name`));
         console.error(`\nUsage: ${pc.cyan("spawn list -c <cloud>")}`);
         process.exit(1);
       }
       cloudFilter = args[i + 1];
       i++;
+    } else if (!args[i].startsWith("-")) {
+      positional.push(args[i]);
     }
   }
+
+  // Support bare positional filter: "spawn list claude" or "spawn list hetzner"
+  if (!agentFilter && !cloudFilter && positional.length > 0) {
+    agentFilter = positional[0];
+  }
+
   return { agentFilter, cloudFilter };
 }
 

--- a/cli/src/manifest.ts
+++ b/cli/src/manifest.ts
@@ -208,4 +208,9 @@ export function countImplemented(m: Manifest): number {
   return count;
 }
 
+/** Clear the in-memory manifest cache (for testing only) */
+export function _resetCacheForTesting(): void {
+  _cached = null;
+}
+
 export { RAW_BASE, REPO, CACHE_DIR };


### PR DESCRIPTION
## Summary
- Support `spawn list claude` as shorthand for `spawn list -a claude` (positional filtering)
- Add `--agent` and `--cloud` as long-flag aliases for `-a` and `-c`
- Fix flaky cmdlist-integration tests by priming manifest in-memory cache in beforeEach and isolating `XDG_CACHE_HOME`
- Update help text with new filter syntax and examples

## Test plan
- [x] All 5253 tests pass (4 new tests added)
- [x] `spawn list claude` filters by agent
- [x] `--agent`/`--cloud` long flags work alongside `-a`/`-c`
- [x] Positional args are ignored when explicit `-a`/`-c` flags are present
- [x] Empty args still show unfiltered list
- [x] cmdlist-integration tests are deterministic regardless of test file ordering