### PR TITLE
feat: Add ramnode/amazonq implementation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1209,7 +1209,7 @@
     "ramnode/codex": "missing",
     "ramnode/interpreter": "implemented",
     "ramnode/gemini": "missing",
-    "ramnode/amazonq": "missing",
+    "ramnode/amazonq": "implemented",
     "ramnode/cline": "implemented",
     "ramnode/gptme": "implemented",
     "ramnode/opencode": "missing",

--- a/ramnode/amazonq.sh
+++ b/ramnode/amazonq.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=ramnode/lib/common.sh
+
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ramnode/lib/common.sh)"
+fi
+
+log_info "Amazon Q on RamNode Cloud"
+echo ""
+
+ensure_ramnode_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${RAMNODE_SERVER_IP}"
+wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
+
+log_step "Installing Amazon Q CLI..."
+run_server "${RAMNODE_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "RamNode server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
+echo ""
+
+log_step "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && q chat"


### PR DESCRIPTION
## Summary
- Implements ramnode/amazonq.sh using RamNode OpenStack API + Amazon Q CLI
- Combines RamNode cloud primitives with Amazon Q agent setup
- Injects OPENROUTER_API_KEY, OPENAI_API_KEY, and OPENAI_BASE_URL
- Updates manifest.json matrix to "implemented"

## Test plan
- [ ] Script passes `bash -n` syntax check
- [ ] Follows local-or-remote source fallback pattern
- [ ] OpenRouter injection mandatory (env vars + config)
- [ ] Uses shared helpers from ramnode/lib/common.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)