### PR TITLE
fix: use timing-safe comparison for trigger server auth

### DIFF
--- a/.claude/skills/setup-trigger-service/trigger-server.ts
+++ b/.claude/skills/setup-trigger-service/trigger-server.ts
@@ -21,6 +21,8 @@
  * continues to drain to the server console.
  */
 
+import { timingSafeEqual } from "crypto";
+
 const PORT = 8080;
 const TRIGGER_SECRET = process.env.TRIGGER_SECRET ?? "";
 const TARGET_SCRIPT = process.env.TARGET_SCRIPT ?? "";
@@ -310,7 +312,11 @@ const server = Bun.serve({
       }
 
       const auth = req.headers.get("Authorization") ?? "";
-      if (auth !== `Bearer ${TRIGGER_SECRET}`) {
+      const expected = `Bearer ${TRIGGER_SECRET}`;
+      if (
+        auth.length !== expected.length ||
+        !timingSafeEqual(Buffer.from(auth), Buffer.from(expected))
+      ) {
         return Response.json({ error: "unauthorized" }, { status: 401 });
       }
 


### PR DESCRIPTION
## Summary
- Replace direct string comparison (`!==`) with `timingSafeEqual` from Node's `crypto` module for Bearer token validation in `trigger-server.ts`
- The previous comparison could leak information about the secret through response time analysis (timing side-channel)
- The `key-server.ts` already used `timingSafeEqual` correctly; this brings the trigger server in line with that pattern

## Details
The `trigger-server.ts` `/trigger` endpoint validated the `Authorization` header using JavaScript's `!==` operator, which short-circuits on the first mismatched character. While the practical exploitability is low (internal service, network jitter), using timing-safe comparison is a security best practice for secret comparison and eliminates this class of vulnerability entirely.

The fix:
1. Imports `timingSafeEqual` from `crypto`
2. Checks length equality first (required by `timingSafeEqual`)
3. Uses `timingSafeEqual` with `Buffer.from()` for constant-time comparison

## Test plan
- [ ] Verify trigger server still accepts valid Bearer tokens
- [ ] Verify trigger server still rejects invalid Bearer tokens
- [ ] Existing CLI tests pass (no trigger-server tests exist yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)