### PR TITLE
fix: replace log_warn with log_step/log_info for non-warning messages

### DIFF
--- a/github-codespaces/aider.sh
+++ b/github-codespaces/aider.sh
@@ -64,7 +64,7 @@ echo ""
 
 # 8. Start Aider interactively
 log_step "Starting Aider..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/amazonq.sh
+++ b/github-codespaces/amazonq.sh
@@ -63,7 +63,7 @@ echo ""
 
 # 7. Start amazon q interactively
 log_step "Starting Amazon Q CLI..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/claude.sh
+++ b/github-codespaces/claude.sh
@@ -73,7 +73,7 @@ setup_claude_code_config "$OPENROUTER_API_KEY" "upload_file" "run_server"
 echo ""
 log_info "Setup complete. Opening interactive session..."
 echo ""
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 
 # 8. Source env vars and launch Claude

--- a/github-codespaces/cline.sh
+++ b/github-codespaces/cline.sh
@@ -63,7 +63,7 @@ echo ""
 
 # 7. Start cline interactively
 log_step "Starting cline..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/codex.sh
+++ b/github-codespaces/codex.sh
@@ -63,7 +63,7 @@ echo ""
 
 # 7. Start codex interactively
 log_step "Starting codex..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/gemini.sh
+++ b/github-codespaces/gemini.sh
@@ -64,7 +64,7 @@ echo ""
 
 # 7. Start gemini interactively
 log_step "Starting gemini..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/goose.sh
+++ b/github-codespaces/goose.sh
@@ -62,7 +62,7 @@ echo ""
 
 # 7. Start goose interactively
 log_step "Starting goose..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/gptme.sh
+++ b/github-codespaces/gptme.sh
@@ -64,7 +64,7 @@ echo ""
 
 # 8. Start gptme interactively
 log_step "Starting gptme..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/interpreter.sh
+++ b/github-codespaces/interpreter.sh
@@ -63,7 +63,7 @@ echo ""
 
 # 7. Start interpreter interactively
 log_step "Starting open-interpreter..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/kilocode.sh
+++ b/github-codespaces/kilocode.sh
@@ -63,7 +63,7 @@ echo ""
 
 # 7. Start kilocode interactively
 log_step "Starting kilocode..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/nanoclaw.sh
+++ b/github-codespaces/nanoclaw.sh
@@ -81,7 +81,7 @@ echo ""
 # 8. Start nanoclaw
 log_step "Starting nanoclaw..."
 log_warn "You will need to scan a WhatsApp QR code to authenticate."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/openclaw.sh
+++ b/github-codespaces/openclaw.sh
@@ -82,7 +82,7 @@ echo ""
 
 # 9. Start openclaw gateway in background, then TUI
 log_step "Starting openclaw..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/opencode.sh
+++ b/github-codespaces/opencode.sh
@@ -61,7 +61,7 @@ echo ""
 
 # 7. Start opencode interactively
 log_step "Starting opencode..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/github-codespaces/plandex.sh
+++ b/github-codespaces/plandex.sh
@@ -61,7 +61,7 @@ echo ""
 
 # 7. Start plandex interactively
 log_step "Starting plandex..."
-log_warn "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
+log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""
 sleep 1
 

