### PR TITLE
fix: filter Hetzner server types by location availability

### DIFF
--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -114,7 +114,12 @@ types = []
 for t in data.get('server_types', []):
     if t.get('deprecation') is not None:
         continue
-    # Check if this type is available in the requested location
+    # Check if this type is actually available in the requested location
+    # The 'locations' array is the authoritative source — 'prices' may list
+    # locations where the type cannot actually be provisioned (e.g. ARM in ash)
+    available_locations = {loc['name'] for loc in t.get('locations', [])}
+    if location not in available_locations:
+        continue
     avail = {p['location']: p for p in t.get('prices', [])}
     if location not in avail:
         continue


### PR DESCRIPTION
## Summary

- Filter Hetzner server types using the `locations` array (authoritative source) in addition to the `prices` array
- Prevents showing server types that can't be provisioned in the selected location (e.g. ARM `cax*` types in `ash`/Ashburn)

The Hetzner API includes pricing data for all locations in the `prices` array, even when the type can't actually be created there. The `locations` array on each server type is the authoritative source for where it can be provisioned.

Fixes #786

## Test plan

- [ ] Verify `bash -n hetzner/lib/common.sh` passes
- [ ] Verify `bun test` passes with no regressions
- [ ] Manual test: select `ash` location and confirm ARM types are not listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)