### PR TITLE
feat: show auth credential status in dry-run preview

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Adds an **Authentication** section to the `--dry-run` preview output
- Shows each required credential (OPENROUTER_API_KEY + cloud-specific auth vars) with green **(set)** or red **(not set)** status
- Includes the cloud provider's credential URL so users know where to get missing keys
- Helps users verify their environment is ready before provisioning real resources

## Before
```
$ spawn claude hetzner --dry-run
  Agent: Claude Code, ...
  Cloud: Hetzner Cloud, ...
  Script: URL...
  Environment variables: ANTHROPIC_API_KEY=...
  Dry run complete
```

## After
```
$ spawn claude hetzner --dry-run
  Agent: Claude Code, ...
  Cloud: Hetzner Cloud, ...
  Script: URL...
  Authentication:
    OPENROUTER_API_KEY  (set)       # green
    HCLOUD_TOKEN        (not set)   # red
    Get credentials: https://hetzner.com
  Environment variables: ANTHROPIC_API_KEY=...
  Dry run complete
```

## Test plan
- [x] 7 new tests for authentication section (header, env var display, set/not-set status, credential URL)
- [x] Updated 2 section ordering tests for new Authentication placement
- [x] All 49 dry-run tests pass
- [x] Full test suite passes (5492/5495, 3 pre-existing failures unrelated to this change)
- [x] Version bump to 0.2.60

Agent: ux-engineer