### PR TITLE
refactor: reduce complexity in oracle and ramnode cloud libs

### DIFF
--- a/ramnode/lib/common.sh
+++ b/ramnode/lib/common.sh
@@ -214,43 +214,9 @@ for f in flavors:
 "
 }
 
-# Interactive flavor picker
+# Interactive flavor picker (delegates to shared interactive_pick)
 _pick_flavor() {
-    if [[ -n "${RAMNODE_FLAVOR:-}" ]]; then
-        echo "$RAMNODE_FLAVOR"
-        return
-    fi
-
-    log_info "Fetching available instance types..."
-    local flavors
-    flavors=$(_list_flavors)
-
-    if [[ -z "$flavors" ]]; then
-        log_warn "Could not fetch flavors, using default: 1GB"
-        echo "1GB"
-        return
-    fi
-
-    log_info "Available instance types:"
-    local i=1
-    local names=()
-    while IFS='|' read -r name cores ram disk; do
-        printf "  %2d) %-12s  %-8s  %-12s  %s\n" "$i" "$name" "$cores" "$ram" "$disk" >&2
-        names+=("$name")
-        i=$((i + 1))
-    done <<< "$flavors"
-
-    local choice
-    printf "\n" >&2
-    choice=$(safe_read "Select instance type [1]: ") || choice=""
-    choice="${choice:-1}"
-
-    if [[ "$choice" -ge 1 && "$choice" -le "${#names[@]}" ]] 2>/dev/null; then
-        echo "${names[$((choice - 1))]}"
-    else
-        log_warn "Invalid choice, using default: 1GB"
-        echo "1GB"
-    fi
+    interactive_pick "RAMNODE_FLAVOR" "1GB" "instance types" "_list_flavors"
 }
 
 # List available images


### PR DESCRIPTION
## Summary
- **Oracle `_setup_vcn_networking` (48 lines -> 12-line orchestrator + 3 focused helpers)**: Split into `_create_internet_gateway`, `_setup_default_route`, and `_setup_security_list` -- each does one thing with clear naming
- **Oracle `_get_ubuntu_image_id` (41 lines -> 18+19 lines)**: Extract `_oci_image_list` helper to deduplicate the nearly-identical OCI image list CLI commands (shape-filtered vs unfiltered)
- **RamNode `_pick_flavor` (37 lines -> 3 lines)**: Replace manual interactive picker with the shared `interactive_pick` helper, matching the pattern already used by netcup and other providers

Net: -19 lines, 3 complex functions simplified.

## Test plan
- [x] `bash -n oracle/lib/common.sh` passes
- [x] `bash -n ramnode/lib/common.sh` passes
- [x] `bun test` -- all 5486 tests pass
- [ ] Verify Oracle VCN creation still works end-to-end (manual)
- [ ] Verify RamNode flavor picker works with and without RAMNODE_FLAVOR env var (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)