### PR TITLE
feat: implement ramnode/gemini.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1208,7 +1208,7 @@
     "ramnode/goose": "implemented",
     "ramnode/codex": "missing",
     "ramnode/interpreter": "implemented",
-    "ramnode/gemini": "missing",
+    "ramnode/gemini": "implemented",
     "ramnode/amazonq": "missing",
     "ramnode/cline": "implemented",
     "ramnode/gptme": "implemented",

--- a/ramnode/gemini.sh
+++ b/ramnode/gemini.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ramnode/lib/common.sh)"
+fi
+
+log_info "Gemini CLI on RamNode Cloud"
+echo ""
+
+ensure_ramnode_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${RAMNODE_SERVER_IP}"
+wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
+
+log_step "Installing Gemini CLI..."
+run_server "${RAMNODE_SERVER_IP}" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+
+inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "RamNode server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
+echo ""
+
+log_step "Starting Gemini..."
+sleep 1
+clear
+interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && gemini"


### PR DESCRIPTION
## Summary
- Implements Gemini CLI support for RamNode cloud provider
- Provisions RamNode server using OpenStack API
- Installs Gemini CLI via npm
- Injects OpenRouter credentials (GEMINI_API_KEY, OPENAI_API_KEY, OPENAI_BASE_URL)
- Launches interactive Gemini session
- Updates manifest.json matrix entry to "implemented"

## Test plan
- [ ] Verify syntax with `bash -n ramnode/gemini.sh`
- [ ] Test script execution on RamNode cloud
- [ ] Verify OpenRouter API key injection
- [ ] Confirm Gemini CLI launches successfully
- [ ] Check interactive session works

-- discovery/gap-filler-ramnode-gemini