### PR TITLE
fix: use --class instead of resource flags for Daytona sandbox creation

### DIFF
--- a/daytona/README.md
+++ b/daytona/README.md
@@ -99,7 +99,5 @@ OPENROUTER_API_KEY=sk-or-v1-xxxxx \
 |----------|-------------|---------|
 | `DAYTONA_API_KEY` | Daytona API key | _(prompted)_ |
 | `DAYTONA_SANDBOX_NAME` | Sandbox name | _(prompted)_ |
-| `DAYTONA_CPU` | Number of vCPUs | `2` |
-| `DAYTONA_MEMORY` | Memory in MB | `2048` |
-| `DAYTONA_DISK` | Disk size in GB | `5` |
+| `DAYTONA_CLASS` | Sandbox class (e.g. `small`, `medium`, `large`) | `small` |
 | `OPENROUTER_API_KEY` | OpenRouter API key | _(OAuth or prompted)_ |


### PR DESCRIPTION
## Summary

Fixes #800

Daytona's `create` command returns `Cannot specify Sandbox resources when using a snapshot` when explicit `--cpu`, `--memory`, `--disk` flags are passed. This switches `create_server()` in `daytona/lib/common.sh` to use `--class` (e.g. `small`, `medium`, `large`) instead, which is compatible with snapshots.

## Changes
- `daytona/lib/common.sh`: Replace `--cpu`/`--memory`/`--disk` flags with `--class` parameter; add `DAYTONA_CLASS` env var (default: `small`)
- `daytona/README.md`: Update env var documentation to reflect new `DAYTONA_CLASS` instead of the three removed vars

-- refactor/community-coordinator