### PR TITLE
refactor: simplify load_cloud_keys_from_config and run_shellcheck

### DIFF
--- a/shared/key-request.sh
+++ b/shared/key-request.sh
@@ -33,6 +33,50 @@ for var in re.split(r'\s*\+\s*', auth):
 " "${REPO_ROOT}/manifest.json" "${cloud}" 2>/dev/null
 }
 
+# Try to load a single env var from a config JSON file
+# Returns 0 if loaded, 1 if not found
+# Usage: _try_load_env_var_from_config CONFIG_FILE VAR_NAME
+_try_load_env_var_from_config() {
+    local config_file="${1}" var_name="${2}"
+    [[ -f "${config_file}" ]] || return 1
+
+    local val
+    val=$(python3 -c "
+import json, sys
+data = json.load(open(sys.argv[1]))
+v = data.get(sys.argv[2], '') or data.get('api_key', '') or data.get('token', '')
+print(v)
+" "${config_file}" "${var_name}" 2>/dev/null)
+
+    if [[ -n "${val}" ]]; then
+        export "${var_name}=${val}"
+        return 0
+    fi
+    return 1
+}
+
+# Load all env vars for a single cloud from env or config file
+# Returns 0 if all vars are set, 1 if any are missing
+# Usage: _load_cloud_env_vars AUTH_STRING CONFIG_FILE
+_load_cloud_env_vars() {
+    local auth_string="${1}" config_file="${2}"
+
+    local env_vars
+    env_vars=$(printf '%s' "${auth_string}" | tr '+' '\n' | sed 's/^ *//;s/ *$//')
+
+    local var_name
+    while IFS= read -r var_name; do
+        [[ -z "${var_name}" ]] && continue
+        # Already set in environment? Skip
+        [[ -n "${!var_name:-}" ]] && continue
+        # Try loading from config file
+        _try_load_env_var_from_config "${config_file}" "${var_name}" && continue
+        # This env var is missing
+        return 1
+    done <<< "${env_vars}"
+    return 0
+}
+
 # Load cloud API keys from ~/.config/spawn/{cloud}.json into environment
 # Reads manifest.json to determine which clouds need API-token auth
 # Skips CLI-based auth (sprite login, aws configure, etc.)
@@ -71,42 +115,7 @@ for key, cloud in manifest.get('clouds', {}).items():
         [[ -z "${cloud_key}" ]] && continue
         total=$((total + 1))
 
-        # Parse env var names from auth string (split on " + ")
-        local env_vars
-        env_vars=$(printf '%s' "${auth_string}" | tr '+' '\n' | sed 's/^ *//;s/ *$//')
-
-        local cloud_complete=true
-        local config_file="${HOME}/.config/spawn/${cloud_key}.json"
-
-        while IFS= read -r var_name; do
-            [[ -z "${var_name}" ]] && continue
-
-            # Already set in environment? Skip
-            local current_val="${!var_name:-}"
-            if [[ -n "${current_val}" ]]; then
-                continue
-            fi
-
-            # Try loading from config file
-            if [[ -f "${config_file}" ]]; then
-                local val
-                val=$(python3 -c "
-import json, sys
-data = json.load(open(sys.argv[1]))
-v = data.get(sys.argv[2], '') or data.get('api_key', '') or data.get('token', '')
-print(v)
-" "${config_file}" "${var_name}" 2>/dev/null)
-                if [[ -n "${val}" ]]; then
-                    export "${var_name}=${val}"
-                    continue
-                fi
-            fi
-
-            # This env var is missing
-            cloud_complete=false
-        done <<< "${env_vars}"
-
-        if [[ "${cloud_complete}" == "true" ]]; then
+        if _load_cloud_env_vars "${auth_string}" "${HOME}/.config/spawn/${cloud_key}.json"; then
             loaded=$((loaded + 1))
         else
             missing_providers="${missing_providers} ${cloud_key}"

--- a/test/run.sh
+++ b/test/run.sh
@@ -713,21 +713,16 @@ run_shellcheck() {
         return 0
     fi
 
-    # Find all shell scripts
-    local all_scripts=(
-        "${REPO_ROOT}"/sprite/*.sh
-        "${REPO_ROOT}"/sprite/lib/common.sh
-        "${REPO_ROOT}"/shared/common.sh
-        "${REPO_ROOT}"/digitalocean/*.sh
-        "${REPO_ROOT}"/digitalocean/lib/common.sh
-        "${REPO_ROOT}"/hetzner/*.sh
-        "${REPO_ROOT}"/hetzner/lib/common.sh
-        "${REPO_ROOT}"/linode/*.sh
-        "${REPO_ROOT}"/linode/lib/common.sh
-        "${REPO_ROOT}"/vultr/*.sh
-        "${REPO_ROOT}"/vultr/lib/common.sh
-        "${REPO_ROOT}"/test/run.sh
-    )
+    # Dynamically find all shell scripts (shared, cloud libs, agent scripts, tests)
+    local all_scripts=()
+    all_scripts+=("${REPO_ROOT}"/shared/*.sh)
+    all_scripts+=("${REPO_ROOT}"/test/run.sh)
+    local cloud_dir
+    for cloud_dir in "${REPO_ROOT}"/*/lib; do
+        [[ -d "${cloud_dir}" ]] || continue
+        all_scripts+=("${cloud_dir}"/common.sh)
+        all_scripts+=("${cloud_dir}"/../*.sh)
+    done
 
     local issue_count=0
     local checked_count=0


### PR DESCRIPTION
## Summary

- **shared/key-request.sh**: Extract `_try_load_env_var_from_config` and `_load_cloud_env_vars` helpers from `load_cloud_keys_from_config`, reducing nesting depth from 7 to 3 and shrinking the main function from 81 to 46 lines
- **test/run.sh**: Replace hardcoded 4-cloud script list in `run_shellcheck` with dynamic discovery that automatically finds all cloud lib and agent scripts (covers all 33 clouds)

## Test plan

- [x] `bash -n` passes on both modified files
- [x] `bun test` passes (4 pre-existing failures unrelated to this change)
- [ ] Manual verification that `run_shellcheck` discovers scripts from newly added clouds

Agent: complexity-hunter

🤖 Generated with [Claude Code](https://claude.com/claude-code)