### PR TITLE
fix: prevent Python code injection via unescaped variables

### DIFF
--- a/civo/lib/common.sh
+++ b/civo/lib/common.sh
@@ -206,18 +206,18 @@ build_create_instance_body() {
 import json, sys
 script = json.loads(sys.stdin.read())
 body = {
-    'hostname': '$name',
-    'size': '$size',
-    'region': '$region',
-    'network_id': '$network_id',
-    'template_id': '$template_id',
-    'ssh_key_id': '$ssh_key_id',
+    'hostname': sys.argv[1],
+    'size': sys.argv[2],
+    'region': sys.argv[3],
+    'network_id': sys.argv[4],
+    'template_id': sys.argv[5],
+    'ssh_key_id': sys.argv[6],
     'initial_user': 'root',
     'script': script,
     'public_ip': 'create'
 }
 print(json.dumps(body))
-" <<< "$json_script"
+" "$name" "$size" "$region" "$network_id" "$template_id" "$ssh_key_id" <<< "$json_script"
 }
 
 # Wait for a Civo instance to become ACTIVE and retrieve its public IP

--- a/genesiscloud/lib/common.sh
+++ b/genesiscloud/lib/common.sh
@@ -126,15 +126,15 @@ _genesis_build_instance_body() {
 import json, sys
 userdata = sys.stdin.read()
 body = {
-    'name': '$name',
-    'type': '$instance_type',
-    'region': '$region',
-    'image': '$image',
-    'ssh_key_ids': $ssh_key_ids,
+    'name': sys.argv[1],
+    'type': sys.argv[2],
+    'region': sys.argv[3],
+    'image': sys.argv[4],
+    'ssh_key_ids': json.loads(sys.argv[5]),
     'startup_script': userdata
 }
 print(json.dumps(body))
-"
+" "$name" "$instance_type" "$region" "$image" "$ssh_key_ids"
 }
 
 # Poll Genesis Cloud API until instance is active, then extract IP

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -115,21 +115,22 @@ _list_server_types_for_location() {
     echo "$response" | python3 -c "
 import json, sys
 data = json.loads(sys.stdin.read())
+location = sys.argv[1]
 types = []
 for t in data.get('server_types', []):
     if t.get('deprecation') is not None:
         continue
     # Check if this type is available in the requested location
     avail = {p['location']: p for p in t.get('prices', [])}
-    if '$location' not in avail:
+    if location not in avail:
         continue
-    price = float(avail['$location']['price_hourly']['gross'])
+    price = float(avail[location]['price_hourly']['gross'])
     ram_gb = t['memory']
     types.append((price, t['name'], t['cores'], ram_gb, t['disk'], t['cpu_type']))
 types.sort()
 for price, name, cores, ram, disk, cpu in types:
     print(f'{name}|{cores} vCPU|{ram:.0f} GB RAM|{disk} GB disk|{cpu}|\$  {price:.4f}/hr')
-"
+" "$location"
 }
 
 # Fetch available locations
@@ -172,16 +173,16 @@ _hetzner_build_create_body() {
 import json, sys
 userdata = sys.stdin.read()
 body = {
-    'name': '$name',
-    'server_type': '$server_type',
-    'location': '$location',
-    'image': '$image',
-    'ssh_keys': $ssh_key_ids,
+    'name': sys.argv[1],
+    'server_type': sys.argv[2],
+    'location': sys.argv[3],
+    'image': sys.argv[4],
+    'ssh_keys': json.loads(sys.argv[5]),
     'user_data': userdata,
     'start_after_create': True
 }
 print(json.dumps(body))
-"
+" "$name" "$server_type" "$location" "$image" "$ssh_key_ids"
 }
 
 # Check Hetzner API response for errors and log diagnostics

--- a/kamatera/lib/common.sh
+++ b/kamatera/lib/common.sh
@@ -68,13 +68,15 @@ _kamatera_queue_field() {
     python3 -c "
 import json, sys
 data = json.loads(sys.stdin.read())
+field = sys.argv[1]
+default = sys.argv[2]
 if isinstance(data, list) and len(data) > 0:
-    print(data[0].get('$field', '$default'))
+    print(data[0].get(field, default))
 elif isinstance(data, dict):
-    print(data.get('$field', '$default'))
+    print(data.get(field, default))
 else:
-    print('$default')
-" <<< "$json_data" 2>/dev/null
+    print(default)
+" "$field" "$default" <<< "$json_data" 2>/dev/null
 }
 
 # Wait for an async Kamatera command to complete
