### PR TITLE
fix: replace unsafe heredoc JSON with json_escape in 4 scripts

### DIFF
--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -54,48 +54,10 @@ inject_env_vars_fly \
     "CLAUDE_CODE_ENABLE_TELEMETRY=0" \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
-# 7. Configure Claude Code settings
-log_step "Configuring Claude Code..."
-
-run_server "mkdir -p ~/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch ~/.claude/CLAUDE.md"
+# 7. Configure Claude Code settings (uses json_escape for safe API key handling)
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file" \
+    "run_server"
 
 echo ""
 log_info "Fly.io machine setup completed successfully!"

--- a/koyeb/claude.sh
+++ b/koyeb/claude.sh
@@ -54,48 +54,10 @@ inject_env_vars \
     "CLAUDE_CODE_ENABLE_TELEMETRY=0" \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
-# 7. Configure Claude Code settings
-log_step "Configuring Claude Code..."
-
-run_server "mkdir -p /root/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch /root/.claude/CLAUDE.md"
+# 7. Configure Claude Code settings (uses json_escape for safe API key handling)
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file" \
+    "run_server"
 
 echo ""
 log_info "Koyeb service setup completed successfully!"

--- a/local/continue.sh
+++ b/local/continue.sh
@@ -52,24 +52,10 @@ log_step "Appending environment variables to ~/.zshrc..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-# 6. Configure Continue
-log_step "Configuring Continue..."
-CONTINUE_CONFIG_DIR="${HOME}/.continue"
-mkdir -p "${CONTINUE_CONFIG_DIR}"
-
-cat > "${CONTINUE_CONFIG_DIR}/config.json" <<EOF
-{
-  "models": [
-    {
-      "title": "OpenRouter",
-      "provider": "openrouter",
-      "model": "openrouter/auto",
-      "apiBase": "https://openrouter.ai/api/v1",
-      "apiKey": "${OPENROUTER_API_KEY}"
-    }
-  ]
-}
-EOF
+# 6. Configure Continue (uses json_escape for safe API key handling)
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file" \
+    "run_server"
 
 echo ""
 log_info "Local setup completed successfully!"

--- a/railway/claude.sh
+++ b/railway/claude.sh
@@ -54,48 +54,10 @@ inject_env_vars \
     "CLAUDE_CODE_ENABLE_TELEMETRY=0" \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
-# 7. Configure Claude Code settings
-log_step "Configuring Claude Code..."
-
-run_server "mkdir -p /root/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch /root/.claude/CLAUDE.md"
+# 7. Configure Claude Code settings (uses json_escape for safe API key handling)
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file" \
+    "run_server"
 
 echo ""
 log_info "Railway service setup completed successfully!"


### PR DESCRIPTION
## Summary

- **Security fix**: 3 claude.sh scripts (railway, fly, koyeb) and local/continue.sh embedded OPENROUTER_API_KEY directly into JSON via shell heredocs without using json_escape, creating a potential JSON injection vulnerability if the API key contained double quotes, backslashes, or other JSON-special characters
- Refactored all 4 scripts to use the shared setup_claude_code_config / setup_continue_config helpers which properly use json_escape for safe API key embedding
- This also eliminates ~130 lines of duplicated config setup code, making the scripts consistent with the rest of the codebase

## Details

The vulnerable pattern embedded the API key directly in a heredoc:
    cat > settings.json << EOF
    { "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}" }
    EOF

The safe pattern (used by all other scripts) calls the shared helper which uses json_escape (python3 json.dumps) to safely encode the API key value.

## Affected files
- railway/claude.sh
- fly/claude.sh
- koyeb/claude.sh
- local/continue.sh

## Test plan
- [x] All 4 modified scripts pass bash -n syntax check
- [ ] Verify setup_claude_code_config and setup_continue_config work with these providers upload_file/run_server signatures (no IP argument)

Agent: security-auditor