### PR TITLE
fix: validate provider names in key-server, use safe env injection in continue.sh

### DIFF
--- a/daytona/continue.sh
+++ b/daytona/continue.sh
@@ -29,8 +29,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/e2b/continue.sh
+++ b/e2b/continue.sh
@@ -33,8 +33,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/github-codespaces/continue.sh
+++ b/github-codespaces/continue.sh
@@ -38,8 +38,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/latitude/continue.sh
+++ b/latitude/continue.sh
@@ -32,8 +32,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.bashrc"
-run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.zshrc"
+inject_env_vars_ssh "${LATITUDE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${LATITUDE_SERVER_IP}" \

--- a/modal/continue.sh
+++ b/modal/continue.sh
@@ -32,8 +32,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/scaleway/continue.sh
+++ b/scaleway/continue.sh
@@ -34,8 +34,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.bashrc"
-run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.zshrc"
+inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${SCALEWAY_SERVER_IP}" \

--- a/upcloud/continue.sh
+++ b/upcloud/continue.sh
@@ -31,8 +31,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.bashrc"
-run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.zshrc"
+inject_env_vars_ssh "${UPCLOUD_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${UPCLOUD_SERVER_IP}" \


### PR DESCRIPTION
## Summary

- **key-server.ts**: Add provider name validation in `/request-batch` endpoint to prevent path traversal. Without this, a crafted provider name like `../../.ssh/foo` could write files to arbitrary paths via `saveKeys()`. Also adds defense-in-depth validation directly in `saveKeys()`.
- **7 continue.sh scripts**: Replace inline `OPENROUTER_API_KEY` interpolation in shell command strings (e.g. `run_server "printf ... '${OPENROUTER_API_KEY}' >> ~/.bashrc"`) with the safe `inject_env_vars_ssh` / `inject_env_vars_local` / `inject_env_vars` pattern that writes env vars to a temp file before uploading. This matches the pattern already used by all other agent scripts in these providers.

Affected clouds: scaleway, upcloud, latitude, modal, e2b, daytona, github-codespaces

## Security Details

### Path traversal in key-server.ts (HIGH)
The `/request-batch` endpoint accepted arbitrary strings as provider names without validation. These names were later used in `saveKeys()` to construct file paths: `join(CONFIG_DIR, "${provider}.json")`. Since `path.join` resolves `..` segments, a malicious provider name could write JSON files to arbitrary paths on the server.

While the endpoint requires Bearer auth (limiting the attack to holders of `KEY_SERVER_SECRET`), the signed URL mechanism means batch submissions via the form are unauthenticated. Defense-in-depth dictates validating at both entry points.

### Inline API key injection in continue.sh (MEDIUM)
Several continue.sh scripts directly interpolated `OPENROUTER_API_KEY` into shell command strings sent via SSH. If the key contained shell metacharacters (particularly single quotes), it could break out of quoting. While the practical risk is low (API keys come from OAuth or validated manual entry), this pattern is inconsistent with all other agent scripts which use the safe temp-file-based injection.

## Test plan
- [x] `bash -n` passes on all 7 modified shell scripts
- [x] `bun test` passes (pre-existing failures unrelated to changes)
- [ ] Manual verification: key-server rejects provider names with path traversal characters

Agent: security-auditor

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>