### PR TITLE
test: add resolveListFilters and manifest cache TTL tests

### DIFF
--- a/cli/src/__tests__/manifest-cache-ttl.test.ts
+++ b/cli/src/__tests__/manifest-cache-ttl.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  rmSync,
+  utimesSync,
+  statSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { Manifest } from "../manifest";
+import { createMockManifest } from "./test-helpers";
+
+/**
+ * Tests for manifest.ts cache TTL (time-to-live) boundary behavior.
+ *
+ * The disk cache has a TTL of 3600 seconds (1 hour). The cacheAge function
+ * checks the file's mtime to decide if it's fresh or stale. The
+ * tryLoadFromDiskCache function gates on this TTL before reading the cache.
+ *
+ * Since cacheAge and tryLoadFromDiskCache are internal (not exported),
+ * we test exact replicas here. This is the same pattern used by other
+ * test files in this codebase (e.g., list-display.test.ts tests
+ * formatTimestamp via replica).
+ *
+ * Tested behaviors:
+ * - cacheAge: file mtime calculation, missing files, error handling
+ * - TTL boundary: fresh (< 3600s) vs stale (>= 3600s) determination
+ * - tryLoadFromDiskCache: TTL gating + JSON parsing + error recovery
+ * - writeCache: directory creation, JSON formatting, round-trip integrity
+ *
+ * Agent: test-engineer
+ */
+
+const CACHE_TTL = 3600; // 1 hour, must match manifest.ts
+
+const mockManifest = createMockManifest();
+
+// ── Replica of cacheAge from manifest.ts (lines 52-59) ──────────────────────
+
+function cacheAge(cacheFile: string): number {
+  try {
+    const st: ReturnType<typeof statSync> = statSync(cacheFile);
+    return (Date.now() - st.mtimeMs) / 1000;
+  } catch {
+    return Infinity;
+  }
+}
+
+// ── Replica of readCache from manifest.ts (lines 67-75) ─────────────────────
+
+function readCache(cacheFile: string): Manifest | null {
+  try {
+    return JSON.parse(readFileSync(cacheFile, "utf-8")) as Manifest;
+  } catch {
+    return null;
+  }
+}
+
+// ── Replica of writeCache from manifest.ts (lines 77-80) ────────────────────
+
+function writeCache(cacheDir: string, cacheFile: string, data: Manifest): void {
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(cacheFile, JSON.stringify(data, null, 2), "utf-8");
+}
+
+// ── Replica of tryLoadFromDiskCache from manifest.ts (lines 113-116) ────────
+
+function tryLoadFromDiskCache(cacheFile: string): Manifest | null {
+  if (cacheAge(cacheFile) >= CACHE_TTL) return null;
+  return readCache(cacheFile);
+}
+
+// ── Replica of isValidManifest from manifest.ts (lines 84-86) ──────────────
+
+function isValidManifest(data: any): data is Manifest {
+  return data && data.agents && data.clouds && data.matrix;
+}
+
+describe("Manifest Cache TTL Behavior", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `spawn-cache-ttl-${Date.now()}-${Math.random()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  // ── cacheAge ──────────────────────────────────────────────────────────
+
+  describe("cacheAge", () => {
+    it("should return Infinity when file does not exist", () => {
+      expect(cacheAge(join(testDir, "nonexistent.json"))).toBe(Infinity);
+    });
+
+    it("should return near-zero age for freshly created file", () => {
+      const file = join(testDir, "fresh.json");
+      writeFileSync(file, "{}");
+      expect(cacheAge(file)).toBeLessThan(5);
+    });
+
+    it("should return approximately 1800 seconds for a 30-minute-old file", () => {
+      const file = join(testDir, "aged.json");
+      writeFileSync(file, "{}");
+      const thirtyMinAgo = new Date(Date.now() - 30 * 60 * 1000);
+      utimesSync(file, thirtyMinAgo, thirtyMinAgo);
+
+      const age = cacheAge(file);
+      expect(age).toBeGreaterThan(1790);
+      expect(age).toBeLessThan(1810);
+    });
+
+    it("should return approximately CACHE_TTL for a 1-hour-old file", () => {
+      const file = join(testDir, "stale.json");
+      writeFileSync(file, "{}");
+      const oneHourAgo = new Date(Date.now() - CACHE_TTL * 1000);
+      utimesSync(file, oneHourAgo, oneHourAgo);
+
+      const age = cacheAge(file);
+      expect(age).toBeGreaterThan(CACHE_TTL - 10);
+      expect(age).toBeLessThan(CACHE_TTL + 10);
+    });
+
+    it("should return approximately 86400 for a 24-hour-old file", () => {
+      const file = join(testDir, "old.json");
+      writeFileSync(file, "{}");
+      const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      utimesSync(file, dayAgo, dayAgo);
+
+      const age = cacheAge(file);
+      expect(age).toBeGreaterThan(86000);
+      expect(age).toBeLessThan(86500);
+    });
+
+    it("should return Infinity for inaccessible path", () => {
+      expect(cacheAge("/root/definitely/not/accessible/manifest.json")).toBe(Infinity);
+    });
+
+    it("should handle directory path (directories have mtimes too)", () => {
+      expect(cacheAge(testDir)).toBeLessThan(60);
+    });
+  });
+
+  // ── TTL boundary: fresh vs stale ──────────────────────────────────────
+
+  describe("TTL boundary determination", () => {
+    it("should be fresh when age is 0", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, "{}");
+      expect(cacheAge(file) < CACHE_TTL).toBe(true);
+    });
+
+    it("should be fresh when age is TTL - 1 second (3599s)", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, "{}");
+      const almostStale = new Date(Date.now() - (CACHE_TTL - 1) * 1000);
+      utimesSync(file, almostStale, almostStale);
+      expect(cacheAge(file) < CACHE_TTL).toBe(true);
+    });
+
+    it("should be stale when age equals TTL exactly (3600s)", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, "{}");
+      const exactTTL = new Date(Date.now() - CACHE_TTL * 1000);
+      utimesSync(file, exactTTL, exactTTL);
+      expect(cacheAge(file) >= CACHE_TTL).toBe(true);
+    });
+
+    it("should be stale when age is TTL + 1 second (3601s)", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, "{}");
+      const justStale = new Date(Date.now() - (CACHE_TTL + 1) * 1000);
+      utimesSync(file, justStale, justStale);
+      expect(cacheAge(file) >= CACHE_TTL).toBe(true);
+    });
+
+    it("should be stale when age is 2x TTL (7200s)", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, "{}");
+      const veryStale = new Date(Date.now() - CACHE_TTL * 2 * 1000);
+      utimesSync(file, veryStale, veryStale);
+      expect(cacheAge(file) >= CACHE_TTL).toBe(true);
+    });
+
+    it("should treat non-existent file as stale (Infinity >= TTL)", () => {
+      expect(cacheAge(join(testDir, "nope.json")) >= CACHE_TTL).toBe(true);
+    });
+  });
+
+  // ── tryLoadFromDiskCache ──────────────────────────────────────────────
+
+  describe("tryLoadFromDiskCache TTL gating", () => {
+    it("should return manifest when cache is fresh (10 seconds old)", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, JSON.stringify(mockManifest));
+      const tenSecsAgo = new Date(Date.now() - 10 * 1000);
+      utimesSync(file, tenSecsAgo, tenSecsAgo);
+
+      const result = tryLoadFromDiskCache(file);
+      expect(result).not.toBeNull();
+      expect(result!.agents.claude.name).toBe("Claude Code");
+    });
+
+    it("should return null when cache is stale (TTL + 1 second)", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, JSON.stringify(mockManifest));
+      const staleTime = new Date(Date.now() - (CACHE_TTL + 1) * 1000);
+      utimesSync(file, staleTime, staleTime);
+
+      expect(tryLoadFromDiskCache(file)).toBeNull();
+    });
+
+    it("should return null when file does not exist", () => {
+      expect(tryLoadFromDiskCache(join(testDir, "nope.json"))).toBeNull();
+    });
+
+    it("should return null for invalid JSON in fresh cache", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, "not json{{{");
+      expect(tryLoadFromDiskCache(file)).toBeNull();
+    });
+
+    it("should return null for empty fresh cache file", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, "");
+      expect(tryLoadFromDiskCache(file)).toBeNull();
+    });
+
+    it("should return manifest at TTL - 1 second boundary", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, JSON.stringify(mockManifest));
+      const almostStale = new Date(Date.now() - (CACHE_TTL - 1) * 1000);
+      utimesSync(file, almostStale, almostStale);
+
+      expect(tryLoadFromDiskCache(file)).not.toBeNull();
+    });
+
+    it("should return null at exact TTL boundary", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, JSON.stringify(mockManifest));
+      const exactTTL = new Date(Date.now() - CACHE_TTL * 1000);
+      utimesSync(file, exactTTL, exactTTL);
+
+      expect(tryLoadFromDiskCache(file)).toBeNull();
+    });
+
+    it("should preserve all manifest fields through cache read", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, JSON.stringify(mockManifest, null, 2));
+
+      const result = tryLoadFromDiskCache(file);
+      expect(result).not.toBeNull();
+      expect(result!.agents.claude.name).toBe("Claude Code");
+      expect(result!.agents.aider.name).toBe("Aider");
+      expect(result!.clouds.sprite.name).toBe("Sprite");
+      expect(result!.clouds.hetzner.name).toBe("Hetzner Cloud");
+      expect(result!.matrix["sprite/claude"]).toBe("implemented");
+      expect(result!.matrix["hetzner/aider"]).toBe("missing");
+    });
+  });
+
+  // ── readCache ─────────────────────────────────────────────────────────
+
+  describe("readCache", () => {
+    it("should parse valid JSON cache file", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, JSON.stringify(mockManifest));
+      const result = readCache(file);
+      expect(result).not.toBeNull();
+      expect(result!.agents).toBeDefined();
+    });
+
+    it("should return null for missing file", () => {
+      expect(readCache(join(testDir, "nope.json"))).toBeNull();
+    });
+
+    it("should return null for corrupted JSON", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, "corrupted{{{");
+      expect(readCache(file)).toBeNull();
+    });
+
+    it("should return null for empty file", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, "");
+      expect(readCache(file)).toBeNull();
+    });
+
+    it("should parse JSON with whitespace/formatting", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, JSON.stringify(mockManifest, null, 4));
+      const result = readCache(file);
+      expect(result).not.toBeNull();
+      expect(result!.agents.claude.name).toBe("Claude Code");
+    });
+
+    it("should return the parsed object (not validate structure)", () => {
+      const file = join(testDir, "cache.json");
+      writeFileSync(file, JSON.stringify({ random: "data" }));
+      const result = readCache(file);
+      // readCache only parses JSON, doesn't validate
+      expect(result).not.toBeNull();
+      expect((result as any).random).toBe("data");
+    });
+  });
+
+  // ── writeCache ────────────────────────────────────────────────────────
+
+  describe("writeCache", () => {
+    it("should create directory if it does not exist", () => {
+      const cacheDir = join(testDir, "nested", "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      expect(existsSync(file)).toBe(true);
+    });
+
+    it("should write pretty-printed JSON", () => {
+      const cacheDir = join(testDir, "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      const raw = readFileSync(file, "utf-8");
+      // Pretty-printed JSON has indentation
+      expect(raw).toContain("  ");
+      expect(raw).toContain("\n");
+    });
+
+    it("should produce valid JSON that can be parsed back", () => {
+      const cacheDir = join(testDir, "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      const parsed = JSON.parse(readFileSync(file, "utf-8"));
+      expect(parsed.agents.claude.name).toBe("Claude Code");
+      expect(parsed.clouds.sprite.name).toBe("Sprite");
+      expect(parsed.matrix["sprite/claude"]).toBe("implemented");
+    });
+
+    it("should overwrite existing cache file", () => {
+      const cacheDir = join(testDir, "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      const updatedManifest = createMockManifest();
+      updatedManifest.agents.claude.description = "Updated";
+      writeCache(cacheDir, file, updatedManifest);
+
+      const parsed = JSON.parse(readFileSync(file, "utf-8"));
+      expect(parsed.agents.claude.description).toBe("Updated");
+    });
+
+    it("should produce file that passes isValidManifest", () => {
+      const cacheDir = join(testDir, "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      const parsed = JSON.parse(readFileSync(file, "utf-8"));
+      expect(isValidManifest(parsed)).toBeTruthy();
+    });
+
+    it("should write with UTF-8 encoding", () => {
+      const cacheDir = join(testDir, "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      // readFileSync with utf-8 should work
+      const raw = readFileSync(file, "utf-8");
+      expect(typeof raw).toBe("string");
+      expect(raw.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Round-trip: writeCache -> tryLoadFromDiskCache ─────────────────────
+
+  describe("writeCache -> tryLoadFromDiskCache round-trip", () => {
+    it("should be readable immediately after writing (fresh cache)", () => {
+      const cacheDir = join(testDir, "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      const result = tryLoadFromDiskCache(file);
+      expect(result).not.toBeNull();
+      expect(result!.agents.claude.name).toBe("Claude Code");
+    });
+
+    it("should preserve all fields through write -> read cycle", () => {
+      const cacheDir = join(testDir, "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      const result = tryLoadFromDiskCache(file);
+      expect(result).not.toBeNull();
+      // Verify every key-value pair
+      for (const [key, agent] of Object.entries(mockManifest.agents)) {
+        expect(result!.agents[key].name).toBe(agent.name);
+        expect(result!.agents[key].description).toBe(agent.description);
+      }
+      for (const [key, cloud] of Object.entries(mockManifest.clouds)) {
+        expect(result!.clouds[key].name).toBe(cloud.name);
+        expect(result!.clouds[key].type).toBe(cloud.type);
+      }
+      for (const [key, status] of Object.entries(mockManifest.matrix)) {
+        expect(result!.matrix[key]).toBe(status);
+      }
+    });
+
+    it("should not be readable after TTL expires", () => {
+      const cacheDir = join(testDir, "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      // Simulate cache aging past TTL
+      const staleTime = new Date(Date.now() - (CACHE_TTL + 100) * 1000);
+      utimesSync(file, staleTime, staleTime);
+
+      expect(tryLoadFromDiskCache(file)).toBeNull();
+    });
+
+    it("should be readable at TTL - 1 second", () => {
+      const cacheDir = join(testDir, "spawn");
+      const file = join(cacheDir, "manifest.json");
+
+      writeCache(cacheDir, file, mockManifest);
+
+      const almostStale = new Date(Date.now() - (CACHE_TTL - 1) * 1000);
+      utimesSync(file, almostStale, almostStale);
+
+      expect(tryLoadFromDiskCache(file)).not.toBeNull();
+    });
+  });
+});

--- a/cli/src/__tests__/resolve-list-filters.test.ts
+++ b/cli/src/__tests__/resolve-list-filters.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createMockManifest, createConsoleMocks, restoreMocks } from "./test-helpers";
+import type { SpawnRecord } from "../history";
+
+/**
+ * Tests for the resolveListFilters function in commands.ts (lines 938-968).
+ *
+ * resolveListFilters is an internal async function that:
+ * 1. Loads the manifest (or gracefully handles failure)
+ * 2. Resolves an agentFilter display name to its key
+ * 3. Falls back a bare positional arg from agent to cloud when it doesn't
+ *    match any agent but does match a cloud
+ * 4. Resolves a cloudFilter display name to its key
+ *
+ * This logic is critical because it determines how "spawn list <filter>"
+ * routes the user's filter input to the correct entity type. A bug here
+ * causes empty results for valid inputs.
+ *
+ * Since resolveListFilters is not exported, we test it through cmdList
+ * which calls it at the top of its flow.
+ *
+ * Agent: test-engineer
+ */
+
+const mockManifest = createMockManifest();
+
+// Mock @clack/prompts
+const mockLogError = mock(() => {});
+const mockLogInfo = mock(() => {});
+const mockLogStep = mock(() => {});
+const mockLogSuccess = mock(() => {});
+const mockSpinnerStart = mock(() => {});
+const mockSpinnerStop = mock(() => {});
+
+mock.module("@clack/prompts", () => ({
+  spinner: () => ({
+    start: mockSpinnerStart,
+    stop: mockSpinnerStop,
+    message: mock(() => {}),
+  }),
+  log: {
+    step: mockLogStep,
+    info: mockLogInfo,
+    error: mockLogError,
+    warn: mock(() => {}),
+    success: mockLogSuccess,
+  },
+  intro: mock(() => {}),
+  outro: mock(() => {}),
+  cancel: mock(() => {}),
+  select: mock(() => {}),
+  isCancel: () => false,
+}));
+
+// Import after mock setup
+const { cmdList } = await import("../commands.js");
+const { loadManifest } = await import("../manifest.js");
+
+describe("resolveListFilters (via cmdList)", () => {
+  let testDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+  let consoleMocks: ReturnType<typeof createConsoleMocks>;
+  let originalFetch: typeof global.fetch;
+  let processExitSpy: ReturnType<typeof spyOn>;
+
+  function writeHistory(records: SpawnRecord[]) {
+    writeFileSync(join(testDir, "history.json"), JSON.stringify(records));
+  }
+
+  function consoleOutput(): string {
+    return consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+  }
+
+  function logInfoOutput(): string {
+    return mockLogInfo.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+  }
+
+  const sampleRecords: SpawnRecord[] = [
+    { agent: "claude", cloud: "sprite", timestamp: "2026-01-01T00:00:00Z" },
+    { agent: "aider", cloud: "hetzner", timestamp: "2026-01-02T00:00:00Z" },
+    { agent: "claude", cloud: "hetzner", timestamp: "2026-01-03T00:00:00Z" },
+    { agent: "aider", cloud: "sprite", timestamp: "2026-01-04T00:00:00Z" },
+  ];
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `spawn-resolve-filters-${Date.now()}-${Math.random()}`);
+    mkdirSync(testDir, { recursive: true });
+
+    originalEnv = { ...process.env };
+    process.env.SPAWN_HOME = testDir;
+    process.env.XDG_CACHE_HOME = join(testDir, "cache");
+
+    consoleMocks = createConsoleMocks();
+    mockLogError.mockClear();
+    mockLogInfo.mockClear();
+    mockLogStep.mockClear();
+    mockLogSuccess.mockClear();
+    mockSpinnerStart.mockClear();
+    mockSpinnerStop.mockClear();
+
+    originalFetch = global.fetch;
+
+    // Prime manifest cache
+    global.fetch = mock(() =>
+      Promise.resolve({ ok: true, json: async () => mockManifest }) as any
+    );
+    await loadManifest(true);
+    global.fetch = originalFetch;
+
+    processExitSpy = spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as any);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+    processExitSpy.mockRestore();
+    restoreMocks(consoleMocks.log, consoleMocks.error);
+  });
+
+  // ── Agent key resolution ────────────────────────────────────────────────
+
+  describe("agent filter resolution", () => {
+    it("should resolve exact agent key filter", async () => {
+      writeHistory(sampleRecords);
+      await cmdList("claude");
+      const output = consoleOutput();
+      // "claude" is an exact agent key, should filter to 2 records
+      expect(output).toContain("2 of 4");
+    });
+
+    it("should resolve agent display name to key", async () => {
+      writeHistory(sampleRecords);
+      // "Claude Code" is the display name for agent key "claude"
+      await cmdList("Claude Code");
+      const output = consoleOutput();
+      // Should resolve to "claude" and filter to 2 records
+      expect(output).toContain("2 of 4");
+    });
+
+    it("should resolve case-insensitive agent key", async () => {
+      writeHistory(sampleRecords);
+      await cmdList("CLAUDE");
+      const output = consoleOutput();
+      expect(output).toContain("2 of 4");
+    });
+
+    it("should resolve case-insensitive agent display name", async () => {
+      writeHistory(sampleRecords);
+      await cmdList("claude code");
+      const output = consoleOutput();
+      expect(output).toContain("2 of 4");
+    });
+  });
+
+  // ── Cloud filter resolution ─────────────────────────────────────────────
+
+  describe("cloud filter resolution", () => {
+    it("should resolve exact cloud key filter", async () => {
+      writeHistory(sampleRecords);
+      await cmdList(undefined, "sprite");
+      const output = consoleOutput();
+      // "sprite" is an exact cloud key, should filter to 2 records
+      expect(output).toContain("2 of 4");
+    });
+
+    it("should resolve cloud display name to key", async () => {
+      writeHistory(sampleRecords);
+      // "Hetzner Cloud" is the display name for cloud key "hetzner"
+      await cmdList(undefined, "Hetzner Cloud");
+      const output = consoleOutput();
+      expect(output).toContain("2 of 4");
+    });
+
+    it("should resolve case-insensitive cloud key", async () => {
+      writeHistory(sampleRecords);
+      await cmdList(undefined, "HETZNER");
+      const output = consoleOutput();
+      expect(output).toContain("2 of 4");
+    });
+  });
+
+  // ── Bare positional arg fallback: agent -> cloud ────────────────────────
+
+  describe("bare positional arg fallback (agent filter -> cloud filter)", () => {
+    it("should treat bare arg as cloud filter when it does not match any agent but matches a cloud", async () => {
+      writeHistory(sampleRecords);
+      // "sprite" is a cloud key but NOT an agent key, so the bare positional
+      // arg should fall back from agentFilter to cloudFilter
+      await cmdList("sprite");
+      const output = consoleOutput();
+      // Should find 2 records (claude/sprite and aider/sprite)
+      expect(output).toContain("2 of 4");
+    });
+
+    it("should treat bare arg as cloud filter via display name", async () => {
+      writeHistory(sampleRecords);
+      // "Hetzner Cloud" is a cloud display name, not an agent key
+      await cmdList("Hetzner Cloud");
+      const output = consoleOutput();
+      expect(output).toContain("2 of 4");
+    });
+
+    it("should prefer agent key match over cloud fallback when both exist", async () => {
+      // Create a manifest where a key exists as both agent and cloud display name
+      // In our mock manifest, "claude" is only an agent and "sprite" is only a cloud
+      writeHistory(sampleRecords);
+      await cmdList("claude");
+      const output = consoleOutput();
+      // Should resolve as agent filter (2 records with agent=claude)
+      expect(output).toContain("2 of 4");
+    });
+
+    it("should not fall back to cloud when an explicit cloudFilter is already provided", async () => {
+      writeHistory(sampleRecords);
+      // When both filters are provided, agentFilter should not fall back
+      // "nonexistent" doesn't match any agent or cloud
+      await cmdList("nonexistent", "sprite");
+      // Should show empty results since "nonexistent" doesn't match any agent
+      const info = logInfoOutput();
+      expect(info).toContain("No spawns found");
+    });
+  });
+
+  // ── Unresolvable filter ─────────────────────────────────────────────
+
+  describe("unresolvable filter", () => {
+    it("should show empty results for a filter that does not match any agent or cloud", async () => {
+      writeHistory(sampleRecords);
+
+      await cmdList("zzz-nonexistent");
+      // "zzz-nonexistent" doesn't match any agent or cloud in the manifest
+      // After failed resolution, filterHistory("zzz-nonexistent") returns []
+      const info = logInfoOutput();
+      expect(info).toContain("No spawns found");
+    });
+
+    it("should show the unresolved filter name in the empty message", async () => {
+      writeHistory(sampleRecords);
+
+      await cmdList("totally-unknown");
+      const info = logInfoOutput();
+      expect(info).toContain("totally-unknown");
+    });
+  });
+
+  // ── Both filters combined ──────────────────────────────────────────────
+
+  describe("combined agent + cloud filter resolution", () => {
+    it("should resolve both agent display name and cloud display name", async () => {
+      writeHistory(sampleRecords);
+      await cmdList("Claude Code", "Sprite");
+      const output = consoleOutput();
+      // Should find 1 record (claude/sprite)
+      expect(output).toContain("1 of 4");
+    });
+
+    it("should resolve agent key + cloud display name", async () => {
+      writeHistory(sampleRecords);
+      await cmdList("aider", "Hetzner Cloud");
+      const output = consoleOutput();
+      expect(output).toContain("1 of 4");
+    });
+
+    it("should resolve agent display name + cloud key", async () => {
+      writeHistory(sampleRecords);
+      await cmdList("Aider", "sprite");
+      const output = consoleOutput();
+      expect(output).toContain("1 of 4");
+    });
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("should handle empty string filter", async () => {
+      writeHistory(sampleRecords);
+      await cmdList("");
+      const output = consoleOutput();
+      // Empty string should show all records (filterHistory treats "" as no filter)
+      expect(output).toContain("4 spawns");
+    });
+
+    it("should handle undefined filters", async () => {
+      writeHistory(sampleRecords);
+      await cmdList(undefined, undefined);
+      const output = consoleOutput();
+      expect(output).toContain("4 spawns");
+    });
+
+    it("should show record count correctly for single match", async () => {
+      writeHistory(sampleRecords);
+      await cmdList("claude", "sprite");
+      const output = consoleOutput();
+      expect(output).toContain("1 of 4");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 19 tests for `resolveListFilters` (commands.ts) covering agent/cloud key resolution, display name resolution, case-insensitive matching, bare positional arg agent-to-cloud fallback, and unresolvable filter error paths
- Add 37 tests for manifest cache TTL boundary behavior (manifest.ts) covering `cacheAge`, `tryLoadFromDiskCache`, `readCache`, `writeCache` replicas with TTL boundary conditions, error recovery, and write-read round-trip integrity
- 56 new tests total (5542 overall, up from 5486)

## Test plan
- [x] All 56 new tests pass individually
- [x] Full test suite passes (5542 tests, 0 failures)
- [x] No changes to source code, only test additions

Agent: test-engineer