### PR TITLE
fix: redirect 'spawn agents <name>' to info page

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -351,6 +351,17 @@ async function dispatchCommand(cmd: string, filteredArgs: string[], prompt: stri
 
   if (SUBCOMMANDS[cmd]) {
     if (hasTrailingHelpFlag(filteredArgs)) { cmdHelp(); return; }
+
+    // "spawn agents <name>" or "spawn clouds <name>" -> show info for that name
+    if ((cmd === "agents" || cmd === "clouds") && filteredArgs.length > 1 && !filteredArgs[1].startsWith("-")) {
+      const name = filteredArgs[1];
+      warnExtraArgs(filteredArgs, 2);
+      console.error(pc.dim(`Tip: next time you can just run ${pc.cyan(`spawn ${name}`)}`));
+      console.error();
+      await showInfoOrError(name);
+      return;
+    }
+
     warnExtraArgs(filteredArgs, 1);
     await SUBCOMMANDS[cmd]();
     return;


### PR DESCRIPTION
## Summary
- When users type `spawn agents claude` or `spawn clouds hetzner`, they intuitively expect to see info about that specific agent/cloud
- Previously, the extra argument was silently ignored with a "Warning: extra argument ignored" message, and the full list was shown instead
- Now these commands redirect to the info page for the given name (same as `spawn claude` or `spawn hetzner`), with a tip suggesting the shorter form

## Before
```
$ spawn agents claude
Warning: extra argument ignored: claude
  Usage: spawn <agent> <cloud> [--prompt "..."]

  [full agents list]
```

## After
```
$ spawn agents claude
  Tip: next time you can just run spawn claude

  [claude agent info page with available clouds, quick start, etc.]
```

## Test plan
- [x] Added 8 new dispatch routing tests covering the new behavior
- [x] Tests verify `spawn agents <name>` and `spawn clouds <name>` redirect to info
- [x] Tests verify `spawn agents --help` and `spawn agents -h` still route to help
- [x] Tests verify `spawn matrix <name>` and `spawn update <name>` are NOT affected (only agents/clouds)
- [x] Full test suite passes (5492 pass, same 3 pre-existing failures)

Agent: ux-engineer

Generated with [Claude Code](https://claude.com/claude-code)