### PR TITLE
refactor: replace Python with jq in Hetzner lib, fix /lab → /labs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Launch any AI agent on any cloud with a single command. Coding agents, research 
 ## Install
 
 ```bash
-curl -fsSL https://openrouter.ai/lab/spawn/cli/install.sh | bash
+curl -fsSL https://openrouter.ai/labs/spawn/cli/install.sh | bash
 ```
 
 Or install directly from GitHub:
@@ -56,7 +56,7 @@ spawn claude                             # Show clouds available for Claude
 Every combination works as a one-liner — no install required:
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/{cloud}/{agent}.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/{cloud}/{agent}.sh)
 ```
 
 ### Non-Interactive Mode

--- a/aws-lightsail/README.md
+++ b/aws-lightsail/README.md
@@ -9,79 +9,79 @@ AWS Lightsail instances via AWS CLI. [AWS Lightsail](https://aws.amazon.com/ligh
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -89,5 +89,5 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/plandex.sh)
 ```bash
 LIGHTSAIL_SERVER_NAME=dev-mk1 \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/aws-lightsail/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws-lightsail/claude.sh)
 ```

--- a/civo/README.md
+++ b/civo/README.md
@@ -7,79 +7,79 @@ Civo cloud-native instances via REST API. [Civo](https://www.civo.com/)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -88,7 +88,7 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/plandex.sh)
 CIVO_SERVER_NAME=dev-mk1 \
 CIVO_API_TOKEN=your-token \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/civo/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/civo/claude.sh)
 ```
 
 ## Environment Variables

--- a/cli/README.md
+++ b/cli/README.md
@@ -260,7 +260,7 @@ When you run `spawn <agent> <cloud>`:
 
 1. **Load manifest**: Fetch from GitHub or use cached version
 2. **Validate combination**: Check that `matrix["<cloud>/<agent>"]` is `"implemented"`
-3. **Download script**: Fetch `https://openrouter.ai/lab/spawn/<cloud>/<agent>.sh`
+3. **Download script**: Fetch `https://openrouter.ai/labs/spawn/<cloud>/<agent>.sh`
    - Fallback to GitHub raw URL if OpenRouter CDN fails
 4. **Execute**: Pipe script to `bash -c` with inherited stdio
 5. **Interactive handoff**: User interacts directly with the spawned agent

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -658,7 +658,7 @@ export function isRetryableExitCode(errMsg: string): boolean {
 }
 
 async function execScript(cloud: string, agent: string, prompt?: string, authHint?: string): Promise<void> {
-  const url = `https://openrouter.ai/lab/spawn/${cloud}/${agent}.sh`;
+  const url = `https://openrouter.ai/labs/spawn/${cloud}/${agent}.sh`;
   const ghUrl = `${RAW_BASE}/${cloud}/${agent}.sh`;
 
   let scriptContent: string;

--- a/daytona/README.md
+++ b/daytona/README.md
@@ -9,79 +9,79 @@ Daytona sandboxed environments for AI code execution. [Daytona](https://www.dayt
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -90,7 +90,7 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/plandex.sh)
 DAYTONA_SANDBOX_NAME=dev-mk1 \
 DAYTONA_API_KEY=your-api-key \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/daytona/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/claude.sh)
 ```
 
 ## Environment Variables

--- a/digitalocean/README.md
+++ b/digitalocean/README.md
@@ -7,79 +7,79 @@ DigitalOcean Droplets via REST API. [DigitalOcean](https://www.digitalocean.com/
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -88,5 +88,5 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/plandex.sh)
 DO_DROPLET_NAME=dev-mk1 \
 DO_API_TOKEN=your-token \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/digitalocean/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/claude.sh)
 ```

--- a/e2b/README.md
+++ b/e2b/README.md
@@ -9,79 +9,79 @@ E2B sandboxed cloud containers via CLI/SDK. [E2B](https://e2b.dev)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -90,5 +90,5 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/plandex.sh)
 E2B_SANDBOX_NAME=dev-mk1 \
 E2B_API_KEY=your-key \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/e2b/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/e2b/claude.sh)
 ```

--- a/exoscale/README.md
+++ b/exoscale/README.md
@@ -7,19 +7,19 @@ Exoscale European cloud compute via CLI with per-second billing. [Exoscale](http
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/exoscale/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/exoscale/claude.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/exoscale/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/exoscale/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/exoscale/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/exoscale/goose.sh)
 ```
 
 ## Non-Interactive Mode
