### PR TITLE
feat: Add local/plandex

### DIFF
--- a/local/plandex.sh
+++ b/local/plandex.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "Plandex on local machine"
+echo ""
+
+# 1. Ensure local prerequisites
+ensure_local_ready
+
+# 2. Install Plandex if not already installed
+if command -v plandex &>/dev/null; then
+    log_info "Plandex already installed"
+else
+    log_step "Installing Plandex..."
+    curl -sL https://plandex.ai/install.sh | bash
+    export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+# Verify installation
+if ! command -v plandex &>/dev/null; then
+    log_error "Plandex installation failed"
+    log_error "The 'plandex' command is not available"
+    log_error "Try installing manually: curl -sL https://plandex.ai/install.sh | bash"
+    exit 1
+fi
+log_info "Plandex installation verified"
+
+# 3. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 4. Inject environment variables
+log_step "Appending environment variables to ~/.zshrc..."
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Local setup completed successfully!"
+echo ""
+
+# 5. Start Plandex
+if [[ -n "${SPAWN_PROMPT:-}" ]]; then
+    log_step "Executing Plandex with prompt..."
+    export PATH="${HOME}/.local/bin:${PATH}"
+    source ~/.zshrc 2>/dev/null || true
+    plandex new && plandex tell "${SPAWN_PROMPT}"
+else
+    log_step "Starting Plandex..."
+    sleep 1
+    clear 2>/dev/null || true
+    export PATH="${HOME}/.local/bin:${PATH}"
+    source ~/.zshrc 2>/dev/null || true
+    exec plandex
+fi

--- a/manifest.json
+++ b/manifest.json
@@ -1198,7 +1198,7 @@
     "local/cline": "missing",
     "local/gptme": "implemented",
     "local/opencode": "implemented",
-    "local/plandex": "missing",
+    "local/plandex": "implemented",
     "local/kilocode": "missing",
     "local/continue": "implemented",
     "ramnode/claude": "implemented",


### PR DESCRIPTION
## Summary
Implements `local/plandex.sh` by combining:
- Local cloud primitives from `local/lib/common.sh`
- Plandex agent setup pattern from other clouds

## Implementation
- Installs Plandex via official installer
- Injects `OPENROUTER_API_KEY` into shell environment
- Supports both interactive and prompt modes
- Follows curl|bash compatibility rules

## Changes
- ✅ Created `local/plandex.sh`
- ✅ Updated `manifest.json` matrix entry to `"implemented"`
- ✅ Syntax check passed (`bash -n`)

-- discovery/gap-filler-local-plandex