### PR TITLE
fix: show prompt preview in launch message

### DIFF
--- a/cli/src/__tests__/cmdrun-happy-path.test.ts
+++ b/cli/src/__tests__/cmdrun-happy-path.test.ts
@@ -524,26 +524,24 @@ describe("cmdRun happy-path pipeline", () => {
       expect(launchMsg).toContain("Sprite");
     });
 
-    it("should append 'with prompt...' when prompt is provided", async () => {
+    it("should show prompt preview in info message when prompt is provided", async () => {
       global.fetch = mockFetchForDownload({ primaryOk: true });
       await loadManifest(true);
 
       await cmdRun("claude", "sprite", "Fix bugs");
 
-      const stepCalls = mockLogStep.mock.calls.map((c: any[]) => c.join(" "));
-      const launchMsg = stepCalls.find((msg: string) => msg.includes("Launching"));
-      expect(launchMsg).toContain("with prompt");
+      const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls.some((msg: string) => msg.includes("Prompt:") && msg.includes("Fix bugs"))).toBe(true);
     });
 
-    it("should append '...' without prompt when no prompt provided", async () => {
+    it("should not show prompt preview when no prompt provided", async () => {
       global.fetch = mockFetchForDownload({ primaryOk: true });
       await loadManifest(true);
 
       await cmdRun("claude", "sprite");
 
-      const stepCalls = mockLogStep.mock.calls.map((c: any[]) => c.join(" "));
-      const launchMsg = stepCalls.find((msg: string) => msg.includes("Launching"));
-      expect(launchMsg).not.toContain("with prompt");
+      const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls.some((msg: string) => msg.includes("Prompt:"))).toBe(false);
     });
   });
 

--- a/cli/src/__tests__/commands-error-paths.test.ts
+++ b/cli/src/__tests__/commands-error-paths.test.ts
@@ -323,7 +323,7 @@ describe("Commands Error Paths", () => {
       expect(stepCalls.some((msg: string) => msg.includes("Claude Code") && msg.includes("Sprite"))).toBe(true);
     });
 
