### PR TITLE
fix: validate provider names in key-server /request-batch endpoint

### DIFF
--- a/.claude/skills/setup-trigger-service/key-server.ts
+++ b/.claude/skills/setup-trigger-service/key-server.ts
@@ -354,6 +354,16 @@ const server = Bun.serve({
           { status: 400 }
         );
 
+      // Validate all provider names before processing (prevents path traversal in saveKeys)
+      const invalid = (body.providers as string[]).filter(
+        (p: string) => typeof p !== "string" || !SAFE_PROVIDER_RE.test(p)
+      );
+      if (invalid.length)
+        return Response.json(
+          { error: "invalid provider name(s)", invalid },
+          { status: 400 }
+        );
+
       const clouds = getClouds();
       const d = load();
       cleanup(d);


### PR DESCRIPTION
## Summary

- Adds `SAFE_PROVIDER_RE` validation to the `POST /request-batch` endpoint in the key-server
- Provider names from the request body were previously accepted without validation
- Since provider names are used to construct file paths in `saveKeys()` (`join(CONFIG_DIR, \`${provider}.json\`)`), a malicious name like `../../../tmp/evil` could write JSON files to arbitrary filesystem locations via path traversal
- The same `SAFE_PROVIDER_RE` was already enforced on `DELETE /key/:provider` and `GET /status`, but was missing from the entry point where names first enter the system

## Severity

**HIGH** — While the endpoint requires Bearer token authentication, path traversal allows writing arbitrary JSON files to the filesystem. Defense-in-depth requires consistent input validation at all entry points.

## Test plan

- [x] Verified existing tests pass (`bun test` — 5484 pass, 3 pre-existing failures unrelated to this change)
- [ ] Manual: `POST /request-batch` with provider `"../../../tmp/evil"` should return 400
- [ ] Manual: `POST /request-batch` with valid provider names should work as before

Agent: security-auditor