### PR TITLE
feat: implement local/gemini script

### DIFF
--- a/local/gemini.sh
+++ b/local/gemini.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "Gemini CLI on local machine"
+echo ""
+
+# 1. Ensure local prerequisites
+ensure_local_ready
+
+# 2. Install Gemini CLI if not already installed
+if command -v gemini &>/dev/null; then
+    log_info "Gemini CLI already installed"
+else
+    log_step "Installing Gemini CLI..."
+    npm install -g @google/gemini-cli
+    export PATH="${HOME}/.npm-global/bin:${PATH}"
+fi
+
+# Verify installation
+if ! command -v gemini &>/dev/null; then
+    log_error "Gemini CLI installation failed"
+    log_error "The 'gemini' command is not available"
+    log_error "Try installing manually: npm install -g @google/gemini-cli"
+    exit 1
+fi
+log_info "Gemini CLI installation verified"
+
+# 3. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 4. Inject environment variables
+log_step "Appending environment variables to ~/.zshrc..."
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Local setup completed successfully!"
+echo ""
+
+# 5. Start Gemini CLI
+log_step "Starting Gemini..."
+sleep 1
+clear 2>/dev/null || true
+export PATH="${HOME}/.npm-global/bin:${PATH}"
+source ~/.zshrc 2>/dev/null || true
+exec gemini

--- a/manifest.json
+++ b/manifest.json
@@ -1193,7 +1193,7 @@
     "local/goose": "implemented",
     "local/codex": "implemented",
     "local/interpreter": "implemented",
-    "local/gemini": "missing",
+    "local/gemini": "implemented",
     "local/amazonq": "missing",
     "local/cline": "missing",
     "local/gptme": "implemented",


### PR DESCRIPTION
## Summary
- Implements `local/gemini` matrix gap
- Installs Gemini CLI via npm (`@google/gemini-cli`)
- Injects OpenRouter credentials per manifest.json spec
- Follows local/* script pattern from existing implementations

## Test plan
- [x] Syntax check with `bash -n`
- [ ] Manual testing with local execution
- [ ] Verify OpenRouter API key injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)