### PR TITLE
feat: security triage gate + team building workflow routing

### DIFF
--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '*/30 * * * *'
   issues:
-    types: [opened, reopened]
+    types: [opened, reopened, labeled]
   workflow_dispatch:
 
 concurrency:
@@ -15,11 +15,12 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    # Only trigger on cloud-request or agent-request issues (or schedule/manual)
+    # Only trigger on issues with safe-to-work AND (cloud-request or agent-request) labels, or schedule/manual
     if: >-
       github.event_name != 'issues' ||
-      contains(github.event.issue.labels.*.name, 'cloud-request') ||
-      contains(github.event.issue.labels.*.name, 'agent-request')
+      (contains(github.event.issue.labels.*.name, 'safe-to-work') &&
+       (contains(github.event.issue.labels.*.name, 'cloud-request') ||
+        contains(github.event.issue.labels.*.name, 'agent-request')))
     steps:
       - name: Trigger and stream discovery cycle
         env:

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '*/5 * * * *'
   issues:
-    types: [opened, reopened]
+    types: [opened, reopened, labeled]
   workflow_dispatch:
 
 concurrency:
@@ -15,11 +15,12 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    # Only trigger on bug or cli issues (or schedule/manual)
+    # Only trigger on issues with safe-to-work AND (bug or cli) labels, or schedule/manual
     if: >-
       github.event_name != 'issues' ||
-      contains(github.event.issue.labels.*.name, 'bug') ||
-      contains(github.event.issue.labels.*.name, 'cli')
+      (contains(github.event.issue.labels.*.name, 'safe-to-work') &&
+       (contains(github.event.issue.labels.*.name, 'bug') ||
+        contains(github.event.issue.labels.*.name, 'cli')))
     steps:
       - name: Trigger and stream refactor cycle
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,10 +33,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Only trigger on team-building issues (or PR/schedule/manual)
-    if: >-
-      github.event_name != 'issues' ||
-      contains(github.event.issue.labels.*.name, 'team-building')
+    # Trigger on ALL issues (triage or team-building) plus PR/schedule/manual
     steps:
       - name: Trigger security review
         env:
@@ -53,8 +50,12 @@ jobs:
             REASON="pull_request"
             ISSUE_NUM="${{ github.event.pull_request.number }}"
           elif [ "${{ github.event_name }}" = "issues" ]; then
-            REASON="team_building"
             ISSUE_NUM="${{ github.event.issue.number }}"
+            if [ "${{ contains(github.event.issue.labels.*.name, 'team-building') }}" = "true" ]; then
+              REASON="team_building"
+            else
+              REASON="triage"
+            fi
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             # Distinguish between cron schedules:
             # '0 6 * * *' = daily scan, '0 */6 * * *' = hygiene every 6h


### PR DESCRIPTION
## Summary
- **Security triage mode**: New `triage` mode in security.sh acts as gatekeeper for all incoming issues — checks for prompt injection, social engineering, spam, and unsafe payloads before other agents can work on them
- **`safe-to-work` gate**: Discovery and refactor workflows now require the `safe-to-work` label (added by security triage) in addition to their existing label requirements (`cloud-request`/`agent-request` for discovery, `bug`/`cli` for refactor)
- **Team Building template + routing**: New GitHub issue template for requesting agent team changes, routed to security's `team_building` mode via label-based dispatch

## Test plan
- [ ] Open a normal bug report → security triages, adds `safe-to-work` → refactor fires
- [ ] Open a malicious issue → security closes it with `malicious` label
- [ ] Open a cloud request → security triages, adds `safe-to-work` → discovery fires
- [ ] Open a team-building issue → security fires `team_building` mode (unchanged)
- [ ] Schedule/manual/PR triggers still work for all workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)