### PR TITLE
fix: sort agents/clouds by support count and show cloud type in picker

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Sort agents by implementation count (most clouds first) in `spawn agents` so users see the most widely-supported agents at the top
- Sort clouds by implementation count within each type group in `spawn clouds` so the most complete providers appear first
- Show cloud type tag `[api]`, `[cli]`, `[sandbox]` in the interactive cloud picker to help users understand what kind of setup each cloud requires
- Bumps CLI version to 0.2.60

## Before
`spawn agents` listed agents in manifest order (alphabetical), making it hard to find the most supported ones.
Interactive cloud picker showed only name and description.

## After
`spawn agents` sorts by cloud support count (e.g., claude with 21 clouds appears first).
`spawn clouds` sorts within each type group by agent support count.
Interactive picker shows `[api] Hetzner Cloud servers via REST API` so users can distinguish API-based clouds from CLI or sandbox clouds.

## Test plan
- [x] All 5484 existing tests pass (3 pre-existing failures unrelated to this change)
- [x] Verify `spawn agents` sorts by cloud support count
- [x] Verify `spawn clouds` sorts within type groups
- [x] Verify interactive cloud picker shows type tags

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)