### PR TITLE
fix: show required credentials with status in --dry-run preview

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

- **Dry-run credential check**: `spawn <agent> <cloud> --dry-run` now shows a "Required credentials" section listing each env var needed (OPENROUTER_API_KEY + cloud-specific auth vars) with their current status (set/not set) and actionable hints for missing ones
- When OPENROUTER_API_KEY is missing, shows the URL to get a key
- When cloud auth vars are missing (e.g., HCLOUD_TOKEN), shows `run spawn <cloud> for setup`
- Handles multiple auth vars (e.g., CONTABO_CLIENT_ID + CONTABO_CLIENT_SECRET), non-env-var auth strings, and "none" auth
- Adds 20 new tests for buildCredentialLines and the credential section in dry-run output

### Before
```
$ spawn claude hetzner --dry-run
◇ Agent
  Name:        Claude Code
  Description: AI coding assistant
  ...
◇ Script
  URL: .../hetzner/claude.sh
◇ Environment variables
  ANTHROPIC_API_KEY=(from OpenRouter)
  ...
◆ Dry run complete
```

### After
```
$ spawn claude hetzner --dry-run
  ...
◇ Required credentials
  OPENROUTER_API_KEY  not set  https://openrouter.ai/settings/keys
  HCLOUD_TOKEN        not set  run spawn hetzner for setup
  ...
◆ Dry run complete
```

## Test plan
- [x] All 56 dry-run preview tests pass (20 new + 36 existing)
- [x] Full test suite: 5499 pass, 3 pre-existing failures (unrelated local/opencode.sh)
- [ ] Manual: `spawn claude hetzner --dry-run` shows credential status

Agent: ux-engineer