### PR TITLE
refactor: extract mock env config into per-cloud fixture files

### DIFF
--- a/test/fixtures/binarylane/_env.sh
+++ b/test/fixtures/binarylane/_env.sh
@@ -1,0 +1,4 @@
+export BINARYLANE_API_TOKEN="test-token-bl"
+export BINARYLANE_SERVER_NAME="test-srv"
+export BINARYLANE_SIZE="std-min"
+export BINARYLANE_REGION="syd"

--- a/test/fixtures/civo/_api_assertions.sh
+++ b/test/fixtures/civo/_api_assertions.sh
@@ -1,0 +1,2 @@
+assert_api_called "GET" "/sshkeys" "fetches SSH keys"
+assert_api_called "POST" "/instances" "creates instance"

--- a/test/fixtures/civo/_env.sh
+++ b/test/fixtures/civo/_env.sh
@@ -1,0 +1,3 @@
+export CIVO_API_TOKEN="test-token-civo"
+export CIVO_SERVER_NAME="test-srv"
+export CIVO_REGION="lon1"

--- a/test/fixtures/digitalocean/_api_assertions.sh
+++ b/test/fixtures/digitalocean/_api_assertions.sh
@@ -1,0 +1,2 @@
+assert_api_called "GET" "/account/keys" "fetches SSH keys"
+assert_api_called "POST" "/droplets" "creates droplet"

--- a/test/fixtures/digitalocean/_env.sh
+++ b/test/fixtures/digitalocean/_env.sh
@@ -1,0 +1,4 @@
+export DO_API_TOKEN="test-token-do"
+export DO_DROPLET_NAME="test-srv"
+export DO_DROPLET_SIZE="s-2vcpu-2gb"
+export DO_REGION="nyc3"

--- a/test/fixtures/genesiscloud/_env.sh
+++ b/test/fixtures/genesiscloud/_env.sh
@@ -1,0 +1,2 @@
+export GENESIS_API_KEY="test-token-genesis"
+export GENESIS_SERVER_NAME="test-srv"

--- a/test/fixtures/hetzner/_api_assertions.sh
+++ b/test/fixtures/hetzner/_api_assertions.sh
@@ -1,0 +1,2 @@
+assert_api_called "GET" "/ssh_keys" "fetches SSH keys"
+assert_api_called "POST" "/servers" "creates server"

--- a/test/fixtures/hetzner/_env.sh
+++ b/test/fixtures/hetzner/_env.sh
@@ -1,0 +1,4 @@
+export HCLOUD_TOKEN="test-token-hetzner"
+export HETZNER_SERVER_NAME="test-srv"
+export HETZNER_SERVER_TYPE="cpx11"
+export HETZNER_LOCATION="fsn1"

--- a/test/fixtures/hyperstack/_env.sh
+++ b/test/fixtures/hyperstack/_env.sh
@@ -1,0 +1,2 @@
+export HYPERSTACK_API_KEY="test-token-hyper"
+export HYPERSTACK_SERVER_NAME="test-srv"

--- a/test/fixtures/kamatera/_env.sh
+++ b/test/fixtures/kamatera/_env.sh
@@ -1,0 +1,3 @@
+export KAMATERA_API_CLIENT_ID="test-client-id"
+export KAMATERA_API_SECRET="test-secret"
+export KAMATERA_SERVER_NAME="test-srv"

--- a/test/fixtures/lambda/_api_assertions.sh
+++ b/test/fixtures/lambda/_api_assertions.sh
@@ -1,0 +1,2 @@
+assert_api_called "GET" "/ssh-keys" "fetches SSH keys"
+assert_api_called "POST" "/instance-operations/launch" "launches instance"

--- a/test/fixtures/lambda/_env.sh
+++ b/test/fixtures/lambda/_env.sh
@@ -1,0 +1,2 @@
+export LAMBDA_API_KEY="test-token-lambda"
+export LAMBDA_SERVER_NAME="test-srv"

