### PR TITLE
fix: add actionable guidance to exit code 126 and 137 failure messages

### DIFF
--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -63,9 +63,23 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("could not be executed");
     });
 
-    it("should return exactly 1 guidance line", () => {
+    it("should suggest possible causes", () => {
       const lines = getScriptFailureGuidance(126, "sprite");
-      expect(lines).toHaveLength(1);
+      const joined = lines.join("\n");
+      expect(joined).toContain("execute permissions");
+      expect(joined).toContain("root/sudo");
+    });
+
+    it("should include a link to report the issue", () => {
+      const lines = getScriptFailureGuidance(126, "sprite");
+      const joined = lines.join("\n");
+      expect(joined).toContain("github.com");
+      expect(joined).toContain("issues");
+    });
+
+    it("should return exactly 4 guidance lines", () => {
+      const lines = getScriptFailureGuidance(126, "sprite");
+      expect(lines).toHaveLength(4);
     });
   });
 
@@ -224,9 +238,21 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("out of memory");
     });
 
-    it("should return exactly 1 guidance line", () => {
+    it("should suggest trying a larger instance", () => {
       const lines = getScriptFailureGuidance(137, "sprite");
-      expect(lines).toHaveLength(1);
+      const joined = lines.join("\n");
+      expect(joined).toContain("larger instance size");
+    });
+
+    it("should suggest checking cloud provider dashboard", () => {
+      const lines = getScriptFailureGuidance(137, "sprite");
+      const joined = lines.join("\n");
+      expect(joined).toContain("cloud provider dashboard");
+    });
+
+    it("should return exactly 4 guidance lines", () => {
+      const lines = getScriptFailureGuidance(137, "sprite");
+      expect(lines).toHaveLength(4);
     });
   });
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -531,7 +531,12 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
         "  Check your cloud provider dashboard to stop or delete any unused servers.",
       ];
     case 137:
-      return ["Script was killed (likely by the system due to timeout or out of memory)."];
+      return [
+        "Script was killed (likely by the system due to timeout or out of memory).",
+        "  - The server may not have enough RAM for this agent",
+        "  - Try a larger instance size or a different cloud provider",
+        "  - Check your cloud provider dashboard to stop or delete any unused servers",
+      ];
     case 255:
       return [
         "SSH connection failed. Common causes:",
@@ -546,7 +551,12 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
         `  - Cloud-specific CLI tools (run ${pc.cyan(`spawn ${cloud}`)} for details)`,
       ];
     case 126:
-      return ["A command was found but could not be executed (permission denied)."];
+      return [
+        "A command was found but could not be executed (permission denied).",
+        "  - A downloaded binary may lack execute permissions",
+        "  - The script may require root/sudo access",
+        `  - Report it if this persists: ${pc.cyan(`https://github.com/OpenRouterTeam/spawn/issues`)}`,
+      ];
     case 2:
       return [
         "Shell syntax or argument error. This is likely a bug in the script.",


### PR DESCRIPTION
## Summary
- Exit code 126 (permission denied) now suggests: execute permissions, root/sudo access, and a bug report link
- Exit code 137 (killed/OOM) now suggests: larger instance size, different cloud provider, and checking dashboard for orphaned servers
- Both were previously single-line messages with no actionable steps, unlike every other exit code
- Updated tests to cover the new guidance content (60 tests, all passing)

## Test plan
- [x] `bun test src/__tests__/script-failure-guidance.test.ts` -- 60 pass
- [x] `bun test` -- 5420 pass, 0 fail