### PR TITLE
fix: handle 'spawn info/show/describe <name>' as info page aliases

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.62",
+  "version": "0.2.63",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/verb-aliases.test.ts
+++ b/cli/src/__tests__/verb-aliases.test.ts
@@ -7,11 +7,14 @@ import { describe, it, expect } from "bun:test";
  * "spawn run claude sprite", "spawn launch aider hetzner", etc.
  * The CLI should transparently strip these verb prefixes and forward
  * to the default agent/cloud handler.
+ *
+ * Also tests info aliases: "spawn info claude" -> show agent info page.
  */
 
 // ── Replica of dispatch logic from index.ts ─────────────────────────────────
 
 const VERB_ALIASES = new Set(["run", "launch", "start", "deploy", "exec"]);
+const INFO_ALIASES = new Set(["info", "show", "describe"]);
 
 const IMMEDIATE_COMMAND_KEYS = new Set([
   "help", "--help", "-h",
@@ -27,6 +30,8 @@ type DispatchResult =
   | { type: "subcommand"; cmd: string }
   | { type: "verb_alias"; agent: string; cloud: string | undefined; prompt: string | undefined }
   | { type: "verb_alias_bare"; verb: string }
+  | { type: "info_alias"; name: string }
+  | { type: "info_alias_bare"; verb: string }
   | { type: "default"; agent: string; cloud: string | undefined; prompt: string | undefined };
 
 function dispatchCommand(
@@ -54,6 +59,14 @@ function dispatchCommand(
       };
     }
     return { type: "verb_alias_bare", verb: cmd };
+  }
+
+  // Handle info aliases: "spawn info claude" -> "spawn claude" (show info)
+  if (INFO_ALIASES.has(cmd)) {
+    if (filteredArgs.length > 1) {
+      return { type: "info_alias", name: filteredArgs[1] };
+    }
+    return { type: "info_alias_bare", verb: cmd };
   }
 
   return {
@@ -220,6 +233,119 @@ describe("verb alias handling", () => {
 
     it("unknown names fall to default, not verb alias", () => {
       const result = dispatchCommand("claude", ["claude", "sprite"], undefined);
+      expect(result.type).toBe("default");
+    });
+  });
+});
+
+describe("info alias handling", () => {
+  describe("recognized info aliases", () => {
+    for (const verb of ["info", "show", "describe"]) {
+      it(`should recognize "${verb}" as an info alias`, () => {
+        expect(INFO_ALIASES.has(verb)).toBe(true);
+      });
+    }
+  });
+
+  describe("info alias with a name", () => {
+    it("should strip 'info' and forward to info handler", () => {
+      const result = dispatchCommand("info", ["info", "claude"], undefined);
+      expect(result.type).toBe("info_alias");
+      if (result.type === "info_alias") {
+        expect(result.name).toBe("claude");
+      }
+    });
+
+    it("should strip 'show' and forward to info handler", () => {
+      const result = dispatchCommand("show", ["show", "hetzner"], undefined);
+      expect(result.type).toBe("info_alias");
+      if (result.type === "info_alias") {
+        expect(result.name).toBe("hetzner");
+      }
+    });
+
+    it("should strip 'describe' and forward to info handler", () => {
+      const result = dispatchCommand("describe", ["describe", "aider"], undefined);
+      expect(result.type).toBe("info_alias");
+      if (result.type === "info_alias") {
+        expect(result.name).toBe("aider");
+      }
+    });
+
+    it("should work with cloud names", () => {
+      const result = dispatchCommand("info", ["info", "sprite"], undefined);
+      expect(result.type).toBe("info_alias");
+      if (result.type === "info_alias") {
+        expect(result.name).toBe("sprite");
+      }
+    });
+  });
+
+  describe("bare info alias (no name)", () => {
+    it("should return bare info alias for 'info' alone", () => {
+      const result = dispatchCommand("info", ["info"], undefined);
+      expect(result.type).toBe("info_alias_bare");
+      if (result.type === "info_alias_bare") {
+        expect(result.verb).toBe("info");
+      }
+    });
+
+    it("should return bare info alias for 'show' alone", () => {
+      const result = dispatchCommand("show", ["show"], undefined);
+      expect(result.type).toBe("info_alias_bare");
+      if (result.type === "info_alias_bare") {
+        expect(result.verb).toBe("show");
+      }
+    });
+
+    it("should return bare info alias for 'describe' alone", () => {
+      const result = dispatchCommand("describe", ["describe"], undefined);
+      expect(result.type).toBe("info_alias_bare");
+      if (result.type === "info_alias_bare") {
+        expect(result.verb).toBe("describe");
+      }
+    });
+  });
+
+  describe("info aliases do not shadow real commands or verb aliases", () => {
+    it("should not treat 'info' as a verb alias", () => {
+      expect(VERB_ALIASES.has("info")).toBe(false);
+    });
+
+    it("should not treat 'show' as a verb alias", () => {
+      expect(VERB_ALIASES.has("show")).toBe(false);
+    });
+
+    it("should not treat 'describe' as a verb alias", () => {
+      expect(VERB_ALIASES.has("describe")).toBe(false);
+    });
+
+    it("should not treat 'run' as an info alias", () => {
+      expect(INFO_ALIASES.has("run")).toBe(false);
+    });
+
+    it("should not treat 'list' as an info alias", () => {
+      expect(INFO_ALIASES.has("list")).toBe(false);
+    });
+
+    it("should not treat 'help' as an info alias", () => {
+      expect(INFO_ALIASES.has("help")).toBe(false);
+    });
+  });
+
+  describe("routing priority: info aliases checked after verb aliases", () => {
+    it("'info claude' routes as info_alias, not default", () => {
+      const result = dispatchCommand("info", ["info", "claude"], undefined);
+      expect(result.type).toBe("info_alias");
+    });
+
+    it("'run claude' routes as verb_alias, not info_alias", () => {
+      const result = dispatchCommand("run", ["run", "claude"], undefined);
+      expect(result.type).toBe("verb_alias");
+    });
+
+    it("'claude' routes as default, not info_alias", () => {
+      const result = dispatchCommand("claude", ["claude"], undefined);
       expect(result.type).toBe("default");
     });
   });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -283,6 +283,9 @@ const LIST_COMMANDS = new Set(["list", "ls", "history"]);
 // These are not real subcommands -- we strip them and forward to the default handler
 const VERB_ALIASES = new Set(["run", "launch", "start", "deploy", "exec"]);
 
+// Info verb aliases: "spawn info claude" -> "spawn claude" (show info page)
+const INFO_ALIASES = new Set(["info", "show", "describe"]);
+
 /** Warn when extra positional arguments are silently ignored */
 function warnExtraArgs(filteredArgs: string[], maxExpected: number): void {
   const extra = filteredArgs.slice(maxExpected);
@@ -367,6 +370,22 @@ async function dispatchCommand(cmd: string, filteredArgs: string[], prompt: stri
     console.error(pc.red(`Error: ${pc.bold(cmd)} requires an agent and cloud`));
     console.error(`\nUsage: ${pc.cyan("spawn <agent> <cloud>")}`);
     console.error(pc.dim(`  The "${cmd}" keyword is optional -- just use ${pc.cyan("spawn <agent> <cloud>")} directly.`));
+    process.exit(1);
+  }
+
+  // Handle info aliases: "spawn info claude" -> "spawn claude" (show info page)
+  if (INFO_ALIASES.has(cmd)) {
+    if (filteredArgs.length > 1) {
+      warnExtraArgs(filteredArgs, 2);
+      await showInfoOrError(filteredArgs[1]);
+      return;
+    }
+    console.error(pc.red(`Error: ${pc.bold(cmd)} requires an agent or cloud name`));
+    console.error(`\nUsage: ${pc.cyan("spawn <name>")}`);
+    console.error(pc.dim(`  The "${cmd}" keyword is optional -- just use ${pc.cyan("spawn <name>")} directly.`));
+    console.error();
+    console.error(`  Run ${pc.cyan("spawn agents")} to see available agents.`);
+    console.error(`  Run ${pc.cyan("spawn clouds")} to see available clouds.`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- Adds `info`, `show`, and `describe` as info-style verb aliases in the CLI dispatcher
- `spawn info claude` now shows the Claude info page instead of "Unknown agent: info" error
- `spawn show hetzner` now shows the Hetzner setup page instead of failing
- Bare usage (`spawn info` without a name) shows a helpful error with suggestions
- Adds 19 new tests covering all info alias behaviors

## Motivation
Users coming from other CLIs (kubectl, docker, npm, etc.) naturally try `spawn info <name>` or `spawn show <name>` to get details. Previously this produced a confusing "Unknown agent: info" error because `info` was treated as an agent name. This fix follows the same pattern as the existing verb aliases (`run`, `launch`, `start`, `deploy`, `exec`) but routes to the info page instead of the run handler.

## Test plan
- [x] All 46 verb-alias tests pass (27 existing + 19 new)
- [x] Full test suite passes (5522 pass, same 3 pre-existing failures)
- [x] `spawn info claude` -> shows agent info page
- [x] `spawn show hetzner` -> shows cloud info page
- [x] `spawn describe aider` -> shows agent info page
- [x] `spawn info` (bare) -> shows helpful error
- [x] `spawn info unknown-name` -> shows "Unknown command" with fuzzy suggestions

Agent: ux-engineer