### PR TITLE
fix: show per-variable credential status in failure guidance

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.67",
+  "version": "0.2.68",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -116,9 +116,9 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("provisioning failed");
     });
 
-    it("should return at least 4 guidance lines", () => {
+    it("should return at least 3 guidance lines", () => {
       const lines = getScriptFailureGuidance(1, "sprite");
-      expect(lines.length).toBeGreaterThanOrEqual(4);
+      expect(lines.length).toBeGreaterThanOrEqual(3);
     });
   });
 
@@ -157,9 +157,9 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("spawn linode");
     });
 
-    it("should return at least 4 guidance lines", () => {
+    it("should return at least 3 guidance lines", () => {
       const lines = getScriptFailureGuidance(42, "linode");
-      expect(lines.length).toBeGreaterThanOrEqual(4);
+      expect(lines.length).toBeGreaterThanOrEqual(3);
     });
   });
 
@@ -183,9 +183,9 @@ describe("getScriptFailureGuidance", () => {
       expect(joined).toContain("spawn sprite");
     });
 
-    it("should return at least 4 guidance lines", () => {
+    it("should return at least 3 guidance lines", () => {
       const lines = getScriptFailureGuidance(null, "sprite");
-      expect(lines.length).toBeGreaterThanOrEqual(4);
+      expect(lines.length).toBeGreaterThanOrEqual(3);
     });
   });
 
@@ -356,7 +356,9 @@ describe("getScriptFailureGuidance", () => {
     it("should handle multi-credential auth hint", () => {
       const lines = getScriptFailureGuidance(1, "contabo", "CONTABO_CLIENT_ID + CONTABO_CLIENT_SECRET");
       const joined = lines.join("\n");
-      expect(joined).toContain("CONTABO_CLIENT_ID + CONTABO_CLIENT_SECRET");
+      expect(joined).toContain("CONTABO_CLIENT_ID");
+      expect(joined).toContain("CONTABO_CLIENT_SECRET");
+      expect(joined).toContain("OPENROUTER_API_KEY");
     });
 
     it("should not affect non-credential exit codes (130, 137, etc.)", () => {
@@ -371,20 +373,22 @@ describe("getScriptFailureGuidance", () => {
       expect(joined255).toContain("SSH");
     });
 
-    it("should include setup instruction line for exit code 1 with authHint", () => {
+    it("should include setup instruction and per-var status for exit code 1 with authHint", () => {
       const lines = getScriptFailureGuidance(1, "hetzner", "HCLOUD_TOKEN");
-      expect(lines).toHaveLength(5);
+      expect(lines.length).toBeGreaterThanOrEqual(5);
       const joined = lines.join("\n");
+      expect(joined).toContain("HCLOUD_TOKEN");
+      expect(joined).toContain("OPENROUTER_API_KEY");
       expect(joined).toContain("spawn hetzner");
-      expect(joined).toContain("setup");
     });
 
-    it("should include setup instruction line for default case with authHint", () => {
+    it("should include setup instruction and per-var status for default case with authHint", () => {
       const lines = getScriptFailureGuidance(42, "hetzner", "HCLOUD_TOKEN");
-      expect(lines).toHaveLength(5);
+      expect(lines.length).toBeGreaterThanOrEqual(5);
       const joined = lines.join("\n");
+      expect(joined).toContain("HCLOUD_TOKEN");
+      expect(joined).toContain("OPENROUTER_API_KEY");
       expect(joined).toContain("spawn hetzner");
-      expect(joined).toContain("setup");
     });
   });
 


### PR DESCRIPTION
## Summary
- When a spawn script fails with exit code 1 (most common failure), the error guidance now shows **per-variable credential status** (set/missing) instead of a generic "Missing or invalid credentials" line
- When all credentials are set but the script still fails, the message now says "Credentials appear set (but may be invalid or expired)" -- guiding users to check validity rather than re-export existing vars
- Multi-credential providers (e.g., UpCloud with `UPCLOUD_USERNAME + UPCLOUD_PASSWORD`) show each variable's status on its own line

### Before
```
Common causes:
  - Missing or invalid credentials (need HCLOUD_TOKEN + OPENROUTER_API_KEY)
    Run spawn hetzner for setup instructions
```

### After (when vars are missing)
```
Common causes:
  - Credential status:
    HCLOUD_TOKEN -- not set
    OPENROUTER_API_KEY -- set
    Run spawn hetzner for setup instructions
```

### After (when vars are all set)
```
Common causes:
  - Credentials appear set (but may be invalid or expired)
    Run spawn hetzner to verify setup
```

## Test plan
- [x] Updated `script-failure-guidance.test.ts` -- all 68 tests pass
- [x] Updated `commands-internal-helpers.test.ts` replica + tests -- all 59 tests pass  
- [x] Verified `download-and-failure.test.ts` still passes (42 tests)
- [x] Added test for "all credentials set" path
- [x] Bumped CLI version to 0.2.68

-- refactor/ux-engineer