### PR TITLE
refactor: extract helpers from run_test() and record_cloud()

### DIFF
--- a/test/record.sh
+++ b/test/record.sh
@@ -764,100 +764,82 @@ print(json.dumps(body))
     printf '%b\n' "  ${CYAN}live${NC} Instance ${instance_id} deleted"
 }
 
-# --- Record one cloud ---
-record_cloud() {
+# --- Ensure credentials are available for a cloud, prompting if needed ---
+# Returns 0 if credentials are available, 1 if skipped
+_ensure_cloud_credentials() {
     local cloud="$1"
 
-    if ! has_credentials "$cloud"; then
-        local env_var
-        env_var=$(get_auth_env_var "$cloud")
-        if [[ "$PROMPT_FOR_CREDS" == "true" ]]; then
-            printf '%b\n' "${CYAN}━━━ ${cloud} ━━━${NC}"
-            printf '%b\n' "  ${YELLOW}missing${NC} ${env_var}"
-            if ! prompt_credentials "$cloud"; then
-                printf '%b\n' "  ${YELLOW}skip${NC} ${cloud}"
-                SKIPPED=$((SKIPPED + 1))
-                return 0
-            fi
-        else
-            printf '%b\n' "  ${YELLOW}skip${NC} ${cloud} — ${env_var} not set"
-            SKIPPED=$((SKIPPED + 1))
-            return 0
-        fi
+    if has_credentials "$cloud"; then
+        return 0
     fi
 
-    printf '%b\n' "${CYAN}━━━ Recording ${cloud} ━━━${NC}"
+    local env_var
+    env_var=$(get_auth_env_var "$cloud")
 
-    # Create fixture directory
-    local fixture_dir="${FIXTURES_DIR}/${cloud}"
-    mkdir -p "$fixture_dir"
-
-    # Source the cloud's lib in a subshell to avoid namespace collisions
-    # Capture results via temp files
-    local endpoints
-    endpoints=$(get_endpoints "$cloud")
-
-    local cloud_recorded=0
-    local cloud_errors=0
-    local metadata_entries=""
-
-    while IFS=: read -r fixture_name endpoint; do
-        [[ -z "$fixture_name" ]] && continue
-
-        local response=""
-        local record_ok=false
-
-        # Call API in a subshell that sources the cloud lib
-        local tmp_response
-        tmp_response=$(mktemp /tmp/spawn-record-XXXXXX)
-
-        (
-            # Source cloud lib (this also sources shared/common.sh)
-            source "${REPO_ROOT}/${cloud}/lib/common.sh" 2>/dev/null
-
-            # Suppress any interactive prompts by ensuring tokens are loaded
-            # The API call itself uses env vars directly
-            call_api "$cloud" "$endpoint" 2>/dev/null
-        ) > "$tmp_response" 2>/dev/null || true
-
-        response=$(cat "$tmp_response")
-        rm -f "$tmp_response"
-
-        if [[ -z "$response" ]]; then
-            printf '%b\n' "  ${RED}fail${NC} ${fixture_name} — empty response"
-            cloud_errors=$((cloud_errors + 1))
-            continue
+    if [[ "$PROMPT_FOR_CREDS" == "true" ]]; then
+        printf '%b\n' "${CYAN}━━━ ${cloud} ━━━${NC}"
+        printf '%b\n' "  ${YELLOW}missing${NC} ${env_var}"
+        if prompt_credentials "$cloud"; then
+            return 0
         fi
+        printf '%b\n' "  ${YELLOW}skip${NC} ${cloud}"
+    else
+        printf '%b\n' "  ${YELLOW}skip${NC} ${cloud} — ${env_var} not set"
+    fi
 
-        if ! echo "$response" | is_valid_json; then
-            printf '%b\n' "  ${RED}fail${NC} ${fixture_name} — invalid JSON"
-            cloud_errors=$((cloud_errors + 1))
-            continue
-        fi
+    SKIPPED=$((SKIPPED + 1))
+    return 1
+}
 
-        if has_api_error "$cloud" "$response"; then
-            printf '%b\n' "  ${RED}fail${NC} ${fixture_name} — API error response"
-            cloud_errors=$((cloud_errors + 1))
-            continue
-        fi
+# --- Record a single endpoint fixture via subshell API call ---
+# Updates cloud_recorded, cloud_errors, metadata_entries in caller scope
+_record_endpoint() {
+    local cloud="$1" fixture_dir="$2" fixture_name="$3" endpoint="$4"
 
-        # Save pretty-printed fixture
-        echo "$response" | pretty_json > "${fixture_dir}/${fixture_name}.json"
-        printf '%b\n' "  ${GREEN}  ok${NC} ${fixture_name} → fixtures/${cloud}/${fixture_name}.json"
-        cloud_recorded=$((cloud_recorded + 1))
+    local tmp_response
+    tmp_response=$(mktemp /tmp/spawn-record-XXXXXX)
 
-        # Build metadata entry
-        local timestamp
-        timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        metadata_entries="${metadata_entries}    \"${fixture_name}\": {\"endpoint\": \"${endpoint}\", \"recorded_at\": \"${timestamp}\"},
+    (
+        source "${REPO_ROOT}/${cloud}/lib/common.sh" 2>/dev/null
+        call_api "$cloud" "$endpoint" 2>/dev/null
+    ) > "$tmp_response" 2>/dev/null || true
+
+    local response
+    response=$(cat "$tmp_response")
+    rm -f "$tmp_response"
+
+    if [[ -z "$response" ]]; then
+        printf '%b\n' "  ${RED}fail${NC} ${fixture_name} — empty response"
+        cloud_errors=$((cloud_errors + 1))
+        return 1
+    fi
+
+    if ! echo "$response" | is_valid_json; then
+        printf '%b\n' "  ${RED}fail${NC} ${fixture_name} — invalid JSON"
+        cloud_errors=$((cloud_errors + 1))
+        return 1
+    fi
+
+    if has_api_error "$cloud" "$response"; then
+        printf '%b\n' "  ${RED}fail${NC} ${fixture_name} — API error response"
+        cloud_errors=$((cloud_errors + 1))
+        return 1
+    fi
+
+    echo "$response" | pretty_json > "${fixture_dir}/${fixture_name}.json"
+    printf '%b\n' "  ${GREEN}  ok${NC} ${fixture_name} → fixtures/${cloud}/${fixture_name}.json"
+    cloud_recorded=$((cloud_recorded + 1))
+
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    metadata_entries="${metadata_entries}    \"${fixture_name}\": {\"endpoint\": \"${endpoint}\", \"recorded_at\": \"${timestamp}\"},
 "
-    done <<< "$endpoints"
+}
 
-    # --- Live create+delete cycle for write endpoint fixtures ---
-    # || true prevents set -e from killing the whole script if one cloud's live cycle fails
-    _record_live_cycle "$cloud" "$fixture_dir" cloud_recorded cloud_errors metadata_entries || true
+# --- Write metadata JSON for recorded fixtures ---
+_write_fixture_metadata() {
+    local cloud="$1" fixture_dir="$2"
 
-    # Write metadata
     local meta_timestamp
     meta_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -873,6 +855,35 @@ ${metadata_entries}
   }
 }
 METADATA_EOF
