### PR TITLE
fix: source-mode wrapper cwd for package resolution

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -191,7 +191,7 @@ build_and_install() {
         cp -r node_modules src package.json "${spawn_lib}/"
         cat > "${INSTALL_DIR}/spawn" <<'WRAPPER'
 #!/usr/bin/env bash
-exec bun "$HOME/.spawn/src/index.ts" "$@"
+cd "$HOME/.spawn" && exec bun src/index.ts "$@"
 WRAPPER
         chmod +x "${INSTALL_DIR}/spawn"
     fi

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.61",
+  "version": "0.2.62",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

- Fix the source-mode fallback wrapper to `cd` into `~/.spawn/` before running bun, so `node_modules` is resolved from the current directory

## Context

Follow-up to #707. The source-mode fallback installed correctly but bun 1.3.8 on Termux proot couldn't find packages:
```
error: Cannot find package 'picocolors' from '/root/.spawn/src/index.ts'
```

bun 1.3.8 in proot doesn't walk up from `src/` to find `node_modules/` in the parent. The fix is trivial — `cd "$HOME/.spawn"` in the wrapper so bun resolves packages from the directory containing `node_modules/`.

## Test plan

- [ ] Termux proot (bun 1.3.8): `spawn version` works after source-mode install
- [ ] Normal systems: bundled build path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)