--- a/ionos/lib/common.sh
+++ b/ionos/lib/common.sh
@@ -165,7 +165,7 @@ _ionos_find_existing_datacenter() {
 # Sets IONOS_DATACENTER_ID on success
 _ionos_create_datacenter() {
     local location="$1"
-    log_warn "No datacenter found, creating new datacenter..."
+    log_step "No datacenter found, creating new datacenter..."
 
     local dc_body
     dc_body=$(python3 -c "
@@ -388,7 +388,7 @@ _ionos_launch_and_attach() {
     export IONOS_SERVER_ID
 
     # Attach volume to server
-    log_warn "Attaching volume to server..."
+    log_step "Attaching volume to server..."
     local attach_response
     attach_response=$(ionos_api POST "/datacenters/${IONOS_DATACENTER_ID}/servers/${IONOS_SERVER_ID}/volumes" "{\"id\": \"${volume_id}\"}")
 

--- a/kamatera/lib/common.sh
+++ b/kamatera/lib/common.sh
@@ -173,7 +173,7 @@ get_kamatera_server_ip() {
     local max_attempts=${2:-30}
     local attempt=1
 
-    log_warn "Retrieving server IP address..."
+    log_step "Retrieving server IP address..."
     while [[ "$attempt" -le "$max_attempts" ]]; do
         local info_response
         info_response=$(kamatera_api POST "/service/server/info" "{\"name\":\"$name\"}")
@@ -333,7 +333,7 @@ interactive_session() { ssh_interactive_session "$@"; }
 
 destroy_server() {
     local server_name="$1"
-    log_warn "Terminating server $server_name..."
+    log_step "Terminating server $server_name..."
     local response
     response=$(kamatera_api POST "/service/server/terminate" "{\"name\":\"$server_name\",\"force\":true}")
 

--- a/local/claude.sh
+++ b/local/claude.sh
@@ -42,7 +42,7 @@ else
 fi
 
 # 4. Inject environment variables
-log_warn "Appending environment variables to ~/.zshrc..."
+log_step "Appending environment variables to ~/.zshrc..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \

--- a/local/codex.sh
+++ b/local/codex.sh
@@ -48,7 +48,7 @@ else
 fi
 
 # 5. Inject environment variables
-log_warn "Appending environment variables to ~/.zshrc..."
+log_step "Appending environment variables to ~/.zshrc..."
 inject_env_vars_local upload_file run_server \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_BASE_URL=https://openrouter.ai/api/v1" \

--- a/local/continue.sh
+++ b/local/continue.sh
@@ -48,7 +48,7 @@ else
 fi
 
 # 5. Inject environment variables
-log_warn "Appending environment variables to ~/.zshrc..."
+log_step "Appending environment variables to ~/.zshrc..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 

--- a/local/goose.sh
+++ b/local/goose.sh
@@ -41,7 +41,7 @@ else
 fi
 
 # 4. Inject environment variables
-log_warn "Appending environment variables to ~/.zshrc..."
+log_step "Appending environment variables to ~/.zshrc..."
 inject_env_vars_local upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/local/nanoclaw.sh
+++ b/local/nanoclaw.sh
@@ -52,7 +52,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_warn "Appending environment variables to ~/.zshrc..."
+log_step "Appending environment variables to ~/.zshrc..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \

--- a/local/openclaw.sh
+++ b/local/openclaw.sh
@@ -42,7 +42,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 6. Inject environment variables
-log_warn "Appending environment variables to ~/.zshrc..."
+log_step "Appending environment variables to ~/.zshrc..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \

--- a/modal/lib/common.sh
+++ b/modal/lib/common.sh
@@ -47,7 +47,7 @@ ensure_modal_cli() {
     fi
     # Check if authenticated
     if ! modal profile current &>/dev/null; then
-        log_warn "Modal not authenticated. Running setup..."
+        log_step "Modal not authenticated. Running setup..."
         modal setup
     fi
     log_info "Modal CLI ready"
@@ -214,7 +214,7 @@ p.wait()
 destroy_server() {
     local sandbox_id="${1:-${MODAL_SANDBOX_ID}}"
     validate_sandbox_id "${sandbox_id}" || return 1
-    log_warn "Terminating sandbox..."
+    log_step "Terminating sandbox..."
     # SECURITY: Pass sandbox ID via environment variable to prevent Python injection
     _MODAL_SB_ID="${sandbox_id}" python3 -c "
 import modal, os


### PR DESCRIPTION
## Summary

- **local/*.sh (6 files)**: Changed `log_warn` to `log_step` for "Appending environment variables to ~/.zshrc..." messages. These are normal progress steps, not warnings -- yellow text made users think something was wrong.

- **github-codespaces/*.sh (14 files)**: Changed `log_warn` to `log_info` for "To delete codespace later..." cleanup hints. This is informational guidance, not a warning about something going wrong.

- **kamatera/lib/common.sh**: Changed `log_warn` to `log_step` for "Retrieving server IP address..." (progress) and "Terminating server..." (progress).

- **modal/lib/common.sh**: Changed `log_warn` to `log_step` for "Modal not authenticated. Running setup..." (progress) and "Terminating sandbox..." (progress).

- **ionos/lib/common.sh**: Changed `log_warn` to `log_step` for "No datacenter found, creating new datacenter..." (progress) and "Attaching volume to server..." (progress).

This complements PR #580 which fixed the same issue in render, koyeb, and github-codespaces lib files. This PR covers the remaining providers and agent scripts.

## Context

`log_warn` (yellow) should only be used for actual warnings. `log_step` (cyan) is for progress messages. `log_info` is for informational messages. Using yellow for normal operations makes users anxious that something is failing.

## Test plan

- [x] `bash -n` syntax check passes on all 23 modified files
- [ ] Manual: verify `log_step` shows cyan (not yellow) for progress messages
- [ ] Manual: verify `log_info` shows normal text for codespace cleanup hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)