### PR TITLE
feat: team suggestion template + cross-review PR workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/team_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/team_suggestion.yml
@@ -1,0 +1,55 @@
+name: Team Improvement / Suggestion
+description: Suggest an improvement to how the automated refactoring team operates
+title: "[Team]: "
+labels: ["team-improvement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve the automated team! Suggestions about agent roles,
+        workflows, review processes, or coordination are all welcome.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the team does this affect?
+      options:
+        - Agent roles (add, remove, or change a team member)
+        - PR workflow (review, merge, labeling)
+        - Issue handling (triage, labels, coordination)
+        - Safety / security (review gates, approval flow)
+        - Performance (timeouts, parallelism, resource usage)
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What should change?
+      description: Describe the improvement or new behavior you'd like to see.
+      placeholder: |
+        Agents should not merge their own PRs. Instead, a different agent
+        should review and approve each PR before it gets merged.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why?
+      description: What problem does this solve or what benefit does it provide?
+      placeholder: |
+        Cross-review catches duplicate work and ensures a second pair of eyes
+        on every change before it lands on main.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other details, examples from past cycles, or references
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- **New issue template** (`.github/ISSUE_TEMPLATE/team_suggestion.yml`): Structured form for suggesting improvements to the automated refactoring team — covers agent roles, PR workflow, issue handling, safety, and performance
- **Cross-review rule**: Agents can no longer merge their own PRs. Every PR gets labeled `needs-team-review` and is assigned to a different agent for review before merging (security-auditor ↔ ux-engineer, complexity-hunter ↔ test-engineer, etc.)
- **Duplicate work detection**: Before creating any PR, agents must check open and recently-merged PRs for overlapping file changes to avoid redundant work
- **Created labels**: `needs-team-review` (red) and `team-improvement` (blue) on the repo

### Changes in refactor.sh

| Section | What changed |
|---|---|
| New "Cross-Review Rule" section | Full review assignment table, reviewer responsibilities, team lead escalation for stale reviews |
| New "Duplicate Work Detection" section | 5-step checklist agents run before every PR |
| Per-Agent Worktree Pattern | Steps 4-6 updated: create PR → label for review → reviewer merges (no self-merge) |
| Issue Fix Workflow | Steps 11-14 updated: PR goes through cross-review instead of immediate self-merge |
| Issue mode team structure | issue-fixer creates PR + labels it; issue-tester reviews and merges |
| Issue mode workflow | Added label + review steps, renumbered to 14 steps |
| Monitoring loop | Added cross-review polling (check `needs-team-review` PRs, nudge stale reviewers) |
| Shutdown checklist | PRs with `needs-team-review` must be resolved before shutdown |

## Test plan

- [ ] `bash -n .claude/skills/setup-trigger-service/refactor.sh` passes
- [ ] New issue template appears in GitHub issue creation UI
- [ ] Trigger a refactor cycle and verify agents label PRs with `needs-team-review` instead of self-merging
- [ ] Verify the monitoring loop catches stale review PRs and escalates

🤖 Generated with [Claude Code](https://claude.com/claude-code)