### PR TITLE
refactor: replace inline Claude config with shared helper in fly/koyeb/railway

### DIFF
--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -55,47 +55,9 @@ inject_env_vars_fly \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
 # 7. Configure Claude Code settings
-log_step "Configuring Claude Code..."
-
-run_server "mkdir -p ~/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch ~/.claude/CLAUDE.md"
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file" \
+    "run_server"
 
 echo ""
 log_info "Fly.io machine setup completed successfully!"

--- a/koyeb/claude.sh
+++ b/koyeb/claude.sh
@@ -55,47 +55,9 @@ inject_env_vars \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
 # 7. Configure Claude Code settings
-log_step "Configuring Claude Code..."
-
-run_server "mkdir -p /root/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch /root/.claude/CLAUDE.md"
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file" \
+    "run_server"
 
 echo ""
 log_info "Koyeb service setup completed successfully!"

--- a/railway/claude.sh
+++ b/railway/claude.sh
@@ -55,47 +55,9 @@ inject_env_vars \
     "PATH=\$HOME/.claude/local/bin:\$HOME/.bun/bin:\$PATH"
 
 # 7. Configure Claude Code settings
-log_step "Configuring Claude Code..."
-
-run_server "mkdir -p /root/.claude"
-
-# Upload settings.json
-SETTINGS_TEMP=$(mktemp)
-chmod 600 "$SETTINGS_TEMP"
-cat > "$SETTINGS_TEMP" << EOF
-{
-  "theme": "dark",
-  "editor": "vim",
-  "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
-    "ANTHROPIC_AUTH_TOKEN": "${OPENROUTER_API_KEY}"
-  },
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "dangerouslySkipPermissions": true
-  }
-}
-EOF
-
-upload_file "$SETTINGS_TEMP" "/root/.claude/settings.json"
-rm "$SETTINGS_TEMP"
-
-# Upload ~/.claude.json global state
-GLOBAL_STATE_TEMP=$(mktemp)
-chmod 600 "$GLOBAL_STATE_TEMP"
-cat > "$GLOBAL_STATE_TEMP" << EOF
-{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}
-EOF
-
-upload_file "$GLOBAL_STATE_TEMP" "/root/.claude.json"
-rm "$GLOBAL_STATE_TEMP"
-
-# Create empty CLAUDE.md
-run_server "touch /root/.claude/CLAUDE.md"
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file" \
+    "run_server"
 
 echo ""
 log_info "Railway service setup completed successfully!"


### PR DESCRIPTION
## Summary
- Replace 40 lines of duplicated inline Claude Code configuration in `fly/claude.sh`, `koyeb/claude.sh`, and `railway/claude.sh` with 3-line calls to the shared `setup_claude_code_config` helper from `shared/common.sh`
- Net reduction: **123 lines deleted, 9 added** (-114 lines)
- The shared helper also uses `json_escape` for the API key, improving security over the raw heredoc interpolation that was used before
- Matches the pattern already used by 30+ other `claude.sh` scripts (e.g., `daytona/claude.sh`, `hetzner/claude.sh`, `sprite/claude.sh`)

## What changed
Each of the 3 scripts had an identical ~40-line block that:
1. Created `~/.claude` directory
2. Generated `settings.json` via mktemp + heredoc + upload + rm
3. Generated `.claude.json` via mktemp + heredoc + upload + rm
4. Created empty `CLAUDE.md`

This was replaced with a single call:
```bash
setup_claude_code_config "${OPENROUTER_API_KEY}" \
    "upload_file" \
    "run_server"
```

## Test plan
- [x] `bash -n` passes on all 3 modified files
- [x] `bun test` passes (80 pre-existing failures, 0 new)
- [x] Verified pattern matches existing usage in `daytona/claude.sh`, `hetzner/claude.sh`, etc.

Agent: complexity-hunter