### PR TITLE
fix: show post-session reminder that server is still running

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1443,8 +1443,17 @@ ssh_upload_file() {
 ssh_interactive_session() {
     local ip="${1}"
     local cmd="${2}"
+    local ssh_exit=0
     # shellcheck disable=SC2086
-    ssh -t $SSH_OPTS "${SSH_USER:-root}@${ip}" "${cmd}"
+    ssh -t $SSH_OPTS "${SSH_USER:-root}@${ip}" "${cmd}" || ssh_exit=$?
+
+    # After the SSH session ends, remind the user their server is still running
+    echo "" >&2
+    log_warn "Session ended. Your server is still running and may incur charges."
+    log_step "  Reconnect: ssh ${SSH_USER:-root}@${ip}"
+    log_step "  Stop billing: delete the server from your cloud provider's dashboard"
+    echo "" >&2
+    return ${ssh_exit}
 }
 
 # Wait for SSH connectivity to a server


### PR DESCRIPTION
## Summary
- After an SSH interactive session ends, the user now sees a warning that their server is still running and may incur charges
- Shows the SSH reconnect command and a reminder to delete the server from the cloud provider's dashboard
- Affects all 400+ VPS-based agent scripts via the shared `ssh_interactive_session` function in `shared/common.sh` -- no individual script changes needed

## Problem
When a user exits their SSH session (e.g., types `exit` or closes the terminal), the script ends silently. The VPS server continues running and incurring charges. Only `github-codespaces` scripts had a deletion reminder; none of the 20+ SSH-based cloud providers showed any post-session guidance.

## Solution
Added a post-session message block to `ssh_interactive_session()` in `shared/common.sh` that displays:
```
Session ended. Your server is still running and may incur charges.
  Reconnect: ssh root@<ip>
  Stop billing: delete the server from your cloud provider's dashboard
```

Uses `|| ssh_exit=$?` pattern to ensure the message is shown even if SSH exits with a non-zero code (which would otherwise trigger `set -e`).

## Test plan
- [x] `bash -n shared/common.sh` passes
- [x] All 75 shell script tests pass (`bash test/run.sh`)
- [x] All 5486 CLI tests pass (`bun test`)
- [ ] Manual: run any VPS cloud script, exit the SSH session, verify reminder appears

Generated with [Claude Code](https://claude.com/claude-code)