### PR TITLE
fix: validate provider names to prevent path traversal in key-server

### DIFF
--- a/.claude/skills/setup-trigger-service/key-server.ts
+++ b/.claude/skills/setup-trigger-service/key-server.ts
@@ -364,6 +364,11 @@ const server = Bun.serve({
       const skipped: string[] = [];
 
       for (const pk of body.providers as string[]) {
+        // SECURITY: Validate provider names to prevent path traversal in saveKeys
+        if (typeof pk !== "string" || !SAFE_PROVIDER_RE.test(pk)) {
+          skipped.push(pk);
+          continue;
+        }
         if (
           d.batches.some(
             (b) =>

--- a/shared/key-request.sh
+++ b/shared/key-request.sh
@@ -175,6 +175,13 @@ print(json.dumps(providers))
 # Usage: invalidate_cloud_key CLOUD_KEY
 invalidate_cloud_key() {
     local provider="${1}"
+
+    # SECURITY: Validate provider name to prevent path traversal
+    if [[ ! "${provider}" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]]; then
+        log "invalidate_cloud_key: invalid provider name: ${provider}"
+        return 1
+    fi
+
     local config_file="${HOME}/.config/spawn/${provider}.json"
 
     if [[ -f "${config_file}" ]]; then


### PR DESCRIPTION
## Security Fix

### HIGH: Path traversal via unvalidated provider names in key-server

**Vulnerability**: The `POST /request-batch` endpoint in `key-server.ts` accepted provider names from the request body without validating them against `SAFE_PROVIDER_RE`. These names were stored in batch data and later used by `saveKeys()` to construct file paths (`${CONFIG_DIR}/${provider}.json`). A crafted provider name like `../../.ssh/authorized_keys` would write to arbitrary paths on disk.

**Impact**: An authenticated attacker (with `KEY_SERVER_SECRET`) could write arbitrary JSON files to any path accessible by the server process. While the endpoint requires authentication, the secret is shared with the bash client (`key-request.sh`), widening the attack surface.

**Fix**: Added `SAFE_PROVIDER_RE` validation for each provider name at the entry point in `POST /request-batch`. Invalid names are silently skipped (added to `skipped` array).

### MEDIUM: Path traversal via unvalidated provider name in invalidate_cloud_key

**Vulnerability**: `invalidate_cloud_key()` in `shared/key-request.sh` used the provider argument directly in a file path (`$HOME/.config/spawn/${provider}.json`) without validation, potentially enabling path traversal file deletion.

**Impact**: Lower risk since the provider name comes from parsing internal test output (not externally controlled), but defense-in-depth applies.

**Fix**: Added the same `^[a-z0-9][a-z0-9._-]{0,63}$` regex validation used by the key-server.

### Files Changed
- `.claude/skills/setup-trigger-service/key-server.ts` — validate provider names in POST /request-batch
- `shared/key-request.sh` — validate provider name in invalidate_cloud_key()

Agent: security-auditor