### PR TITLE
fix: consistent log_step for in-progress messages

### DIFF
--- a/cherry/lib/common.sh
+++ b/cherry/lib/common.sh
@@ -167,7 +167,7 @@ get_server_name() {
 # Sets CHERRY_SERVER_IP on success
 _cherry_wait_for_ip() {
     local server_id="$1"
-    log_info "Waiting for IP address assignment..."
+    log_step "Waiting for IP address assignment..."
     local ip_address=""
     local attempts=0
     local max_attempts=60
@@ -181,10 +181,13 @@ _cherry_wait_for_ip() {
         ip_address=$(printf '%s' "$server_info" | _cherry_extract_primary_ip)
 
         attempts=$((attempts + 1))
+        if [[ -z "$ip_address" ]] && [[ $((attempts % 5)) -eq 0 ]]; then
+            log_step "Still waiting for IP address... (attempt ${attempts}/${max_attempts})"
+        fi
     done
 
     if [[ -z "$ip_address" ]]; then
-        log_error "Failed to get server IP address"
+        log_error "Failed to get server IP address after ${max_attempts} attempts"
         return 1
     fi
 
@@ -209,7 +212,7 @@ create_server() {
     local project_id
     project_id=$(get_cherry_project_id) || return 1
 
-    log_info "Creating Cherry Servers server..."
+    log_step "Creating Cherry Servers server..."
     log_info "Plan: $plan, Region: $region, Image: $image"
 
     local payload
@@ -260,7 +263,7 @@ wait_for_cloud_init() {
     local ip="$1"
     local timeout="${2:-300}"
 
-    log_info "Waiting for system initialization..."
+    log_step "Waiting for system initialization..."
 
     if ! run_server "$ip" "cloud-init status --wait --long" 2>/dev/null; then
         log_warn "cloud-init wait timed out or not available, proceeding anyway"

--- a/contabo/lib/common.sh
+++ b/contabo/lib/common.sh
@@ -239,7 +239,7 @@ create_server() {
     export CONTABO_INSTANCE_ID
 
     log_info "Instance created: ID=$CONTABO_INSTANCE_ID"
-    log_info "Waiting for instance to be provisioned..."
+    log_step "Waiting for instance to be provisioned..."
 
     _contabo_wait_for_instance "$CONTABO_INSTANCE_ID"
 }

--- a/github-codespaces/aider.sh
+++ b/github-codespaces/aider.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/amazonq.sh
+++ b/github-codespaces/amazonq.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/claude.sh
+++ b/github-codespaces/claude.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/cline.sh
+++ b/github-codespaces/cline.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/codex.sh
+++ b/github-codespaces/codex.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/gemini.sh
+++ b/github-codespaces/gemini.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/goose.sh
+++ b/github-codespaces/goose.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/gptme.sh
+++ b/github-codespaces/gptme.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/interpreter.sh
+++ b/github-codespaces/interpreter.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/kilocode.sh
+++ b/github-codespaces/kilocode.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/lib/common.sh
+++ b/github-codespaces/lib/common.sh
@@ -89,7 +89,7 @@ create_codespace() {
     local machine="${2:-basicLinux32gb}"
     local idle_timeout="${3:-30m}"
 
-    log_info "Creating GitHub Codespace..."
+    log_step "Creating GitHub Codespace..."
     log_info "Repo: $repo"
     log_info "Machine: $machine"
     log_info "Idle timeout: $idle_timeout"
@@ -117,7 +117,7 @@ wait_for_codespace() {
     local max_attempts=60
     local attempt=0
 
-    log_info "Waiting for codespace to be ready..."
+    log_step "Waiting for codespace to be ready..."
 
     while [[ $attempt -lt $max_attempts ]]; do
         local state

--- a/github-codespaces/nanoclaw.sh
+++ b/github-codespaces/nanoclaw.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/openclaw.sh
+++ b/github-codespaces/openclaw.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/opencode.sh
+++ b/github-codespaces/opencode.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/github-codespaces/plandex.sh
+++ b/github-codespaces/plandex.sh
@@ -21,7 +21,7 @@ REPO="${GITHUB_REPO:-OpenRouterTeam/spawn}"
 MACHINE="${CODESPACE_MACHINE:-basicLinux32gb}"
 IDLE_TIMEOUT="${CODESPACE_IDLE_TIMEOUT:-30m}"
 
-log_info "Creating codespace for repo: $REPO"
+log_step "Creating codespace for repo: $REPO"
 CODESPACE=$(create_codespace "$REPO" "$MACHINE" "$IDLE_TIMEOUT")
 
 if [[ -z "$CODESPACE" ]]; then

--- a/netcup/lib/common.sh
+++ b/netcup/lib/common.sh
@@ -216,7 +216,7 @@ print(json.dumps(param))
 # Poll the Netcup API until the VPS has an IPv4 address
 # Sets NETCUP_SERVER_IP on success
 _netcup_wait_for_ip() {
-    log_info "Waiting for IP assignment..."
+    log_step "Waiting for IP assignment..."
     local ip=""
     local attempts=0
     while [[ -z "$ip" ]] && [[ $attempts -lt 60 ]]; do
@@ -233,10 +233,13 @@ except:
     pass
 " 2>/dev/null || echo "")
         attempts=$((attempts + 1))
+        if [[ -z "$ip" ]] && [[ $((attempts % 5)) -eq 0 ]]; then
+            log_step "Still waiting for IP assignment... (attempt ${attempts}/60)"
+        fi
     done
 
     if [[ -z "$ip" ]]; then
-        log_error "Timeout waiting for IP assignment"
+        log_error "Timeout waiting for IP assignment after 60 attempts"
         return 1
     fi
 

--- a/ramnode/lib/common.sh
+++ b/ramnode/lib/common.sh
@@ -221,7 +221,7 @@ _pick_flavor() {
         return
     fi
 
-    log_info "Fetching available instance types..."
+    log_step "Fetching available instance types..."
     local flavors
     flavors=$(_list_flavors)
 
@@ -231,7 +231,7 @@ _pick_flavor() {
         return
     fi
 
-    log_info "Available instance types:"
+    log_step "Available instance types:"
     local i=1
     local names=()
     while IFS='|' read -r name cores ram disk; do
@@ -314,7 +314,7 @@ print(json.dumps(body))
 # Poll the RamNode API until the server has an IPv4 address
 # Sets RAMNODE_SERVER_IP on success
 _ramnode_wait_for_ip() {
-    log_info "Waiting for IP address..."
+    log_step "Waiting for IP address..."
     local max_attempts=30
     local attempt=0
     while [[ $attempt -lt $max_attempts ]]; do
@@ -340,9 +340,12 @@ for net_name, addrs in addresses.items():
         fi
 
         attempt=$((attempt + 1))
+        if [[ $((attempt % 5)) -eq 0 ]]; then
+            log_step "Still waiting for IP address... (attempt ${attempt}/${max_attempts})"
+        fi
     done
 
-    log_error "Timeout waiting for IP address"
+    log_error "Timeout waiting for IP address after ${max_attempts} attempts"
     return 1
 }
 
@@ -378,7 +381,7 @@ create_server() {
     flavor=$(_pick_flavor)
 
     # Get image ID
-    log_info "Fetching Ubuntu 24.04 image..."
+    log_step "Fetching Ubuntu 24.04 image..."
     local image_id
     image_id=$(_list_images)
     if [[ -z "$image_id" ]]; then

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -541,7 +541,7 @@ wait_for_oauth_code() {
     local timeout="${2:-120}"
     local elapsed=0
 
-    log_info "Waiting for authentication in browser (this usually takes 10-30 seconds, timeout: ${timeout}s)..."
+    log_step "Waiting for authentication in browser (this usually takes 10-30 seconds, timeout: ${timeout}s)..."
     while [[ ! -f "${code_file}" ]] && [[ ${elapsed} -lt ${timeout} ]]; do
         sleep "${POLL_INTERVAL}"
         elapsed=$((elapsed + POLL_INTERVAL))
@@ -1793,7 +1793,7 @@ _multi_creds_validate() {
         return 0
     fi
 
-    log_info "Testing ${provider_name} credentials..."
+    log_step "Testing ${provider_name} credentials..."
     if ! "${test_func}"; then
         log_error "Invalid ${provider_name} credentials"
         log_error "The credentials may be expired, revoked, or incorrectly copied."
@@ -2108,7 +2108,7 @@ _display_and_select() {
     local default_value="${2}"
     local default_id="${3:-}"
 
-    log_info "Available ${prompt_text}:"
+    log_step "Available ${prompt_text}:"
     local i=1
     local ids=()
     local default_idx=1
@@ -2150,7 +2150,7 @@ interactive_pick() {
         return
     fi
 
-    log_info "Fetching available ${prompt_text}..."
+    log_step "Fetching available ${prompt_text}..."
     local items
     items=$("${list_callback}")
 


### PR DESCRIPTION
## Summary

- Use `log_step` (cyan) instead of `log_info` (green) for in-progress/status messages across 20 shell scripts
- Affected operations: "Waiting for...", "Fetching...", "Creating...", "Testing..." messages in shared/common.sh and cloud-specific scripts
- Adds periodic progress updates to silent IP polling loops in ramnode, cherry, and netcup (every 5 attempts)
- Improves timeout error messages to include attempt count

## Rationale

The convention (established in PR #440) is:
- **`log_step` (cyan)**: progress messages for operations still running
- **`log_info` (green)**: success/completion messages

Several scripts were still using `log_info` for in-progress operations, making it hard for users to distinguish "still working" from "done". This PR fixes the remaining inconsistencies.

## Files changed

- `shared/common.sh` -- 4 messages (OAuth wait, credential test, interactive picker)
- `cherry/lib/common.sh` -- 3 messages + progress indicator in IP wait loop
- `contabo/lib/common.sh` -- 1 message
- `netcup/lib/common.sh` -- 1 message + progress indicator in IP wait loop
- `ramnode/lib/common.sh` -- 4 messages + progress indicator in IP wait loop
- `github-codespaces/lib/common.sh` -- 2 messages
- 14 `github-codespaces/*.sh` agent scripts -- 1 message each

## Test plan

- [x] `bash -n` syntax check passes on all 20 modified files
- [ ] Verify cyan/green color distinction works in terminal output
- [ ] Manual test: run a spawn on any cloud to confirm progress messages appear in cyan

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>