### PR TITLE
feat: add interactive launch picker to agent/cloud info pages

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1154,6 +1154,20 @@ export async function cmdAgentInfo(agent: string): Promise<void> {
     (c) => `spawn ${agentKey} ${c}`
   );
   console.log();
+
+  // In interactive terminals, offer to launch directly
+  if (isInteractiveTTY()) {
+    const cloudChoice = await p.select({
+      message: `Launch ${agentDef.name} on`,
+      options: [
+        ...mapToSelectOptions(implClouds, manifest.clouds),
+        { value: "__exit__", label: "Exit", hint: "just show info" },
+      ],
+    });
+    if (p.isCancel(cloudChoice) || cloudChoice === "__exit__") return;
+
+    await execScript(cloudChoice, agentKey, undefined, getAuthHint(manifest, cloudChoice));
+  }
 }
 
 // ── Cloud Info ─────────────────────────────────────────────────────────────────
@@ -1226,6 +1240,20 @@ export async function cmdCloudInfo(cloud: string): Promise<void> {
   console.log();
   console.log(pc.dim(`  Full setup guide: ${pc.cyan(`https://github.com/${REPO}/tree/main/${cloudKey}`)}`));
   console.log();
+
+  // In interactive terminals, offer to launch directly
+  if (isInteractiveTTY() && implAgents.length > 0) {
+    const agentChoice = await p.select({
+      message: `Launch on ${c.name}`,
+      options: [
+        ...mapToSelectOptions(implAgents, manifest.agents),
+        { value: "__exit__", label: "Exit", hint: "just show info" },
+      ],
+    });
+    if (p.isCancel(agentChoice) || agentChoice === "__exit__") return;
+
+    await execScript(cloudKey, agentChoice, undefined, getAuthHint(manifest, cloudKey));
+  }
 }
 
 // ── Update ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- When users run `spawn <agent>` or `spawn <cloud>` in an interactive terminal, they now get a picker to launch directly instead of being shown a static list and having to retype a command
- Non-interactive terminals (piped, CI, SSH without TTY) still show the static info output as before
- Added "Exit" option so users can dismiss the picker if they only wanted to see info

## Motivation
Running `spawn claude` currently shows a list of available clouds with example commands, then exits. The user has to manually type `spawn claude <cloud>` to actually launch. This is a dead-end that adds friction, especially for first-time users who are exploring. The same applies to `spawn hetzner` showing agents.

With this change, `spawn claude` becomes a smooth 2-step flow: see info -> pick a cloud -> launch.

## Test plan
- [x] All existing tests pass (5484 pass, 3 pre-existing failures unrelated to this change)
- [ ] Manual test: `spawn claude` in interactive terminal shows picker after cloud list
- [ ] Manual test: `spawn hetzner` in interactive terminal shows picker after agent list
- [ ] Manual test: Selecting "Exit" in picker returns without launching
- [ ] Manual test: Pressing Ctrl+C in picker returns without launching
- [ ] Manual test: Piping output (e.g., `spawn claude | cat`) does NOT show picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)