### PR TITLE
feat: add Team Building issue template + route workflows by label

### DIFF
--- a/.github/ISSUE_TEMPLATE/team_building.yml
+++ b/.github/ISSUE_TEMPLATE/team_building.yml
@@ -1,0 +1,33 @@
+name: Team Building
+description: Request a change or new capability for an agent team
+title: "[Team]: "
+labels: ["team-building"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Request an improvement to one of the agent teams (discovery, refactor, security, QA).
+
+  - type: dropdown
+    id: team
+    attributes:
+      label: Agent Team
+      description: Which team should be improved?
+      options:
+        - Security Team (security.sh)
+        - Refactor Team (refactor.sh)
+        - Discovery Team (discovery.sh)
+        - QA Team (qa.sh)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What to Change
+      description: Describe the new capability, behavior change, or improvement.
+      placeholder: |
+        The security team should also check for...
+        The refactor team should add a new agent that...
+    validations:
+      required: true

--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -15,6 +15,11 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # Only trigger on cloud-request or agent-request issues (or schedule/manual)
+    if: >-
+      github.event_name != 'issues' ||
+      contains(github.event.issue.labels.*.name, 'cloud-request') ||
+      contains(github.event.issue.labels.*.name, 'agent-request')
     steps:
       - name: Trigger and stream discovery cycle
         env:
@@ -26,7 +31,7 @@ jobs:
           # -N: no output buffering (stream chunks in real-time)
           # --max-time: hard cap matching the Sprite's cycle timeout + grace
           curl -sSN --http1.1 --fail-with-body --max-time 5400 -X POST \
-            "${SPRITE_URL}/trigger?reason=${{ github.event_name }}" \
+            "${SPRITE_URL}/trigger?reason=${{ github.event_name }}&issue=${{ github.event.issue.number || '' }}" \
             -H "Authorization: Bearer ${TRIGGER_SECRET}"
           CURL_EXIT=$?
           set -e

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -15,6 +15,11 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # Only trigger on bug or cli issues (or schedule/manual)
+    if: >-
+      github.event_name != 'issues' ||
+      contains(github.event.issue.labels.*.name, 'bug') ||
+      contains(github.event.issue.labels.*.name, 'cli')
     steps:
       - name: Trigger and stream refactor cycle
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,8 @@ name: Security Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  issues:
+    types: [opened, reopened]
   schedule:
     # Full repo security scan — daily at 06:00 UTC
     - cron: '0 6 * * *'
@@ -24,13 +26,17 @@ on:
         type: string
 
 concurrency:
-  group: security-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'schedule' && github.event.schedule || 'manual' }}
+  group: security-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'issues' && format('issue-{0}', github.event.issue.number) || github.event_name == 'schedule' && github.event.schedule || 'manual' }}
   cancel-in-progress: true
 
 jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Only trigger on team-building issues (or PR/schedule/manual)
+    if: >-
+      github.event_name != 'issues' ||
+      contains(github.event.issue.labels.*.name, 'team-building')
     steps:
       - name: Trigger security review
         env:
@@ -45,7 +51,10 @@ jobs:
           # Determine reason and issue/PR number based on trigger type
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             REASON="pull_request"
-            PR_NUM="${{ github.event.pull_request.number }}"
+            ISSUE_NUM="${{ github.event.pull_request.number }}"
+          elif [ "${{ github.event_name }}" = "issues" ]; then
+            REASON="team_building"
+            ISSUE_NUM="${{ github.event.issue.number }}"
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             # Distinguish between cron schedules:
             # '0 6 * * *' = daily scan, '0 */6 * * *' = hygiene every 6h
@@ -55,11 +64,11 @@ jobs:
             else
               REASON="hygiene"
             fi
-            PR_NUM=""
+            ISSUE_NUM=""
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             MODE="${{ github.event.inputs.mode || 'scan' }}"
-            PR_NUM="${{ github.event.inputs.pr_number || '' }}"
-            if [ -n "$PR_NUM" ]; then
+            ISSUE_NUM="${{ github.event.inputs.pr_number || '' }}"
+            if [ -n "$ISSUE_NUM" ]; then
               REASON="pull_request"
             elif [ "$MODE" = "hygiene" ]; then
               REASON="hygiene"
@@ -68,17 +77,17 @@ jobs:
             fi
           else
             REASON="schedule"
-            PR_NUM=""
+            ISSUE_NUM=""
           fi
 
-          echo "Mode: reason=$REASON, pr=$PR_NUM"
+          echo "Mode: reason=$REASON, issue=$ISSUE_NUM"
 
           set +e
           # --fail-with-body: exit 22 on HTTP errors but still print the body
           # -N: no output buffering (stream chunks in real-time)
           # --max-time: hard cap matching the Sprite's cycle timeout + grace
           curl -sSN --http1.1 --fail-with-body --max-time 2700 -X POST \
-            "${SPRITE_URL}/trigger?reason=${REASON}&issue=${PR_NUM}" \
+            "${SPRITE_URL}/trigger?reason=${REASON}&issue=${ISSUE_NUM}" \
             -H "Authorization: Bearer ${TRIGGER_SECRET}"
           CURL_EXIT=$?
           set -e


### PR DESCRIPTION
## Summary
- New **Team Building** issue template with `team-building` label — 2 fields: which agent team + what to change
- Security team gets a `team_building` mode: reads the issue, spawns implementer + reviewer (both Opus), creates PR, reviews, merges, closes the issue
- Workflows now filter issues by label so the right team handles the right requests:
  - **Discovery** → `cloud-request`, `agent-request`
  - **Refactor** → `bug`, `cli`
  - **Security** → `team-building`
- All workflows still run on schedule and `workflow_dispatch` as before

## Label → Workflow Routing

| Issue Template | Label | Workflow |
|---|---|---|
| Cloud Provider Request | `cloud-request` | discovery.yml |
| Agent Request | `agent-request` | discovery.yml |
| Bug Report | `bug` | refactor.yml |
| CLI Feature Request | `cli` | refactor.yml |
| Team Building | `team-building` | security.yml |

## Test plan
- [ ] Open a Team Building issue → verify security workflow triggers
- [ ] Open a Cloud Request issue → verify only discovery workflow triggers
- [ ] Open a Bug Report → verify only refactor workflow triggers
- [ ] Verify schedule/manual triggers still work for all workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)