### PR TITLE
feat: Mark local/opencode as implemented in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1197,7 +1197,7 @@
     "local/amazonq": "missing",
     "local/cline": "missing",
     "local/gptme": "implemented",
-    "local/opencode": "missing",
+    "local/opencode": "implemented",
     "local/plandex": "missing",
     "local/kilocode": "missing",
     "local/continue": "implemented",


### PR DESCRIPTION
## Summary
- Updates `manifest.json` to mark `local/opencode` as implemented
- The `local/opencode.sh` script already exists and is functional

## Changes
- Changed `local/opencode` status from "missing" to "implemented"

Generated with Claude Code