### PR TITLE
fix: show auth requirements in interactive cloud picker

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -67,6 +67,26 @@ function mapToSelectOptions<T extends { name: string; description: string }>(
   }));
 }
 
+function mapCloudSelectOptions(
+  keys: string[],
+  clouds: Record<string, { name: string; description: string; auth: string }>
+): Array<{ value: string; label: string; hint: string }> {
+  return keys.map((key) => {
+    const cloud = clouds[key];
+    const authVars = parseAuthEnvVars(cloud.auth);
+    const authSuffix = authVars.length > 0
+      ? ` (auth: ${authVars.join(", ")})`
+      : cloud.auth.toLowerCase() !== "none"
+        ? ` (auth: ${cloud.auth})`
+        : "";
+    return {
+      value: key,
+      label: cloud.name,
+      hint: cloud.description + authSuffix,
+    };
+  });
+}
+
 export function getImplementedClouds(manifest: Manifest, agent: string): string[] {
   return cloudKeys(manifest).filter(
     (c: string): boolean => matrixStatus(manifest, c, agent) === "implemented"
@@ -299,7 +319,7 @@ export async function cmdInteractive(): Promise<void> {
 
   const cloudChoice = await p.select({
     message: "Select a cloud provider",
-    options: mapToSelectOptions(clouds, manifest.clouds),
+    options: mapCloudSelectOptions(clouds, manifest.clouds),
   });
   if (p.isCancel(cloudChoice)) handleCancel();
 


### PR DESCRIPTION
## Summary
- When running `spawn` interactively and selecting a cloud provider, the picker now shows auth requirements (e.g., `HCLOUD_TOKEN`, `DO_API_TOKEN`) alongside each cloud's description
- Helps users choose clouds they already have credentials for without needing to run `spawn <cloud>` first
- Adds a new `mapCloudSelectOptions` helper that enriches cloud picker hints with auth info extracted from the manifest

## Before
```
Select a cloud provider
  Hetzner Cloud   Cloud VMs from EUR 3.29/mo
  DigitalOcean    Simple cloud computing
```

## After
```
Select a cloud provider
  Hetzner Cloud   Cloud VMs from EUR 3.29/mo (auth: HCLOUD_TOKEN)
  DigitalOcean    Simple cloud computing (auth: DO_API_TOKEN)
```

## Test plan
- [x] All 5484+ existing tests pass (3 pre-existing failures unrelated to this change)
- [x] Interactive mode tests (`cmd-interactive.test.ts`) pass: 15/15
- [x] Helper tests pass: 117/117
- [ ] Manual: run `spawn` with no args and verify auth info shows in cloud picker hints

Agent: ux-engineer