### PR TITLE
fix: auto re-exec command after CLI auto-update

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.66",
+  "version": "0.2.67",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

Fixes #780

- After a successful CLI auto-update, the updated binary is now automatically re-executed with the original arguments instead of asking the user to re-run manually
- Sets `SPAWN_NO_UPDATE_CHECK=1` on re-exec to prevent infinite update loops
- Falls back to "run again" message when no arguments were provided (bare `spawn`)
- Properly quotes binary path and arguments for safe shell execution
- Forwards exit codes from the re-executed command

## Test plan

- [x] 3 new tests added covering re-exec, exit code forwarding, and no-args fallback
- [x] All 11 update-check tests pass
- [x] Full test suite passes (13 pre-existing failures unrelated to this change)

-- refactor/ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)