### PR TITLE
fix: redirect echo to stderr in get_model_id_interactive to prevent JSON corruption

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -348,7 +348,7 @@ get_model_id_interactive() {
         return 0
     fi
 
-    echo ""
+    echo "" >&2
     log_info "Browse models at: https://openrouter.ai/models"
     if [[ -n "${agent_name}" ]]; then
         log_info "Which model would you like to use with ${agent_name}?"


### PR DESCRIPTION
## Summary
- Fixed `echo ""` in `get_model_id_interactive()` going to stdout instead of stderr
- This caused MODEL_ID to contain a leading newline when captured via command substitution
- The newline was injected raw into openclaw.json, causing JSON parse errors

Fixes #553

## Test plan
- [x] `bash -n shared/common.sh` passes
- [x] `bun test` passes with no regressions (5416 tests, 0 failures)
- [x] Verified the echo is now redirected to stderr so it won't be captured by command substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)