### PR TITLE
fix: improve compact matrix view and listing display clarity

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cloud-agent-quickstart.test.ts
+++ b/cli/src/__tests__/cloud-agent-quickstart.test.ts
@@ -424,11 +424,13 @@ describe("cmdCloudInfo - Not yet available agents", () => {
   });
 
   describe("many missing agents (6 missing, > 5 threshold)", () => {
-    it("should NOT show 'Not yet available' section", async () => {
+    it("should show count instead of listing individual agent names", async () => {
       await setupManifest(manyAgentManifest);
       await cmdCloudInfo("testcloud");
       const output = getOutput();
-      expect(output).not.toContain("Not yet available");
+      // Shows count summary instead of individual names
+      expect(output).toContain("other agents not yet available");
+      expect(output).not.toContain("Not yet available:");
     });
 
     it("should still show the implemented agent", async () => {

--- a/cli/src/__tests__/commands-info-details.test.ts
+++ b/cli/src/__tests__/commands-info-details.test.ts
@@ -339,12 +339,13 @@ describe("cmdCloudInfo - missing agents display", () => {
       expect(output).toContain("Codex CLI");
     });
 
-    it("should NOT show 'Not yet available' when missing agents > 5", async () => {
+    it("should show count instead of listing names when missing agents > 5", async () => {
       await setManifest(manyAgentsManifest);
       await cmdCloudInfo("sprite");
       const output = getOutput();
-      // 6 missing agents exceeds the <= 5 threshold
-      expect(output).not.toContain("Not yet available");
+      // 6 missing agents exceeds the <= 5 threshold: shows count instead of individual names
+      expect(output).toContain("other agents not yet available");
+      expect(output).not.toContain("OpenClaw");
     });
 
     it("should NOT show 'Not yet available' when all agents are implemented", async () => {

--- a/cli/src/__tests__/list-filter-suggestions.test.ts
+++ b/cli/src/__tests__/list-filter-suggestions.test.ts
@@ -626,10 +626,10 @@ describe("cmdMatrix - compact vs grid view", () => {
       await cmdMatrix();
 
       const output = getOutput();
-      // Compact view shows "all clouds supported" or "Not yet available" column
+      // Compact view shows "all clouds supported" or available/missing clouds column
       expect(output).toContain("Agent");
       expect(output).toContain("Clouds");
-      expect(output).toContain("Not yet available");
+      expect(output).toContain("Details");
     });
 
     it("should show green for fully-supported agents in compact view", async () => {
@@ -643,15 +643,16 @@ describe("cmdMatrix - compact vs grid view", () => {
       expect(output).toContain("all clouds supported");
     });
 
-    it("should list missing cloud names in compact view for partial agents", async () => {
+    it("should list available cloud names in compact view when fewer implemented than missing", async () => {
       process.stdout.columns = 40;
       await setManifest(wideManifest);
 
       await cmdMatrix();
 
       const output = getOutput();
-      // aider is missing on several clouds
-      expect(output).toContain("Hetzner Cloud");
+      // aider has 1 implemented (Sprite) out of 8 clouds
+      // Since 1 <= 7, shows available clouds instead of missing ones
+      expect(output).toContain("Sprite");
     });
 
     it("should show ratio X/Y for each agent in compact view", async () => {


### PR DESCRIPTION
## Summary
- **Adaptive compact matrix view**: When `spawn matrix` uses the compact view (narrow terminals), it now adaptively shows which clouds are available (green) when fewer are implemented than missing, rather than always listing missing clouds. When most clouds are supported, it shows the few missing ones with a "missing:" prefix. This helps users quickly identify which clouds they can actually use.
- **Dimmed unavailable entries**: Agents with 0 cloud implementations in `spawn agents` and clouds with 0 agent implementations in `spawn clouds` are now dimmed with a yellow count, signaling they can't be used yet.
- **Missing agent count for cloud info**: `spawn <cloud>` now shows "N other agents not yet available on this cloud" when more than 5 agents are missing, instead of silently hiding the information.

## Test plan
- [x] All 5487 existing tests pass (0 failures)
- [x] Updated compact list tests to verify adaptive display behavior
- [x] Updated cloud-agent-quickstart tests for new count display
- [x] Updated commands-info-details tests for count threshold behavior
- [ ] Manual verification: `spawn matrix` in narrow terminal shows available clouds for agents with few implementations
- [ ] Manual verification: `spawn agents` dims agents with 0 clouds

Generated with [Claude Code](https://claude.com/claude-code)