### PR TITLE
fix: eliminate shell injection via inline API key in run_server commands

### DIFF
--- a/daytona/continue.sh
+++ b/daytona/continue.sh
@@ -29,8 +29,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/e2b/continue.sh
+++ b/e2b/continue.sh
@@ -33,8 +33,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/github-codespaces/continue.sh
+++ b/github-codespaces/continue.sh
@@ -38,8 +38,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/kamatera/nanoclaw.sh
+++ b/kamatera/nanoclaw.sh
@@ -39,8 +39,12 @@ inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-# Write .env file for NanoClaw
-run_server "${KAMATERA_SERVER_IP}" "printf 'ANTHROPIC_API_KEY=%s\n' '${OPENROUTER_API_KEY}' > ~/nanoclaw/.env"
+# Write .env file for NanoClaw (use temp file + upload to avoid inline key injection)
+NANOCLAW_ENV_TEMP=$(mktemp)
+track_temp_file "${NANOCLAW_ENV_TEMP}"
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${NANOCLAW_ENV_TEMP}"
+upload_file "${KAMATERA_SERVER_IP}" "${NANOCLAW_ENV_TEMP}" "/tmp/nanoclaw_env"
+run_server "${KAMATERA_SERVER_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "Kamatera server setup completed successfully!"

--- a/latitude/continue.sh
+++ b/latitude/continue.sh
@@ -32,8 +32,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.bashrc"
-run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.zshrc"
+inject_env_vars_ssh "$LATITUDE_SERVER_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${LATITUDE_SERVER_IP}" \

--- a/modal/continue.sh
+++ b/modal/continue.sh
@@ -32,8 +32,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/scaleway/continue.sh
+++ b/scaleway/continue.sh
@@ -34,8 +34,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.bashrc"
-run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.zshrc"
+inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${SCALEWAY_SERVER_IP}" \

--- a/upcloud/continue.sh
+++ b/upcloud/continue.sh
@@ -31,8 +31,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.bashrc"
-run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.zshrc"
+inject_env_vars_ssh "$UPCLOUD_SERVER_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${UPCLOUD_SERVER_IP}" \


### PR DESCRIPTION
## Summary

- Replace unsafe inline `OPENROUTER_API_KEY` interpolation in `run_server` command strings with the safe `inject_env_vars_ssh`/`inject_env_vars_local` helpers
- A single quote in the API key could break out of the shell quoting and execute arbitrary commands on the remote server
- The safe helpers write env vars to a temp file, upload it, and append to shell config -- avoiding any inline shell interpolation

## Affected Scripts

**continue.sh** (7 files -- used the old pattern of `run_server ... '${OPENROUTER_API_KEY}' >> ~/.bashrc`):
- `scaleway/continue.sh`
- `upcloud/continue.sh`
- `latitude/continue.sh` (worst: completely unquoted `${OPENROUTER_API_KEY}`)
- `modal/continue.sh`
- `e2b/continue.sh`
- `daytona/continue.sh`
- `github-codespaces/continue.sh`

**nanoclaw.sh** (1 file -- used `run_server` with inline API key):
- `kamatera/nanoclaw.sh`

## Fix Pattern

Before (vulnerable):
```bash
run_server "$IP" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
```

After (safe -- uses file upload):
```bash
inject_env_vars_ssh "$IP" upload_file run_server \
    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
```

## Test plan

- [x] `bash -n` passes on all 8 modified scripts
- [x] `bun test` passes (5484/5487, 3 pre-existing failures unrelated to this change)
- [ ] Manual: verify continue.sh scripts still correctly inject env vars on a cloud provider

Note: This supersedes the unmerged PR #602 which identified the same issue.

Agent: security-auditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)