### PR TITLE
fix: better error for uppercase agent/cloud names

### DIFF
--- a/cli/src/__tests__/commands-swap-resolve.test.ts
+++ b/cli/src/__tests__/commands-swap-resolve.test.ts
@@ -364,6 +364,38 @@ describe("resolveAndLog via cmdRun", () => {
       expect(infoCalls.some((msg: string) => msg.includes("Resolved") && msg.includes("sprite"))).toBe(true);
     });
   });
+
+  describe("unresolvable uppercase names", () => {
+    it("should lowercase unresolvable agent name and show 'Unknown agent' instead of 'invalid characters'", async () => {
+      await setManifestAndScript(mockManifest);
+
+      try {
+        await cmdRun("FooBar", "sprite");
+      } catch {
+        // Expected: process.exit from validateEntities
+      }
+
+      const errorCalls = mockLogError.mock.calls.map((c: any[]) => c.join(" "));
+      // Should get "Unknown agent" error, NOT "invalid characters"
+      expect(errorCalls.some((msg: string) => msg.includes("Unknown agent"))).toBe(true);
+      expect(errorCalls.some((msg: string) => msg.includes("invalid characters"))).toBe(false);
+    });
+
+    it("should lowercase unresolvable cloud name and show 'Unknown cloud' instead of 'invalid characters'", async () => {
+      await setManifestAndScript(mockManifest);
+
+      try {
+        await cmdRun("claude", "BazCloud");
+      } catch {
+        // Expected: process.exit from validateEntities
+      }
+
+      const errorCalls = mockLogError.mock.calls.map((c: any[]) => c.join(" "));
+      // Should get "Unknown cloud" error, NOT "invalid characters"
+      expect(errorCalls.some((msg: string) => msg.includes("Unknown cloud"))).toBe(true);
+      expect(errorCalls.some((msg: string) => msg.includes("invalid characters"))).toBe(false);
+    });
+  });
 });
 
 // ── isValidManifest tests (via loadManifest) ──────────────────────────────────

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -314,7 +314,9 @@ export async function cmdInteractive(): Promise<void> {
 
 // ── Run ────────────────────────────────────────────────────────────────────────
 
-/** Resolve display names / casing and log if resolved to a different key */
+/** Resolve display names / casing and log if resolved to a different key.
+ *  Unresolved names are lowercased so they pass identifier validation and
+ *  reach the more helpful "Unknown agent/cloud" error with suggestions. */
 function resolveAndLog(
   manifest: Manifest,
   agent: string,
@@ -322,13 +324,21 @@ function resolveAndLog(
 ): { agent: string; cloud: string } {
   const resolvedAgent = resolveAgentKey(manifest, agent);
   const resolvedCloud = resolveCloudKey(manifest, cloud);
-  if (resolvedAgent && resolvedAgent !== agent) {
-    p.log.info(`Resolved "${agent}" to ${pc.cyan(resolvedAgent)}`);
+  if (resolvedAgent) {
+    if (resolvedAgent !== agent) {
+      p.log.info(`Resolved "${agent}" to ${pc.cyan(resolvedAgent)}`);
+    }
     agent = resolvedAgent;
+  } else {
+    agent = agent.toLowerCase();
   }
-  if (resolvedCloud && resolvedCloud !== cloud) {
-    p.log.info(`Resolved "${cloud}" to ${pc.cyan(resolvedCloud)}`);
+  if (resolvedCloud) {
+    if (resolvedCloud !== cloud) {
+      p.log.info(`Resolved "${cloud}" to ${pc.cyan(resolvedCloud)}`);
+    }
     cloud = resolvedCloud;
+  } else {
+    cloud = cloud.toLowerCase();
   }
   return { agent, cloud };
 }


### PR DESCRIPTION
## Summary
- When users type `spawn FooBar sprite` (with uppercase), they previously got a confusing error: `Agent name "FooBar" contains invalid characters`
- Now, unresolved names are lowercased before validation, so the user sees the much more helpful `Unknown agent: foobar` error with typo suggestions and a list of available agents
- This applies to both the agent and cloud arguments in `spawn <agent> <cloud>`

## Before
```
$ spawn FooBar sprite
ERROR  Agent name "FooBar" contains invalid characters.
       Only lowercase letters, numbers, hyphens, and underscores are allowed.
       Run 'spawn agents' or 'spawn clouds' to see valid names.
```

## After
```
$ spawn FooBar sprite
ERROR  Unknown agent: foobar
i  Run spawn agents to see available agents.
```

## Test plan
- [x] Added 2 new tests for unresolvable uppercase agent and cloud names
- [x] All 25 tests in `commands-swap-resolve.test.ts` pass
- [x] Full test suite passes (5486/5489 pass, 3 pre-existing failures unrelated to this change)

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)