### PR TITLE
fix: suggest subcommands for typo correction in unknown command errors

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/show-info-or-error.test.ts
+++ b/cli/src/__tests__/show-info-or-error.test.ts
@@ -224,6 +224,75 @@ describe("showInfoOrError - single argument routing", () => {
     });
   });
 
+  // ── Subcommand typo correction ─────────────────────────────────────────
+
+  describe("subcommand typo correction", () => {
+    it("should suggest 'matrix' for 'matrixx'", () => {
+      const result = runCli(["matrixx"]);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("Did you mean");
+      expect(output).toContain("spawn matrix");
+    });
+
+    it("should suggest 'clouds' for 'clousd'", () => {
+      const result = runCli(["clousd"]);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("Did you mean");
+      expect(output).toContain("spawn clouds");
+    });
+
+    it("should suggest 'agents' for 'agens'", () => {
+      const result = runCli(["agens"]);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("Did you mean");
+      expect(output).toContain("spawn agents");
+    });
+
+    it("should suggest 'update' for 'updte'", () => {
+      const result = runCli(["updte"]);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("Did you mean");
+      expect(output).toContain("spawn update");
+    });
+
+    it("should suggest 'list' for 'listt'", () => {
+      const result = runCli(["listt"]);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("Did you mean");
+      expect(output).toContain("spawn list");
+    });
+
+    it("should suggest 'history' for 'histry'", () => {
+      const result = runCli(["histry"]);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("Did you mean");
+      expect(output).toContain("spawn history");
+    });
+
+    it("should suggest 'version' for 'vrsion'", () => {
+      const result = runCli(["vrsion"]);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("Did you mean");
+      expect(output).toContain("spawn version");
+    });
+
+    it("should suggest 'help' for 'hlp'", () => {
+      const result = runCli(["hlp"]);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("Did you mean");
+      expect(output).toContain("spawn help");
+    });
+
+    it("should not suggest subcommands for completely unrelated input", () => {
+      const result = runCli(["xyzzyplugh"]);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("Unknown command");
+      expect(output).not.toContain("spawn matrix");
+      expect(output).not.toContain("spawn update");
+      expect(output).not.toContain("spawn list");
+    });
+  });
+
   // ── Edge cases ─────────────────────────────────────────────────────────
 
   describe("edge cases", () => {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,7 @@ import {
   cmdCloudInfo,
   cmdUpdate,
   cmdHelp,
+  findClosestMatch,
   findClosestKeyByNameOrKey,
   resolveAgentKey,
   resolveCloudKey,
@@ -89,9 +90,13 @@ function checkUnknownFlags(args: string[]): void {
 function showUnknownCommandError(name: string, manifest: { agents: Record<string, { name: string }>; clouds: Record<string, { name: string }> }): never {
   const agentMatch = findClosestKeyByNameOrKey(name, agentKeys(manifest), (k) => manifest.agents[k].name);
   const cloudMatch = findClosestKeyByNameOrKey(name, cloudKeys(manifest), (k) => manifest.clouds[k].name);
+  const subcommandMatch = findClosestMatch(name, ALL_SUBCOMMANDS);
 
   console.error(pc.red(`Unknown command: ${pc.bold(name)}`));
   console.error();
+  if (subcommandMatch) {
+    console.error(`  Did you mean ${pc.cyan(`spawn ${subcommandMatch}`)}?`);
+  }
   if (agentMatch || cloudMatch) {
     const suggestions: string[] = [];
     if (agentMatch) suggestions.push(`${pc.cyan(agentMatch)} (agent: ${manifest.agents[agentMatch].name})`);
@@ -282,6 +287,9 @@ const LIST_COMMANDS = new Set(["list", "ls", "history"]);
 // Common verb prefixes that users naturally try (e.g. "spawn run claude sprite")
 // These are not real subcommands -- we strip them and forward to the default handler
 const VERB_ALIASES = new Set(["run", "launch", "start", "deploy", "exec"]);
+
+// All user-facing subcommands for typo correction (excludes flag variants like --help, -v)
+const ALL_SUBCOMMANDS = ["help", "version", "matrix", "agents", "clouds", "update", "list", "history"];
 
 /** Warn when extra positional arguments are silently ignored */
 function warnExtraArgs(filteredArgs: string[], maxExpected: number): void {


### PR DESCRIPTION
## Summary
- When a user types a misspelled subcommand (e.g., `spawn matrixx`, `spawn clousd`, `spawn updte`), the CLI now suggests the closest matching subcommand alongside existing agent/cloud suggestions
- Uses the existing `findClosestMatch` (Levenshtein distance) function already used for agent/cloud typo correction
- Covers all 8 user-facing subcommands: `help`, `version`, `matrix`, `agents`, `clouds`, `update`, `list`, `history`
- Adds 9 tests for subcommand typo correction
- Bumps CLI version to 0.2.60

## Before
```
$ spawn matrixx
Unknown command: matrixx

  Run spawn agents to see available agents.
  Run spawn clouds to see available clouds.
  Run spawn help for usage information.
```

## After
```
$ spawn matrixx
Unknown command: matrixx

  Did you mean spawn matrix?

  Run spawn agents to see available agents.
  Run spawn clouds to see available clouds.
  Run spawn help for usage information.
```

## Test plan
- [x] `spawn matrixx` suggests `spawn matrix`
- [x] `spawn clousd` suggests `spawn clouds`
- [x] `spawn agens` suggests `spawn agents`
- [x] `spawn updte` suggests `spawn update`
- [x] `spawn listt` suggests `spawn list`
- [x] `spawn histry` suggests `spawn history`
- [x] `spawn vrsion` suggests `spawn version`
- [x] `spawn hlp` suggests `spawn help`
- [x] `spawn xyzzyplugh` does NOT suggest any subcommand (no false positives)
- [x] `spawn claude` still shows agent info (not intercepted by subcommand matcher)
- [x] All 34 tests pass in `show-info-or-error.test.ts` (25 existing + 9 new)
- [x] Full test suite passes (pre-existing failures only)

Agent: ux-engineer