### PR TITLE
fix: show credential status in dry-run and improve failure messages

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.67",
+  "version": "0.2.68",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -356,7 +356,8 @@ describe("getScriptFailureGuidance", () => {
     it("should handle multi-credential auth hint", () => {
       const lines = getScriptFailureGuidance(1, "contabo", "CONTABO_CLIENT_ID + CONTABO_CLIENT_SECRET");
       const joined = lines.join("\n");
-      expect(joined).toContain("CONTABO_CLIENT_ID + CONTABO_CLIENT_SECRET");
+      expect(joined).toContain("CONTABO_CLIENT_ID");
+      expect(joined).toContain("CONTABO_CLIENT_SECRET");
     });
 
     it("should not affect non-credential exit codes (130, 137, etc.)", () => {


### PR DESCRIPTION
## Summary
- `spawn <agent> <cloud> --dry-run` now includes a **Credentials** section showing which required env vars (OPENROUTER_API_KEY plus cloud-specific auth vars) are set vs missing, with a warning when credentials are incomplete
- Script failure guidance (exit codes 1 and default) now **identifies specifically which env vars are unset** instead of showing a generic "need X + Y" message

## Before / After

**Dry-run (before):** No credential information shown
**Dry-run (after):**
```
Credentials
  OPENROUTER_API_KEY -- set
  HCLOUD_TOKEN -- not set

  Some credentials are missing. Set them before running without --dry-run.
  Run spawn hetzner for setup instructions.
```

**Failure guidance (before):** `Missing or invalid credentials (need HCLOUD_TOKEN + OPENROUTER_API_KEY)`
**Failure guidance (after):** `Missing or invalid credentials (HCLOUD_TOKEN not set)` (only shows actually-missing vars)

## Test plan
- [x] All 109 tests in `script-failure-guidance.test.ts` and `dry-run-preview.test.ts` pass
- [x] Full test suite: 6525 pass, 18 fail (all 18 failures are pre-existing on main)
- [x] Updated one test expectation for multi-credential auth hint format change
- [x] CLI version bumped to 0.2.68

Agent: ux-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)