+}
+
+# --- Record one cloud ---
+record_cloud() {
+    local cloud="$1"
+
+    _ensure_cloud_credentials "$cloud" || return 0
+
+    printf '%b\n' "${CYAN}━━━ Recording ${cloud} ━━━${NC}"
+
+    local fixture_dir="${FIXTURES_DIR}/${cloud}"
+    mkdir -p "$fixture_dir"
+
+    local endpoints
+    endpoints=$(get_endpoints "$cloud")
+
+    local cloud_recorded=0
+    local cloud_errors=0
+    local metadata_entries=""
+
+    while IFS=: read -r fixture_name endpoint; do
+        [[ -z "$fixture_name" ]] && continue
+        _record_endpoint "$cloud" "$fixture_dir" "$fixture_name" "$endpoint" || true
+    done <<< "$endpoints"
+
+    # Live create+delete cycle for write endpoint fixtures
+    _record_live_cycle "$cloud" "$fixture_dir" cloud_recorded cloud_errors metadata_entries || true
+
+    _write_fixture_metadata "$cloud" "$fixture_dir"
 
     RECORDED=$((RECORDED + cloud_recorded))
     ERRORS=$((ERRORS + cloud_errors))


### PR DESCRIPTION
## Summary
- Extract 5 helpers from `run_test()` in `test/mock.sh` (149 -> ~30 lines): `_run_script_with_timeout()`, `_show_failure_output()`, `_assert_error_scenario()`, `_assert_cloud_api_calls()`, `_record_test_result()`
- Extract 3 helpers from `record_cloud()` in `test/record.sh` (106 -> ~30 lines): `_ensure_cloud_credentials()`, `_record_endpoint()`, `_write_fixture_metadata()`

## Test plan
- [x] `bash -n test/mock.sh` passes
- [x] `bash -n test/record.sh` passes
- [x] `bash test/mock.sh` results unchanged (330 passed, 105 failed, 1 skipped)
- [x] `bun test` results unchanged (5484 passed, 3 pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)