### PR TITLE
refactor: reduce complexity in ramnode, scaleway, and latitude cloud libs

### DIFF
--- a/ramnode/lib/common.sh
+++ b/ramnode/lib/common.sh
@@ -214,43 +214,9 @@ for f in flavors:
 "
 }
 
-# Interactive flavor picker
+# Interactive flavor picker — delegates to shared interactive_pick
 _pick_flavor() {
-    if [[ -n "${RAMNODE_FLAVOR:-}" ]]; then
-        echo "$RAMNODE_FLAVOR"
-        return
-    fi
-
-    log_info "Fetching available instance types..."
-    local flavors
-    flavors=$(_list_flavors)
-
-    if [[ -z "$flavors" ]]; then
-        log_warn "Could not fetch flavors, using default: 1GB"
-        echo "1GB"
-        return
-    fi
-
-    log_info "Available instance types:"
-    local i=1
-    local names=()
-    while IFS='|' read -r name cores ram disk; do
-        printf "  %2d) %-12s  %-8s  %-12s  %s\n" "$i" "$name" "$cores" "$ram" "$disk" >&2
-        names+=("$name")
-        i=$((i + 1))
-    done <<< "$flavors"
-
-    local choice
-    printf "\n" >&2
-    choice=$(safe_read "Select instance type [1]: ") || choice=""
-    choice="${choice:-1}"
-
-    if [[ "$choice" -ge 1 && "$choice" -le "${#names[@]}" ]] 2>/dev/null; then
-        echo "${names[$((choice - 1))]}"
-    else
-        log_warn "Invalid choice, using default: 1GB"
-        echo "1GB"
-    fi
+    interactive_pick "RAMNODE_FLAVOR" "1GB" "instance types" _list_flavors
 }
 
 # List available images

--- a/scaleway/lib/common.sh
+++ b/scaleway/lib/common.sh
@@ -192,27 +192,8 @@ get_server_name() {
     get_validated_server_name "SCALEWAY_SERVER_NAME" "Enter server name: "
 }
 
-# Parse Scaleway server response to extract public IP address
-_scaleway_extract_ip() {
-    python3 -c "
-import json, sys
-server = json.loads(sys.stdin.read())['server']
-ip = server.get('public_ip', {})
-if ip:
-    print(ip.get('address', ''))
-else:
-    ips = server.get('public_ips', [])
-    for pip in ips:
-        if pip.get('address'):
-            print(pip['address'])
-            sys.exit(0)
-    print('')
-"
-}
-
-# Power on and wait for Scaleway instance to become running with a public IP
-# Sets SCALEWAY_SERVER_IP on success
-_scaleway_power_on_and_wait() {
+# Power on a Scaleway instance
+_scaleway_power_on() {
     local server_id="$1"
 
     log_step "Powering on instance..."
@@ -224,32 +205,19 @@ _scaleway_power_on_and_wait() {
     else
         log_warn "Power on may have failed, checking status..."
     fi
+}
 
-    log_step "Waiting for instance to become active..."
-    local max_attempts=60
-    local attempt=1
-    while [[ "$attempt" -le "$max_attempts" ]]; do
-        local status_response
-        status_response=$(scaleway_instance_api GET "/servers/$server_id")
-        local state
-        state=$(echo "$status_response" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['server']['state'])")
+# Power on and wait for Scaleway instance to become running with a public IP
+# Sets SCALEWAY_SERVER_IP on success
+_scaleway_power_on_and_wait() {
+    local server_id="$1"
 
-        if [[ "$state" == "running" ]]; then
-            SCALEWAY_SERVER_IP=$(echo "$status_response" | _scaleway_extract_ip)
-            if [[ -n "$SCALEWAY_SERVER_IP" ]]; then
-                export SCALEWAY_SERVER_IP
-                log_info "Instance active: IP=$SCALEWAY_SERVER_IP"
-                return 0
-            fi
-        fi
+    _scaleway_power_on "$server_id"
 
-        log_step "Instance state: $state ($attempt/$max_attempts)"
-        sleep "${INSTANCE_STATUS_POLL_DELAY}"
-        attempt=$((attempt + 1))
-    done
-
-    log_error "Instance did not become active in time"
-    return 1
+    generic_wait_for_instance scaleway_instance_api "/servers/$server_id" "running" \
+        "d['server']['state']" \
+        "(d['server'].get('public_ip') or {}).get('address','') or next((p['address'] for p in d['server'].get('public_ips',[]) if p.get('address')),'')" \
+        SCALEWAY_SERVER_IP "Scaleway instance" 60
 }
 
 create_server() {


### PR DESCRIPTION
## Summary

Reduces complexity in 3 cloud provider libraries by replacing custom polling loops and selection logic with shared helpers from `shared/common.sh`.

### Changes

- **ramnode/lib/common.sh**: Replace 37-line custom `_pick_flavor` interactive picker with a one-line call to shared `interactive_pick` helper
- **scaleway/lib/common.sh**: Split `_scaleway_power_on_and_wait` (39 lines) into a focused `_scaleway_power_on` function + `generic_wait_for_instance` call. Remove unused `_scaleway_extract_ip` helper (IP extraction now inline in the `generic_wait_for_instance` call)
- **latitude/lib/common.sh**: Replace `wait_for_server_ready` (38 lines) + `extract_latitude_server_ip` (34 lines) with a single `generic_wait_for_instance` call using inline Python expressions for status normalization (`on`/`active` -> `on`) and multi-fallback IP extraction

### Impact

- **-132 net lines** (19 added, 151 removed)
- All Python expressions tested in isolation for correctness
- All modified files pass `bash -n` syntax check
- CLI tests pass (5484 pass, 3 pre-existing failures unrelated to this change)

### Verification

- Scaleway IP extraction handles: `public_ip.address`, `public_ips[].address`, and no-IP cases
- Latitude status normalization maps both `"on"` and `"active"` to target `"on"`
- Latitude IP extraction handles: `network.ip`, `ip_addresses[]` (dict and string), `primary_ipv4`, and IPv6 filtering

Agent: complexity-hunter