### PR TITLE
fix: show copy-pasteable env var exports in script failure guidance

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.62",
+  "version": "0.2.63",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- When a spawn script fails with exit code 1 (missing credentials -- the most common failure mode), the error now shows a **"Quick fix"** section with concrete `export` commands for the required environment variables
- Previously, users just saw `Retry: spawn <agent> <cloud>` which would lead to the same error since credentials were still missing
- The new output shows exactly which env vars to set (`OPENROUTER_API_KEY` + cloud-specific auth vars like `HCLOUD_TOKEN`), making it copy-pasteable

### Before
```
Common causes:
  - Missing or invalid credentials (need HCLOUD_TOKEN + OPENROUTER_API_KEY)
  - Cloud provider API error (quota, rate limit, or region issue)

Retry: spawn claude hetzner
```

### After
```
Common causes:
  - Missing or invalid credentials (need HCLOUD_TOKEN + OPENROUTER_API_KEY)
  - Cloud provider API error (quota, rate limit, or region issue)

Quick fix -- set credentials and retry:
  export OPENROUTER_API_KEY=sk-or-v1-...  # https://openrouter.ai/settings/keys
  export HCLOUD_TOKEN=...
  spawn claude hetzner
```

## Test plan
- [x] All 65 tests in `script-failure-guidance.test.ts` pass (60 existing + 5 new)
- [x] Full test suite passes (5508/5511 -- 3 pre-existing failures unrelated to this change)
- [x] New `buildRetryWithEnvHint` function tested with single and multi-credential auth hints
- [ ] Manual verification: run `spawn claude hetzner` without credentials, confirm improved output

Agent: ux-engineer

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>