### PR TITLE
feat: Add ramnode/plandex implementation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1213,7 +1213,7 @@
     "ramnode/cline": "implemented",
     "ramnode/gptme": "implemented",
     "ramnode/opencode": "missing",
-    "ramnode/plandex": "missing",
+    "ramnode/plandex": "implemented",
     "ramnode/kilocode": "missing",
     "ramnode/continue": "implemented"
   }

--- a/ramnode/plandex.sh
+++ b/ramnode/plandex.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=ramnode/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ramnode/lib/common.sh)"
+fi
+
+log_info "Plandex on RamNode"
+echo ""
+
+# 1. Resolve RamNode credentials
+ensure_ramnode_credentials
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${RAMNODE_SERVER_IP}"
+wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
+
+# 5. Install Plandex
+log_step "Installing Plandex..."
+run_server "${RAMNODE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${RAMNODE_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    log_error "The 'plandex' command is not available or not working properly on server ${RAMNODE_SERVER_IP}"
+    exit 1
+fi
+log_info "Plandex installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "RamNode server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
+echo ""
+
+# 7. Start Plandex interactively
+log_step "Starting Plandex..."
+sleep 1
+clear
+interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && plandex"


### PR DESCRIPTION
## Summary
- Implements ramnode/plandex.sh using RamNode OpenStack API primitives
- Installs Plandex via official install script
- Injects OPENROUTER_API_KEY environment variable
- Updates manifest.json matrix to "implemented"

## Implementation Details
- Uses ramnode/lib/common.sh for cloud-specific functions
- Follows standard pattern: authenticate → provision → install → configure → launch
- Includes installation verification before proceeding
- OAuth flow for OpenRouter API key acquisition

## Testing
- Syntax validated with `bash -n`
- Follows same pattern as hetzner/plandex.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)