### PR TITLE
fix: address medium security findings from #753

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,15 @@ node_modules/
 __pycache__/
 .claude/skills/*/start-*.sh
 cli/cli.js
+
+# Sensitive files — never commit secrets or private keys
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+id_rsa
+id_ed25519
+credentials.json
+service-account.json

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -21,9 +21,9 @@ YELLOW='\033[1;33m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-log_info()  { echo -e "${GREEN}[spawn]${NC} $1"; }
-log_warn()  { echo -e "${YELLOW}[spawn]${NC} $1"; }
-log_error() { echo -e "${RED}[spawn]${NC} $1"; }
+log_info()  { printf "${GREEN}[spawn]${NC} %s\n" "$1"; }
+log_warn()  { printf "${YELLOW}[spawn]${NC} %s\n" "$1"; }
+log_error() { printf "${RED}[spawn]${NC} %s\n" "$1"; }
 
 # --- Helper: compare semver strings ---
 # Returns 0 (true) if $1 >= $2

--- a/test/run.sh
+++ b/test/run.sh
@@ -15,7 +15,7 @@
 #   bash test/run.sh claude       # test one script
 #   bash test/run.sh --remote     # test remote source (from GitHub)
 
-set -uo pipefail
+set -eo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEST_DIR=$(mktemp -d)
@@ -310,7 +310,7 @@ _test_sprite_remote_source() {
     fi
     local remote_fns
     remote_fns=$(bash -c '
-        source <(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sprite/lib/common.sh)
+        eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sprite/lib/common.sh)"
         type log_info &>/dev/null && echo "OK" || echo "FAIL"
     ' 2>/dev/null)
     assert_equals "${remote_fns}" "OK" "Remote source from GitHub works"


### PR DESCRIPTION
## Summary

Fixes four medium-severity findings from #753:

- **`cli/install.sh:24-26`**: Replace `echo -e` with `printf` for macOS bash 3.x compatibility (macOS ships bash 3.2 which does not support `echo -e`)
- **`test/run.sh:18`**: Remove `-u` (nounset) from `set -uo pipefail` — project convention is `set -eo pipefail` with `${VAR:-}` for optional vars
- **`test/run.sh:313`**: Replace `source <(curl ...)` with `eval "$(curl ...)"` — `source <()` fails inside `bash <(curl ...)` (process substitution nesting)
- **`.gitignore`**: Add patterns for sensitive files (`.env`, `*.pem`, `*.key`, `*.p12`, `*.pfx`, `id_rsa`, `id_ed25519`, `credentials.json`, `service-account.json`)

## Security scan results

No new HIGH/CRITICAL vulnerabilities found. Existing HIGH issue (#736) already has PR #742.

## Test plan

- [x] `bash -n cli/install.sh` — passes
- [x] `bash -n test/run.sh` — passes
- [x] `bun test` — all pre-existing passes still pass (13 pre-existing failures unchanged)

Refs #753