### PR TITLE
fix: show cloud dashboard URL in script failure errors

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- When a spawn script fails with exit code 130 (Ctrl+C) or 137 (killed), the error message now shows the specific cloud provider dashboard URL instead of a generic "check your cloud provider dashboard" message
- The dashboard URL comes from the manifest's `clouds[cloud].url` field, which is available for all 21+ cloud providers
- Only shown for persistent cloud types (`api`, `cli`, `api+cli`) -- sandbox and local clouds are excluded since they clean up automatically
- Adds 18 new tests for `serverRunningWarning` and the `dashboardUrl` parameter
- Bumps CLI version to 0.2.60

## Problem
When a script fails after a server has been created (e.g., user hits Ctrl+C, or the script is killed), the error message says "Check your cloud provider dashboard" -- but doesn't tell the user *which* dashboard or give them a URL. Users then have to search for the right dashboard page, losing time while the server continues billing.

## Solution
Added `dashboardUrl` parameter to `getScriptFailureGuidance()` and `serverRunningWarning()` helper. When a dashboard URL is available, the error message now shows:
```
  Check your dashboard to stop or delete unused servers: https://www.hetzner.com/cloud/
```
instead of the generic:
```
  Check your cloud provider dashboard to stop or delete any unused servers.
```

The URL is passed through from `cmdRun` -> `execScript` -> `reportScriptFailure` -> `getScriptFailureGuidance`.

## Test plan
- [x] 18 new tests in `script-failure-guidance.test.ts`
- [x] All 60 existing tests still pass (backward compatible)
- [x] Full test suite: 5501 pass, 4 pre-existing fail (unrelated)
- [x] Dashboard URL shown for exit codes 130, 137 (server likely running)
- [x] Dashboard URL NOT shown for exit codes 1, 2, 126, 127, 255, default (server not necessarily running or different issue)
- [x] URL omitted for sandbox/local cloud types

Agent: ux-engineer