### PR TITLE
test: add 83 tests for install.sh script validation

### DIFF
--- a/cli/src/__tests__/install-script-validation.test.ts
+++ b/cli/src/__tests__/install-script-validation.test.ts
@@ -1,0 +1,526 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync, existsSync } from "fs";
+import { resolve, join } from "path";
+
+/**
+ * Validation tests for cli/install.sh.
+ *
+ * install.sh is the critical entry point for all new users
+ * (curl -fsSL ... | bash). It has been modified in multiple recent PRs
+ * but had zero test coverage. These tests validate structure, conventions,
+ * security, curl|bash compatibility, and the source-mode fallback wrapper.
+ *
+ * Agent: test-engineer
+ */
+
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const INSTALL_SH = join(REPO_ROOT, "cli", "install.sh");
+const content = readFileSync(INSTALL_SH, "utf-8");
+const lines = content.split("\n");
+
+/** Get non-comment, non-empty lines */
+function codeLines(): string[] {
+  return lines.filter(
+    (line) => line.trim() !== "" && !line.trimStart().startsWith("#")
+  );
+}
+
+describe("install.sh validation", () => {
+  // ── File existence and structure ─────────────────────────────────────
+
+  describe("file structure", () => {
+    it("should exist on disk", () => {
+      expect(existsSync(INSTALL_SH)).toBe(true);
+    });
+
+    it("should start with #!/bin/bash shebang", () => {
+      expect(lines[0]).toBe("#!/bin/bash");
+    });
+
+    it("should use set -eo pipefail", () => {
+      expect(content).toContain("set -eo pipefail");
+    });
+
+    it("should not be empty", () => {
+      expect(content.trim().length).toBeGreaterThan(100);
+    });
+
+    it("should not use set -u or set -o nounset", () => {
+      const code = codeLines();
+      const hasSetU = code.some(
+        (l) =>
+          (/\bset\s+.*-.*u\b/.test(l) && !l.includes("pipefail")) ||
+          /set\s+-o\s+nounset/.test(l)
+      );
+      expect(hasSetU).toBe(false);
+    });
+  });
+
+  // ── Repository constants ─────────────────────────────────────────────
+
+  describe("repository constants", () => {
+    it("should define SPAWN_REPO pointing to OpenRouterTeam/spawn", () => {
+      expect(content).toContain('SPAWN_REPO="OpenRouterTeam/spawn"');
+    });
+
+    it("should define SPAWN_RAW_BASE using SPAWN_REPO", () => {
+      expect(content).toContain("SPAWN_RAW_BASE=");
+      expect(content).toContain("raw.githubusercontent.com");
+      expect(content).toContain("${SPAWN_REPO}");
+    });
+
+    it("should define MIN_BUN_VERSION", () => {
+      expect(content).toMatch(/MIN_BUN_VERSION="[0-9]+\.[0-9]+\.[0-9]+"/);
+    });
+  });
+
+  // ── Required functions ───────────────────────────────────────────────
+
+  describe("required functions", () => {
+    it("should define log_info function", () => {
+      expect(content).toMatch(/log_info\(\)/);
+    });
+
+    it("should define log_warn function", () => {
+      expect(content).toMatch(/log_warn\(\)/);
+    });
+
+    it("should define log_error function", () => {
+      expect(content).toMatch(/log_error\(\)/);
+    });
+
+    it("should define version_gte function", () => {
+      expect(content).toContain("version_gte()");
+    });
+
+    it("should define ensure_min_bun_version function", () => {
+      expect(content).toContain("ensure_min_bun_version()");
+    });
+
+    it("should define find_install_dir function", () => {
+      expect(content).toContain("find_install_dir()");
+    });
+
+    it("should define ensure_in_path function", () => {
+      expect(content).toContain("ensure_in_path()");
+    });
+
+    it("should define clone_cli function", () => {
+      expect(content).toContain("clone_cli()");
+    });
+
+    it("should define build_and_install function", () => {
+      expect(content).toContain("build_and_install()");
+    });
+  });
+
+  // ── curl|bash compatibility ──────────────────────────────────────────
+
+  describe("curl|bash compatibility", () => {
+    it("should not use source <(...) process substitution", () => {
+      const code = codeLines();
+      const hasProcessSub = code.some((l) => /source\s+<\(/.test(l));
+      expect(hasProcessSub).toBe(false);
+    });
+
+    it("should not rely on BASH_SOURCE for path resolution", () => {
+      // install.sh runs via curl|bash so BASH_SOURCE is meaningless
+      expect(content).not.toContain("BASH_SOURCE");
+    });
+
+    it("should not rely on dirname $0 for path resolution", () => {
+      expect(content).not.toContain('dirname "$0"');
+      expect(content).not.toContain("dirname $0");
+    });
+
+    it("should use SPAWN_INSTALL_DIR env var for override", () => {
+      expect(content).toContain("SPAWN_INSTALL_DIR");
+    });
+
+    it("should check for SPAWN_INSTALL_DIR before defaulting", () => {
+      // The find_install_dir function should check SPAWN_INSTALL_DIR first
+      const fnStart = content.indexOf("find_install_dir()");
+      const fnBody = content.slice(fnStart, content.indexOf("}", fnStart) + 1);
+      expect(fnBody).toContain("SPAWN_INSTALL_DIR");
+    });
+  });
+
+  // ── Bun installation ────────────────────────────────────────────────
+
+  describe("bun installation", () => {
+    it("should check if bun is available via command -v", () => {
+      expect(content).toContain("command -v bun");
+    });
+
+    it("should install bun from bun.sh if not found", () => {
+      expect(content).toContain("https://bun.sh/install");
+    });
+
+    it("should set BUN_INSTALL and PATH after installing bun", () => {
+      expect(content).toContain("BUN_INSTALL=");
+      expect(content).toContain("${BUN_INSTALL}/bin");
+    });
+
+    it("should show error and exit if bun installation fails", () => {
+      // After installing bun, should check again and show error if still not found
+      const afterInstall = content.slice(
+        content.indexOf("https://bun.sh/install")
+      );
+      expect(afterInstall).toContain("command -v bun");
+      expect(afterInstall).toContain("log_error");
+      expect(afterInstall).toContain("exit 1");
+    });
+
+    it("should call ensure_min_bun_version after bun is available", () => {
+      // ensure_min_bun_version should be called in the main flow
+      const mainFlow = content.slice(content.lastIndexOf("ensure_min_bun_version"));
+      expect(mainFlow).toContain("build_and_install");
+    });
+  });
+
+  // ── Version comparison ──────────────────────────────────────────────
+
+  describe("version_gte logic", () => {
+    // Extract the full function body by finding the next function or end of file
+    const fnStart = content.indexOf("version_gte()");
+    const fnEnd = content.indexOf("\n\n# ---", fnStart);
+    const fnBody = content.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined);
+
+    it("should use IFS='.' to split semver", () => {
+      expect(fnBody).toContain("IFS='.'");
+    });
+
+    it("should handle missing segments with default 0", () => {
+      // ${a[$i]:-0} or similar default-to-zero pattern
+      expect(fnBody).toContain(":-0");
+    });
+
+    it("should return 1 (false) when version is less", () => {
+      expect(fnBody).toContain("return 1");
+    });
+
+    it("should return 0 (true) when version is greater or equal", () => {
+      expect(fnBody).toContain("return 0");
+    });
+  });
+
+  // ── Build and install logic ─────────────────────────────────────────
+
+  describe("build_and_install", () => {
+    it("should create a temp directory", () => {
+      expect(content).toContain("mktemp -d");
+    });
+
+    it("should clean up temp directory on exit via trap", () => {
+      expect(content).toContain("trap");
+      expect(content).toContain("rm -rf");
+    });
+
+    it("should clone CLI source", () => {
+      expect(content).toContain("clone_cli");
+    });
+
+    it("should run bun install", () => {
+      expect(content).toContain("bun install");
+    });
+
+    it("should attempt bun run build", () => {
+      expect(content).toContain("bun run build");
+    });
+
+    it("should use find_install_dir to determine install location", () => {
+      expect(content).toContain("find_install_dir");
+    });
+
+    it("should create the install directory if it does not exist", () => {
+      const fnStart = content.indexOf("build_and_install()");
+      const fnBody = content.slice(fnStart);
+      expect(fnBody).toContain('mkdir -p "${INSTALL_DIR}"');
+    });
+
+    it("should set chmod +x on the spawn binary", () => {
+      expect(content).toContain('chmod +x "${INSTALL_DIR}/spawn"');
+    });
+
+    it("should call ensure_in_path at the end", () => {
+      const fnStart = content.indexOf("build_and_install()");
+      const fnBody = content.slice(fnStart);
+      expect(fnBody).toContain("ensure_in_path");
+    });
+  });
+
+  // ── Source-mode fallback (PR #707, #710) ────────────────────────────
+
+  describe("source-mode fallback wrapper", () => {
+    it("should fall back to source mode when bundled build fails", () => {
+      // The script should have a fallback path when build_ok is not 1
+      expect(content).toContain("source");
+      expect(content).toContain("Bundled build");
+    });
+
+    it("should install source files to ~/.spawn", () => {
+      expect(content).toContain('${HOME}/.spawn');
+    });
+
+    it("should copy node_modules, src, and package.json to spawn lib dir", () => {
+      expect(content).toContain("node_modules");
+      expect(content).toContain("package.json");
+    });
+
+    it("should create a wrapper script that changes to ~/.spawn before exec", () => {
+      // PR #710: the wrapper must cd into ~/.spawn for package resolution
+      expect(content).toContain('cd "$HOME/.spawn"');
+    });
+
+    it("should use exec bun in the source-mode wrapper", () => {
+      expect(content).toContain("exec bun");
+    });
+
+    it("should use bash shebang in the wrapper (not /usr/bin/env bun)", () => {
+      // The wrapper script itself should use bash, not bun directly
+      expect(content).toContain("#!/usr/bin/env bash");
+    });
+
+    it('should pass "$@" to forward arguments', () => {
+      expect(content).toContain('"$@"');
+    });
+
+    it("should try forced reinstall if first build fails", () => {
+      expect(content).toContain("bun install --force");
+    });
+  });
+
+  // ── clone_cli function ──────────────────────────────────────────────
+
+  describe("clone_cli", () => {
+    it("should check for git availability", () => {
+      expect(content).toContain("command -v git");
+    });
+
+    it("should use sparse checkout for git clone", () => {
+      expect(content).toContain("sparse-checkout");
+    });
+
+    it("should use --depth 1 for shallow clone", () => {
+      expect(content).toContain("--depth 1");
+    });
+
+    it("should fall back to curl download when git is not available", () => {
+      // Extract clone_cli function body up to the next top-level function
+      const fnStart = content.indexOf("clone_cli()");
+      const fnEnd = content.indexOf("\n# --- Helper: build", fnStart);
+      const fnBody = content.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined);
+      // Should have an else branch that uses curl
+      expect(fnBody).toContain("curl");
+      expect(fnBody).toContain("api.github.com");
+    });
+
+    it("should download package.json and bun.lock", () => {
+      expect(content).toContain("package.json");
+      expect(content).toContain("bun.lock");
+    });
+
+    it("should download tsconfig.json", () => {
+      expect(content).toContain("tsconfig.json");
+    });
+
+    it("should exclude __tests__ directory from downloads", () => {
+      expect(content).toContain("__tests__");
+    });
+
+    it("should clean up temporary repo directory after sparse checkout", () => {
+      const fnStart = content.indexOf("clone_cli()");
+      const fnBody = content.slice(fnStart);
+      // Should remove the temporary repo dir
+      expect(fnBody).toContain('rm -rf "${dest}/repo"');
+    });
+  });
+
+  // ── find_install_dir function ──────────────────────────────────────
+
+  describe("find_install_dir", () => {
+    it("should respect SPAWN_INSTALL_DIR when set", () => {
+      const fnStart = content.indexOf("find_install_dir()");
+      const fnBody = content.slice(fnStart, content.indexOf("}", fnStart) + 50);
+      expect(fnBody).toContain("SPAWN_INSTALL_DIR");
+    });
+
+    it("should check ~/.local/bin as a candidate", () => {
+      expect(content).toContain("${HOME}/.local/bin");
+    });
+
+    it("should check bun global bin directory", () => {
+      expect(content).toContain("bun pm bin -g");
+    });
+
+    it("should check ~/.bun/bin as a candidate", () => {
+      expect(content).toContain("${HOME}/.bun/bin");
+    });
+
+    it("should check ~/bin as a candidate", () => {
+      expect(content).toContain("${HOME}/bin");
+    });
+
+    it("should verify candidate directory is in PATH", () => {
+      expect(content).toContain("${PATH}");
+    });
+
+    it("should default to ~/.local/bin if nothing is in PATH", () => {
+      // Last resort fallback
+      const fnStart = content.indexOf("find_install_dir()");
+      const fnBody = content.slice(fnStart);
+      const lastLocalBin = fnBody.lastIndexOf("${HOME}/.local/bin");
+      expect(lastLocalBin).toBeGreaterThan(0);
+    });
+  });
+
+  // ── ensure_in_path function ────────────────────────────────────────
+
+  describe("ensure_in_path", () => {
+    it("should check if install dir is in PATH", () => {
+      const fnStart = content.indexOf("ensure_in_path()");
+      const fnBody = content.slice(fnStart);
+      expect(fnBody).toContain("${PATH}");
+    });
+
+    it("should run spawn version if in PATH", () => {
+      // Uses "${install_dir}/spawn" version
+      expect(content).toContain("/spawn\" version");
+    });
+
+    it("should show zsh instructions for zsh users", () => {
+      expect(content).toContain(".zshrc");
+    });
+
+    it("should show fish instructions for fish users", () => {
+      expect(content).toContain("fish_add_path");
+    });
+
+    it("should show bash instructions as default", () => {
+      expect(content).toContain(".bashrc");
+    });
+
+    it("should detect shell from SHELL env var", () => {
+      expect(content).toContain("${SHELL:-");
+    });
+
+    it("should provide direct run command as alternative", () => {
+      expect(content).toContain("Or run directly");
+    });
+  });
+
+  // ── Security ─────────────────────────────────────────────────────────
+
+  describe("security", () => {
+    it("should not contain hardcoded API keys or tokens", () => {
+      const code = codeLines();
+      for (const line of code) {
+        expect(line).not.toMatch(/sk-[a-zA-Z0-9]{20,}/);
+        expect(line).not.toMatch(/token[=:]\s*[a-f0-9]{32,}/i);
+      }
+    });
+
+    it("should not use eval to execute downloaded content", () => {
+      const code = codeLines();
+      // eval should not be used to run arbitrary downloaded scripts
+      // (bun.sh/install is piped to bash, which is standard practice)
+      const evalLines = code.filter(
+        (l) =>
+          l.includes("eval") &&
+          !l.includes("2>/dev/null") &&
+          !l.includes("#")
+      );
+      expect(evalLines).toEqual([]);
+    });
+
+    it("should quote variables in file operations", () => {
+      // Critical paths should quote variables
+      expect(content).toContain('"${INSTALL_DIR}/spawn"');
+      expect(content).toContain('"${tmpdir}"');
+    });
+
+    it("should use -fsSL flags for curl downloads", () => {
+      const curlLines = codeLines().filter((l) => l.includes("curl"));
+      for (const line of curlLines) {
+        expect(line).toMatch(/-fsSL/);
+      }
+    });
+  });
+
+  // ── Consistency with package.json ──────────────────────────────────
+
+  describe("consistency with package.json", () => {
+    it("should reference same repo as package.json", () => {
+      const pkgContent = readFileSync(
+        join(REPO_ROOT, "cli", "package.json"),
+        "utf-8"
+      );
+      const pkg = JSON.parse(pkgContent);
+      // install.sh uses OpenRouterTeam/spawn
+      expect(content).toContain("OpenRouterTeam/spawn");
+      // package.json should reference same repo
+      if (pkg.repository) {
+        const repo =
+          typeof pkg.repository === "string"
+            ? pkg.repository
+            : pkg.repository.url || "";
+        expect(repo.toLowerCase()).toContain("openrouterteam/spawn");
+      }
+    });
+
+    it("should download the correct files that exist in cli/src/", () => {
+      // The curl-based download path downloads .ts files from cli/src/
+      // Verify that the files listed in install.sh actually exist
+      const srcDir = join(REPO_ROOT, "cli", "src");
+      expect(existsSync(join(srcDir, "index.ts"))).toBe(true);
+      expect(existsSync(join(srcDir, "commands.ts"))).toBe(true);
+      expect(existsSync(join(srcDir, "manifest.ts"))).toBe(true);
+    });
+  });
+
+  // ── Main flow order ────────────────────────────────────────────────
+
+  describe("main execution flow", () => {
+    it("should check for bun before building", () => {
+      const bunCheck = content.indexOf("command -v bun");
+      const buildCall = content.lastIndexOf("build_and_install");
+      expect(bunCheck).toBeLessThan(buildCall);
+    });
+
+    it("should ensure min bun version before building", () => {
+      const versionCheck = content.lastIndexOf("ensure_min_bun_version");
+      const buildCall = content.lastIndexOf("build_and_install");
+      expect(versionCheck).toBeLessThan(buildCall);
+    });
+
+    it("should call build_and_install as the last major step", () => {
+      const lastFewLines = lines.slice(-5).join("\n");
+      expect(lastFewLines).toContain("build_and_install");
+    });
+  });
+
+  // ── Error handling ────────────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("should show re-run instructions on bun install failure", () => {
+      expect(content).toContain("curl -fsSL ${SPAWN_RAW_BASE}/cli/install.sh | bash");
+    });
+
+    it("should show manual bun install instructions on failure", () => {
+      expect(content).toContain("curl -fsSL https://bun.sh/install | bash");
+    });
+
+    it("should exit with code 1 on failures", () => {
+      const exitLines = codeLines().filter((l) => l.trim() === "exit 1");
+      expect(exitLines.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should show upgrade instructions if bun version is too low", () => {
+      const fnStart = content.indexOf("ensure_min_bun_version()");
+      const fnEnd = content.indexOf("\n# --- Helper: find", fnStart);
+      const fnBody = content.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined);
+      expect(fnBody).toContain("bun upgrade");
+      expect(fnBody).toContain("exit 1");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 83 tests validating `cli/install.sh` which had zero test coverage
- `install.sh` has been modified in 3 recent PRs (#704, #707, #710) but never had tests
- Validates file structure, repository constants, required functions, curl|bash compatibility, bun installation flow, version comparison logic, build_and_install pipeline, source-mode fallback wrapper (PR #707/#710), clone_cli with git sparse-checkout and curl fallback, find_install_dir directory selection, ensure_in_path PATH detection, security (no hardcoded secrets, quoted variables, -fsSL flags), consistency with package.json, main execution flow order, and error handling

## Test plan
- [x] All 83 new tests pass
- [x] Full test suite passes (5586 pass, 3 fail - same pre-existing failures as main)
- [x] Pre-existing failures are unrelated (missing `local/opencode.sh` script)

Agent: test-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)