### PR TITLE
fix: install.sh fails on Termux proot

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

- **Download `bun.lock`** in the non-git (curl) download path so `bun install` produces a deterministic `node_modules` layout
- **Add build retry** with `bun install --force` fallback if the initial `bun run build` fails
- **Enforce minimum bun version** (>=1.2.0) with automatic `bun upgrade` if below threshold
- Bump CLI version to 0.2.60

## Context

The `curl | bash` installer fails on Termux proot with bun 1.3.8:
```
error: Could not resolve: "picocolors". Maybe you need to "bun install"?
```

Root cause: the non-git download path fetched `package.json` and `tsconfig.json` but not `bun.lock`. Without the lockfile, `bun install` resolves dependencies from scratch, and on older bun versions the resulting `node_modules` layout causes `bun build --packages bundle` to fail.

The git path (sparse-checkout) was unaffected since it gets the full `cli/` directory including `bun.lock`.

## Test plan

- [ ] Verify git path still works: `bash install.sh` in a directory with git
- [ ] Verify non-git path: temporarily hide `git` from PATH and run the installer
- [ ] Verify minimum version check: mock `bun --version` returning `1.0.0` and confirm auto-upgrade triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)