--- a/test/fixtures/latitude/_env.sh
+++ b/test/fixtures/latitude/_env.sh
@@ -1,0 +1,2 @@
+export LATITUDE_API_KEY="test-token-lat"
+export LATITUDE_SERVER_NAME="test-srv"

--- a/test/fixtures/linode/_api_assertions.sh
+++ b/test/fixtures/linode/_api_assertions.sh
@@ -1,0 +1,2 @@
+assert_api_called "GET" "/profile/sshkeys" "fetches SSH keys"
+assert_api_called "POST" "/linode/instances" "creates instance"

--- a/test/fixtures/linode/_env.sh
+++ b/test/fixtures/linode/_env.sh
@@ -1,0 +1,4 @@
+export LINODE_API_TOKEN="test-token-linode"
+export LINODE_SERVER_NAME="test-srv"
+export LINODE_TYPE="g6-standard-1"
+export LINODE_REGION="us-east"

--- a/test/fixtures/ovh/_env.sh
+++ b/test/fixtures/ovh/_env.sh
@@ -1,0 +1,5 @@
+export OVH_APPLICATION_KEY="test-app-key"
+export OVH_APPLICATION_SECRET="test-app-secret"
+export OVH_CONSUMER_KEY="test-consumer-key"
+export OVH_PROJECT_ID="test-project-id"
+export OVH_SERVER_NAME="test-srv"

--- a/test/fixtures/scaleway/_env.sh
+++ b/test/fixtures/scaleway/_env.sh
@@ -1,0 +1,3 @@
+export SCW_SECRET_KEY="test-token-scw"
+export SCALEWAY_SERVER_NAME="test-srv"
+export SCALEWAY_ZONE="fr-par-1"

--- a/test/fixtures/upcloud/_env.sh
+++ b/test/fixtures/upcloud/_env.sh
@@ -1,0 +1,5 @@
+export UPCLOUD_USERNAME="test-user"
+export UPCLOUD_PASSWORD="test-pass"
+export UPCLOUD_SERVER_NAME="test-srv"
+export UPCLOUD_PLAN="1xCPU-1GB"
+export UPCLOUD_ZONE="us-chi1"

--- a/test/fixtures/vultr/_api_assertions.sh
+++ b/test/fixtures/vultr/_api_assertions.sh
@@ -1,0 +1,2 @@
+assert_api_called "GET" "/ssh-keys" "fetches SSH keys"
+assert_api_called "POST" "/instances" "creates instance"

--- a/test/fixtures/vultr/_env.sh
+++ b/test/fixtures/vultr/_env.sh
@@ -1,0 +1,4 @@
+export VULTR_API_KEY="test-token-vultr"
+export VULTR_SERVER_NAME="test-srv"
+export VULTR_PLAN="vc2-1c-2gb"
+export VULTR_REGION="ewr"


### PR DESCRIPTION
## Summary

- Extracts `setup_env_for_cloud` (84 lines -> 8 lines) from `test/mock.sh` into per-cloud `_env.sh` files in `test/fixtures/`
- Extracts `assert_cloud_api_calls` (32 lines -> 9 lines) from `test/mock.sh` into per-cloud `_api_assertions.sh` files in `test/fixtures/`
- Adding a new cloud's test config now requires creating small files in the fixtures directory rather than editing case branches in mock.sh
- Zero test regressions: all mock tests produce identical results before and after

## Test plan

- [x] `bash -n test/mock.sh` passes
- [x] `bash test/mock.sh` produces identical pass/fail counts vs main
- [x] `bash test/mock.sh hetzner claude` passes (5/5)
- [x] `bash test/mock.sh digitalocean claude` passes (5/5)
- [x] `bash test/run.sh` passes (79/79)
- [x] `cd cli && bun test` matches main (6376 pass, 13 pre-existing fail)

-- refactor/complexity-hunter