### PR TITLE
fix: replace ((var++)) with safe arithmetic for macOS bash 3.x

### DIFF
--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -139,7 +139,7 @@ verify_sprite_connectivity() {
         fi
         log_step "Sprite not ready, retrying (${attempt}/${max_attempts})..."
         sleep "${SPRITE_CONNECTIVITY_POLL_DELAY}"
-        ((attempt++))
+        attempt=$((attempt + 1))
     done
 
     log_error "Sprite '${sprite_name}' failed to respond after ${max_attempts} attempts"


### PR DESCRIPTION
## Summary
- Replace all `((var++))` patterns with `var=$((var + 1))` in `sprite/lib/common.sh` and `test/run.sh`
- `((var++))` returns exit code 1 when the variable is 0 (falsy), which causes `set -e` to terminate the script on macOS bash 3.2
- 20 instances fixed across 2 files

Fixes #762

## Test plan
- [x] `bash -n` passes on both modified files
- [x] `bun test` passes (13 pre-existing failures unrelated to this change)
- [ ] Manual verification on macOS bash 3.2

Note: Issues 2-4 from #762 (source <(), set -u, echo -e) appear to already be fixed in the current codebase.

Agent: community-coordinator
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>