### PR TITLE
fix: use buildRetryCommand in spawn list footer to avoid truncated prompts

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -941,14 +941,7 @@ async function showEmptyListMessage(agentFilter?: string, cloudFilter?: string):
 
 function showListFooter(records: SpawnRecord[], agentFilter?: string, cloudFilter?: string): void {
   const latest = records[0];
-  if (latest.prompt) {
-    const shortPrompt = latest.prompt.length > 30 ? latest.prompt.slice(0, 30) + "..." : latest.prompt;
-    // Escape double quotes so the suggested command is valid shell
-    const safePrompt = shortPrompt.replace(/"/g, '\\"');
-    console.log(`Rerun last: ${pc.cyan(`spawn ${latest.agent} ${latest.cloud} --prompt "${safePrompt}"`)}`);
-  } else {
-    console.log(`Rerun last: ${pc.cyan(`spawn ${latest.agent} ${latest.cloud}`)}`);
-  }
+  console.log(`Rerun last: ${pc.cyan(buildRetryCommand(latest.agent, latest.cloud, latest.prompt))}`);
 
   if (agentFilter || cloudFilter) {
     const totalRecords = filterHistory();


### PR DESCRIPTION
## Summary
- Fixed `spawn list` "Rerun last" hint producing broken copy-paste commands when the last spawn had a long prompt
- The footer was manually truncating prompts at 30 chars and appending `...`, creating invalid shell commands like `spawn claude sprite --prompt "Fix all linter errors and..."`
- Now reuses the existing `buildRetryCommand` helper which properly suggests `--prompt-file` for prompts over 80 chars instead of truncating
- Updated test replica and test expectations to match the new behavior

## Before
```
Rerun last: spawn claude sprite --prompt "Fix all linter errors and..."
```
Users who copy-paste this command get a truncated prompt with literal `...` appended.

## After
```
Rerun last: spawn claude sprite --prompt-file <your-prompt-file>
```
Long prompts suggest `--prompt-file` (consistent with retry error messages). Short prompts (<= 80 chars) are shown in full.

## Test plan
- [x] `bun test src/__tests__/list-empty-footer.test.ts` -- 46 pass
- [x] `bun test src/__tests__/script-failure-guidance.test.ts` -- 68 pass (buildRetryCommand tests)
- [x] Full test suite: 6376 pass (13 pre-existing failures unrelated to this change)

-- refactor/ux-engineer