### PR TITLE
refactor: simplify parseListFilters to reuse extractFlagValue

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -296,34 +296,13 @@ function warnExtraArgs(filteredArgs: string[], maxExpected: number): void {
 /** Parse -a/--agent <agent> and -c/--cloud <cloud> filter flags from args.
  *  Also accepts a bare positional arg as a filter (e.g. "spawn list claude"). */
 function parseListFilters(args: string[]): { agentFilter?: string; cloudFilter?: string } {
-  let agentFilter: string | undefined;
-  let cloudFilter: string | undefined;
-  const positional: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "-a" || args[i] === "--agent") {
-      if (!args[i + 1] || args[i + 1].startsWith("-")) {
-        console.error(pc.red(`Error: ${pc.bold(args[i])} requires an agent name`));
-        console.error(`\nUsage: ${pc.cyan("spawn list -a <agent>")}`);
-        process.exit(1);
-      }
-      agentFilter = args[i + 1];
-      i++;
-    } else if (args[i] === "-c" || args[i] === "--cloud") {
-      if (!args[i + 1] || args[i + 1].startsWith("-")) {
-        console.error(pc.red(`Error: ${pc.bold(args[i])} requires a cloud name`));
-        console.error(`\nUsage: ${pc.cyan("spawn list -c <cloud>")}`);
-        process.exit(1);
-      }
-      cloudFilter = args[i + 1];
-      i++;
-    } else if (!args[i].startsWith("-")) {
-      positional.push(args[i]);
-    }
-  }
+  const [agentFilter, afterAgent] = extractFlagValue(args, ["-a", "--agent"], "agent name", "spawn list -a <agent>");
+  const [cloudFilter, remaining] = extractFlagValue(afterAgent, ["-c", "--cloud"], "cloud name", "spawn list -c <cloud>");
 
   // Support bare positional filter: "spawn list claude" or "spawn list hetzner"
-  if (!agentFilter && !cloudFilter && positional.length > 0) {
-    agentFilter = positional[0];
+  if (!agentFilter && !cloudFilter) {
+    const positional = remaining.find(a => !a.startsWith("-"));
+    if (positional) return { agentFilter: positional };
   }
 
   return { agentFilter, cloudFilter };


### PR DESCRIPTION
## Summary

- Refactored `parseListFilters` in `cli/src/index.ts` to reuse the existing `extractFlagValue` helper instead of re-implementing the same flag validation logic (check flag exists, check next arg is a value, error if missing)
- Reduced the function from 33 lines to 12 lines (-63%) with identical behavior
- All 5484 passing tests still pass, zero regressions

## Details

The old `parseListFilters` manually iterated through args with a `for` loop, checking for `-a`/`--agent` and `-c`/`--cloud` flags and their values with inline validation logic. This duplicated the exact same pattern that `extractFlagValue` (defined 10 lines above in the same file) already provides.

The refactored version calls `extractFlagValue` twice (once for agent filter, once for cloud filter), then handles the bare positional fallback in 3 lines.

## Test plan

- [x] All 181 parseListFilters-related tests pass (list-display.test.ts + index-dispatch-routing.test.ts)
- [x] Full test suite: 5484 pass, 3 pre-existing failures (unrelated: local/opencode.sh missing)
- [x] Verified same 3 failures exist on main branch

Agent: complexity-hunter