### PR TITLE
fix: set IS_SANDBOX=1 in all spawn environments

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -857,6 +857,8 @@ get_openrouter_api_key_oauth() {
 generate_env_config() {
     echo ""
     echo "# [spawn:env]"
+    # All spawn environments are disposable cloud VMs — mark as sandbox
+    echo "export IS_SANDBOX='1'"
     for env_pair in "$@"; do
         local key="${env_pair%%=*}"
         local value="${env_pair#*=}"
@@ -1033,6 +1035,9 @@ runcmd:
   - su - root -c 'curl -fsSL https://bun.sh/install | bash'
   # Install Claude Code
   - su - root -c 'curl -fsSL https://claude.ai/install.sh | bash'
+  # Mark as sandbox environment (disposable cloud VM)
+  - echo 'export IS_SANDBOX=1' >> /root/.bashrc
+  - echo 'export IS_SANDBOX=1' >> /root/.zshrc
   # Configure PATH in .bashrc
   - echo 'export PATH="${HOME}/.claude/local/bin:${HOME}/.bun/bin:${PATH}"' >> /root/.bashrc
   # Configure PATH in .zshrc


### PR DESCRIPTION
## Summary

- Sets `IS_SANDBOX=1` environment variable in all spawn cloud VMs
- Helps agents (Claude Code, etc.) recognize disposable sandbox environments, avoiding unnecessary safety prompts for root-level operations

## Where it's set

| Location | Coverage |
|---|---|
| `generate_env_config()` | Every env injection call across all clouds and agents |
| `get_cloud_init_userdata()` | Written to `.bashrc` and `.zshrc` during cloud-init boot |

This covers both SSH-based clouds (Hetzner, DigitalOcean, Vultr, etc.) and non-SSH providers (Sprite, Modal, E2B, etc.) since all paths go through `generate_env_config`.

## Test plan

- [x] `bash -n shared/common.sh` — syntax check passes
- [x] `bash test/run.sh` — all 79 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)