@@ -222,25 +224,25 @@ build_kamatera_server_body() {
 import json, sys
 data = json.loads(sys.stdin.read())
 body = {
-    'name': '$name',
-    'password': '$password',
-    'passwordValidate': '$password',
+    'name': sys.argv[1],
+    'password': sys.argv[2],
+    'passwordValidate': sys.argv[2],
     'ssh-key': data['ssh_key'],
-    'datacenter': '$datacenter',
-    'image': '$image',
-    'cpu': '$cpu',
-    'ram': $ram,
-    'disk': '$disk',
+    'datacenter': sys.argv[3],
+    'image': sys.argv[4],
+    'cpu': sys.argv[5],
+    'ram': int(sys.argv[6]),
+    'disk': sys.argv[7],
     'dailybackup': 'no',
     'managed': 'no',
     'network': 'name=wan,ip=auto',
     'quantity': 1,
-    'billingcycle': '$billing',
+    'billingcycle': sys.argv[8],
     'poweronaftercreate': 'yes',
     'script-file': data['script']
 }
 print(json.dumps(body))
-" <<< "{\"ssh_key\": $json_ssh_key, \"script\": $json_script}"
+" "$name" "$password" "$datacenter" "$image" "$cpu" "$ram" "$disk" "$billing" <<< "{\"ssh_key\": $json_ssh_key, \"script\": $json_script}"
 }
 
 # Read SSH public key if available, prints to stdout

--- a/latitude/lib/common.sh
+++ b/latitude/lib/common.sh
@@ -133,22 +133,22 @@ print(json.dumps(ids))
 _latitude_build_server_body() {
     local hostname="$1" plan="$2" site="$3" os="$4" project_id="$5" ssh_key_ids="$6"
     python3 -c "
-import json
+import json, sys
 body = {
     'data': {
         'type': 'servers',
         'attributes': {
-            'hostname': '$hostname',
-            'plan': '$plan',
-            'site': '$site',
-            'operating_system': '$os',
-            'project': '$project_id',
-            'ssh_keys': $ssh_key_ids
+            'hostname': sys.argv[1],
+            'plan': sys.argv[2],
+            'site': sys.argv[3],
+            'operating_system': sys.argv[4],
+            'project': sys.argv[5],
+            'ssh_keys': json.loads(sys.argv[6])
         }
     }
 }
 print(json.dumps(body))
-"
+" "$hostname" "$plan" "$site" "$os" "$project_id" "$ssh_key_ids"
 }
 
 # Check if SSH key is registered with Latitude.sh
@@ -171,13 +171,13 @@ body = {
     'data': {
         'type': 'ssh_keys',
         'attributes': {
-            'name': '$key_name',
+            'name': sys.argv[1],
             'public_key': pub_key
         }
     }
 }
 print(json.dumps(body))
-")
+" "$key_name")
 
     local response
     response=$(latitude_api POST "/ssh_keys" "$body")

--- a/scaleway/lib/common.sh
+++ b/scaleway/lib/common.sh
@@ -160,12 +160,12 @@ scaleway_register_ssh_key() {
 import json, sys
 pub_key = json.loads(sys.stdin.read())
 body = {
-    'name': '$key_name',
+    'name': sys.argv[1],
     'public_key': pub_key,
-    'project_id': '$project_id'
+    'project_id': sys.argv[2]
 }
 print(json.dumps(body))
-" <<< "$json_pub_key")
+" "$key_name" "$project_id" <<< "$json_pub_key")
 
     local register_response
     register_response=$(scaleway_api POST "${SCALEWAY_ACCOUNT_API}/ssh-keys" "$register_body")
@@ -272,16 +272,16 @@ create_server() {
 
     local body
     body=$(python3 -c "
-import json
+import json, sys
 body = {
-    'name': '$name',
-    'commercial_type': '$commercial_type',
-    'image': '$image_id',
-    'project': '$project_id',
+    'name': sys.argv[1],
+    'commercial_type': sys.argv[2],
+    'image': sys.argv[3],
+    'project': sys.argv[4],
     'dynamic_ip_required': True
 }
 print(json.dumps(body))
-")
+" "$name" "$commercial_type" "$image_id" "$project_id")
 
     local response
     response=$(scaleway_instance_api POST "/servers" "$body")


### PR DESCRIPTION
## Summary
- Fix Python code injection via unescaped shell variables in inline Python across 6 cloud lib files and test/record.sh
- Fix eval injection in test/record.sh try_load_config() for OVH config loading
- Use sys.argv pattern to pass shell values to Python instead of string interpolation

**Files changed:**
- `hetzner/lib/common.sh` - `_hetzner_build_create_body()` and `_list_server_types_for_location()`
- `civo/lib/common.sh` - `build_create_instance_body()`
- `genesiscloud/lib/common.sh` - `_genesis_build_instance_body()`
- `scaleway/lib/common.sh` - `scaleway_register_ssh_key()` and `create_server()`
- `kamatera/lib/common.sh` - `_kamatera_queue_field()` and `build_kamatera_server_body()`
- `latitude/lib/common.sh` - `_latitude_build_server_body()` and `latitude_register_ssh_key()`
- `test/record.sh` - `try_load_config()`, `save_config()`, `has_api_error()`, and all live cycle functions

Fixes #759
Fixes #760

## Test plan
- [x] bash -n on all 7 modified .sh files
- [x] bun test passes (6191 pass, 13 pre-existing failures unrelated to this change)
- [x] Manual review of all Python string interpolation sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)