### PR TITLE
fix: improve dry-run credential visibility and CLI messages

### DIFF
--- a/cli/src/__tests__/commands-internal-helpers.test.ts
+++ b/cli/src/__tests__/commands-internal-helpers.test.ts
@@ -62,12 +62,16 @@ function buildAgentLines(agentInfo: {
 function buildCloudLines(cloudInfo: {
   name: string;
   description: string;
+  auth?: string;
   defaults?: Record<string, string>;
 }): string[] {
   const lines = [
     `  Name:        ${cloudInfo.name}`,
     `  Description: ${cloudInfo.description}`,
   ];
+  if (cloudInfo.auth) {
+    lines.push(`  Auth:        ${cloudInfo.auth}`);
+  }
   if (cloudInfo.defaults) {
     lines.push(`  Defaults:`);
     for (const [k, v] of Object.entries(cloudInfo.defaults)) {
@@ -322,6 +326,17 @@ describe("buildCloudLines", () => {
     expect(lines).toHaveLength(2);
     expect(lines[0]).toContain("Sprite");
     expect(lines[1]).toContain("Lightweight VMs");
+  });
+
+  it("includes auth when present", () => {
+    const lines = buildCloudLines({
+      name: "Hetzner Cloud",
+      description: "European cloud provider",
+      auth: "HCLOUD_TOKEN",
+    });
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toContain("Auth:");
+    expect(lines[2]).toContain("HCLOUD_TOKEN");
   });
 
   it("includes defaults when present", () => {


### PR DESCRIPTION
## Summary
- **Dry-run now shows auth requirements**: `buildCloudLines` includes the cloud's `auth` field, so users see what credentials are needed before running
- **Dry-run shows credential status**: new "Credentials" section shows whether each required env var (cloud auth + `OPENROUTER_API_KEY`) is set or not, with green/red indicators
- **Dry-run shows "Run for real" command**: after dry-run completes, shows the exact command to run without `--dry-run`
- **Clearer SSH retry message**: changed from generic "Script failed (exited with code 255)" to "SSH connection failed. Server may still be booting." so users understand what's happening
- **Accurate interactive outro**: changed "Handing off to spawn script..." to "Starting provisioning..." since the script runs inline, not in a separate process

## Test plan
- [x] All 6377 tests pass (13 pre-existing failures unrelated to changes)
- [x] `commands-internal-helpers.test.ts` updated with new `buildCloudLines` auth test
- [x] `dry-run-preview.test.ts` passes
- [x] `ssh-retry.test.ts` passes
- [x] `exec-script-errors.test.ts` passes

-- refactor/ux-engineer