### PR TITLE
fix: include both agent and cloud in typo correction suggestions

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/build-suggestion-cmd.test.ts
+++ b/cli/src/__tests__/build-suggestion-cmd.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { buildSuggestionCmd } from "../commands";
+
+/**
+ * Tests for buildSuggestionCmd (commands.ts).
+ *
+ * This helper builds the suggested spawn command shown in typo correction hints.
+ * When pairArg is provided, it includes both agent and cloud in the correct order.
+ *
+ * Agent: ux-engineer
+ */
+
+describe("buildSuggestionCmd", () => {
+  it("should return 'spawn <match>' when no pairArg for agent", () => {
+    expect(buildSuggestionCmd("claude", "agent")).toBe("spawn claude");
+  });
+
+  it("should return 'spawn <match>' when no pairArg for cloud", () => {
+    expect(buildSuggestionCmd("sprite", "cloud")).toBe("spawn sprite");
+  });
+
+  it("should return 'spawn <agent> <cloud>' when kind is agent with cloud pairArg", () => {
+    expect(buildSuggestionCmd("claude", "agent", "sprite")).toBe("spawn claude sprite");
+  });
+
+  it("should return 'spawn <agent> <cloud>' when kind is cloud with agent pairArg", () => {
+    expect(buildSuggestionCmd("sprite", "cloud", "claude")).toBe("spawn claude sprite");
+  });
+
+  it("should put agent first regardless of which is the match", () => {
+    // When match is an agent correction (kind=agent), match goes first
+    expect(buildSuggestionCmd("aider", "agent", "hetzner")).toBe("spawn aider hetzner");
+    // When match is a cloud correction (kind=cloud), pairArg (agent) goes first
+    expect(buildSuggestionCmd("hetzner", "cloud", "aider")).toBe("spawn aider hetzner");
+  });
+
+  it("should handle undefined pairArg same as no pairArg", () => {
+    expect(buildSuggestionCmd("claude", "agent", undefined)).toBe("spawn claude");
+    expect(buildSuggestionCmd("sprite", "cloud", undefined)).toBe("spawn sprite");
+  });
+});

--- a/cli/src/__tests__/check-entity-messages.test.ts
+++ b/cli/src/__tests__/check-entity-messages.test.ts
@@ -324,4 +324,45 @@ describe("checkEntity message output", () => {
       expect(mockLogInfo.mock.calls.length).toBe(0);
     });
   });
+
+  // ── pairArg: complete command suggestions ──────────────────────────────
+
+  describe("pairArg builds complete spawn commands in suggestions", () => {
+    it("should suggest 'spawn claude sprite' for agent typo with cloud pairArg", () => {
+      checkEntity(manifest, "claud", "agent", "sprite");
+
+      const info = infoCalls();
+      expect(info.some(m => m.includes("spawn claude sprite"))).toBe(true);
+    });
+
+    it("should suggest 'spawn claude hetzner' for cloud typo with agent pairArg", () => {
+      checkEntity(manifest, "hetzne", "cloud", "claude");
+
+      const info = infoCalls();
+      expect(info.some(m => m.includes("spawn claude hetzner"))).toBe(true);
+    });
+
+    it("should show 'spawn aider sprite' for cloud typo 'sprit' with agent pairArg", () => {
+      checkEntity(manifest, "sprit", "cloud", "aider");
+
+      const info = infoCalls();
+      expect(info.some(m => m.includes("spawn aider sprite"))).toBe(true);
+    });
+
+    it("should show bare 'spawn claude' when no pairArg given", () => {
+      checkEntity(manifest, "claud", "agent");
+
+      const info = infoCalls();
+      expect(info.some(m => m.includes("spawn claude") && !m.includes("spawn claude "))).toBe(true);
+    });
+
+    it("should still return true for valid entity with pairArg", () => {
+      expect(checkEntity(manifest, "claude", "agent", "sprite")).toBe(true);
+      expect(mockLogError.mock.calls.length).toBe(0);
+    });
+
+    it("should still return false for unknown entity with pairArg", () => {
+      expect(checkEntity(manifest, "kubernetes", "agent", "sprite")).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- When a user misspells an agent or cloud name in `spawn <agent> <cloud>`, the "Did you mean" suggestion now includes both arguments (e.g., `spawn claude sprite` instead of just `spawn claude`)
- Previously, the bare suggestion `spawn claude` would open the agent info page instead of launching the intended command, confusing users
- Adds `buildSuggestionCmd` helper and passes the paired argument through `checkEntity` so suggestions always show the full launch command

## Test plan
- [x] All 94 check-entity tests pass (88 existing + 6 new pairArg tests)
- [x] 6 new unit tests for `buildSuggestionCmd` verify correct argument ordering
- [x] Full test suite: 5496 pass, 3 pre-existing fail (unchanged)
- [ ] Manual test: `spawn claud sprite` should suggest `spawn claude sprite`
- [ ] Manual test: `spawn claude hetnzer` should suggest `spawn claude hetzner`

Generated with [Claude Code](https://claude.com/claude-code)