### PR TITLE
feat: prioritize clouds with detected credentials in interactive mode

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.64",
+  "version": "0.2.65",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cloud-credentials.test.ts
+++ b/cli/src/__tests__/cloud-credentials.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { hasCloudCredentials, parseAuthEnvVars } from "../commands";
+
+describe("hasCloudCredentials", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  function setEnv(key: string, value: string): void {
+    savedEnv[key] = process.env[key];
+    process.env[key] = value;
+  }
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    // Clear saved state
+    for (const key of Object.keys(savedEnv)) {
+      delete savedEnv[key];
+    }
+  });
+
+  it("should return true when single env var is set", () => {
+    setEnv("HCLOUD_TOKEN", "test-token");
+    expect(hasCloudCredentials("HCLOUD_TOKEN")).toBe(true);
+  });
+
+  it("should return false when single env var is not set", () => {
+    delete process.env["HCLOUD_TOKEN"];
+    expect(hasCloudCredentials("HCLOUD_TOKEN")).toBe(false);
+  });
+
+  it("should return true when all multiple env vars are set", () => {
+    setEnv("UPCLOUD_USERNAME", "user");
+    setEnv("UPCLOUD_PASSWORD", "pass");
+    expect(hasCloudCredentials("UPCLOUD_USERNAME + UPCLOUD_PASSWORD")).toBe(true);
+  });
+
+  it("should return false when only some env vars are set", () => {
+    setEnv("UPCLOUD_USERNAME", "user");
+    delete process.env["UPCLOUD_PASSWORD"];
+    expect(hasCloudCredentials("UPCLOUD_USERNAME + UPCLOUD_PASSWORD")).toBe(false);
+  });
+
+  it("should return false for non-env-var auth like 'none'", () => {
+    expect(hasCloudCredentials("none")).toBe(false);
+  });
+
+  it("should return false for CLI-based auth like 'gcloud auth login'", () => {
+    expect(hasCloudCredentials("gcloud auth login")).toBe(false);
+  });
+
+  it("should return false for auth like 'sprite login'", () => {
+    expect(hasCloudCredentials("sprite login")).toBe(false);
+  });
+
+  it("should return false for empty string", () => {
+    expect(hasCloudCredentials("")).toBe(false);
+  });
+
+  it("should return false when env var is set to empty string", () => {
+    setEnv("HCLOUD_TOKEN", "");
+    expect(hasCloudCredentials("HCLOUD_TOKEN")).toBe(false);
+  });
+
+  it("should handle complex multi-var auth like contabo", () => {
+    setEnv("CONTABO_CLIENT_ID", "id");
+    setEnv("CONTABO_CLIENT_SECRET", "secret");
+    setEnv("CONTABO_API_USER", "user");
+    setEnv("CONTABO_API_PASSWORD", "pass");
+    expect(hasCloudCredentials("CONTABO_CLIENT_ID + CONTABO_CLIENT_SECRET + CONTABO_API_USER + CONTABO_API_PASSWORD")).toBe(true);
+  });
+
+  it("should return false for complex auth with one var missing", () => {
+    setEnv("CONTABO_CLIENT_ID", "id");
+    setEnv("CONTABO_CLIENT_SECRET", "secret");
+    setEnv("CONTABO_API_USER", "user");
+    delete process.env["CONTABO_API_PASSWORD"];
+    expect(hasCloudCredentials("CONTABO_CLIENT_ID + CONTABO_CLIENT_SECRET + CONTABO_API_USER + CONTABO_API_PASSWORD")).toBe(false);
+  });
+
+  it("should handle auth with mixed text and env vars", () => {
+    // e.g. "aws configure (AWS credentials)" - no valid env var names
+    expect(hasCloudCredentials("aws configure (AWS credentials)")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- When running `spawn` interactively, clouds with detected auth credentials are now prioritized (moved to the top) in the cloud selection picker
- Clouds with credentials show a "credentials detected" hint alongside their description
- A count of detected clouds is shown before the picker (e.g. "2 clouds with credentials detected")
- Added `hasCloudCredentials()` helper that checks if all required auth env vars for a cloud are set
- Bumped CLI version to 0.2.65

Fixes #685

## How it works

The `parseAuthEnvVars()` function (already existing) extracts env var names from a cloud's `auth` field. The new `hasCloudCredentials()` checks if all extracted vars are present and non-empty in `process.env`. In `cmdInteractive()`, clouds are partitioned into "with credentials" and "without", then concatenated so credentialed clouds appear first.

## Test plan

- [x] 12 new tests for `hasCloudCredentials()` covering single vars, multiple vars, missing vars, CLI-based auth, empty strings
- [x] Full test suite passes (6062 pass, 12 pre-existing failures unrelated to this change)
- [ ] Manual test: set `HCLOUD_TOKEN=x` and run `spawn` interactively -- Hetzner should appear first with "credentials detected" hint

Agent: ux-engineer