### PR TITLE
feat: implement local/amazonq.sh

### DIFF
--- a/local/amazonq.sh
+++ b/local/amazonq.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "Amazon Q CLI on local machine"
+echo ""
+
+# 1. Ensure local prerequisites
+ensure_local_ready
+
+# 2. Install Amazon Q CLI if not already installed
+if command -v q &>/dev/null; then
+    log_info "Amazon Q CLI already installed"
+else
+    log_step "Installing Amazon Q CLI..."
+    curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash
+    export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+# Verify installation
+if ! command -v q &>/dev/null; then
+    log_error "Amazon Q CLI installation failed"
+    log_error "The 'q' command is not available"
+    log_error "Try installing manually: curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+    exit 1
+fi
+log_info "Amazon Q CLI installation verified"
+
+# 3. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 4. Inject environment variables
+log_step "Setting up environment variables..."
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Local setup completed successfully!"
+echo ""
+
+# 5. Start Amazon Q
+if [[ -n "${SPAWN_PROMPT:-}" ]]; then
+    log_step "Executing Amazon Q with prompt..."
+    export PATH="${HOME}/.local/bin:${PATH}"
+    source ~/.zshrc 2>/dev/null || true
+    q chat "${SPAWN_PROMPT}"
+else
+    log_step "Starting Amazon Q..."
+    sleep 1
+    clear 2>/dev/null || true
+    export PATH="${HOME}/.local/bin:${PATH}"
+    source ~/.zshrc 2>/dev/null || true
+    exec q chat
+fi

--- a/manifest.json
+++ b/manifest.json
@@ -1239,7 +1239,7 @@
     "local/codex": "implemented",
     "local/interpreter": "implemented",
     "local/gemini": "implemented",
-    "local/amazonq": "missing",
+    "local/amazonq": "implemented",
     "local/cline": "implemented",
     "local/gptme": "implemented",
     "local/opencode": "implemented",


### PR DESCRIPTION
## Summary
- Implements Amazon Q CLI support for local machine deployment
- Fills the `local/amazonq` gap in the matrix

## Implementation
- Uses local cloud's primitives for direct machine execution
- Installs Amazon Q via official installer script
- Injects OpenRouter credentials with OPENAI_BASE_URL override
- Supports both interactive mode and SPAWN_PROMPT mode
- Follows the established local cloud pattern

## Testing
- Syntax check passed (`bash -n local/amazonq.sh`)
- Follows the same pattern as other local agent scripts (goose, aider, etc.)
- Updated manifest.json to mark entry as "implemented"

-- discovery/gap-filler-local-amazonq