@@ -29,7 +29,7 @@ EXOSCALE_SERVER_NAME=dev-mk1 \
 EXOSCALE_API_KEY=your-key \
 EXOSCALE_API_SECRET=your-secret \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/exoscale/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/exoscale/claude.sh)
 ```
 
 ## Environment Variables

--- a/fly/README.md
+++ b/fly/README.md
@@ -7,79 +7,79 @@ Fly.io Machines via REST API and flyctl CLI. [Fly.io](https://fly.io)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -88,7 +88,7 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/plandex.sh)
 FLY_APP_NAME=dev-mk1 \
 FLY_API_TOKEN=your-token \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/fly/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/claude.sh)
 ```
 
 ## Environment Variables

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -9,79 +9,79 @@ Google Cloud Compute Engine instances via gcloud CLI. [GCP Compute Engine](https
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -89,5 +89,5 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/plandex.sh)
 ```bash
 GCP_INSTANCE_NAME=dev-mk1 \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/gcp/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/claude.sh)
 ```

--- a/github-codespaces/README.md
+++ b/github-codespaces/README.md
@@ -7,19 +7,19 @@ GitHub Codespaces development environments via gh CLI. [GitHub Codespaces](https
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/github-codespaces/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/github-codespaces/claude.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/github-codespaces/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/github-codespaces/aider.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/github-codespaces/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/github-codespaces/gptme.sh)
 ```
 
 ## Non-Interactive Mode
@@ -27,7 +27,7 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/github-codespaces/gptme.sh)
 ```bash
 GITHUB_REPO=OpenRouterTeam/spawn \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/github-codespaces/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/github-codespaces/claude.sh)
 ```
 
 ## Environment Variables

--- a/hetzner/README.md
+++ b/hetzner/README.md
@@ -7,91 +7,91 @@ Hetzner Cloud servers via REST API. [Hetzner Cloud](https://www.hetzner.com/clou
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/plandex.sh)
 ```
 
 #### Kilo Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/kilocode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/kilocode.sh)
 ```
 
 #### Continue
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/continue.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/continue.sh)
 ```
 
 ## Non-Interactive Mode
@@ -100,5 +100,5 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/continue.sh)
 HETZNER_SERVER_NAME=dev-mk1 \
 HCLOUD_TOKEN=your-token \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/hetzner/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/claude.sh)
 ```

--- a/kamatera/README.md
+++ b/kamatera/README.md
@@ -7,79 +7,79 @@ Kamatera cloud servers via REST API. [Kamatera](https://www.kamatera.com/)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -89,7 +89,7 @@ KAMATERA_SERVER_NAME=dev-mk1 \
 KAMATERA_API_CLIENT_ID=your-client-id \
 KAMATERA_API_SECRET=your-api-secret \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/kamatera/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/kamatera/claude.sh)
 ```
 
 ## Environment Variables

--- a/koyeb/README.md
+++ b/koyeb/README.md
@@ -7,19 +7,19 @@ Koyeb serverless container platform via CLI. [Koyeb](https://www.koyeb.com/)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/koyeb/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/koyeb/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/koyeb/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/koyeb/openclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/koyeb/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/koyeb/aider.sh)
 ```
 
 ## Non-Interactive Mode
@@ -27,7 +27,7 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/koyeb/aider.sh)
 ```bash
 KOYEB_TOKEN=your-token \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/koyeb/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/koyeb/claude.sh)
 ```
 
 ## Environment Variables

--- a/latitude/README.md
+++ b/latitude/README.md
@@ -7,79 +7,79 @@ Bare metal and VM cloud servers via REST API. [Latitude.sh](https://www.latitude
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -88,7 +88,7 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/plandex.sh)
 LATITUDE_SERVER_NAME=dev-mk1 \
 LATITUDE_API_KEY=your-api-key \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/latitude/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/latitude/claude.sh)
 ```
 
 ## Environment Variables

