### PR TITLE
fix: use log_step (cyan) for in-progress messages in shared libs and installer

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -21,7 +21,10 @@ YELLOW='\033[1;33m'
 BOLD='\033[1m'
 NC='\033[0m'
 
+CYAN='\033[0;36m'
+
 log_info()  { printf "${GREEN}[spawn]${NC} %s\n" "$1"; }
+log_step()  { printf "${CYAN}[spawn]${NC} %s\n" "$1"; }
 log_warn()  { printf "${YELLOW}[spawn]${NC} %s\n" "$1"; }
 log_error() { printf "${RED}[spawn]${NC} %s\n" "$1"; }
 
@@ -129,7 +132,7 @@ ensure_in_path() {
 clone_cli() {
     local dest="$1"
     if command -v git &>/dev/null; then
-        log_info "Cloning CLI source..."
+        log_step "Cloning CLI source..."
         git clone --depth 1 --filter=blob:none --sparse \
             "https://github.com/${SPAWN_REPO}.git" "${dest}/repo" 2>/dev/null
         cd "${dest}/repo"
@@ -138,7 +141,7 @@ clone_cli() {
         cd "${dest}"
         rm -rf "${dest}/repo"
     else
-        log_info "Downloading CLI source..."
+        log_step "Downloading CLI source..."
         mkdir -p "${dest}/cli/src"
         # Download all source files via GitHub API
         local files
@@ -184,7 +187,7 @@ build_and_install() {
 
 # --- Install bun if not present ---
 if ! command -v bun &>/dev/null; then
-    log_info "bun not found. Installing bun..."
+    log_step "bun not found. Installing bun..."
     curl -fsSL https://bun.sh/install | bash
 
     # Source the updated PATH so bun is available immediately
@@ -207,5 +210,5 @@ fi
 
 ensure_min_bun_version
 
-log_info "Installing spawn via bun..."
+log_step "Installing spawn via bun..."
 build_and_install

--- a/contabo/openclaw.sh
+++ b/contabo/openclaw.sh
@@ -51,7 +51,7 @@ inject_env_vars_ssh "${CONTABO_SERVER_IP}" upload_file run_server \
 echo ""
 log_info "Contabo instance setup completed successfully!"
 log_info "Instance: ${SERVER_NAME} (ID: ${CONTABO_INSTANCE_ID}, IP: ${CONTABO_SERVER_IP})"
-log_info "Starting OpenClaw gateway in background..."
+log_step "Starting OpenClaw gateway in background..."
 run_server "${CONTABO_SERVER_IP}" "nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 

--- a/github-codespaces/claude.sh
+++ b/github-codespaces/claude.sh
@@ -71,7 +71,7 @@ inject_env_vars \
 setup_claude_code_config "$OPENROUTER_API_KEY" "upload_file" "run_server"
 
 echo ""
-log_info "Setup complete. Opening interactive session..."
+log_step "Setup complete. Opening interactive session..."
 echo ""
 log_info "To delete codespace later, run: gh codespace delete --codespace $CODESPACE --force"
 echo ""

--- a/github-codespaces/lib/common.sh
+++ b/github-codespaces/lib/common.sh
@@ -69,7 +69,7 @@ ensure_gh_cli() {
 ensure_gh_auth() {
     if ! gh auth status &>/dev/null; then
         log_step "Not authenticated with GitHub CLI"
-        log_info "Initiating GitHub CLI authentication..."
+        log_step "Initiating GitHub CLI authentication..."
         gh auth login || {
             log_error "Failed to authenticate with GitHub CLI"
             log_error "Run: gh auth login"
@@ -160,7 +160,7 @@ copy_to_codespace() {
 # Args: $1 = codespace name
 ssh_to_codespace() {
     local codespace="$1"
-    log_info "Opening SSH session to codespace..."
+    log_step "Opening SSH session to codespace..."
     gh codespace ssh --codespace "$codespace"
 }
 
@@ -168,7 +168,7 @@ ssh_to_codespace() {
 # Args: $1 = codespace name
 delete_codespace() {
     local codespace="$1"
-    log_info "Deleting codespace $codespace..."
+    log_step "Deleting codespace $codespace..."
     gh codespace delete --codespace "$codespace" --force || {
         log_warn "Failed to delete codespace (may already be deleted)"
     }

--- a/ionos/lib/common.sh
+++ b/ionos/lib/common.sh
@@ -214,7 +214,7 @@ ensure_datacenter() {
 # Find Ubuntu 24.04 HDD image ID from IONOS API
 # Outputs the image ID on stdout
 _ionos_find_ubuntu_image() {
-    log_info "Finding Ubuntu 24.04 image..."
+    log_step "Finding Ubuntu 24.04 image..."
     local images_response
     images_response=$(ionos_api GET "/images?depth=2")
 

--- a/ionos/openclaw.sh
+++ b/ionos/openclaw.sh
@@ -70,7 +70,7 @@ echo ""
 
 # 9. Start openclaw interactively
 log_step "Starting openclaw..."
-log_info "First starting openclaw gateway in background..."
+log_step "First starting openclaw gateway in background..."
 run_server "${IONOS_SERVER_IP}" "nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 log_step "Starting openclaw tui..."

--- a/koyeb/lib/common.sh
+++ b/koyeb/lib/common.sh
@@ -280,7 +280,7 @@ interactive_session() {
         return 1
     fi
 
-    log_info "Starting interactive session..."
+    log_step "Starting interactive session..."
     # SECURITY: Properly escape command to prevent injection
     local escaped_cmd
     escaped_cmd=$(printf '%q' "$launch_cmd")

--- a/railway/lib/common.sh
+++ b/railway/lib/common.sh
@@ -232,7 +232,7 @@ inject_env_vars() {
 interactive_session() {
     local launch_cmd="${1:-bash}"
 
-    log_info "Starting interactive session..."
+    log_step "Starting interactive session..."
 
     # Railway CLI has a shell command for interactive sessions
     railway shell

--- a/render/lib/common.sh
+++ b/render/lib/common.sh
@@ -255,7 +255,7 @@ interactive_session() {
         return 1
     fi
 
-    log_info "Starting interactive session..."
+    log_step "Starting interactive session..."
     # SECURITY: Properly escape command to prevent injection
     local escaped_cmd
     escaped_cmd=$(printf '%q' "$launch_cmd")

--- a/render/openclaw.sh
+++ b/render/openclaw.sh
@@ -68,7 +68,7 @@ echo ""
 
 # 10. Start openclaw
 log_step "Starting openclaw..."
-log_info "Starting gateway in background, then launching TUI..."
+log_step "Starting gateway in background, then launching TUI..."
 sleep 1
 clear
 interactive_session "source /root/.bashrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 & sleep 2 && openclaw tui"

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -682,7 +682,7 @@ _setup_oauth_server() {
     local port_file="${3}"
     local state_file="${4}"
 
-    log_info "Starting local OAuth server (trying ports ${callback_port}-$((callback_port + 10)))..."
+    log_step "Starting local OAuth server (trying ports ${callback_port}-$((callback_port + 10)))..."
     local server_pid
     server_pid=$(start_oauth_server "${callback_port}" "${code_file}" "${port_file}" "${state_file}")
 
@@ -747,7 +747,7 @@ _await_oauth_callback() {
 
     local callback_url="http://localhost:${actual_port}/callback"
     local auth_url="https://openrouter.ai/auth?callback_url=${callback_url}&state=${csrf_state}"
-    log_info "Opening browser to authenticate with OpenRouter..."
+    log_step "Opening browser to authenticate with OpenRouter..."
     open_browser "${auth_url}"
 
     if ! _wait_for_oauth "${code_file}"; then
@@ -770,7 +770,7 @@ _await_oauth_callback() {
 try_oauth_flow() {
     local callback_port=${1:-5180}
 
-    log_info "Attempting OAuth authentication..."
+    log_step "Attempting OAuth authentication..."
 
     if ! _check_oauth_prerequisites; then
         return 1
@@ -798,7 +798,7 @@ try_oauth_flow() {
     cleanup_oauth_session "${server_pid}" "${oauth_dir}"
 
     # Exchange code for API key
-    log_info "Exchanging OAuth code for API key..."
+    log_step "Exchanging OAuth code for API key..."
     local api_key
     api_key=$(exchange_oauth_code "${oauth_code}") || return 1
 
@@ -1328,7 +1328,7 @@ execute_agent_non_interactive() {
     local prompt="${4}"
     local exec_callback="${5}"
 
-    log_info "Executing ${agent_name} with prompt in non-interactive mode..."
+    log_step "Executing ${agent_name} with prompt in non-interactive mode..."
 
     # Escape the prompt for safe shell execution
     # We use printf %q which properly escapes special characters for bash


### PR DESCRIPTION
## Summary
- Replace `log_info` (green = success) with `log_step` (cyan = in-progress) for messages that describe actions currently happening
- Fixes 15 instances across `shared/common.sh`, `cli/install.sh`, 5 cloud `lib/common.sh` files, and 4 agent scripts
- Adds `log_step` function to `cli/install.sh` (which has its own log functions separate from shared/common.sh)

## Affected files
- `shared/common.sh`: OAuth flow steps (starting server, opening browser, exchanging code, attempting auth), non-interactive agent execution
- `cli/install.sh`: Added `log_step()`, changed download/install/clone progress messages
- Cloud libs: `render`, `railway`, `koyeb`, `ionos`, `github-codespaces` -- interactive session starts, image finding, auth initiation
- Agent scripts: `render/openclaw.sh`, `ionos/openclaw.sh`, `contabo/openclaw.sh`, `github-codespaces/claude.sh` -- gateway startup, session opening

## Color semantics (now consistent)
- **Green** (`log_info`) = success, completion, informational facts
- **Cyan** (`log_step`) = in-progress actions, status updates  
- **Yellow** (`log_warn`) = warnings
- **Red** (`log_error`) = errors

## Test plan
- [x] `bash -n` passes on all 11 modified files
- [x] `bun test` -- all pre-existing tests pass (13 pre-existing failures unrelated to this change)
- [ ] Manual: verify cyan color appears for in-progress messages during OAuth flow

Agent: ux-engineer