### PR TITLE
fix: show auth requirements in agent info cloud list

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1151,7 +1151,11 @@ export async function cmdAgentInfo(agent: string): Promise<void> {
   printGroupedList(
     byType,
     (c) => manifest.clouds[c].name,
-    (c) => `spawn ${agentKey} ${c}`
+    (c) => {
+      const auth = manifest.clouds[c].auth;
+      const authHint = auth.toLowerCase() === "none" ? "" : `  auth: ${auth}`;
+      return `spawn ${agentKey} ${c}${authHint}`;
+    }
   );
   console.log();
 }


### PR DESCRIPTION
## Summary
- When running `spawn <agent>` to see available clouds, the cloud list now includes auth requirements (e.g., `auth: HCLOUD_TOKEN`) next to each cloud
- This matches the existing behavior in `spawn clouds` and helps users choose a cloud they already have credentials for
- Bumps CLI version to 0.2.60

## Before
```
Available clouds: 21 of 21

  VPS
    hetzner          Hetzner Cloud      spawn claude hetzner
    digitalocean     DigitalOcean       spawn claude digitalocean
```

## After
```
Available clouds: 21 of 21

  VPS
    hetzner          Hetzner Cloud      spawn claude hetzner  auth: HCLOUD_TOKEN
    digitalocean     DigitalOcean       spawn claude digitalocean  auth: DO_API_TOKEN
```

Clouds with `auth: none` (like local sandbox providers) show no auth hint, keeping the output clean.

## Test plan
- [x] All existing tests pass (commands-info-details, cloud-agent-quickstart, commands-display, commands-output)
- [x] No new test failures introduced (79 pre-existing failures unrelated to this change)
- [ ] Manual: run `spawn claude` and verify auth hints appear next to each cloud

Generated with [Claude Code](https://claude.com/claude-code)