### PR TITLE
refactor: extract check_ssh_key_by_fingerprint into shared helper

### DIFF
--- a/binarylane/lib/common.sh
+++ b/binarylane/lib/common.sh
@@ -63,10 +63,7 @@ ensure_binarylane_token() {
 
 # Check if SSH key is registered with BinaryLane
 binarylane_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(binarylane_api GET "/account/keys")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint binarylane_api "/account/keys" "$1"
 }
 
 # Register SSH key with BinaryLane

--- a/cherry/lib/common.sh
+++ b/cherry/lib/common.sh
@@ -91,10 +91,7 @@ ensure_cherry_token() {
 
 # Check if SSH key is registered with Cherry Servers
 cherry_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(cherry_api GET "/ssh-keys")
-    printf '%s' "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint cherry_api "/ssh-keys" "$1"
 }
 
 # Register SSH key with Cherry Servers

--- a/civo/lib/common.sh
+++ b/civo/lib/common.sh
@@ -55,10 +55,7 @@ test_civo_token() {
 
 # Check if SSH key is registered with Civo
 civo_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(civo_api GET "/sshkeys")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint civo_api "/sshkeys" "$1"
 }
 
 # Register SSH key with Civo

--- a/contabo/lib/common.sh
+++ b/contabo/lib/common.sh
@@ -104,10 +104,7 @@ ensure_contabo_credentials() {
 
 # Check if SSH key is registered with Contabo
 contabo_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(contabo_api GET "/compute/secrets")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint contabo_api "/compute/secrets" "$1"
 }
 
 # Register SSH key with Contabo as a secret

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -68,10 +68,7 @@ ensure_do_token() {
 
 # Check if SSH key is registered with DigitalOcean
 do_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(do_api GET "/account/keys")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint do_api "/account/keys" "$1"
 }
 
 # Register SSH key with DigitalOcean

--- a/genesiscloud/lib/common.sh
+++ b/genesiscloud/lib/common.sh
@@ -63,10 +63,7 @@ ensure_genesis_token() {
 
 # Check if SSH key is registered with Genesis Cloud
 genesis_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(genesis_api GET "/ssh-keys")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint genesis_api "/ssh-keys" "$1"
 }
 
 # Register SSH key with Genesis Cloud

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -62,10 +62,7 @@ ensure_hcloud_token() {
 
 # Check if SSH key is registered with Hetzner
 hetzner_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(hetzner_api GET "/ssh_keys")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint hetzner_api "/ssh_keys" "$1"
 }
 
 # Register SSH key with Hetzner

--- a/hostinger/lib/common.sh
+++ b/hostinger/lib/common.sh
@@ -65,10 +65,7 @@ ensure_hostinger_token() {
 
 # Check if SSH key is registered with Hostinger
 hostinger_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(hostinger_api GET "/ssh-keys")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint hostinger_api "/ssh-keys" "$1"
 }
 
 # Register SSH key with Hostinger

--- a/latitude/lib/common.sh
+++ b/latitude/lib/common.sh
@@ -153,10 +153,7 @@ print(json.dumps(body))
 
 # Check if SSH key is registered with Latitude.sh
 latitude_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(latitude_api GET "/ssh_keys")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint latitude_api "/ssh_keys" "$1"
 }
 
 # Register SSH key with Latitude.sh

--- a/linode/lib/common.sh
+++ b/linode/lib/common.sh
@@ -62,10 +62,7 @@ ensure_linode_token() {
 
 # Check if SSH key is registered with Linode
 linode_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(linode_api GET "/profile/sshkeys")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint linode_api "/profile/sshkeys" "$1"
 }
 
 # Register SSH key with Linode

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -173,10 +173,7 @@ ensure_ovh_authenticated() {
 
 # Check if SSH key is registered with OVH
 ovh_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(ovh_api_call GET "/cloud/project/${OVH_PROJECT_ID}/sshkey")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint ovh_api_call "/cloud/project/${OVH_PROJECT_ID}/sshkey" "$1"
 }
 
 # Register SSH key with OVH

--- a/scaleway/lib/common.sh
+++ b/scaleway/lib/common.sh
@@ -139,10 +139,7 @@ get_ubuntu_image_id() {
 
 # Check if SSH key is registered with Scaleway
 scaleway_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(scaleway_api GET "${SCALEWAY_ACCOUNT_API}/ssh-keys?per_page=50")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint scaleway_api "${SCALEWAY_ACCOUNT_API}/ssh-keys?per_page=50" "$1"
 }
 
 # Register SSH key with Scaleway

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2099,6 +2099,21 @@ interactive_pick() {
 # SSH key registration helpers
 # ============================================================
 
+# Generic SSH key check: queries the provider's API and greps for the fingerprint.
+# Most providers follow this exact pattern. Use this to avoid duplicating 5-line
+# check functions across every cloud lib.
+# Usage: check_ssh_key_by_fingerprint API_FUNC ENDPOINT FINGERPRINT
+# Example: check_ssh_key_by_fingerprint hetzner_api "/ssh_keys" "$fingerprint"
+check_ssh_key_by_fingerprint() {
+    local api_func="${1}"
+    local endpoint="${2}"
+    local fingerprint="${3}"
+
+    local existing_keys
+    existing_keys=$("${api_func}" GET "${endpoint}")
+    echo "${existing_keys}" | grep -q "${fingerprint}"
+}
+
 # Generic SSH key registration pattern used by all cloud providers
 # Eliminates ~220 lines of duplicate code across 5 provider libraries
 #

--- a/vultr/lib/common.sh
+++ b/vultr/lib/common.sh
@@ -64,10 +64,7 @@ ensure_vultr_token() {
 
 # Check if SSH key is registered with Vultr
 vultr_check_ssh_key() {
-    local fingerprint="$1"
-    local existing_keys
-    existing_keys=$(vultr_api GET "/ssh-keys")
-    echo "$existing_keys" | grep -q "$fingerprint"
+    check_ssh_key_by_fingerprint vultr_api "/ssh-keys" "$1"
 }
 
 # Register SSH key with Vultr


### PR DESCRIPTION
## Summary

- Extract identical `check_ssh_key` functions from 13 cloud providers into a shared `check_ssh_key_by_fingerprint` helper in `shared/common.sh`
- Each cloud's 5-line function (fetch keys from API, grep for fingerprint) is now a single-line call to the shared helper
- Net reduction: -24 lines (15 added to shared, 52 removed from cloud libs)

**Affected clouds:** BinaryLane, Cherry, Civo, Contabo, DigitalOcean, Genesis Cloud, Hetzner, Hostinger, Latitude, Linode, OVH, Scaleway, Vultr

## Test plan

- [x] `bash -n shared/common.sh` and all 13 modified cloud lib files pass syntax check
- [x] All 5286 CLI tests pass (`bun test`)
- [x] All 75 shell tests pass (`bash test/run.sh`)

Agent: complexity-hunter