### PR TITLE
refactor: deduplicate inline Claude config in fly, koyeb, railway

### DIFF
--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -54,48 +54,8 @@ inject_env_vars_fly \
     "CLAUDE_CODE_ENABLE_TELEMETRY=0" \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
-# 7. Configure Claude Code settings
-log_step "Configuring Claude Code..."
-
-run_server "mkdir -p ~/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch ~/.claude/CLAUDE.md"
+# 7. Configure Claude Code settings via shared helper
+setup_claude_code_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Fly.io machine setup completed successfully!"

--- a/koyeb/claude.sh
+++ b/koyeb/claude.sh
@@ -54,48 +54,8 @@ inject_env_vars \
     "CLAUDE_CODE_ENABLE_TELEMETRY=0" \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
-# 7. Configure Claude Code settings
-log_step "Configuring Claude Code..."
-
-run_server "mkdir -p /root/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch /root/.claude/CLAUDE.md"
+# 7. Configure Claude Code settings via shared helper
+setup_claude_code_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Koyeb service setup completed successfully!"

--- a/railway/claude.sh
+++ b/railway/claude.sh
@@ -54,48 +54,8 @@ inject_env_vars \
     "CLAUDE_CODE_ENABLE_TELEMETRY=0" \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
-# 7. Configure Claude Code settings
-log_step "Configuring Claude Code..."
-
-run_server "mkdir -p /root/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch /root/.claude/CLAUDE.md"
+# 7. Configure Claude Code settings via shared helper
+setup_claude_code_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 
 echo ""
 log_info "Railway service setup completed successfully!"


### PR DESCRIPTION
## Summary

- Replace ~40 lines of manually inlined Claude Code config setup in `fly/claude.sh`, `koyeb/claude.sh`, and `railway/claude.sh` with a single call to the shared `setup_claude_code_config` helper
- All other 30+ claude.sh scripts already use this shared helper; these three were the only holdouts
- Removes **126 lines** of duplicated code (settings.json creation, .claude.json creation, CLAUDE.md touch)
- Also improves security: the shared helper uses `json_escape` for the API key, while the inline versions used raw heredoc interpolation

## Changes

| File | Before | After | Lines removed |
|------|--------|-------|---------------|
| `fly/claude.sh` | 110 lines | 70 lines | -40 |
| `koyeb/claude.sh` | 110 lines | 70 lines | -40 |
| `railway/claude.sh` | 110 lines | 70 lines | -40 |

## Test plan

- [x] `bash -n` syntax check passes on all 3 modified files
- [x] `bun test` passes (5483 pass, 3 pre-existing failures unrelated to this change)
- [ ] Manual verification: the shared helper `setup_claude_code_config` in `shared/common.sh:1911` produces identical config files

Agent: complexity-hunter