### PR TITLE
refactor: decompose run_test() and load_cloud_keys_from_config()

### DIFF
--- a/test/mock.sh
+++ b/test/mock.sh
@@ -662,41 +662,19 @@ discover_agents() {
 }
 
 # ============================================================
-# Test runner
+# Test runner helpers
 # ============================================================
 
-run_test() {
-    local cloud="$1"
-    local agent="$2"
-    local script_path="${REPO_ROOT}/${cloud}/${agent}.sh"
-
-    if [[ ! -f "$script_path" ]]; then
-        printf '%b\n' "  ${YELLOW}skip${NC} ${cloud}/${agent}.sh — file not found"
-        SKIPPED=$((SKIPPED + 1))
-        return 0
-    fi
-
-    printf '%b\n' "  ${CYAN}test${NC} ${cloud}/${agent}.sh"
-
-    # Snapshot failure count before this test's assertions
-    local _pre_failed="${FAILED}"
-
-    # Reset mock log
-    : > "${MOCK_LOG}"
-
-    # Set up environment
-    setup_env_for_cloud "$cloud"
-
-    # Fake HOME to avoid polluting real home
-    local fake_home
-    fake_home=$(setup_fake_home)
-
-    # Set up state file for state tracking
-    local state_file="${TEST_DIR}/state_${cloud}_${agent}.log"
-    : > "${state_file}"
-
-    # Run the script with mocked PATH + HOME (10s timeout — all calls are fake)
-    local exit_code=0
+# Run a script in background with a timeout (4 seconds).
+# Sets exit code via nameref. Returns 0 always.
+# Usage: _run_script_with_timeout SCRIPT_PATH CLOUD STATE_FILE FAKE_HOME EXIT_CODE_VAR
+_run_script_with_timeout() {
+    local script_path="$1"
+    local cloud="$2"
+    local state_file="$3"
+    local fake_home="$4"
+    local -n _exit_code="$5"
+    _exit_code=0
 
     MOCK_LOG="${MOCK_LOG}" \
     MOCK_FIXTURE_DIR="${FIXTURES_DIR}/${cloud}" \
@@ -715,17 +693,18 @@ run_test() {
         if [[ "$i" -ge 4 ]]; then
             kill -9 "$pid" 2>/dev/null
             wait "$pid" 2>/dev/null || true
-            exit_code=124
-            break
+            _exit_code=124
+            return 0
         fi
         sleep 1
         i=$((i + 1))
     done
-    if [[ "$exit_code" -ne 124 ]]; then
-        wait "$pid" 2>/dev/null || exit_code=$?
-    fi
+    wait "$pid" 2>/dev/null || _exit_code=$?
+}
 
-    # Show last lines of output on failure
+# Print last 20 lines of output on failure
+_show_failure_output() {
+    local exit_code="$1"
     if [[ "${exit_code}" -ne 0 ]]; then
         printf '%b\n' "    ${RED}--- output (last 20 lines) ---${NC}"
         tail -20 "${TEST_DIR}/output.log" 2>/dev/null | while IFS= read -r line; do
@@ -733,30 +712,32 @@ run_test() {
         done
         printf '%b\n' "    ${RED}--- end output ---${NC}"
     fi
+}
 
-    # --- Assertions ---
-    if [[ -n "${MOCK_ERROR_SCENARIO:-}" ]]; then
-        # Error scenarios: expect non-zero exit
-        if [[ "${exit_code}" -ne 0 ]]; then
-            printf '%b\n' "    ${GREEN}✓${NC} fails on ${MOCK_ERROR_SCENARIO} (exit code ${exit_code})"
-            PASSED=$((PASSED + 1))
-            if [[ -n "${RESULTS_FILE:-}" ]]; then
-                printf '%s/%s:pass\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
-            fi
-        else
-            printf '%b\n' "    ${RED}✗${NC} should fail on ${MOCK_ERROR_SCENARIO} but exited 0"
-            FAILED=$((FAILED + 1))
-            if [[ -n "${RESULTS_FILE:-}" ]]; then
-                printf '%s/%s:fail\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
-            fi
-        fi
-        printf '\n'
-        return 0
+# Handle error scenario assertion (expects non-zero exit).
+# Returns 0 if this was an error scenario (caller should return), 1 otherwise.
+_assert_error_scenario() {
+    local exit_code="$1"
+    local cloud="$2"
+    local agent="$3"
+
+    [[ -n "${MOCK_ERROR_SCENARIO:-}" ]] || return 1
+
+    if [[ "${exit_code}" -ne 0 ]]; then
+        printf '%b\n' "    ${GREEN}✓${NC} fails on ${MOCK_ERROR_SCENARIO} (exit code ${exit_code})"
+        PASSED=$((PASSED + 1))
+        _record_test_result "${cloud}" "${agent}" "pass"
+    else
+        printf '%b\n' "    ${RED}✗${NC} should fail on ${MOCK_ERROR_SCENARIO} but exited 0"
+        FAILED=$((FAILED + 1))
+        _record_test_result "${cloud}" "${agent}" "fail"
     fi
+    return 0
+}
 
-    assert_exit_code "${exit_code}" 0 "exits successfully"
-
-    # Cloud-specific API call assertions
+# Assert cloud-specific API calls were made
+_assert_cloud_api_calls() {
+    local cloud="$1"
     case "$cloud" in
         hetzner)
             assert_api_called "GET" "/ssh_keys" "fetches SSH keys"
@@ -786,31 +767,78 @@ run_test() {
             assert_log_contains "curl (GET|POST) https://" "makes API calls"
             ;;
     esac
+}
 
-    # Check that SSH was used (for remote execution)
+# Record pass/fail result to RESULTS_FILE if set
+_record_test_result() {
+    local cloud="$1"
+    local agent="$2"
+    local result="$3"
+    if [[ -n "${RESULTS_FILE:-}" ]]; then
+        printf '%s/%s:%s\n' "${cloud}" "${agent}" "${result}" >> "${RESULTS_FILE}"
+    fi
+}
+
+# ============================================================
+# Test runner
+# ============================================================
+
+run_test() {
+    local cloud="$1"
+    local agent="$2"
+    local script_path="${REPO_ROOT}/${cloud}/${agent}.sh"
+
+    if [[ ! -f "$script_path" ]]; then
+        printf '%b\n' "  ${YELLOW}skip${NC} ${cloud}/${agent}.sh — file not found"
+        SKIPPED=$((SKIPPED + 1))
+        return 0
+    fi
+
+    printf '%b\n' "  ${CYAN}test${NC} ${cloud}/${agent}.sh"
+
+    local _pre_failed="${FAILED}"
+
+    # Reset mock log and set up environment
+    : > "${MOCK_LOG}"
+    setup_env_for_cloud "$cloud"
+
+    local fake_home
+    fake_home=$(setup_fake_home)
+
+    local state_file="${TEST_DIR}/state_${cloud}_${agent}.log"
+    : > "${state_file}"
+
+    # Run script with timeout
+    local exit_code
+    _run_script_with_timeout "${script_path}" "${cloud}" "${state_file}" "${fake_home}" exit_code
+
+    _show_failure_output "${exit_code}"
+
+    # Error scenario: assert failure and return early
+    if _assert_error_scenario "${exit_code}" "${cloud}" "${agent}"; then
+        printf '\n'
+        return 0
+    fi
+
+    # Normal scenario assertions
+    assert_exit_code "${exit_code}" 0 "exits successfully"
+    _assert_cloud_api_calls "$cloud"
     assert_log_contains "ssh " "uses SSH"
-
-    # Check OpenRouter API key injection
     assert_env_injected "OPENROUTER_API_KEY"
 
-    # Body validation (when enabled)
     if [[ "${MOCK_VALIDATE_BODY:-}" == "1" ]]; then
         assert_no_body_errors
     fi
-
-    # State tracking (when enabled)
     if [[ "${MOCK_TRACK_STATE:-}" == "1" ]]; then
         assert_server_cleaned_up "${state_file}"
     fi
 
-    # Write per-test result to RESULTS_FILE (used by qa-dry-run.sh / qa-cycle.sh)
-    if [[ -n "${RESULTS_FILE:-}" ]]; then
-        local pre_fail=$((FAILED - _pre_failed))
-        if [[ "$pre_fail" -gt 0 ]]; then
-            printf '%s/%s:fail\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
-        else
-            printf '%s/%s:pass\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
-        fi
+    # Record result
+    local pre_fail=$((FAILED - _pre_failed))
+    if [[ "$pre_fail" -gt 0 ]]; then
+        _record_test_result "${cloud}" "${agent}" "fail"
+    else
+        _record_test_result "${cloud}" "${agent}" "pass"
     fi
 
     printf '\n'


### PR DESCRIPTION
## Summary

- **test/mock.sh**: Decomposed `run_test()` from 149 lines into 59 lines (60% reduction) by extracting 5 focused helpers:
  - `_run_script_with_timeout()` — script execution with 4s timeout
  - `_show_failure_output()` — display last 20 lines on failure
  - `_assert_error_scenario()` — error scenario assertion logic
  - `_assert_cloud_api_calls()` — cloud-specific API call assertions (case block)
  - `_record_test_result()` — write pass/fail to RESULTS_FILE

- **shared/key-request.sh**: Decomposed `load_cloud_keys_from_config()` from 81 lines into 47 lines (42% reduction) by extracting:
  - `_try_load_var_from_config()` — load a single env var from JSON config
  - `_ensure_cloud_vars()` — check/load all env vars for a cloud provider

  This eliminates 4 levels of nesting (while-inside-while-inside-if-inside-if).

## Test plan

- [x] `bash -n test/mock.sh` passes
- [x] `bash -n shared/key-request.sh` passes
- [x] `bash test/mock.sh` produces identical results to main (330 pass, 105 fail, 1 skip)
- [x] `bash test/run.sh` passes (75/75)
- [x] `cd cli && bun test` shows no regressions vs main