-    it("should show prompt indicator when prompt is provided", async () => {
+    it("should show prompt preview when prompt is provided", async () => {
       global.fetch = mock(async (url: string) => {
         if (typeof url === "string" && url.includes("manifest.json")) {
           return {
@@ -346,8 +346,8 @@ describe("Commands Error Paths", () => {
         // Expected
       }
 
-      const stepCalls = mockLogStep.mock.calls.map((c: any[]) => c.join(" "));
-      expect(stepCalls.some((msg: string) => msg.includes("with prompt"))).toBe(true);
+      const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls.some((msg: string) => msg.includes("Prompt:") && msg.includes("Fix all bugs"))).toBe(true);
     });
   });
 

--- a/cli/src/__tests__/commands-resolve-run.test.ts
+++ b/cli/src/__tests__/commands-resolve-run.test.ts
@@ -306,7 +306,7 @@ describe("cmdRun - display name resolution", () => {
       expect(stepCalls.some((msg: string) => msg.includes("Claude Code") && msg.includes("Hetzner Cloud"))).toBe(true);
     });
 
-    it("should show 'with prompt' in launch message when prompt is provided", async () => {
+    it("should show prompt preview in info message when prompt is provided", async () => {
       await setManifestAndScript(mockManifest);
 
       try {
@@ -315,11 +315,11 @@ describe("cmdRun - display name resolution", () => {
         // May throw from script execution
       }
 
-      const stepCalls = mockLogStep.mock.calls.map((c: any[]) => c.join(" "));
-      expect(stepCalls.some((msg: string) => msg.includes("with prompt"))).toBe(true);
+      const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls.some((msg: string) => msg.includes("Prompt:") && msg.includes("Fix all bugs"))).toBe(true);
     });
 
-    it("should not show 'with prompt' when no prompt given", async () => {
+    it("should not show prompt preview when no prompt given", async () => {
       await setManifestAndScript(mockManifest);
 
       try {
@@ -328,8 +328,8 @@ describe("cmdRun - display name resolution", () => {
         // May throw from script execution
       }
 
-      const stepCalls = mockLogStep.mock.calls.map((c: any[]) => c.join(" "));
-      expect(stepCalls.some((msg: string) => msg.includes("with prompt"))).toBe(false);
+      const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls.some((msg: string) => msg.includes("Prompt:"))).toBe(false);
     });
   });
 

--- a/cli/src/__tests__/commands-swap-resolve.test.ts
+++ b/cli/src/__tests__/commands-swap-resolve.test.ts
@@ -539,7 +539,7 @@ describe("prompt handling with swapped args", () => {
     restoreMocks(consoleMocks.log, consoleMocks.error);
   });
 
-  it("should swap args and show 'with prompt' when prompt provided", async () => {
+  it("should swap args and show prompt preview when prompt provided", async () => {
     await setManifestAndScript(mockManifest);
 
     try {
@@ -553,9 +553,8 @@ describe("prompt handling with swapped args", () => {
     const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
     expect(infoCalls.some((msg: string) => msg.includes("swapped"))).toBe(true);
 
-    // Should show launch message with prompt
-    const stepCalls = mockLogStep.mock.calls.map((c: any[]) => c.join(" "));
-    expect(stepCalls.some((msg: string) => msg.includes("with prompt"))).toBe(true);
+    // Should show prompt preview in info message
+    expect(infoCalls.some((msg: string) => msg.includes("Prompt:") && msg.includes("Fix all bugs"))).toBe(true);
   });
 
   it("should validate prompt even when args are swapped", async () => {

--- a/cli/src/__tests__/commands-update-download.test.ts
+++ b/cli/src/__tests__/commands-update-download.test.ts
@@ -506,9 +506,7 @@ describe("Script download and execution", () => {
     expect(allOutput).toContain("try again");
   });
 
-  it("should pass SPAWN_PROMPT and SPAWN_MODE env vars with prompt", async () => {
-    // We can verify the launch step message includes "with prompt"
-    // when a valid prompt is provided
+  it("should show prompt preview in info message when prompt is provided", async () => {
     global.fetch = mock(async (url: string) => {
       if (typeof url === "string" && url.includes("manifest.json")) {
         return {
@@ -531,7 +529,7 @@ describe("Script download and execution", () => {
       // Expected - bash execution in test env
     }
 
-    const stepCalls = mockLogStep.mock.calls.map((c: any[]) => c.join(" "));
-    expect(stepCalls.some((msg: string) => msg.includes("with prompt"))).toBe(true);
+    const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+    expect(infoCalls.some((msg: string) => msg.includes("Prompt:") && msg.includes("Write tests"))).toBe(true);
   });
 });

--- a/cli/src/__tests__/exec-script-errors.test.ts
+++ b/cli/src/__tests__/exec-script-errors.test.ts
@@ -323,19 +323,17 @@ describe("execScript bash execution error handling", () => {
       expect(launchMsg).toBeDefined();
       expect(launchMsg).toContain("Claude Code");
       expect(launchMsg).toContain("Sprite");
-      expect(launchMsg).not.toContain("with prompt");
+      expect(launchMsg).not.toContain("Prompt:");
     });
 
-    it("should show launch step message with prompt suffix when prompt provided", async () => {
+    it("should show prompt preview in info message when prompt provided", async () => {
       mockFetchWithScript("exit 0");
       await loadManifest(true);
 
       await cmdRun("claude", "sprite", "Fix all bugs");
 
-      const stepCalls = mockLogStep.mock.calls.map((c: any[]) => c.join(" "));
-      const launchMsg = stepCalls.find((msg: string) => msg.includes("Launching"));
-      expect(launchMsg).toBeDefined();
-      expect(launchMsg).toContain("with prompt");
+      const infoCalls = mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+      expect(infoCalls.some((msg: string) => msg.includes("Prompt:") && msg.includes("Fix all bugs"))).toBe(true);
     });
   });
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -449,8 +449,11 @@ export async function cmdRun(agent: string, cloud: string, prompt?: string, dryR
 
   const agentName = manifest.agents[agent].name;
   const cloudName = manifest.clouds[cloud].name;
-  const suffix = prompt ? " with prompt..." : "...";
-  p.log.step(`Launching ${pc.bold(agentName)} on ${pc.bold(cloudName)}${suffix}`);
+  p.log.step(`Launching ${pc.bold(agentName)} on ${pc.bold(cloudName)}`);
+  if (prompt) {
+    const preview = prompt.length > 80 ? prompt.slice(0, 77) + "..." : prompt;
+    p.log.info(pc.dim(`Prompt: "${preview}"`));
+  }
 
   await execScript(cloud, agent, prompt, getAuthHint(manifest, cloud));
 }


### PR DESCRIPTION
## Summary

When running `spawn <agent> <cloud> --prompt "..."`, the launch message previously said "Launching X on Y with prompt..." without showing the actual prompt content. Users running automated spawns couldn't visually confirm which prompt was being sent.

Now the launch message shows the prompt as a separate info line with a truncated preview (up to 80 chars):

**Before:**
```
o  Launching Claude Code on Sprite with prompt...
```

**After:**
```
o  Launching Claude Code on Sprite
i  Prompt: "Fix all linter errors and add missing tests"
```

Long prompts are truncated with "..." after 77 characters. When no prompt is provided, no prompt line is shown.

## Changes

- `cli/src/commands.ts`: Replace `"with prompt..."` suffix with a separate `p.log.info` line showing the prompt preview
- 6 test files updated to check for the new prompt display format

## Test plan

- [x] All 144 tests in affected files pass
- [x] Full test suite: 5484 pass, 3 fail (pre-existing failures from missing `local/opencode.sh`)
- [x] Prompt preview shown for short prompts
- [x] Long prompts truncated at 80 chars
- [x] No prompt line when no prompt provided

Agent: ux-engineer