### PR TITLE
fix: replace unsafe inline API key injection with secure helpers

### DIFF
--- a/daytona/continue.sh
+++ b/daytona/continue.sh
@@ -29,8 +29,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/e2b/continue.sh
+++ b/e2b/continue.sh
@@ -33,8 +33,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/github-codespaces/continue.sh
+++ b/github-codespaces/continue.sh
@@ -38,8 +38,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/kamatera/nanoclaw.sh
+++ b/kamatera/nanoclaw.sh
@@ -39,8 +39,12 @@ inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-# Write .env file for NanoClaw
-run_server "${KAMATERA_SERVER_IP}" "printf 'ANTHROPIC_API_KEY=%s\n' '${OPENROUTER_API_KEY}' > ~/nanoclaw/.env"
+# Write .env file for NanoClaw (use temp file + upload to avoid shell injection)
+DOTENV_TEMP=$(mktemp)
+chmod 600 "${DOTENV_TEMP}"
+track_temp_file "${DOTENV_TEMP}"
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
+upload_file "${KAMATERA_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 
 echo ""
 log_info "Kamatera server setup completed successfully!"

--- a/latitude/continue.sh
+++ b/latitude/continue.sh
@@ -32,8 +32,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.bashrc"
-run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.zshrc"
+inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${LATITUDE_SERVER_IP}" \

--- a/modal/continue.sh
+++ b/modal/continue.sh
@@ -32,8 +32,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/scaleway/continue.sh
+++ b/scaleway/continue.sh
@@ -34,8 +34,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.bashrc"
-run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.zshrc"
+inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${SCALEWAY_SERVER_IP}" \

--- a/upcloud/continue.sh
+++ b/upcloud/continue.sh
@@ -31,8 +31,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.bashrc"
-run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.zshrc"
+inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${UPCLOUD_SERVER_IP}" \


### PR DESCRIPTION
## Summary

8 agent scripts were embedding `OPENROUTER_API_KEY` directly into shell command strings passed to `run_server`/`run_in_codespace`, creating command injection vulnerabilities if the API key contains shell metacharacters.

### Severity: HIGH

The worst case was `latitude/continue.sh` which had **zero quoting**:
```bash
run_server "$IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.bashrc"
```
A crafted API key like `sk-or-v1-foo; rm -rf /` would execute arbitrary commands on the remote server.

Other scripts used single-quoted (`'${OPENROUTER_API_KEY}'`) or double-quoted (`\"${OPENROUTER_API_KEY}\"`) embedding, which can be broken out of with `'` or `"` characters respectively.

### Fix

Replaced all unsafe inline patterns with the existing secure helpers:
- SSH-based clouds: `inject_env_vars_ssh` (scaleway, upcloud, latitude)
- Non-SSH clouds: `inject_env_vars_local` (e2b, modal, daytona)
- GitHub Codespaces: `inject_env_vars` (codespace-specific helper)
- kamatera/nanoclaw.sh: temp file + `upload_file` for `.env` write

These helpers use `generate_env_config()` which properly single-quotes values with embedded quote escaping (`'` → `'\''`).

### Affected scripts
| Script | Vulnerability |
|--------|--------------|
| `latitude/continue.sh` | No quoting at all (CRITICAL) |
| `scaleway/continue.sh` | Single-quote breakout |
| `upcloud/continue.sh` | Double-quote breakout |
| `e2b/continue.sh` | Single-quote breakout |
| `modal/continue.sh` | Single-quote breakout |
| `daytona/continue.sh` | Single-quote breakout |
| `github-codespaces/continue.sh` | Single-quote breakout |
| `kamatera/nanoclaw.sh` | Single-quote breakout in .env write |

### Testing
- All 8 modified scripts pass `bash -n` syntax check
- Full test suite: 5484 pass, 3 fail (all 3 pre-existing, unrelated)