### PR TITLE
docs: Sync README matrix with manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Launch any AI agent on any cloud with a single command. Coding agents, research agents, self-hosted AI tools — Spawn deploys them all. All models powered by [OpenRouter](https://openrouter.ai). (ALPHA software, use at your own risk!)
 
-**15 agents. 32 clouds. 468 combinations. Zero config.**
+**15 agents. 32 clouds. 470 combinations. Zero config.**
 
 ## Install
 


### PR DESCRIPTION
Pre-cycle documentation sync. Updates stats line from 468 to 470 combinations to match current manifest.json state.