### PR TITLE
fix: Fix scaleway mock test failures

### DIFF
--- a/test/fixtures/scaleway/_metadata.json
+++ b/test/fixtures/scaleway/_metadata.json
@@ -1,8 +1,11 @@
 {
   "cloud": "scaleway",
-  "recorded_at": "2026-02-11T01:51:27Z",
+  "recorded_at": "2026-02-12T00:00:00Z",
   "fixtures": {
     "servers": {"endpoint": "/servers", "recorded_at": "2026-02-11T01:51:26Z"},
-    "images": {"endpoint": "/images?per_page=10", "recorded_at": "2026-02-11T01:51:27Z"}
+    "images": {"endpoint": "/images?per_page=10", "recorded_at": "2026-02-11T01:51:27Z"},
+    "projects": {"endpoint": "/account/v3/projects", "recorded_at": "2026-02-12T00:00:00Z"},
+    "ssh-keys": {"endpoint": "/account/v3/ssh-keys", "recorded_at": "2026-02-12T00:00:00Z"},
+    "create_server": {"endpoint": "/servers (POST)", "recorded_at": "2026-02-12T00:00:00Z"}
   }
 }

--- a/test/fixtures/scaleway/create_server.json
+++ b/test/fixtures/scaleway/create_server.json
@@ -1,0 +1,50 @@
+{
+  "server": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "name": "test-srv",
+    "organization": "00000000-0000-0000-0000-000000000000",
+    "project": "00000000-0000-0000-0000-000000000000",
+    "allowed_actions": ["poweron", "backup", "stop", "reboot", "terminate"],
+    "arch": "x86_64",
+    "boot_type": "local",
+    "bootscript": null,
+    "commercial_type": "DEV1-S",
+    "creation_date": "2026-02-12T00:00:00.000000+00:00",
+    "dynamic_ip_required": true,
+    "enable_ipv6": false,
+    "hostname": "test-srv",
+    "image": {
+      "id": "ca5e7780-a7c3-451f-a528-0eabc745343c",
+      "name": "Ubuntu 24.04 Noble Jellyfish",
+      "arch": "x86_64"
+    },
+    "ipv6": null,
+    "location": null,
+    "modification_date": "2026-02-12T00:00:00.000000+00:00",
+    "name": "test-srv",
+    "placement_group": null,
+    "private_ip": "10.0.0.1",
+    "protected": false,
+    "public_ip": {
+      "address": "10.0.0.1",
+      "dynamic": true,
+      "id": "00000000-0000-0000-0000-000000000002"
+    },
+    "public_ips": [
+      {
+        "address": "10.0.0.1",
+        "dynamic": true,
+        "id": "00000000-0000-0000-0000-000000000002"
+      }
+    ],
+    "security_group": {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "name": "Default security group"
+    },
+    "state": "stopped",
+    "state_detail": "",
+    "tags": [],
+    "volumes": {},
+    "zone": "fr-par-1"
+  }
+}

--- a/test/fixtures/scaleway/projects.json
+++ b/test/fixtures/scaleway/projects.json
@@ -1,0 +1,13 @@
+{
+  "projects": [
+    {
+      "id": "00000000-0000-0000-0000-000000000000",
+      "name": "default",
+      "organization_id": "00000000-0000-0000-0000-000000000000",
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z",
+      "description": "Default project"
+    }
+  ],
+  "total_count": 1
+}

--- a/test/fixtures/scaleway/ssh-keys.json
+++ b/test/fixtures/scaleway/ssh-keys.json
@@ -1,0 +1,4 @@
+{
+  "ssh_keys": [],
+  "total_count": 0
+}

--- a/test/mock.sh
+++ b/test/mock.sh
@@ -270,7 +270,7 @@ case "$URL" in
     https://api.civo.com/v2*)           ENDPOINT="${URL#https://api.civo.com/v2}" ;;
     https://api.upcloud.com/1.3*)       ENDPOINT="${URL#https://api.upcloud.com/1.3}" ;;
     https://api.binarylane.com.au/v2*)  ENDPOINT="${URL#https://api.binarylane.com.au/v2}" ;;
-    https://api.scaleway.com/*)         ENDPOINT=$(echo "$URL" | sed 's|https://api.scaleway.com/instance/v1/zones/[^/]*/||') ;;
+    https://api.scaleway.com/*)         ENDPOINT=$(echo "$URL" | sed 's|https://api.scaleway.com/instance/v1/zones/[^/]*/||; s|https://api.scaleway.com/account/v3/||') ;;
     https://api.genesiscloud.com/compute/v1*) ENDPOINT="${URL#https://api.genesiscloud.com/compute/v1}" ;;
     https://console.kamatera.com/svc*)  ENDPOINT="${URL#https://console.kamatera.com/svc}" ;;
     https://api.latitude.sh*)           ENDPOINT="${URL#https://api.latitude.sh}" ;;
@@ -367,6 +367,9 @@ case "$METHOD" in
                 lambda)
                     printf '{"data":{"id":"test-uuid-1234","name":"test-srv","status":"active","ip":"10.0.0.1"}}'
                     ;;
+                scaleway)
+                    printf '{"server":{"id":"00000000-0000-0000-0000-000000000001","name":"test-srv","state":"running","public_ip":{"address":"10.0.0.1","dynamic":true},"public_ips":[{"address":"10.0.0.1","dynamic":true}]}}'
+                    ;;
                 *) printf '{}' ;;
             esac
         fi
@@ -376,6 +379,10 @@ case "$METHOD" in
             /ssh_keys|/ssh-keys|/account/keys|/profile/sshkeys|/sshkeys|*/sshkey)
                 # SSH key registration — return success
                 printf '{"ssh_key":{"id":99999,"name":"test-key","fingerprint":"af:0d:c5:57:a8:fd:b2:82:5e:d4:c1:65:f0:0c:8a:9d"}}'
+                ;;
+            */action)
+                # Scaleway instance actions (poweron, poweroff, terminate, etc.)
+                printf '{"task":{"id":"00000000-0000-0000-0000-000000000004","status":"pending","href_from":"/servers/00000000-0000-0000-0000-000000000001/action","description":"server_poweron"}}'
                 ;;
             *)
                 # Server/instance creation


### PR DESCRIPTION
Automated fix from QA cycle. 15 mock test(s) were failing for scaleway: scaleway/aider.sh scaleway/amazonq.sh scaleway/claude.sh scaleway/cline.sh scaleway/codex.sh scaleway/continue.sh scaleway/gemini.sh scaleway/goose.sh scaleway/gptme.sh scaleway/interpreter.sh scaleway/kilocode.sh scaleway/nanoclaw.sh scaleway/openclaw.sh scaleway/opencode.sh scaleway/plandex.sh