### PR TITLE
fix: improve UX with actionable hints for prompts, cleanup, and errors

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -210,10 +210,11 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("may still be running");
     });
 
-    it("should suggest checking cloud provider dashboard", () => {
+    it("should suggest running spawn <cloud> for cleanup instructions", () => {
       const lines = getScriptFailureGuidance(130, "sprite");
       const joined = lines.join("\n");
-      expect(joined).toContain("cloud provider dashboard");
+      expect(joined).toContain("spawn sprite");
+      expect(joined).toContain("cleanup instructions");
     });
 
     it("should return exactly 3 guidance lines", () => {
@@ -244,10 +245,11 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("larger instance size");
     });
 
-    it("should suggest checking cloud provider dashboard", () => {
+    it("should suggest running spawn <cloud> for cleanup instructions", () => {
       const lines = getScriptFailureGuidance(137, "sprite");
       const joined = lines.join("\n");
-      expect(joined).toContain("cloud provider dashboard");
+      expect(joined).toContain("spawn sprite");
+      expect(joined).toContain("cleanup instructions");
     });
 
     it("should return exactly 4 guidance lines", () => {

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -307,6 +307,7 @@ export async function cmdInteractive(): Promise<void> {
   const cloudName = manifest.clouds[cloudChoice].name;
   p.log.step(`Launching ${pc.bold(agentName)} on ${pc.bold(cloudName)}`);
   p.log.info(`Next time, run directly: ${pc.cyan(`spawn ${agentChoice} ${cloudChoice}`)}`);
+  p.log.info(`Or with a prompt:        ${pc.cyan(`spawn ${agentChoice} ${cloudChoice} -p "your task"`)}`);
   p.outro("Handing off to spawn script...");
 
   await execScript(cloudChoice, agentChoice, undefined, getAuthHint(manifest, cloudChoice));
@@ -534,14 +535,14 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
       return [
         "Script was interrupted (Ctrl+C).",
         "Note: If a server was already created, it may still be running.",
-        "  Check your cloud provider dashboard to stop or delete any unused servers.",
+        `  Run ${pc.cyan(`spawn ${cloud}`)} for dashboard and cleanup instructions.`,
       ];
     case 137:
       return [
         "Script was killed (likely by the system due to timeout or out of memory).",
         "  - The server may not have enough RAM for this agent",
         "  - Try a larger instance size or a different cloud provider",
-        "  - Check your cloud provider dashboard to stop or delete any unused servers",
+        `  - Run ${pc.cyan(`spawn ${cloud}`)} for dashboard and cleanup instructions`,
       ];
     case 255:
       return [
@@ -1135,6 +1136,9 @@ export async function cmdAgentInfo(agent: string): Promise<void> {
       console.log(`  ${pc.cyan(`export ${authVars[0]}=...`)}${hint}`);
     }
     console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
+    console.log();
+    console.log(pc.bold("Non-interactive:"));
+    console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud} --prompt "Fix the failing tests"`)}`);
   }
 
   console.log();
@@ -1179,6 +1183,9 @@ function printCloudQuickStart(
   }
   if (exampleAgent) {
     console.log(`  ${pc.cyan(`spawn ${exampleAgent} ${cloudKey}`)}`);
+    console.log();
+    console.log(pc.bold("Non-interactive:"));
+    console.log(`  ${pc.cyan(`spawn ${exampleAgent} ${cloudKey} --prompt "Fix the failing tests"`)}`);
   }
 }
 

--- a/cli/src/security.ts
+++ b/cli/src/security.ts
@@ -95,8 +95,8 @@ export function validatePrompt(prompt: string): void {
   const MAX_PROMPT_LENGTH = 10 * 1024;
   if (prompt.length > MAX_PROMPT_LENGTH) {
     throw new Error(
-      `Prompt exceeds maximum length of ${MAX_PROMPT_LENGTH} characters (${prompt.length} given).\n` +
-      `For longer prompts, use --prompt-file to read from a file instead.`
+      `Prompt exceeds maximum length of ${MAX_PROMPT_LENGTH.toLocaleString()} characters (${prompt.length.toLocaleString()} given).\n` +
+      `Try shortening your prompt or breaking the task into smaller steps.`
     );
   }
 


### PR DESCRIPTION
## Summary
- Add `--prompt` usage hint to interactive mode so users learn about non-interactive execution
- Add "Non-interactive" section to `spawn <agent>` and `spawn <cloud>` info pages showing `--prompt` usage
- Replace vague "check your cloud provider dashboard" with actionable `spawn <cloud>` command in Ctrl+C (exit 130) and OOM (exit 137) error messages
- Fix misleading `--prompt-file` suggestion in prompt length error (both `--prompt` and `--prompt-file` share the same 10KB limit)
- Format prompt length numbers with locale separators for readability (e.g., "10,240" instead of "10240")

## Test plan
- [x] All 5483 tests pass (4 pre-existing failures unrelated to this PR)
- [x] `script-failure-guidance.test.ts` updated for new message wording (60/60 pass)
- [x] Security tests pass (30/30)
- [x] Version bumped to 0.2.60

Agent: ux-engineer