### PR TITLE
fix: include prompt in retry command when spawn script fails

### DIFF
--- a/cli/src/__tests__/build-retry-command.test.ts
+++ b/cli/src/__tests__/build-retry-command.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { buildRetryCommand } from "../commands";
+
+/**
+ * Tests for buildRetryCommand() in commands.ts.
+ *
+ * When a spawn script fails, the CLI shows a "Retry:" line with the command
+ * to re-run. Previously this always omitted the --prompt flag, forcing users
+ * to retype their prompt. Now the retry command includes the prompt when one
+ * was used.
+ *
+ * Agent: ux-engineer
+ */
+
+describe("buildRetryCommand", () => {
+  it("should return basic command without prompt", () => {
+    expect(buildRetryCommand("claude", "sprite")).toBe("spawn claude sprite");
+  });
+
+  it("should include short prompt in retry command", () => {
+    expect(buildRetryCommand("claude", "sprite", "Fix all tests")).toBe(
+      'spawn claude sprite --prompt "Fix all tests"'
+    );
+  });
+
+  it("should include prompt up to 80 chars", () => {
+    const prompt = "a".repeat(80);
+    const result = buildRetryCommand("claude", "hetzner", prompt);
+    expect(result).toBe(`spawn claude hetzner --prompt "${prompt}"`);
+  });
+
+  it("should truncate prompt longer than 80 chars", () => {
+    const prompt = "a".repeat(81);
+    const result = buildRetryCommand("claude", "hetzner", prompt);
+    expect(result).toBe('spawn claude hetzner --prompt "..."');
+  });
+
+  it("should escape double quotes in prompt", () => {
+    const result = buildRetryCommand("aider", "vultr", 'Fix the "broken" test');
+    expect(result).toBe('spawn aider vultr --prompt "Fix the \\"broken\\" test"');
+  });
+
+  it("should handle empty string prompt same as no prompt", () => {
+    expect(buildRetryCommand("claude", "sprite", "")).toBe("spawn claude sprite");
+  });
+
+  it("should handle undefined prompt", () => {
+    expect(buildRetryCommand("claude", "sprite", undefined)).toBe("spawn claude sprite");
+  });
+});


### PR DESCRIPTION
## Summary

- When a spawn script fails after running with `--prompt`, the "Retry:" line now includes the original `--prompt` flag so users can re-run without retyping their prompt
- Prompts longer than 80 characters are truncated with a hint to use the Up arrow key to recall the full command
- Adds `buildRetryCommand` helper (exported + tested with 7 new tests)

## Before
```
Retry: spawn claude sprite
```

## After
```
Retry: spawn claude sprite --prompt "Fix all linter errors"
```

For long prompts (>80 chars):
```
Retry: spawn claude sprite --prompt "..."
  (prompt truncated -- use Up arrow to recall your original command)
```

## Test plan
- [x] New tests for `buildRetryCommand` (7 tests): no prompt, short prompt, 80-char boundary, >80 truncation, quote escaping, empty string, undefined
- [x] Existing `script-failure-guidance` tests still pass (46 tests)
- [x] Existing `exec-script-errors` tests still pass (21 tests)
- [x] Full test suite passes (5491 pass, 3 pre-existing failures unrelated to this change)

Agent: ux-engineer