### PR TITLE
fix: source-mode fallback when bundled build fails

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -163,16 +163,39 @@ build_and_install() {
 
     cd "${tmpdir}/cli"
     bun install
-    if ! bun run build; then
+
+    local build_ok=0
+    if bun run build 2>/dev/null; then
+        build_ok=1
+    else
         log_warn "Build failed, retrying with forced reinstall..."
         bun install --force
-        bun run build
+        if bun run build 2>/dev/null; then
+            build_ok=1
+        fi
     fi
 
     INSTALL_DIR="$(find_install_dir)"
     mkdir -p "${INSTALL_DIR}"
-    cp cli.js "${INSTALL_DIR}/spawn"
-    chmod +x "${INSTALL_DIR}/spawn"
+
+    if [ "$build_ok" = "1" ]; then
+        cp cli.js "${INSTALL_DIR}/spawn"
+        chmod +x "${INSTALL_DIR}/spawn"
+    else
+        # Bundled build failed — fall back to source mode.
+        # Install source + node_modules to ~/.spawn/ and create a wrapper.
+        log_warn "Bundled build unavailable, installing from source..."
+        local spawn_lib="${HOME}/.spawn"
+        rm -rf "${spawn_lib}"
+        mkdir -p "${spawn_lib}"
+        cp -r node_modules src package.json "${spawn_lib}/"
+        cat > "${INSTALL_DIR}/spawn" <<'WRAPPER'
+#!/usr/bin/env bash
+exec bun "$HOME/.spawn/src/index.ts" "$@"
+WRAPPER
+        chmod +x "${INSTALL_DIR}/spawn"
+    fi
+
     log_info "Installed spawn to ${INSTALL_DIR}/spawn"
     ensure_in_path "${INSTALL_DIR}"
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.60",
+  "version": "0.2.61",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

- When `bun build --packages bundle` fails (e.g. bun 1.3.8 on Termux proot), fall back to **source-mode install**: copies source + `node_modules` to `~/.spawn/` and creates a wrapper script that runs via `bun` directly
- Bun natively runs TypeScript, so the CLI works identically in source mode
- Bump CLI version to 0.2.61

## Context

Follow-up to #704. The `bun.lock` download and `--force` retry weren't sufficient — `bun build --packages bundle` is fundamentally broken on bun 1.3.8 in Termux proot. The bundled build can't resolve `picocolors` regardless of lockfile or reinstall.

The source-mode fallback sidesteps the build entirely. The wrapper at `~/.local/bin/spawn` does:
```bash
#!/usr/bin/env bash
exec bun "$HOME/.spawn/src/index.ts" "$@"
```

## Test plan

- [ ] Normal systems: bundled build succeeds, installs single `cli.js` as before
- [ ] Termux proot (bun 1.3.8): bundled build fails, source-mode fallback installs successfully
- [ ] Verify `spawn version` and `spawn list` work in source mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)