### PR TITLE
fix: sanitize API key interpolation in run_server commands

### DIFF
--- a/daytona/continue.sh
+++ b/daytona/continue.sh
@@ -29,8 +29,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=%s\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/e2b/continue.sh
+++ b/e2b/continue.sh
@@ -33,8 +33,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/github-codespaces/continue.sh
+++ b/github-codespaces/continue.sh
@@ -38,8 +38,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_in_codespace "${CODESPACE_NAME}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/kamatera/nanoclaw.sh
+++ b/kamatera/nanoclaw.sh
@@ -39,8 +39,13 @@ inject_env_vars_ssh "${KAMATERA_SERVER_IP}" upload_file run_server \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-# Write .env file for NanoClaw
-run_server "${KAMATERA_SERVER_IP}" "printf 'ANTHROPIC_API_KEY=%s\n' '${OPENROUTER_API_KEY}' > ~/nanoclaw/.env"
+# Write .env file for NanoClaw (use temp file to avoid shell interpolation of API key)
+_nanoclaw_env_temp=$(mktemp)
+chmod 600 "${_nanoclaw_env_temp}"
+track_temp_file "${_nanoclaw_env_temp}"
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${_nanoclaw_env_temp}"
+upload_file "${KAMATERA_SERVER_IP}" "${_nanoclaw_env_temp}" "/tmp/nanoclaw_env"
+run_server "${KAMATERA_SERVER_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "Kamatera server setup completed successfully!"

--- a/latitude/continue.sh
+++ b/latitude/continue.sh
@@ -32,8 +32,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.bashrc"
-run_server "$LATITUDE_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> /root/.zshrc"
+inject_env_vars_ssh "$LATITUDE_SERVER_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${LATITUDE_SERVER_IP}" \

--- a/modal/continue.sh
+++ b/modal/continue.sh
@@ -32,8 +32,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.bashrc"
-run_server "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> ~/.zshrc"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
 

--- a/scaleway/continue.sh
+++ b/scaleway/continue.sh
@@ -34,8 +34,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.bashrc"
-run_server "${SCALEWAY_SERVER_IP}" "printf 'export OPENROUTER_API_KEY=\"%s\"\n' '${OPENROUTER_API_KEY}' >> /root/.zshrc"
+inject_env_vars_ssh "${SCALEWAY_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${SCALEWAY_SERVER_IP}" \

--- a/upcloud/continue.sh
+++ b/upcloud/continue.sh
@@ -31,8 +31,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.bashrc"
-run_server "$UPCLOUD_SERVER_IP" "printf '%s\n' 'export OPENROUTER_API_KEY=\"${OPENROUTER_API_KEY}\"' >> /root/.zshrc"
+inject_env_vars_ssh "$UPCLOUD_SERVER_IP" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${UPCLOUD_SERVER_IP}" \


### PR DESCRIPTION
Fixes #736

## Summary
- Replaced inline `${OPENROUTER_API_KEY}` interpolation in `run_server` command strings with safe `inject_env_vars_ssh` / `inject_env_vars_local` helpers across 8 agent scripts
- These helpers write env vars to a local temp file (with `chmod 600`), upload it to the remote server, and source it — completely avoiding shell metacharacter interpretation of API key values
- For `kamatera/nanoclaw.sh`, the `.env` file write also uses a temp file upload instead of inline interpolation

## Why this matters
If an API key contained shell metacharacters (e.g., `$(cmd)`, backticks, `; cmd`), the previous pattern would execute them on the remote server. The `inject_env_vars_*` helpers from `shared/common.sh` already handle this safely by single-quoting values in `generate_env_config()`.

## Affected files
| File | Fix |
|------|-----|
| `latitude/continue.sh` | `inject_env_vars_ssh` |
| `scaleway/continue.sh` | `inject_env_vars_ssh` |
| `upcloud/continue.sh` | `inject_env_vars_ssh` |
| `kamatera/nanoclaw.sh` | temp file upload for `.env` |
| `daytona/continue.sh` | `inject_env_vars_local` |
| `e2b/continue.sh` | `inject_env_vars_local` |
| `modal/continue.sh` | `inject_env_vars_local` |
| `github-codespaces/continue.sh` | `inject_env_vars_local` |

## Note on #737
Issue #737 (.gitignore gap) is already resolved — the current `.gitignore` uses the broad pattern `.claude/skills/*/start-*.sh` which covers all skill subdirectories.

## Test plan
- [x] `bash -n` passes on all 8 changed files
- [x] `bun test` — no regressions (12 pre-existing failures on main, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)