### PR TITLE
refactor: extract _extract_json_field and optimize instance polling

### DIFF
--- a/binarylane/lib/common.sh
+++ b/binarylane/lib/common.sh
@@ -42,7 +42,7 @@ test_binarylane_token() {
         return 0
     fi
     local error_msg
-    error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','No details available'))" 2>/dev/null || echo "Unable to parse error")
+    error_msg=$(echo "$response" | _extract_json_field "message" "No details available")
     log_error "API Error: $error_msg"
     log_error ""
     log_error "How to fix:"
@@ -83,7 +83,7 @@ binarylane_register_ssh_key() {
     else
         # Parse error details
         local error_msg
-        error_msg=$(echo "$register_response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','Unknown error'))" 2>/dev/null || echo "$register_response")
+        error_msg=$(echo "$register_response" | _extract_json_field "message" "Unknown error")
         log_error "API Error: $error_msg"
 
         log_warn "Common causes:"
@@ -153,7 +153,7 @@ _binarylane_handle_create_response() {
 
     log_error "Failed to create BinaryLane server"
     local error_msg
-    error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','Unknown error'))" 2>/dev/null || echo "$response")
+    error_msg=$(echo "$response" | _extract_json_field "message" "Unknown error")
     log_error "API Error: $error_msg"
     log_warn "Common issues:"
     log_warn "  - Insufficient account balance"

--- a/civo/lib/common.sh
+++ b/civo/lib/common.sh
@@ -74,7 +74,7 @@ civo_register_ssh_key() {
         return 0
     else
         local error_msg
-        error_msg=$(echo "$register_response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('reason','Unknown error'))" 2>/dev/null || echo "$register_response")
+        error_msg=$(echo "$register_response" | _extract_json_field "reason" "Unknown error")
         log_error "API Error: $error_msg"
 
         log_warn "Common causes:"

--- a/contabo/lib/common.sh
+++ b/contabo/lib/common.sh
@@ -77,7 +77,7 @@ test_contabo_credentials() {
     response=$(contabo_api GET "/compute/instances?page=1&size=1")
     if echo "$response" | grep -q '"error"'; then
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','No details available'))" 2>/dev/null || echo "Unable to parse error")
+        error_msg=$(echo "$response" | _extract_json_field "message" "No details available")
         log_error "API Error: $error_msg"
         log_error ""
         log_error "How to fix:"
@@ -121,7 +121,7 @@ contabo_register_ssh_key() {
 
     if echo "$register_response" | grep -q '"error"'; then
         local error_msg
-        error_msg=$(echo "$register_response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','Unknown error'))" 2>/dev/null || echo "$register_response")
+        error_msg=$(echo "$register_response" | _extract_json_field "message" "Unknown error")
         log_error "API Error: $error_msg"
         log_error ""
         log_error "Common causes:"
@@ -224,7 +224,7 @@ create_server() {
     if echo "$response" | grep -q '"error"' || ! echo "$response" | grep -q '"instanceId"'; then
         log_error "Failed to create Contabo instance"
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','Unknown error'))" 2>/dev/null || echo "$response")
+        error_msg=$(echo "$response" | _extract_json_field "message" "Unknown error")
         log_error "API Error: $error_msg"
         log_error ""
         log_error "Common issues:"

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -46,7 +46,7 @@ test_do_token() {
     else
         # Parse error details if available
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','No details available'))" 2>/dev/null || echo "Unable to parse error")
+        error_msg=$(echo "$response" | _extract_json_field "message" "No details available")
         log_error "API Error: $error_msg"
         log_warn "Remediation steps:"
         log_warn "  1. Verify token at: https://cloud.digitalocean.com/account/api/tokens"
@@ -88,7 +88,7 @@ do_register_ssh_key() {
     else
         # Parse error details
         local error_msg
-        error_msg=$(echo "$register_response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','Unknown error'))" 2>/dev/null || echo "$register_response")
+        error_msg=$(echo "$register_response" | _extract_json_field "message" "Unknown error")
         log_error "API Error: $error_msg"
 
         log_warn "Common causes:"
@@ -184,7 +184,7 @@ create_server() {
 
         # Parse error details
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('message','Unknown error'))" 2>/dev/null || echo "$response")
+        error_msg=$(echo "$response" | _extract_json_field "message" "Unknown error")
         log_error "API Error: $error_msg"
 
         log_warn "Common issues:"

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -95,7 +95,7 @@ _validate_fly_token() {
     response=$(fly_api GET "/apps?org_slug=personal")
     if echo "$response" | grep -q '"error"'; then
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error','No details available'))" 2>/dev/null || echo "Unable to parse error")
+        error_msg=$(echo "$response" | _extract_json_field "error" "No details available")
         log_error "Authentication failed: Invalid Fly.io API token"
         log_error "API Error: $error_msg"
         log_warn "Remediation steps:"
@@ -179,7 +179,7 @@ _fly_create_app() {
 
     if echo "$app_response" | grep -q '"error"'; then
         local error_msg
-        error_msg=$(echo "$app_response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error','Unknown error'))" 2>/dev/null || echo "$app_response")
+        error_msg=$(echo "$app_response" | _extract_json_field "error" "Unknown error")
         if echo "$error_msg" | grep -qi "already exists"; then
             log_warn "App '$name' already exists, reusing it"
             return 0
@@ -234,7 +234,7 @@ print(json.dumps(body))
     if echo "$response" | grep -q '"error"'; then
         log_error "Failed to create Fly.io machine"
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error','Unknown error'))" 2>/dev/null || echo "$response")
+        error_msg=$(echo "$response" | _extract_json_field "error" "Unknown error")
         log_error "API Error: $error_msg"
         log_warn "Common issues:"
         log_warn "  - Insufficient account balance or payment method required"

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -38,7 +38,7 @@ test_hcloud_token() {
     if echo "$response" | grep -q '"error"'; then
         # Parse error details
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error',{}).get('message','No details available'))" 2>/dev/null || echo "Unable to parse error")
+        error_msg=$(echo "$response" | _extract_json_field "error.message" "No details available")
         log_error "API Error: $error_msg"
         log_error ""
         log_error "How to fix:"
@@ -80,7 +80,7 @@ hetzner_register_ssh_key() {
     if echo "$register_response" | grep -q '"error"'; then
         # Parse error details
         local error_msg
-        error_msg=$(echo "$register_response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error',{}).get('message','Unknown error'))" 2>/dev/null || echo "$register_response")
+        error_msg=$(echo "$register_response" | _extract_json_field "error.message" "Unknown error")
         log_error "API Error: $error_msg"
         log_error ""
         log_error "Common causes:"

--- a/ramnode/lib/common.sh
+++ b/ramnode/lib/common.sh
@@ -171,7 +171,7 @@ print(json.dumps(body))
 
     if echo "$response" | grep -q '"error"'; then
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error',{}).get('message','Unknown error'))" 2>/dev/null || echo "$response")
+        error_msg=$(echo "$response" | _extract_json_field "error.message" "Unknown error")
         log_error "API Error: $error_msg"
         log_error ""
         log_error "Common causes:"
@@ -354,7 +354,7 @@ _ramnode_handle_create_response() {
     if echo "$response" | grep -q '"error"'; then
         log_error "Failed to create RamNode server"
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error',{}).get('message','Unknown error'))" 2>/dev/null || echo "$response")
+        error_msg=$(echo "$response" | _extract_json_field "error.message" "Unknown error")
         log_error "API Error: $error_msg"
         log_error ""
         log_error "Common issues:"

--- a/scaleway/lib/common.sh
+++ b/scaleway/lib/common.sh
@@ -55,7 +55,7 @@ test_scaleway_token() {
     response=$(scaleway_instance_api GET "/servers?per_page=1")
     if echo "$response" | grep -q '"message"'; then
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','No details available'))" 2>/dev/null || echo "Unable to parse error")
+        error_msg=$(echo "$response" | _extract_json_field "message" "No details available")
         log_error "API Error: $error_msg"
         log_warn "Remediation steps:"
         log_warn "  1. Verify secret key at: https://console.scaleway.com/iam/api-keys"
@@ -174,7 +174,7 @@ print(json.dumps(body))
         return 0
     else
         local error_msg
-        error_msg=$(echo "$register_response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','Unknown error'))" 2>/dev/null || echo "$register_response")
+        error_msg=$(echo "$register_response" | _extract_json_field "message" "Unknown error")
         log_error "API Error: $error_msg"
         log_warn "Common causes:"
         log_warn "  - SSH key already registered with this name"
@@ -293,7 +293,7 @@ print(json.dumps(body))
     else
         log_error "Failed to create Scaleway instance"
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('message','Unknown error'))" 2>/dev/null || echo "$response")
+        error_msg=$(echo "$response" | _extract_json_field "message" "Unknown error")
         log_error "API Error: $error_msg"
         log_warn "Common issues:"
         log_warn "  - Insufficient account balance"

--- a/upcloud/lib/common.sh
+++ b/upcloud/lib/common.sh
@@ -41,7 +41,7 @@ test_upcloud_credentials() {
         return 0
     else
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error',{}).get('error_message','No details available'))" 2>/dev/null || echo "Unable to parse error")
+        error_msg=$(echo "$response" | _extract_json_field "error.error_message" "No details available")
         log_error "API Error: $error_msg"
         log_warn "Remediation steps:"
         log_warn "  1. Verify credentials at: https://hub.upcloud.com/people/account"
@@ -156,7 +156,7 @@ _upcloud_handle_create_response() {
     if echo "$response" | grep -q '"error"'; then
         log_error "Failed to create UpCloud server"
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error',{}).get('error_message','Unknown error'))" 2>/dev/null || echo "$response")
+        error_msg=$(echo "$response" | _extract_json_field "error.error_message" "Unknown error")
         log_error "API Error: $error_msg"
         log_warn "Common issues:"
         log_warn "  - Insufficient account balance"

--- a/vultr/lib/common.sh
+++ b/vultr/lib/common.sh
@@ -43,7 +43,7 @@ test_vultr_token() {
         return 0
     else
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error','No details available'))" 2>/dev/null || echo "Unable to parse error")
+        error_msg=$(echo "$response" | _extract_json_field "error" "No details available")
         log_error "API Error: $error_msg"
         log_warn "Remediation steps:"
         log_warn "  1. Verify API key at: https://my.vultr.com/settings/#settingsapi"
@@ -84,7 +84,7 @@ vultr_register_ssh_key() {
     else
         # Parse error details
         local error_msg
-        error_msg=$(echo "$register_response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error','Unknown error'))" 2>/dev/null || echo "$register_response")
+        error_msg=$(echo "$register_response" | _extract_json_field "error" "Unknown error")
         log_error "API Error: $error_msg"
 
         log_warn "Common causes:"
@@ -176,7 +176,7 @@ create_server() {
     else
         log_error "Failed to create Vultr instance"
         local error_msg
-        error_msg=$(echo "$response" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('error','Unknown error'))" 2>/dev/null || echo "$response")
+        error_msg=$(echo "$response" | _extract_json_field "error" "Unknown error")
         log_error "API Error: $error_msg"
         log_warn "Common issues:"
         log_warn "  - Insufficient account balance"


### PR DESCRIPTION
## Summary
- Extract `_extract_json_field` shared helper in `shared/common.sh` that replaces the repeated `python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get(...))"` pattern used for error message extraction across cloud provider libs
- Apply the helper to 10 cloud providers (binarylane, civo, contabo, digitalocean, fly, hetzner, ramnode, scaleway, upcloud, vultr), replacing 20 inline python3 invocations with single-line `_extract_json_field` calls
- Optimize `generic_wait_for_instance` to merge two separate python3 calls (status extraction + IP extraction) into a single python3 call per polling iteration, reducing process spawns during instance wait loops

## Test plan
- [x] `bash -n` passes on all 11 modified shell scripts
- [x] All 5486 bun tests pass
- [x] All 75 shell tests pass (`test/run.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)