### PR TITLE
refactor: reduce complexity in test runner functions

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -713,21 +713,18 @@ run_shellcheck() {
         return 0
     fi
 
-    # Find all shell scripts
-    local all_scripts=(
-        "${REPO_ROOT}"/sprite/*.sh
-        "${REPO_ROOT}"/sprite/lib/common.sh
-        "${REPO_ROOT}"/shared/common.sh
-        "${REPO_ROOT}"/digitalocean/*.sh
-        "${REPO_ROOT}"/digitalocean/lib/common.sh
-        "${REPO_ROOT}"/hetzner/*.sh
-        "${REPO_ROOT}"/hetzner/lib/common.sh
-        "${REPO_ROOT}"/linode/*.sh
-        "${REPO_ROOT}"/linode/lib/common.sh
-        "${REPO_ROOT}"/vultr/*.sh
-        "${REPO_ROOT}"/vultr/lib/common.sh
-        "${REPO_ROOT}"/test/run.sh
-    )
+    # Auto-discover all shell scripts across clouds, shared/, and test/
+    local all_scripts=("${REPO_ROOT}"/shared/common.sh "${REPO_ROOT}"/test/run.sh)
+    local cloud_dir
+    for cloud_dir in "${REPO_ROOT}"/*/lib/common.sh; do
+        [[ -f "${cloud_dir}" ]] || continue
+        local cloud_root="${cloud_dir%/lib/common.sh}"
+        all_scripts+=("${cloud_dir}")
+        local agent_sh
+        for agent_sh in "${cloud_root}"/*.sh; do
+            [[ -f "${agent_sh}" ]] && all_scripts+=("${agent_sh}")
+        done
+    done
 
     local issue_count=0
     local checked_count=0


### PR DESCRIPTION
## Summary

- **Split `run_test()` in `test/mock.sh`** (150 lines -> 60 lines) into 3 focused helpers:
  - `_run_script_with_timeout()` -- background execution with 4-second timeout and failure output
  - `_assert_cloud_api_calls()` -- cloud-specific SSH key and server creation endpoint assertions
  - `_record_test_result()` -- RESULTS_FILE pass/fail tracking for QA pipeline
- **Replace hardcoded shellcheck list in `test/run.sh`** with auto-discovery loop. The old list only covered 5 of 21+ clouds (sprite, digitalocean, hetzner, linode, vultr). The new loop finds all `*/lib/common.sh` files and their sibling agent scripts dynamically.

## Test plan

- [x] `bash -n test/mock.sh` -- syntax check passes
- [x] `bash -n test/run.sh` -- syntax check passes
- [x] `bun test` -- all 5486 tests pass, no regressions
- [ ] Verify `bash test/mock.sh` with fixtures still works end-to-end

Agent: complexity-hunter

🤖 Generated with [Claude Code](https://claude.com/claude-code)