### PR TITLE
fix: pre-built CLI fallback for Termux proot

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,55 @@
+name: CLI Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cli/src/**'
+      - 'cli/package.json'
+      - 'cli/bun.lock'
+
+jobs:
+  build:
+    name: Build and release CLI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies and build
+        working-directory: cli
+        run: |
+          bun install
+          bun run build
+
+      - name: Get version
+        id: version
+        working-directory: cli
+        run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Update cli-latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Delete existing release if present
+          gh release delete cli-latest --yes 2>/dev/null || true
+          git tag -d cli-latest 2>/dev/null || true
+          git push origin :refs/tags/cli-latest 2>/dev/null || true
+
+          # Create new release with built cli.js
+          gh release create cli-latest \
+            --title "CLI v${{ steps.version.outputs.version }}" \
+            --notes "Pre-built CLI binary (auto-updated on every push to main).
+
+          This release is used as a fallback by \`install.sh\` when the local build fails (e.g. Termux proot).
+
+          **Version:** ${{ steps.version.outputs.version }}
+          **Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --prerelease \
+            cli/cli.js

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.62",
+  "version": "0.2.63",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

- When `bun run build` fails (e.g. Termux proot), download pre-built `cli.js` from the `cli-latest` GitHub release instead
- Add CI workflow that auto-builds and uploads `cli.js` on every push to main
- Remove broken source-mode fallback (`~/.spawn/` + wrapper script)

## Root cause

`bun install` in proot creates **empty directories** in `node_modules/` because proot can't intercept bun's filesystem syscalls (`symlinkat`, `linkat`, `copy_file_range`, `sendfile`). This breaks both:
- `bun build --packages bundle` (can't resolve packages)
- `bun src/index.ts` (can't find modules at runtime)

The pre-built `cli.js` (81KB) bundles all dependencies inline — no module resolution needed at runtime, only the bun binary.

## How it works

**Normal systems:** `bun install` + `bun run build` succeeds on first try, installs locally-built binary.

**Termux proot:** Local build fails → downloads `cli.js` from `https://github.com/OpenRouterTeam/spawn/releases/download/cli-latest/cli.js` → installs that instead.

**CI workflow:** On push to main (when `cli/src/**` or `cli/package.json` changes), builds `cli.js` and updates the `cli-latest` rolling release.

## Bootstrap

The initial `cli-latest` release has already been created manually: https://github.com/OpenRouterTeam/spawn/releases/tag/cli-latest

## Test plan

- [ ] Normal system: `bash install.sh` builds locally as before
- [ ] Termux proot: `curl ... | bash` — local build fails, downloads pre-built, `spawn version` works
- [ ] Verify release download: `curl -fsSL https://github.com/OpenRouterTeam/spawn/releases/download/cli-latest/cli.js | head -1` shows `#!/usr/bin/env bun`

🤖 Generated with [Claude Code](https://claude.com/claude-code)