### PR TITLE
fix: add OAuth browser auth hint to script failure guidance

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.61",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -116,9 +116,16 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("provisioning failed");
     });
 
-    it("should return exactly 4 guidance lines", () => {
+    it("should return exactly 6 guidance lines", () => {
       const lines = getScriptFailureGuidance(1, "sprite");
-      expect(lines).toHaveLength(4);
+      expect(lines).toHaveLength(6);
+    });
+
+    it("should include OAuth browser auth tip", () => {
+      const lines = getScriptFailureGuidance(1, "sprite");
+      const joined = lines.join("\n");
+      expect(joined).toContain("browser");
+      expect(joined).toContain("OPENROUTER_API_KEY");
     });
   });
 
@@ -157,9 +164,16 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("spawn linode");
     });
 
-    it("should return exactly 4 guidance lines", () => {
+    it("should return exactly 6 guidance lines", () => {
       const lines = getScriptFailureGuidance(42, "linode");
-      expect(lines).toHaveLength(4);
+      expect(lines).toHaveLength(6);
+    });
+
+    it("should include OAuth browser auth tip", () => {
+      const lines = getScriptFailureGuidance(42, "linode");
+      const joined = lines.join("\n");
+      expect(joined).toContain("browser");
+      expect(joined).toContain("OPENROUTER_API_KEY");
     });
   });
 
@@ -183,9 +197,9 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("spawn sprite");
     });
 
-    it("should return exactly 4 guidance lines", () => {
+    it("should return exactly 6 guidance lines", () => {
       const lines = getScriptFailureGuidance(null, "sprite");
-      expect(lines).toHaveLength(4);
+      expect(lines).toHaveLength(6);
     });
   });
 
@@ -369,12 +383,12 @@ describe("getScriptFailureGuidance", () => {
 
     it("should preserve line count for exit code 1 with authHint", () => {
       const lines = getScriptFailureGuidance(1, "hetzner", "HCLOUD_TOKEN");
-      expect(lines).toHaveLength(4);
+      expect(lines).toHaveLength(6);
     });
 
     it("should preserve line count for default case with authHint", () => {
       const lines = getScriptFailureGuidance(42, "hetzner", "HCLOUD_TOKEN");
-      expect(lines).toHaveLength(4);
+      expect(lines).toHaveLength(6);
     });
   });
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -574,6 +574,8 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
         credentialHint(cloud, authHint),
         "  - Cloud provider API error (quota, rate limit, or region issue)",
         "  - Server provisioning failed (try again or pick a different region)",
+        "",
+        `Tip: You can skip OPENROUTER_API_KEY and authenticate via browser instead.`,
       ];
     default:
       return [
@@ -581,6 +583,8 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
         credentialHint(cloud, authHint, "Missing"),
         "  - Cloud provider API rate limit or quota exceeded",
         "  - Missing local dependencies (SSH, curl, jq)",
+        "",
+        `Tip: You can skip OPENROUTER_API_KEY and authenticate via browser instead.`,
       ];
   }
 }


### PR DESCRIPTION
## Summary
- When spawn scripts fail with exit code 1 (generic failure) or unknown exit codes, the error guidance now includes a tip that users can skip `OPENROUTER_API_KEY` and authenticate via browser-based OAuth instead
- This complements PR #573 which adds OAuth hints to `spawn <agent>` and `spawn <cloud>` info pages -- this PR adds the hint where it matters most: in the actual error output when a script fails
- Bumps CLI version to 0.2.61

## Test plan
- [x] All 5488 tests pass
- [x] Updated line count expectations in script-failure-guidance tests
- [x] Added 2 new test cases verifying OAuth tip appears in exit code 1 and default guidance

Agent: ux-engineer

Generated with Claude Code