### PR TITLE
fix: warn about orphaned servers in all script failure exit codes

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.62",
+  "version": "0.2.63",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -77,9 +77,11 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("issues");
     });
 
-    it("should return exactly 4 guidance lines", () => {
+    it("should include server cleanup note", () => {
       const lines = getScriptFailureGuidance(126, "sprite");
-      expect(lines).toHaveLength(4);
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+      expect(joined).toContain("cloud provider dashboard");
     });
   });
 
@@ -284,9 +286,11 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("terminated");
     });
 
-    it("should return exactly 4 guidance lines", () => {
+    it("should include server cleanup note", () => {
       const lines = getScriptFailureGuidance(255, "sprite");
-      expect(lines).toHaveLength(4);
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+      expect(joined).toContain("cloud provider dashboard");
     });
   });
 
@@ -312,9 +316,11 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("issues");
     });
 
-    it("should return exactly 2 guidance lines", () => {
+    it("should include server cleanup note", () => {
       const lines = getScriptFailureGuidance(2, "sprite");
-      expect(lines).toHaveLength(2);
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+      expect(joined).toContain("cloud provider dashboard");
     });
   });
 
@@ -373,18 +379,83 @@ describe("getScriptFailureGuidance", () => {
 
     it("should include setup instruction line for exit code 1 with authHint", () => {
       const lines = getScriptFailureGuidance(1, "hetzner", "HCLOUD_TOKEN");
-      expect(lines).toHaveLength(5);
       const joined = lines.join("\n");
       expect(joined).toContain("spawn hetzner");
       expect(joined).toContain("setup");
+      expect(joined).toContain("may still be running");
     });
 
     it("should include setup instruction line for default case with authHint", () => {
       const lines = getScriptFailureGuidance(42, "hetzner", "HCLOUD_TOKEN");
-      expect(lines).toHaveLength(5);
       const joined = lines.join("\n");
       expect(joined).toContain("spawn hetzner");
       expect(joined).toContain("setup");
+      expect(joined).toContain("may still be running");
+    });
+  });
+
+  // ── Server cleanup note ─────────────────────────────────────────────────
+
+  describe("server cleanup note", () => {
+    it("should include cleanup note for exit code 1", () => {
+      const lines = getScriptFailureGuidance(1, "hetzner");
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+      expect(joined).toContain("cloud provider dashboard");
+      expect(joined).toContain("spawn hetzner");
+    });
+
+    it("should include cleanup note for exit code 255", () => {
+      const lines = getScriptFailureGuidance(255, "vultr");
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+      expect(joined).toContain("spawn vultr");
+    });
+
+    it("should include cleanup note for exit code 126", () => {
+      const lines = getScriptFailureGuidance(126, "linode");
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+      expect(joined).toContain("spawn linode");
+    });
+
+    it("should include cleanup note for exit code 2", () => {
+      const lines = getScriptFailureGuidance(2, "digitalocean");
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+      expect(joined).toContain("spawn digitalocean");
+    });
+
+    it("should include cleanup note for unknown exit codes", () => {
+      const lines = getScriptFailureGuidance(42, "civo");
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+      expect(joined).toContain("spawn civo");
+    });
+
+    it("should include cleanup note for null exit code", () => {
+      const lines = getScriptFailureGuidance(null, "scaleway");
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+      expect(joined).toContain("spawn scaleway");
+    });
+
+    it("should not include cleanup note for exit code 127 (command not found)", () => {
+      const lines = getScriptFailureGuidance(127, "sprite");
+      const joined = lines.join("\n");
+      expect(joined).not.toContain("may still be running");
+    });
+
+    it("should include cleanup note in exit 130 (already had it)", () => {
+      const lines = getScriptFailureGuidance(130, "hetzner");
+      const joined = lines.join("\n");
+      expect(joined).toContain("may still be running");
+    });
+
+    it("should include cleanup note in exit 137 (already had it)", () => {
+      const lines = getScriptFailureGuidance(137, "hetzner");
+      const joined = lines.join("\n");
+      expect(joined).toContain("cloud provider dashboard");
     });
   });
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -555,6 +555,9 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
         "  - Server is still booting (wait a moment and retry)",
         "  - Firewall blocking SSH port 22",
         "  - Server was terminated before the session started",
+        "",
+        "Note: The server may still be running.",
+        `  Check your cloud provider dashboard or run ${pc.cyan(`spawn ${cloud}`)} for details.`,
       ];
     case 127:
       return [
@@ -568,11 +571,17 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
         "  - A downloaded binary may lack execute permissions",
         "  - The script may require root/sudo access",
         `  - Report it if this persists: ${pc.cyan(`https://github.com/OpenRouterTeam/spawn/issues`)}`,
+        "",
+        "Note: If a server was already created, it may still be running.",
+        `  Check your cloud provider dashboard or run ${pc.cyan(`spawn ${cloud}`)} for details.`,
       ];
     case 2:
       return [
         "Shell syntax or argument error. This is likely a bug in the script.",
         `  Report it at: ${pc.cyan(`https://github.com/OpenRouterTeam/spawn/issues`)}`,
+        "",
+        "Note: If a server was already created, it may still be running.",
+        `  Check your cloud provider dashboard or run ${pc.cyan(`spawn ${cloud}`)} for details.`,
       ];
     case 1:
       return [
@@ -580,6 +589,9 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
         ...credentialHints(cloud, authHint),
         "  - Cloud provider API error (quota, rate limit, or region issue)",
         "  - Server provisioning failed (try again or pick a different region)",
+        "",
+        "Note: If a server was already created, it may still be running.",
+        `  Check your cloud provider dashboard or run ${pc.cyan(`spawn ${cloud}`)} for details.`,
       ];
     default:
       return [
@@ -587,6 +599,9 @@ export function getScriptFailureGuidance(exitCode: number | null, cloud: string,
         ...credentialHints(cloud, authHint, "Missing"),
         "  - Cloud provider API rate limit or quota exceeded",
         "  - Missing local dependencies (SSH, curl, jq)",
+        "",
+        "Note: If a server was already created, it may still be running.",
+        `  Check your cloud provider dashboard or run ${pc.cyan(`spawn ${cloud}`)} for details.`,
       ];
   }
 }


### PR DESCRIPTION
## Summary
- Previously only exit codes 130 (Ctrl+C) and 137 (killed) warned users that a cloud server may still be running after a script failure
- Exit code 1 (the most common failure after provisioning), 255 (SSH failure), 126 (permission denied), 2 (syntax error), and the default/unknown case all lacked this warning
- Users whose scripts failed after server provisioning had no idea they might have a running server incurring charges
- Now all relevant failure exit codes include: `"Note: If a server was already created, it may still be running."` with a pointer to their cloud dashboard and `spawn <cloud>` for details
- Exit code 127 (command not found) intentionally omits this note since provisioning hasn't started yet

## Test plan
- [x] Updated 4 existing tests that checked exact line counts to validate cleanup note content instead
- [x] Added 9 new tests verifying cleanup note presence for exit codes 1, 255, 126, 2, unknown, null and absence for exit code 127
- [x] All 69 tests in `script-failure-guidance.test.ts` pass
- [x] Full test suite passes (5514/5517, 3 pre-existing failures unrelated to this change)

Agent: ux-engineer