--- a/linode/README.md
+++ b/linode/README.md
@@ -7,79 +7,79 @@ Linode instances via REST API. [Linode (Akamai)](https://www.linode.com/)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -88,5 +88,5 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/plandex.sh)
 LINODE_SERVER_NAME=dev-mk1 \
 LINODE_API_TOKEN=your-token \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/linode/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/linode/claude.sh)
 ```

--- a/local/README.md
+++ b/local/README.md
@@ -23,22 +23,22 @@ spawn continue local
 Or run directly without the CLI:
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/claude.sh)
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/openclaw.sh)
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/nanoclaw.sh)
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/aider.sh)
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/goose.sh)
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/codex.sh)
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/interpreter.sh)
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/gptme.sh)
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/continue.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/continue.sh)
 ```
 
 ## Non-Interactive Mode
 
 ```bash
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/local/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/claude.sh)
 ```
 
 ## What It Does

--- a/modal/README.md
+++ b/modal/README.md
@@ -9,79 +9,79 @@ Modal sandboxed containers via Python SDK. [Modal](https://modal.com)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -89,5 +89,5 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/plandex.sh)
 ```bash
 MODAL_SANDBOX_NAME=dev-mk1 \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/modal/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/modal/claude.sh)
 ```

--- a/netcup/README.md
+++ b/netcup/README.md
@@ -7,37 +7,37 @@ Netcup VPS cloud via REST API. [Netcup](https://www.netcup.com/)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/netcup/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/netcup/claude.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/netcup/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/netcup/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/netcup/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/netcup/goose.sh)
 ```
 
 #### Amazon Q
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/netcup/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/netcup/amazonq.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/netcup/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/netcup/plandex.sh)
 ```
 
 #### Kilo Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/netcup/kilocode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/netcup/kilocode.sh)
 ```
 
 ## Non-Interactive Mode
@@ -48,7 +48,7 @@ NETCUP_CUSTOMER_NUMBER=12345 \
 NETCUP_API_KEY=your-api-key \
 NETCUP_API_PASSWORD=your-api-password \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/netcup/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/netcup/claude.sh)
 ```
 
 ## Authentication

--- a/northflank/README.md
+++ b/northflank/README.md
@@ -9,67 +9,67 @@ Northflank container platform via CLI with exec access. [Northflank](https://nor
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/openclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/aider.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/nanoclaw.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/gptme.sh)
 ```
 
 ## Setup
@@ -89,7 +89,7 @@ NORTHFLANK_SERVICE_NAME=spawn-dev \
 NORTHFLANK_PROJECT_NAME=spawn-project \
 NORTHFLANK_TOKEN=your-token \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/northflank/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/northflank/claude.sh)
 ```
 
 ## Environment Variables

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -15,19 +15,19 @@ Oracle Cloud compute instances via OCI CLI. [Oracle Cloud](https://cloud.oracle.
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/oracle/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/oracle/claude.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/oracle/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/oracle/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/oracle/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/oracle/goose.sh)
 ```
 
 ## Non-Interactive Mode
@@ -36,7 +36,7 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/oracle/goose.sh)
 OCI_COMPARTMENT_ID=ocid1.compartment.oc1..... \
 OCI_INSTANCE_NAME=dev-mk1 \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/oracle/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/oracle/claude.sh)
 ```
 
 ## Environment Variables

--- a/ovh/README.md
+++ b/ovh/README.md
@@ -34,79 +34,79 @@ Required API permissions:
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/claude.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/aider.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/nanoclaw.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/cline.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/codex.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/goose.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/amazonq.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/plandex.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/gptme.sh)
 ```
 
 ## Non-Interactive Mode
@@ -118,5 +118,5 @@ OVH_APPLICATION_SECRET=your-app-secret \
 OVH_CONSUMER_KEY=your-consumer-key \
 OVH_PROJECT_ID=your-project-id \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/ovh/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/ovh/claude.sh)
 ```

--- a/railway/README.md
+++ b/railway/README.md
@@ -7,67 +7,67 @@ Railway serverless container platform via CLI. [Railway](https://railway.app/)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/openclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/aider.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/nanoclaw.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/gptme.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/goose.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/gemini.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/codex.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/amazonq.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/interpreter.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/cline.sh)
 ```
 
 ## Non-Interactive Mode
@@ -76,7 +76,7 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/cline.sh)
 RAILWAY_SERVICE_NAME=dev-mk1 \
 RAILWAY_TOKEN=your-token \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/railway/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/railway/claude.sh)
 ```
 
 ## Environment Variables

--- a/scaleway/README.md
+++ b/scaleway/README.md
@@ -7,73 +7,73 @@ Scaleway Cloud instances via REST API. [Scaleway](https://www.scaleway.com/)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/opencode.sh)
 ```
 
 ## Non-Interactive Mode
@@ -82,7 +82,7 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/opencode.sh)
 SCALEWAY_SERVER_NAME=dev-mk1 \
 SCW_SECRET_KEY=your-secret-key \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/scaleway/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/scaleway/claude.sh)
 ```
 
 ## Environment Variables

--- a/sprite/README.md
+++ b/sprite/README.md
@@ -7,91 +7,91 @@ Sprites.dev managed VMs with CLI. [Sprite](https://sprites.dev)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/plandex.sh)
 ```
 
 #### Kilo Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/kilocode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/kilocode.sh)
 ```
 
 #### Continue
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/continue.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/continue.sh)
 ```
 
 ## Non-Interactive Mode
@@ -99,5 +99,5 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/continue.sh)
 ```bash
 SPRITE_NAME=dev-mk1 \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/sprite/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/claude.sh)
 ```

--- a/upcloud/README.md
+++ b/upcloud/README.md
@@ -7,79 +7,79 @@ UpCloud cloud servers via REST API. [UpCloud](https://upcloud.com/)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -89,7 +89,7 @@ UPCLOUD_SERVER_NAME=dev-mk1 \
 UPCLOUD_USERNAME=your-api-username \
 UPCLOUD_PASSWORD=your-api-password \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/upcloud/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/upcloud/claude.sh)
 ```
 
 ## Environment Variables

--- a/vultr/README.md
+++ b/vultr/README.md
@@ -7,79 +7,79 @@ Vultr Cloud Compute instances via REST API. [Vultr](https://www.vultr.com/)
 #### Claude Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/claude.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/claude.sh)
 ```
 
 #### OpenClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/openclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/openclaw.sh)
 ```
 
 #### NanoClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/nanoclaw.sh)
 ```
 
 #### Aider
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/aider.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/aider.sh)
 ```
 
 #### Goose
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/goose.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/goose.sh)
 ```
 
 #### Codex CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/codex.sh)
 ```
 
 #### Open Interpreter
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/interpreter.sh)
 ```
 
 #### Gemini CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/gemini.sh)
 ```
 
 #### Amazon Q CLI
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/amazonq.sh)
 ```
 
 #### Cline
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/cline.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/cline.sh)
 ```
 
 #### gptme
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/gptme.sh)
 ```
 
 #### OpenCode
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/opencode.sh)
 ```
 
 #### Plandex
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/plandex.sh)
 ```
 
 ## Non-Interactive Mode
@@ -88,5 +88,5 @@ bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/plandex.sh)
 VULTR_SERVER_NAME=dev-mk1 \
 VULTR_API_KEY=your-key \
 OPENROUTER_API_KEY=sk-or-v1-xxxxx \
-  bash <(curl -fsSL https://openrouter.ai/lab/spawn/vultr/claude.sh)
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/vultr/claude.sh)
 ```


