### PR TITLE
fix: remove hardcoded /home/sprite paths from service scripts

### DIFF
--- a/.claude/skills/setup-agent-team/SKILL.md
+++ b/.claude/skills/setup-agent-team/SKILL.md
@@ -45,7 +45,7 @@ GitHub Actions (cron / events / manual)
 ## Step 1: Verify trigger-server.ts
 
 The trigger server lives at:
-`/home/sprite/spawn/.claude/skills/setup-agent-team/trigger-server.ts`
+`$REPO_ROOT/.claude/skills/setup-agent-team/trigger-server.ts`
 
 It reads env vars:
 - `TRIGGER_SECRET` (required) — Bearer token for authenticating requests
@@ -94,16 +94,17 @@ Create `start-<service-name>.sh` in the skill directory:
 
 ```bash
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export TRIGGER_SECRET="<secret-from-step-2>"
-export TARGET_SCRIPT="/home/sprite/spawn/.claude/skills/setup-agent-team/<target-script>.sh"
-export REPO_ROOT="/home/sprite/spawn"
-exec bun run /home/sprite/spawn/.claude/skills/setup-agent-team/trigger-server.ts
+export TARGET_SCRIPT="${SCRIPT_DIR}/<target-script>.sh"
+export REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+exec bun run "${SCRIPT_DIR}/trigger-server.ts"
 ```
 
 Make it executable:
 
 ```bash
-chmod +x /home/sprite/spawn/.claude/skills/setup-agent-team/start-<service-name>.sh
+chmod +x .claude/skills/setup-agent-team/start-<service-name>.sh
 ```
 
 **IMPORTANT:** Verify that `.gitignore` includes wrapper scripts:
@@ -120,8 +121,8 @@ Register the trigger server as a Sprite service with HTTP port forwarding:
 
 ```bash
 sprite-env services create <service-name> \
-  --cmd bash --args /home/sprite/spawn/.claude/skills/setup-agent-team/start-<service-name>.sh \
-  --http-port 8080 --dir /home/sprite/spawn/.claude/skills/setup-agent-team
+  --cmd bash --args "$(pwd)/.claude/skills/setup-agent-team/start-<service-name>.sh" \
+  --http-port 8080 --dir "$(pwd)/.claude/skills/setup-agent-team"
 ```
 
 **Key flags:**
@@ -458,7 +459,7 @@ The `trigger-server.ts` file is **shared** — same code runs on every Sprite, c
 
 To add a new automation script (beyond discovery.sh and refactor.sh):
 
-1. Create the script in `/home/sprite/spawn/.claude/skills/setup-agent-team/<script-name>.sh`
+1. Create the script in `$REPO_ROOT/.claude/skills/setup-agent-team/<script-name>.sh`
 2. Make it executable: `chmod +x <script-name>.sh`
 3. Ensure it follows the single-cycle pattern (sync with origin, run once, exit)
 4. Create a corresponding `start-<script-name>.sh` wrapper with the appropriate env vars

--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -33,7 +33,7 @@ else
     CYCLE_TIMEOUT=1800  # 30 min for refactor runs
 fi
 
-LOG_FILE="/home/sprite/spawn/.docs/${TEAM_NAME}.log"
+LOG_FILE="${REPO_ROOT}/.docs/${TEAM_NAME}.log"
 PROMPT_FILE=""
 
 # Ensure .docs directory exists

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -48,7 +48,7 @@ else
     CYCLE_TIMEOUT=1200  # 20 min for full repo scan
 fi
 
-LOG_FILE="/home/sprite/spawn/.docs/${TEAM_NAME}.log"
+LOG_FILE="${REPO_ROOT}/.docs/${TEAM_NAME}.log"
 PROMPT_FILE=""
 
 # Ensure .docs directory exists


### PR DESCRIPTION
## Summary
- Replace hardcoded `/home/sprite/spawn` paths in `security.sh` and `refactor.sh` with `${REPO_ROOT}` (already dynamically computed at script top)
- Update `SKILL.md` examples to use dynamic `SCRIPT_DIR`-based path resolution instead of hardcoded paths
- Fixes `tee: /home/sprite/spawn/.docs/...: Permission denied` errors when running on non-Sprite environments

## Test plan
- [ ] Verify `bash -n` passes on modified `.sh` files
- [ ] Confirm `REPO_ROOT` resolves correctly when scripts are sourced from different environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)