### PR TITLE
fix: spawn list <cloud> now correctly filters by cloud

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -933,7 +933,8 @@ function buildRecordHint(r: SpawnRecord): string {
   return when;
 }
 
-/** Try to load manifest and resolve filter display names to keys */
+/** Try to load manifest and resolve filter display names to keys.
+ *  When a bare positional filter doesn't match an agent, try it as a cloud. */
 async function resolveListFilters(
   agentFilter?: string,
   cloudFilter?: string
@@ -947,7 +948,16 @@ async function resolveListFilters(
 
   if (manifest && agentFilter) {
     const resolved = resolveAgentKey(manifest, agentFilter);
-    if (resolved) agentFilter = resolved;
+    if (resolved) {
+      agentFilter = resolved;
+    } else if (!cloudFilter) {
+      // Bare positional arg didn't match an agent -- try as a cloud filter
+      const resolvedCloud = resolveCloudKey(manifest, agentFilter);
+      if (resolvedCloud) {
+        cloudFilter = resolvedCloud;
+        agentFilter = undefined;
+      }
+    }
   }
   if (manifest && cloudFilter) {
     const resolved = resolveCloudKey(manifest, cloudFilter);


### PR DESCRIPTION
## Summary
- `spawn list hetzner` (or any cloud name) now correctly filters history by cloud instead of showing "No spawns found"
- When a bare positional argument doesn't resolve as an agent but does resolve as a cloud, `resolveListFilters` auto-reclassifies it as a cloud filter
- This matches the help text which says: "Filter history by agent or cloud name"

## What changed
- `cli/src/commands.ts`: Updated `resolveListFilters` to try cloud resolution when agent resolution fails for bare positional args
- `cli/src/__tests__/cmdlist-filter-resolution.test.ts`: Added 5 tests covering the new behavior
- Version bump 0.2.58 -> 0.2.59

## Test plan
- [x] All 5486 tests pass (5481 existing + 5 new)
- [x] `spawn list hetzner` -> filters by cloud=hetzner (was: "No spawns found")
- [x] `spawn list sprite` -> filters by cloud=sprite
- [x] `spawn list "Hetzner Cloud"` -> resolves display name to cloud key
- [x] `spawn list claude` -> still filters by agent=claude (no regression)
- [x] `spawn list unknown-thing hetzner` -> does NOT reclassify when explicit cloudFilter exists

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)