### PR TITLE
feat: consolidate security review_all and scan into single cycle

### DIFF
--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -193,9 +193,7 @@ Track issue lifecycle with labels: "pending-review" → "under-review" → "in-p
    - Label: \`gh pr edit NUMBER --repo OpenRouterTeam/spawn --add-label "needs-team-review"\`
    - Do NOT merge — PR stays open for external review
 10. Post update comment on the issue linking to the PR
-11. Remove status labels and close the issue:
-    \`gh issue edit ${SPAWN_ISSUE} --repo OpenRouterTeam/spawn --remove-label "in-progress"\`
-    \`gh issue close ${SPAWN_ISSUE}\`
+11. Do NOT close the issue — the PR body contains \`Fixes #${SPAWN_ISSUE}\` which will auto-close the issue when the PR is merged
 12. Clean up worktree: \`git worktree remove ${WORKTREE_BASE}\`
 13. Shutdown all teammates and exit
 
@@ -352,11 +350,11 @@ Create these teammates:
      * Code quality → message complexity-hunter
    - Post interim updates on issues as teammates report findings (only if no similar update exists):
      gh issue comment NUMBER --body "Update: We've identified the root cause — [summary]. Working on a fix now.\n\n-- refactor/community-coordinator"
-   - When a fix PR is merged, post the final resolution (only if no resolution comment exists yet):
-     gh issue comment NUMBER --body "This has been fixed in PR_URL. [Brief explanation of what was changed and why]. The fix is live on main — please try updating and let us know if you still see the issue.\n\n-- refactor/community-coordinator"
-   - Then close: gh issue close NUMBER
-   - For feature requests: comment acknowledging the request, label as enhancement, and close with a note pointing to discussions
-   - For questions: answer directly in a comment, then close
+   - When a fix PR is created, post an update linking to it (only if no similar update exists):
+     gh issue comment NUMBER --body "A fix is up in PR_URL. [Brief explanation of what was changed and why]. The issue will auto-close when the PR is merged.\n\n-- refactor/community-coordinator"
+   - Do NOT close issues manually — PRs contain \`Fixes #NUMBER\` which auto-closes the issue on merge
+   - For feature requests: comment acknowledging the request and label as enhancement (do NOT close — let the implementing PR close it)
+   - For questions: answer directly in a comment (do NOT close — the reporter may have follow-ups)
    - GOAL: Every issue reporter should feel heard and informed. No cold trails.
    - PERIODIC RE-SCAN: After your initial scan AND after every 5 minutes, re-run
      `gh issue list --repo OpenRouterTeam/spawn --state open --json number,title,body,labels,createdAt`
@@ -396,16 +394,15 @@ When fixing a bug reported in a GitHub issue:
 -- refactor/AGENT-NAME"
     gh pr edit NUMBER --repo OpenRouterTeam/spawn --add-label "needs-team-review"
 13. Clean up: git worktree remove WORKTREE_BASE_PLACEHOLDER/fix/issue-NUMBER
-14. Community-coordinator posts final resolution comment with PR link and explanation (only if no resolution exists)
-15. Remove status labels and close the issue:
-    gh issue edit NUMBER --repo OpenRouterTeam/spawn --remove-label "in-progress"
-    gh issue close NUMBER
+14. Community-coordinator posts update comment with PR link (only if no similar update exists)
+15. Do NOT close the issue — the PR body contains \`Fixes #NUMBER\` which will auto-close the issue when merged
 
-NEVER leave a PR without a self-review comment and `needs-team-review` label.
+NEVER leave a PR without a self-review comment and \`needs-team-review\` label.
 If a PR cannot be created (conflicts, superseded, etc.), close it WITH a comment explaining why.
 NEVER close a PR silently — every closed PR MUST have a comment.
-The full cycle is: acknowledge → investigate → worktree → fix → update → PR (references issue) → self-review → label → cleanup worktree.
-Note: merging is handled externally — agents do NOT merge.
+NEVER close an issue manually — let the PR merge auto-close it via \`Fixes #NUMBER\`.
+The full cycle is: acknowledge → investigate → worktree → fix → update → PR (references issue with \`Fixes #NUMBER\`) → self-review → label → cleanup worktree.
+Note: merging is handled externally — agents do NOT merge. Issues close automatically when the PR merges.
 
 ## Commit Markers (MANDATORY)
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,10 +4,8 @@ on:
   issues:
     types: [opened, reopened]
   schedule:
-    # Batch PR security review + hygiene — every 15 min
-    - cron: '*/15 * * * *'
-    # Full repo security scan — every 30 min (offset +5)
-    - cron: '5,35 * * * *'
+    # Consolidated review + scan — every 20 min
+    - cron: '*/20 * * * *'
   workflow_dispatch:
     inputs:
       mode:
@@ -20,7 +18,7 @@ on:
           - scan
 
 concurrency:
-  group: security-${{ github.event_name == 'issues' && format('issue-{0}', github.event.issue.number) || github.event_name == 'schedule' && github.event.schedule || 'manual' }}
+  group: security-${{ github.event_name == 'issues' && format('issue-{0}', github.event.issue.number) || 'scheduled' }}
   cancel-in-progress: true
 
 jobs:
@@ -47,15 +45,7 @@ jobs:
               REASON="triage"
             fi
           elif [ "${{ github.event_name }}" = "schedule" ]; then
-            # Distinguish between cron schedules by their cron string
-            CRON="${{ github.event.schedule }}"
-            if [ "$CRON" = "*/15 * * * *" ]; then
-              REASON="review_all"
-            elif [ "$CRON" = "5,35 * * * *" ]; then
-              REASON="schedule"
-            else
-              REASON="schedule"
-            fi
+            REASON="review_all"
             ISSUE_NUM=""
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             MODE="${{ github.event.inputs.mode || 'review_all' }}"


### PR DESCRIPTION
## Summary

- **Collapse two competing cron schedules** (`*/15` review_all + `5,35` scan) into a single `*/20` consolidated cycle, eliminating 429 conflicts from `MAX_CONCURRENT=1`
- **Expand `review_all` mode** to include lightweight repo scanning (shell-scanner + code-scanner on Sonnet) when ≤5 PRs are open, scoped to files changed in the last 24h
- **Prevent refactor agents from manually closing issues** — issues now auto-close via `Fixes #N` in PR bodies when merged

## Test plan

- [ ] `bash -n .claude/skills/setup-agent-team/security.sh` passes
- [ ] `bash -n .claude/skills/setup-agent-team/refactor.sh` passes
- [ ] Verify workflow YAML renders correctly
- [ ] Monitor next few scheduled runs to confirm 20-min cadence with no 429 drops
- [ ] Verify scan agents spawn correctly when ≤5 PRs open
- [ ] Verify refactor agents no longer call `gh issue close`

🤖 Generated with [Claude Code](https://claude.com/claude-code)