### PR TITLE
feat: implement ramnode/opencode.sh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1212,7 +1212,7 @@
     "ramnode/amazonq": "missing",
     "ramnode/cline": "implemented",
     "ramnode/gptme": "implemented",
-    "ramnode/opencode": "missing",
+    "ramnode/opencode": "implemented",
     "ramnode/plandex": "missing",
     "ramnode/kilocode": "missing",
     "ramnode/continue": "implemented"

--- a/ramnode/opencode.sh
+++ b/ramnode/opencode.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ramnode/lib/common.sh)"
+fi
+
+log_info "OpenCode on RamNode Cloud"
+echo ""
+
+ensure_ramnode_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${RAMNODE_SERVER_IP}"
+wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
+
+log_step "Installing OpenCode..."
+run_server "${RAMNODE_SERVER_IP}" "$(opencode_install_cmd)"
+log_info "OpenCode installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "RamNode server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
+echo ""
+
+log_step "Starting OpenCode..."
+sleep 1
+clear
+interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && opencode"


### PR DESCRIPTION
## Summary
Fills the `ramnode/opencode` gap in the matrix by implementing OpenCode agent deployment on RamNode Cloud.

## Implementation
- Uses RamNode OpenStack API primitives from `ramnode/lib/common.sh`
- Follows the standard pattern from `hetzner/opencode.sh` and `sprite/opencode.sh`
- Installs OpenCode via `opencode_install_cmd` helper
- Injects `OPENROUTER_API_KEY` environment variable (mandatory per CLAUDE.md)
- Launches interactive OpenCode session via SSH

## Testing
- [x] Syntax check passed (`bash -n ramnode/opencode.sh`)
- [x] Matrix entry updated to `"implemented"`
- [x] Follows Shell Script Rules (local-or-remote fallback pattern, macOS bash 3.x compat)

-- discovery/gap-filler-ramnode-opencode