### PR TITLE
refactor: decompose run_test() and record_cloud() into focused helpers

### DIFF
--- a/test/mock.sh
+++ b/test/mock.sh
@@ -665,38 +665,11 @@ discover_agents() {
 # Test runner
 # ============================================================
 
-run_test() {
-    local cloud="$1"
-    local agent="$2"
-    local script_path="${REPO_ROOT}/${cloud}/${agent}.sh"
-
-    if [[ ! -f "$script_path" ]]; then
-        printf '%b\n' "  ${YELLOW}skip${NC} ${cloud}/${agent}.sh — file not found"
-        SKIPPED=$((SKIPPED + 1))
-        return 0
-    fi
-
-    printf '%b\n' "  ${CYAN}test${NC} ${cloud}/${agent}.sh"
-
-    # Snapshot failure count before this test's assertions
-    local _pre_failed="${FAILED}"
-
-    # Reset mock log
-    : > "${MOCK_LOG}"
-
-    # Set up environment
-    setup_env_for_cloud "$cloud"
-
-    # Fake HOME to avoid polluting real home
-    local fake_home
-    fake_home=$(setup_fake_home)
-
-    # Set up state file for state tracking
-    local state_file="${TEST_DIR}/state_${cloud}_${agent}.log"
-    : > "${state_file}"
-
-    # Run the script with mocked PATH + HOME (10s timeout — all calls are fake)
-    local exit_code=0
+# Run a script in the background with a timeout (4 seconds).
+# Sets exit_code in the caller's scope.
+_run_script_with_timeout() {
+    local script_path="$1" cloud="$2" state_file="$3" fake_home="$4"
+    exit_code=0
 
     MOCK_LOG="${MOCK_LOG}" \
     MOCK_FIXTURE_DIR="${FIXTURES_DIR}/${cloud}" \
@@ -725,7 +698,6 @@ run_test() {
         wait "$pid" 2>/dev/null || exit_code=$?
     fi
 
-    # Show last lines of output on failure
     if [[ "${exit_code}" -ne 0 ]]; then
         printf '%b\n' "    ${RED}--- output (last 20 lines) ---${NC}"
         tail -20 "${TEST_DIR}/output.log" 2>/dev/null | while IFS= read -r line; do
@@ -733,30 +705,11 @@ run_test() {
         done
         printf '%b\n' "    ${RED}--- end output ---${NC}"
     fi
+}
 
-    # --- Assertions ---
-    if [[ -n "${MOCK_ERROR_SCENARIO:-}" ]]; then
-        # Error scenarios: expect non-zero exit
-        if [[ "${exit_code}" -ne 0 ]]; then
-            printf '%b\n' "    ${GREEN}✓${NC} fails on ${MOCK_ERROR_SCENARIO} (exit code ${exit_code})"
-            PASSED=$((PASSED + 1))
-            if [[ -n "${RESULTS_FILE:-}" ]]; then
-                printf '%s/%s:pass\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
-            fi
-        else
-            printf '%b\n' "    ${RED}✗${NC} should fail on ${MOCK_ERROR_SCENARIO} but exited 0"
-            FAILED=$((FAILED + 1))
-            if [[ -n "${RESULTS_FILE:-}" ]]; then
-                printf '%s/%s:fail\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
-            fi
-        fi
-        printf '\n'
-        return 0
-    fi
-
-    assert_exit_code "${exit_code}" 0 "exits successfully"
-
-    # Cloud-specific API call assertions
+# Assert cloud-specific API calls were made
+_assert_cloud_api_calls() {
+    local cloud="$1"
     case "$cloud" in
         hetzner)
             assert_api_called "GET" "/ssh_keys" "fetches SSH keys"
@@ -786,33 +739,73 @@ run_test() {
             assert_log_contains "curl (GET|POST) https://" "makes API calls"
             ;;
     esac
+}
 
-    # Check that SSH was used (for remote execution)
+# Record pass/fail result to RESULTS_FILE
+_record_test_result() {
+    local cloud="$1" agent="$2" pre_failed="$3"
+    [[ -z "${RESULTS_FILE:-}" ]] && return 0
+    local pre_fail=$((FAILED - pre_failed))
+    if [[ "$pre_fail" -gt 0 ]]; then
+        printf '%s/%s:fail\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
+    else
+        printf '%s/%s:pass\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
+    fi
+}
+
+run_test() {
+    local cloud="$1"
+    local agent="$2"
+    local script_path="${REPO_ROOT}/${cloud}/${agent}.sh"
+
+    if [[ ! -f "$script_path" ]]; then
+        printf '%b\n' "  ${YELLOW}skip${NC} ${cloud}/${agent}.sh — file not found"
+        SKIPPED=$((SKIPPED + 1))
+        return 0
+    fi
+
+    printf '%b\n' "  ${CYAN}test${NC} ${cloud}/${agent}.sh"
+
+    local _pre_failed="${FAILED}"
+    : > "${MOCK_LOG}"
+    setup_env_for_cloud "$cloud"
+
+    local fake_home
+    fake_home=$(setup_fake_home)
+
+    local state_file="${TEST_DIR}/state_${cloud}_${agent}.log"
+    : > "${state_file}"
+
+    local exit_code
+    _run_script_with_timeout "${script_path}" "${cloud}" "${state_file}" "${fake_home}"
+
+    # --- Assertions ---
+    if [[ -n "${MOCK_ERROR_SCENARIO:-}" ]]; then
+        if [[ "${exit_code}" -ne 0 ]]; then
+            printf '%b\n' "    ${GREEN}✓${NC} fails on ${MOCK_ERROR_SCENARIO} (exit code ${exit_code})"
+            PASSED=$((PASSED + 1))
+        else
+            printf '%b\n' "    ${RED}✗${NC} should fail on ${MOCK_ERROR_SCENARIO} but exited 0"
+            FAILED=$((FAILED + 1))
+        fi
+        _record_test_result "${cloud}" "${agent}" "${_pre_failed}"
+        printf '\n'
+        return 0
+    fi
+
+    assert_exit_code "${exit_code}" 0 "exits successfully"
+    _assert_cloud_api_calls "$cloud"
     assert_log_contains "ssh " "uses SSH"
-
-    # Check OpenRouter API key injection
     assert_env_injected "OPENROUTER_API_KEY"
 
-    # Body validation (when enabled)
     if [[ "${MOCK_VALIDATE_BODY:-}" == "1" ]]; then
         assert_no_body_errors
     fi
-
-    # State tracking (when enabled)
     if [[ "${MOCK_TRACK_STATE:-}" == "1" ]]; then
         assert_server_cleaned_up "${state_file}"
     fi
 
-    # Write per-test result to RESULTS_FILE (used by qa-dry-run.sh / qa-cycle.sh)
-    if [[ -n "${RESULTS_FILE:-}" ]]; then
-        local pre_fail=$((FAILED - _pre_failed))
-        if [[ "$pre_fail" -gt 0 ]]; then
-            printf '%s/%s:fail\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
-        else
-            printf '%s/%s:pass\n' "${cloud}" "${agent}" >> "${RESULTS_FILE}"
-        fi
-    fi
-
+    _record_test_result "${cloud}" "${agent}" "${_pre_failed}"
     printf '\n'
 }
 


### PR DESCRIPTION
## Summary

Decomposes the two longest remaining functions in the test suite into smaller, focused helpers:

**test/mock.sh** - `run_test()` reduced from 150 to 55 lines:
- `_run_script_with_timeout()` - script execution with background process + 4s timeout
- `_assert_cloud_api_calls()` - cloud-specific API call assertion case statement
- `_record_test_result()` - result file recording (pass/fail to RESULTS_FILE)

**test/record.sh** - `record_cloud()` reduced from 107 to 35 lines:
- `_ensure_cloud_credentials()` - credential check + interactive prompt flow
- `_record_endpoint()` - single endpoint recording (API call, JSON validation, fixture save)
- `_write_fixture_metadata()` - metadata JSON file writing

## Test plan
- [x] `bash -n test/mock.sh` - syntax OK
- [x] `bash -n test/record.sh` - syntax OK
- [x] `bash test/mock.sh` - 330 passed, 105 failed, 1 skipped (identical to main)
- [x] `bash test/run.sh` - 74 passed, 0 failed
- [x] `bun test` - 5484 passed, 3 failed (identical to main)

Agent: complexity-hunter