### PR TITLE
feat: implement local/cline.sh

### DIFF
--- a/local/cline.sh
+++ b/local/cline.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "Cline on Local Machine"
+echo ""
+
+ensure_local_ready
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+log_step "Installing Cline..."
+if ! command -v npm &>/dev/null; then
+    log_error "npm is required but not installed. Please install Node.js and npm first."
+    exit 1
+fi
+npm install -g cline
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+# Export env vars for current session
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+
+# Persist to shell config
+SHELL_CONFIG=""
+if [[ -f "${HOME}/.zshrc" ]]; then
+    SHELL_CONFIG="${HOME}/.zshrc"
+elif [[ -f "${HOME}/.bashrc" ]]; then
+    SHELL_CONFIG="${HOME}/.bashrc"
+fi
+
+if [[ -n "${SHELL_CONFIG}" ]]; then
+    # Remove old entries if they exist
+    sed -i.bak '/^export OPENROUTER_API_KEY=/d' "${SHELL_CONFIG}" 2>/dev/null || true
+    sed -i.bak '/^export OPENAI_API_KEY=/d' "${SHELL_CONFIG}" 2>/dev/null || true
+    sed -i.bak '/^export OPENAI_BASE_URL=/d' "${SHELL_CONFIG}" 2>/dev/null || true
+
+    # Add new entries
+    printf '\nexport OPENROUTER_API_KEY="%s"\n' "${OPENROUTER_API_KEY}" >> "${SHELL_CONFIG}"
+    printf 'export OPENAI_API_KEY="%s"\n' "${OPENROUTER_API_KEY}" >> "${SHELL_CONFIG}"
+    printf 'export OPENAI_BASE_URL="https://openrouter.ai/api/v1"\n' >> "${SHELL_CONFIG}"
+
+    log_info "Environment variables persisted to ${SHELL_CONFIG}"
+fi
+
+echo ""
+log_info "Local machine setup completed successfully!"
+echo ""
+
+log_step "Starting Cline..."
+sleep 1
+clear
+cline

--- a/manifest.json
+++ b/manifest.json
@@ -1195,7 +1195,7 @@
     "local/interpreter": "implemented",
     "local/gemini": "implemented",
     "local/amazonq": "missing",
-    "local/cline": "missing",
+    "local/cline": "implemented",
     "local/gptme": "implemented",
     "local/opencode": "implemented",
     "local/plandex": "missing",


### PR DESCRIPTION
## Summary
- Implements local/cline.sh to fill matrix gap "local/cline"
- Combines local provider primitives with Cline agent installation
- Includes mandatory OpenRouter credential injection

## Implementation Details
- Uses npm to install Cline globally
- Injects OpenRouter API key via OAuth flow or environment variable
- Sets required env vars: OPENROUTER_API_KEY, OPENAI_API_KEY, OPENAI_BASE_URL
- Persists environment variables to shell config (.zshrc or .bashrc)
- Uses local provider's bash execution for direct command running

## Testing
- ✅ Syntax validated with `bash -n local/cline.sh`
- ✅ Follows local provider pattern from local/lib/common.sh
- ✅ Matches Cline setup pattern from sprite/cline.sh

## Checklist
- [x] Created local/cline.sh
- [x] Updated manifest.json: "local/cline": "implemented"
- [x] Syntax check passed
- [x] OpenRouter injection included

🤖 Generated by gap-filler-2 agent