### PR TITLE
feat: Add local/kilocode implementation

### DIFF
--- a/local/kilocode.sh
+++ b/local/kilocode.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "Kilo Code on local machine"
+echo ""
+
+# 1. Ensure local prerequisites
+ensure_local_ready
+
+# 2. Install Node.js if not already installed
+if ! command -v node &>/dev/null; then
+    log_error "Node.js is required but not installed"
+    log_error "Please install Node.js from https://nodejs.org/"
+    exit 1
+fi
+
+# 3. Install Kilo Code CLI if not already installed
+if command -v kilocode &>/dev/null; then
+    log_info "Kilo Code already installed"
+else
+    log_step "Installing Kilo Code CLI..."
+    npm install -g @kilocode/cli
+fi
+
+# Verify installation
+if ! command -v kilocode &>/dev/null; then
+    log_error "Kilo Code installation failed"
+    log_error "The 'kilocode' command is not available"
+    log_error "Try installing manually: npm install -g @kilocode/cli"
+    exit 1
+fi
+log_info "Kilo Code installation verified"
+
+# 4. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 5. Inject environment variables
+log_warn "Appending environment variables to ~/.zshrc..."
+inject_env_vars_local upload_file run_server \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Local setup completed successfully!"
+echo ""
+
+# 6. Start Kilo Code
+if [[ -n "${SPAWN_PROMPT:-}" ]]; then
+    log_step "Executing Kilo Code with prompt..."
+    source ~/.zshrc 2>/dev/null || true
+    kilocode -m "${SPAWN_PROMPT}"
+else
+    log_step "Starting Kilo Code..."
+    sleep 1
+    clear 2>/dev/null || true
+    source ~/.zshrc 2>/dev/null || true
+    exec kilocode
+fi

--- a/manifest.json
+++ b/manifest.json
@@ -1199,7 +1199,7 @@
     "local/gptme": "implemented",
     "local/opencode": "missing",
     "local/plandex": "missing",
-    "local/kilocode": "missing",
+    "local/kilocode": "implemented",
     "local/continue": "implemented",
     "ramnode/claude": "implemented",
     "ramnode/openclaw": "implemented",


### PR DESCRIPTION
## Summary
- Implements `local/kilocode.sh` for running Kilo Code on local machine
- Combines local machine primitives with Kilo Code agent setup
- OpenRouter injection via `KILO_PROVIDER_TYPE=openrouter` and `KILO_OPEN_ROUTER_API_KEY`

## Implementation Details
- Node.js requirement check
- npm install of `@kilocode/cli`
- Environment variables injected to `~/.zshrc`
- Launches interactive Kilo Code session

## Testing
- ✅ `bash -n local/kilocode.sh` passes
- ✅ manifest.json updated to `"implemented"`

## Related
- Closes matrix gap: `local/kilocode`

🤖 Generated by gap-filler agent