### PR TITLE
fix: warn about missing credentials before running spawn scripts

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.68",
+  "version": "0.2.69",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/preflight-credentials.test.ts
+++ b/cli/src/__tests__/preflight-credentials.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { preflightCredentialCheck } from "../commands";
+import type { Manifest } from "../manifest";
+
+// Mock @clack/prompts
+const mockLog = { warn: mock(() => {}), info: mock(() => {}) };
+const mockConfirm = mock(() => Promise.resolve(true));
+const mockIsCancel = mock(() => false);
+mock.module("@clack/prompts", () => ({
+  log: mockLog,
+  confirm: mockConfirm,
+  isCancel: mockIsCancel,
+  // Stubs for other imports commands.ts might use
+  intro: mock(() => {}),
+  outro: mock(() => {}),
+  select: mock(() => Promise.resolve("")),
+  spinner: mock(() => ({ start: mock(() => {}), stop: mock(() => {}), message: mock(() => {}) })),
+}));
+
+function makeManifest(cloudAuth: string): Manifest {
+  return {
+    agents: {},
+    clouds: {
+      testcloud: {
+        name: "Test Cloud",
+        description: "A test cloud",
+        url: "https://test.cloud",
+        type: "vps",
+        auth: cloudAuth,
+        provision_method: "api",
+        exec_method: "ssh",
+        interactive_method: "ssh",
+      },
+    },
+    matrix: {},
+  } as Manifest;
+}
+
+describe("preflightCredentialCheck", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  function setEnv(key: string, value: string): void {
+    savedEnv[key] = process.env[key];
+    process.env[key] = value;
+  }
+
+  function clearEnv(key: string): void {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  beforeEach(() => {
+    mockLog.warn.mockClear();
+    mockLog.info.mockClear();
+    mockConfirm.mockClear();
+    mockIsCancel.mockClear();
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    for (const key of Object.keys(savedEnv)) {
+      delete savedEnv[key];
+    }
+  });
+
+  it("should not warn when all credentials are set", async () => {
+    setEnv("OPENROUTER_API_KEY", "sk-or-test");
+    setEnv("HCLOUD_TOKEN", "test-token");
+    const manifest = makeManifest("HCLOUD_TOKEN");
+
+    await preflightCredentialCheck(manifest, "testcloud");
+
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+
+  it("should not warn when cloud auth is 'none'", async () => {
+    clearEnv("OPENROUTER_API_KEY");
+    const manifest = makeManifest("none");
+
+    await preflightCredentialCheck(manifest, "testcloud");
+
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+
+  it("should warn when cloud-specific credential is missing", async () => {
+    setEnv("OPENROUTER_API_KEY", "sk-or-test");
+    clearEnv("HCLOUD_TOKEN");
+    const manifest = makeManifest("HCLOUD_TOKEN");
+
+    await preflightCredentialCheck(manifest, "testcloud");
+
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    const warnMsg = String(mockLog.warn.mock.calls[0][0]);
+    expect(warnMsg).toContain("HCLOUD_TOKEN");
+    expect(warnMsg).toContain("Test Cloud");
+  });
+
+  it("should warn when OPENROUTER_API_KEY is missing", async () => {
+    clearEnv("OPENROUTER_API_KEY");
+    setEnv("HCLOUD_TOKEN", "test-token");
+    const manifest = makeManifest("HCLOUD_TOKEN");
+
+    await preflightCredentialCheck(manifest, "testcloud");
+
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    const warnMsg = String(mockLog.warn.mock.calls[0][0]);
+    expect(warnMsg).toContain("OPENROUTER_API_KEY");
+  });
+
+  it("should warn about multiple missing credentials", async () => {
+    clearEnv("OPENROUTER_API_KEY");
+    clearEnv("HCLOUD_TOKEN");
+    const manifest = makeManifest("HCLOUD_TOKEN");
+
+    await preflightCredentialCheck(manifest, "testcloud");
+
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    const warnMsg = String(mockLog.warn.mock.calls[0][0]);
+    expect(warnMsg).toContain("OPENROUTER_API_KEY");
+    expect(warnMsg).toContain("HCLOUD_TOKEN");
+  });
+
+  it("should show setup instructions hint", async () => {
+    clearEnv("HCLOUD_TOKEN");
+    setEnv("OPENROUTER_API_KEY", "sk-or-test");
+    const manifest = makeManifest("HCLOUD_TOKEN");
+
+    await preflightCredentialCheck(manifest, "testcloud");
+
+    expect(mockLog.info).toHaveBeenCalled();
+    const infoMsg = String(mockLog.info.mock.calls[0][0]);
+    expect(infoMsg).toContain("spawn testcloud");
+  });
+
+  it("should handle multi-credential clouds with partial setup", async () => {
+    setEnv("OPENROUTER_API_KEY", "sk-or-test");
+    setEnv("UPCLOUD_USERNAME", "user");
+    clearEnv("UPCLOUD_PASSWORD");
+    const manifest = makeManifest("UPCLOUD_USERNAME + UPCLOUD_PASSWORD");
+
+    await preflightCredentialCheck(manifest, "testcloud");
+
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    const warnMsg = String(mockLog.warn.mock.calls[0][0]);
+    expect(warnMsg).toContain("UPCLOUD_PASSWORD");
+    expect(warnMsg).not.toContain("UPCLOUD_USERNAME");
+  });
+
+  it("should not warn for CLI-based auth like 'gcloud auth login'", async () => {
+    setEnv("OPENROUTER_API_KEY", "sk-or-test");
+    const manifest = makeManifest("gcloud auth login");
+
+    // gcloud auth login doesn't parse to any env vars, so auth check returns "none"-like
+    // But OPENROUTER_API_KEY is set so no warning
+    await preflightCredentialCheck(manifest, "testcloud");
+
+    // No env vars parsed from "gcloud auth login", only OPENROUTER_API_KEY check
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+
+  it("should warn for CLI-based auth when OPENROUTER_API_KEY is missing", async () => {
+    clearEnv("OPENROUTER_API_KEY");
+    const manifest = makeManifest("gcloud auth login");
+
+    await preflightCredentialCheck(manifest, "testcloud");
+
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    const warnMsg = String(mockLog.warn.mock.calls[0][0]);
+    expect(warnMsg).toContain("OPENROUTER_API_KEY");
+  });
+});


### PR DESCRIPTION
## Summary
- Add pre-flight credential check before script execution in `spawn <agent> <cloud>`
- When cloud-specific env vars (e.g. `HCLOUD_TOKEN`) or `OPENROUTER_API_KEY` are missing, warns the user immediately instead of letting the script fail mid-execution
- In interactive terminals, shows a confirmation prompt so users can abort or continue
- In non-interactive mode (CI/scripts), shows a warning without blocking

## Before/After

**Before:** `spawn claude hetzner` without `HCLOUD_TOKEN` → downloads script → starts executing → fails after 10-30s with a cryptic error, possibly after provisioning resources

**After:** `spawn claude hetzner` without `HCLOUD_TOKEN` → immediately warns:
```
⚠ Missing credentials for Hetzner Cloud: HCLOUD_TOKEN
ℹ Run spawn hetzner for setup instructions.
◆ Continue anyway? The script will likely prompt for credentials or fail.
  Yes / No
```

## Test plan
- [x] 9 new tests in `preflight-credentials.test.ts` covering:
  - All credentials set (no warning)
  - Cloud auth is "none" (no warning)
  - Cloud-specific credential missing (warns with specific var name)
  - OPENROUTER_API_KEY missing (warns)
  - Multiple credentials missing (warns about all)
  - Multi-credential clouds with partial setup (only warns about missing ones)
  - CLI-based auth like "gcloud auth login" (only checks OPENROUTER_API_KEY)
- [x] Full suite: 7004 pass, 18 pre-existing failures unrelated to this change

-- refactor/ux-engineer