### PR TITLE
fix: show setup instructions in script failure credential hints

### DIFF
--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -116,9 +116,9 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("provisioning failed");
     });
 
-    it("should return exactly 4 guidance lines", () => {
+    it("should return at least 4 guidance lines", () => {
       const lines = getScriptFailureGuidance(1, "sprite");
-      expect(lines).toHaveLength(4);
+      expect(lines.length).toBeGreaterThanOrEqual(4);
     });
   });
 
@@ -157,9 +157,9 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("spawn linode");
     });
 
-    it("should return exactly 4 guidance lines", () => {
+    it("should return at least 4 guidance lines", () => {
       const lines = getScriptFailureGuidance(42, "linode");
-      expect(lines).toHaveLength(4);
+      expect(lines.length).toBeGreaterThanOrEqual(4);
     });
   });
 
@@ -183,9 +183,9 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("spawn sprite");
     });
 
-    it("should return exactly 4 guidance lines", () => {
+    it("should return at least 4 guidance lines", () => {
       const lines = getScriptFailureGuidance(null, "sprite");
-      expect(lines).toHaveLength(4);
+      expect(lines.length).toBeGreaterThanOrEqual(4);
     });
   });
 
@@ -321,11 +321,13 @@ describe("getScriptFailureGuidance", () => {
   // ── Auth hint parameter ──────────────────────────────────────────────────
 
   describe("auth hint parameter", () => {
-    it("should show specific env var name for exit code 1 when authHint is provided", () => {
+    it("should show specific env var name and setup hint for exit code 1 when authHint is provided", () => {
       const lines = getScriptFailureGuidance(1, "hetzner", "HCLOUD_TOKEN");
       const joined = lines.join("\n");
       expect(joined).toContain("HCLOUD_TOKEN");
       expect(joined).toContain("OPENROUTER_API_KEY");
+      expect(joined).toContain("spawn hetzner");
+      expect(joined).toContain("setup");
     });
 
     it("should show generic setup hint for exit code 1 when no authHint", () => {
@@ -335,11 +337,13 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).not.toContain("HCLOUD_TOKEN");
     });
 
-    it("should show specific env var name for default case when authHint is provided", () => {
+    it("should show specific env var name and setup hint for default case when authHint is provided", () => {
       const lines = getScriptFailureGuidance(42, "digitalocean", "DO_API_TOKEN");
       const joined = lines.join("\n");
       expect(joined).toContain("DO_API_TOKEN");
       expect(joined).toContain("OPENROUTER_API_KEY");
+      expect(joined).toContain("spawn digitalocean");
+      expect(joined).toContain("setup");
     });
 
     it("should show generic setup hint for default case when no authHint", () => {
@@ -367,14 +371,20 @@ describe("getScriptFailureGuidance", () => {
       expect(joined255).toContain("SSH");
     });
 
-    it("should preserve line count for exit code 1 with authHint", () => {
+    it("should include setup instruction line for exit code 1 with authHint", () => {
       const lines = getScriptFailureGuidance(1, "hetzner", "HCLOUD_TOKEN");
-      expect(lines).toHaveLength(4);
+      expect(lines).toHaveLength(5);
+      const joined = lines.join("\n");
+      expect(joined).toContain("spawn hetzner");
+      expect(joined).toContain("setup");
     });
 
-    it("should preserve line count for default case with authHint", () => {
+    it("should include setup instruction line for default case with authHint", () => {
       const lines = getScriptFailureGuidance(42, "hetzner", "HCLOUD_TOKEN");
-      expect(lines).toHaveLength(4);
+      expect(lines).toHaveLength(5);
+      const joined = lines.join("\n");
+      expect(joined).toContain("spawn hetzner");
+      expect(joined).toContain("setup");
     });
   });
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -522,10 +522,16 @@ function reportDownloadError(ghUrl: string, err: unknown): never {
   process.exit(1);
 }
 
-function credentialHint(cloud: string, authHint?: string, verb = "Missing or invalid"): string {
-  return authHint
-    ? `  - ${verb} credentials (need ${pc.cyan(authHint)} + ${pc.cyan("OPENROUTER_API_KEY")})`
-    : `  - ${verb} credentials (run ${pc.cyan(`spawn ${cloud}`)} for setup)`;
+function credentialHints(cloud: string, authHint?: string, verb = "Missing or invalid"): string[] {
+  if (authHint) {
+    return [
+      `  - ${verb} credentials (need ${pc.cyan(authHint)} + ${pc.cyan("OPENROUTER_API_KEY")})`,
+      `    Run ${pc.cyan(`spawn ${cloud}`)} for setup instructions`,
+    ];
+  }
+  return [
+    `  - ${verb} credentials (run ${pc.cyan(`spawn ${cloud}`)} for setup)`,
+  ];
 }
 
 export function getScriptFailureGuidance(exitCode: number | null, cloud: string, authHint?: string): string[] {
@@ -571,14 +577,14 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
     case 1:
       return [
         "Common causes:",
-        credentialHint(cloud, authHint),
+        ...credentialHints(cloud, authHint),
         "  - Cloud provider API error (quota, rate limit, or region issue)",
         "  - Server provisioning failed (try again or pick a different region)",
       ];
     default:
       return [
         "Common causes:",
-        credentialHint(cloud, authHint, "Missing"),
+        ...credentialHints(cloud, authHint, "Missing"),
         "  - Cloud provider API rate limit or quota exceeded",
         "  - Missing local dependencies (SSH, curl, jq)",
       ];


### PR DESCRIPTION
## Summary
- When a spawn script fails with credential-related errors (exit code 1 or unknown), the error message now always includes `Run spawn <cloud> for setup instructions` alongside the required env var names
- Previously, this actionable setup hint was only shown when the auth env var names were _not_ parseable from the cloud config (the uncommon case). For most clouds (hetzner, digitalocean, vultr, etc.), users only saw `Missing or invalid credentials (need HCLOUD_TOKEN + OPENROUTER_API_KEY)` with no guidance on where to get credentials
- The `credentialHint` function was renamed to `credentialHints` (returning `string[]` instead of `string`) to support the additional setup instruction line

### Before
```
Spawn script failed

Error: Script exited with code 1

Common causes:
  - Missing or invalid credentials (need HCLOUD_TOKEN + OPENROUTER_API_KEY)
  - Cloud provider API error (quota, rate limit, or region issue)
  - Server provisioning failed (try again or pick a different region)

Retry: spawn claude hetzner
```

### After
```
Spawn script failed

Error: Script exited with code 1

Common causes:
  - Missing or invalid credentials (need HCLOUD_TOKEN + OPENROUTER_API_KEY)
    Run spawn hetzner for setup instructions
  - Cloud provider API error (quota, rate limit, or region issue)
  - Server provisioning failed (try again or pick a different region)

Retry: spawn claude hetzner
```

## Test plan
- [x] Updated `commands-internal-helpers.test.ts` -- renamed `credentialHint` tests to `credentialHints`, updated to test `string[]` return type and new setup instruction line
- [x] Updated `script-failure-guidance.test.ts` -- updated line count expectations and added assertions for `spawn <cloud>` and `setup` in auth hint cases
- [x] All 5485 tests pass (3 pre-existing failures unrelated to this change: `local/opencode.sh` script file missing)

Generated with [Claude Code](https://claude.com/claude-code)