### PR TITLE
fix: improve CLI error messages and add OAuth login hints

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -216,9 +216,15 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("cloud provider dashboard");
     });
 
-    it("should return exactly 3 guidance lines", () => {
+    it("should return exactly 4 guidance lines", () => {
       const lines = getScriptFailureGuidance(130, "sprite");
-      expect(lines).toHaveLength(3);
+      expect(lines).toHaveLength(4);
+    });
+
+    it("should suggest checking cloud info for rerun", () => {
+      const lines = getScriptFailureGuidance(130, "sprite");
+      const joined = lines.join("\n");
+      expect(joined).toContain("spawn sprite");
     });
   });
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -473,7 +473,7 @@ async function downloadScriptWithFallback(primaryUrl: string, fallbackUrl: strin
     }
 
     // Fallback to GitHub raw
-    s.message("Trying fallback source...");
+    s.message("Primary source unavailable, trying GitHub fallback...");
     const ghRes = await fetch(fallbackUrl, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT),
     });
@@ -534,7 +534,8 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
       return [
         "Script was interrupted (Ctrl+C).",
         "Note: If a server was already created, it may still be running.",
-        "  Check your cloud provider dashboard to stop or delete any unused servers.",
+        `  Check your cloud provider dashboard to stop or delete any unused servers.`,
+        `  To rerun: ${pc.cyan(`spawn ${cloud}`)} for cloud dashboard info.`,
       ];
     case 137:
       return [
@@ -571,9 +572,9 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
     case 1:
       return [
         "Common causes:",
-        credentialHint(cloud, authHint),
         "  - Cloud provider API error (quota, rate limit, or region issue)",
         "  - Server provisioning failed (try again or pick a different region)",
+        credentialHint(cloud, authHint),
       ];
     default:
       return [
@@ -1135,6 +1136,8 @@ export async function cmdAgentInfo(agent: string): Promise<void> {
       console.log(`  ${pc.cyan(`export ${authVars[0]}=...`)}${hint}`);
     }
     console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
+    console.log();
+    console.log(pc.dim(`  Tip: If you skip OPENROUTER_API_KEY, the script will open a browser for OAuth login.`));
   }
 
   console.log();
@@ -1180,6 +1183,8 @@ function printCloudQuickStart(
   if (exampleAgent) {
     console.log(`  ${pc.cyan(`spawn ${exampleAgent} ${cloudKey}`)}`);
   }
+  console.log();
+  console.log(pc.dim(`  Tip: If you skip OPENROUTER_API_KEY, the script will open a browser for OAuth login.`));
 }
 
 /** Print the list of implemented agents and any missing ones */
@@ -1340,6 +1345,7 @@ ${pc.bold("INSTALL")}
 ${pc.bold("TROUBLESHOOTING")}
   ${pc.dim("*")} Script not found: Run ${pc.cyan("spawn matrix")} to verify the combination exists
   ${pc.dim("*")} Missing credentials: Run ${pc.cyan("spawn <cloud>")} to see setup instructions
+  ${pc.dim("*")} SSH failures: Server may still be booting -- wait a moment and retry
   ${pc.dim("*")} Update issues: Try ${pc.cyan("spawn update")} or reinstall manually
   ${pc.dim("*")} Garbled unicode: Set ${pc.cyan("SPAWN_NO_UNICODE=1")} for ASCII-only output
   ${pc.dim("*")} Slow startup: Set ${pc.cyan("SPAWN_NO_UPDATE_CHECK=1")} to skip auto-update


### PR DESCRIPTION
## Summary
- Add OAuth login tip to agent and cloud quick-start sections (`spawn <agent>`, `spawn <cloud>`) so users know they can skip `OPENROUTER_API_KEY` and use browser-based auth instead
- Make download fallback spinner message more descriptive ("Primary source unavailable, trying GitHub fallback..." instead of "Trying fallback source...")
- Add SSH troubleshooting entry to `spawn help` text
- Add cloud dashboard hint to Ctrl+C (exit 130) error guidance
- Reorder exit code 1 guidance to list API/provisioning errors before credentials (more common cause first)
- Bump CLI version to 0.2.60

## Test plan
- [x] All 5487 tests pass
- [x] Updated script-failure-guidance test for new exit 130 line count

Generated with Claude Code