### PR DESCRIPTION
## Summary

- **Hetzner lib**: Replace all Python JSON parsing with jq (zero Python remaining in `hetzner/lib/common.sh`)
- **Datacenter API**: Use `/datacenters` endpoint as the authoritative source for server type availability (`server_types.available`), cross-referenced with `/server_types` for specs and pricing
- **jq auto-install**: `_ensure_jq` installs jq via apt/dnf/apk/brew if not present
- **URL fix**: Update `openrouter.ai/lab/spawn` → `openrouter.ai/labs/spawn` across all 28 READMEs and CLI source

## Functions converted from Python → jq

| Function | What changed |
|---|---|
| `_list_locations` | Now queries `/datacenters`, extracts unique locations with jq |
| `_list_server_types_for_location` | Uses `/datacenters` for availability IDs, `/server_types` for specs/pricing |
| `_hetzner_build_create_body` | `jq -n` to build JSON body |
| `_hetzner_check_create_error` | jq for error object detection |
| `create_server` (response parsing) | jq for `.server.id` and `.server.public_net.ipv4.ip` |
| `list_servers` | jq + `while read` for formatted table output |

## Test plan

- [x] `bash -n hetzner/lib/common.sh` — syntax check passes
- [x] `bash test/run.sh` — all 79 tests pass
- [x] `grep -r 'python3' hetzner/lib/common.sh` — zero matches
- [x] `grep -r 'openrouter.ai/lab/spawn'` — zero matches (all updated to /labs/)
- [ ] Test with live Hetzner token — server creation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)