### PR TITLE
fix: remove leaked trigger secret and fix service path

### DIFF
--- a/.claude/skills/setup-trigger-service/start-refactor.sh
+++ b/.claude/skills/setup-trigger-service/start-refactor.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-export TRIGGER_SECRET="29521a52b6942933e84fe87f28ed08b909a4bfa61140ad2023af955d9a84aeb2"
-export TARGET_SCRIPT="/home/sprite/spawn/.claude/skills/setup-trigger-service/refactor.sh"
-export REPO_ROOT="/home/sprite/spawn"
-export MAX_CONCURRENT=3          # 1 refactor + 2 issue runs simultaneously
-export RUN_TIMEOUT_MS=14400000   # 4 hours (server-level safety net)
-exec bun run /home/sprite/spawn/.claude/skills/setup-trigger-service/trigger-server.ts

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 .docs/
 __pycache__/
-.claude/skills/setup-agent-team/start-*.sh
+.claude/skills/*/start-*.sh
 cli/cli.js


### PR DESCRIPTION
## Summary

Fixes #735

- **Deleted** `.claude/skills/setup-trigger-service/start-refactor.sh` which contained a hardcoded `TRIGGER_SECRET` committed to the repo
- **Rotated** the `REFACTOR_TRIGGER_SECRET` GitHub Actions secret with a new value
- **Broadened `.gitignore`** from `setup-agent-team/start-*.sh` to `*/start-*.sh` to prevent any skills subdirectory from accidentally committing start scripts
- **Recreated the service** pointing to the correct `setup-agent-team/` location with the new secret and correct paths to `refactor.sh` and `trigger-server.ts`

## What was wrong

The `setup-trigger-service` directory (from before the rename to `setup-agent-team` in aff3000) still had a `start-refactor.sh` with a hardcoded secret that was tracked by git. The `.gitignore` only covered `setup-agent-team/start-*.sh`, not the old directory. The service was also running from the wrong path.

## Test plan

- [x] New secret generated and set in GitHub Actions (`REFACTOR_TRIGGER_SECRET`)
- [x] Service restarted with correct paths (verified via `sprite-env services list`)
- [x] New `start-refactor.sh` is properly gitignored (verified via `git check-ignore`)
- [x] Old file removed from git tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)