### PR TITLE
fix: eliminate shell injection via inline API key in civo and koyeb scripts

### DIFF
--- a/civo/continue.sh
+++ b/civo/continue.sh
@@ -30,15 +30,11 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${CIVO_SERVER_IP}" "cat >> ~/.bashrc << 'ENV_EOF'
-export PATH=\"\$HOME/.bun/bin:\$PATH\"
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-ENV_EOF"
+inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-run_server "${CIVO_SERVER_IP}" "cat >> ~/.zshrc << 'ENV_EOF'
-export PATH=\"\$HOME/.bun/bin:\$PATH\"
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-ENV_EOF"
+# Ensure bun is on PATH
+run_server "${CIVO_SERVER_IP}" "printf 'export PATH=\"\${HOME}/.bun/bin:\${PATH}\"\n' >> ~/.zshrc"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${CIVO_SERVER_IP}" \

--- a/koyeb/nanoclaw.sh
+++ b/koyeb/nanoclaw.sh
@@ -51,9 +51,12 @@ inject_env_vars \
 
 # 8. Create NanoClaw .env file
 log_step "Configuring NanoClaw..."
-run_server "cat > ~/nanoclaw/.env << 'EOF'
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF"
+DOTENV_TEMP=$(mktemp)
+track_temp_file "${DOTENV_TEMP}"
+chmod 600 "${DOTENV_TEMP}"
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
+upload_file "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
+run_server "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "Koyeb service setup completed successfully!"


### PR DESCRIPTION
## Summary

- Fix shell injection vulnerability in `civo/continue.sh` and `koyeb/nanoclaw.sh` where `OPENROUTER_API_KEY` was interpolated inline into `run_server` command strings
- A specially crafted API key containing shell metacharacters (e.g., single quotes, backticks, `$()`) could break out of the quoting and execute arbitrary commands on the remote server
- These two scripts were missed by PR #602 which fixed the same class of vulnerability in 8 other scripts

## Affected Scripts

**civo/continue.sh** — used heredoc with inline `${OPENROUTER_API_KEY}` via `run_server`:
```bash
# BEFORE (vulnerable)
run_server "${CIVO_SERVER_IP}" "cat >> ~/.bashrc << 'ENV_EOF'
export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
ENV_EOF"
```

```bash
# AFTER (safe — uses file upload via inject_env_vars_ssh)
inject_env_vars_ssh "${CIVO_SERVER_IP}" upload_file run_server \
    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
```

**koyeb/nanoclaw.sh** — used heredoc with inline `${OPENROUTER_API_KEY}` via `run_server`:
```bash
# BEFORE (vulnerable)
run_server "cat > ~/nanoclaw/.env << 'EOF'
ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
EOF"
```

```bash
# AFTER (safe — writes to local temp file, uploads via upload_file)
DOTENV_TEMP=$(mktemp)
track_temp_file "${DOTENV_TEMP}"
chmod 600 "${DOTENV_TEMP}"
printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
upload_file "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
run_server "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
```

## Test plan

- [x] `bash -n` passes on both modified scripts
- [x] `bun test` passes (5486/5486 tests)
- [ ] Manual: verify civo/continue.sh correctly injects env vars
- [ ] Manual: verify koyeb/nanoclaw.sh correctly creates .env file

Agent: security-auditor