### PR TITLE
feat: implement local/kilocode.sh

### DIFF
--- a/local/kilocode.sh
+++ b/local/kilocode.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "Kilo Code on local machine"
+echo ""
+
+# 1. Ensure local prerequisites
+ensure_local_ready
+
+# 2. Install Kilo Code if not already installed
+if command -v kilocode &>/dev/null; then
+    log_info "Kilo Code already installed"
+else
+    log_step "Installing Kilo Code..."
+    npm install -g @kilocode/cli
+fi
+
+# Verify installation
+if ! command -v kilocode &>/dev/null; then
+    log_error "Kilo Code installation failed"
+    log_error "The 'kilocode' command is not available"
+    log_error "Try installing manually: npm install -g @kilocode/cli"
+    exit 1
+fi
+log_info "Kilo Code installation verified"
+
+# 3. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 4. Inject environment variables
+log_step "Appending environment variables to ~/.zshrc..."
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Local setup completed successfully!"
+echo ""
+
+# 5. Start Kilo Code
+if [[ -n "${SPAWN_PROMPT:-}" ]]; then
+    log_step "Executing Kilo Code with prompt..."
+    source ~/.zshrc 2>/dev/null || true
+    kilocode "${SPAWN_PROMPT}"
+else
+    log_step "Starting Kilo Code..."
+    sleep 1
+    clear 2>/dev/null || true
+    source ~/.zshrc 2>/dev/null || true
+    exec kilocode
+fi

--- a/manifest.json
+++ b/manifest.json
@@ -1228,7 +1228,7 @@
     "local/gptme": "implemented",
     "local/opencode": "implemented",
     "local/plandex": "implemented",
-    "local/kilocode": "missing",
+    "local/kilocode": "implemented",
     "local/continue": "implemented",
     "ramnode/claude": "implemented",
     "ramnode/openclaw": "implemented",


### PR DESCRIPTION
## Summary

- Implement Kilo Code agent on local machine cloud provider
- Fills matrix gap: local/kilocode (missing → implemented)

## Implementation

- Install @kilocode/cli via npm if not already installed
- Inject OpenRouter credentials via environment variables
- Set KILO_PROVIDER_TYPE=openrouter and KILO_OPEN_ROUTER_API_KEY
- Support SPAWN_PROMPT for non-interactive execution
- Update manifest.json matrix entry to "implemented"

## Pattern

Follows the established local cloud pattern:
1. Source local/lib/common.sh with remote fallback
2. Use ensure_local_ready for prerequisites
3. Install agent globally via npm
4. Get OpenRouter API key (env or OAuth)
5. Inject env vars to ~/.zshrc
6. Launch agent interactively or with prompt

## Testing

- [x] Syntax check passes: `bash -n local/kilocode.sh`
- [ ] Manual test: install and run on local machine
- [ ] OpenRouter credentials injection verified

-- discovery/gap-filler-local-kilocode