### PR TITLE
feat: implement local/plandex.sh

### DIFF
--- a/local/plandex.sh
+++ b/local/plandex.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "Plandex on Local Machine"
+echo ""
+
+# Ensure local machine is ready
+ensure_local_ready
+
+SERVER_NAME=$(get_server_name)
+log_info "Running on: ${SERVER_NAME}"
+
+# Install Plandex
+log_step "Installing Plandex..."
+run_server "curl -sL https://plandex.ai/install.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    log_error "The 'plandex' command is not available or not working properly"
+    exit 1
+fi
+log_info "Plandex installation verified successfully"
+
+# Get OpenRouter API key via OAuth
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Inject environment variables
+log_step "Setting up environment variables..."
+
+# Add to shell config
+SHELL_CONFIG=""
+if [[ -f "${HOME}/.zshrc" ]]; then
+    SHELL_CONFIG="${HOME}/.zshrc"
+elif [[ -f "${HOME}/.bashrc" ]]; then
+    SHELL_CONFIG="${HOME}/.bashrc"
+else
+    SHELL_CONFIG="${HOME}/.bashrc"
+    touch "${SHELL_CONFIG}"
+fi
+
+# Check if already configured
+if ! grep -q "export OPENROUTER_API_KEY=" "${SHELL_CONFIG}" 2>/dev/null; then
+    printf '\n# OpenRouter API Key for Plandex\nexport OPENROUTER_API_KEY="%s"\n' "${OPENROUTER_API_KEY}" >> "${SHELL_CONFIG}"
+fi
+
+# Export for current session
+export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Local setup completed successfully!"
+echo ""
+
+# Check if running in non-interactive mode
+if [[ -n "${SPAWN_PROMPT:-}" ]]; then
+    # Non-interactive mode: execute prompt and exit
+    log_step "Executing Plandex with prompt..."
+
+    # Escape prompt for safe shell execution
+    escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
+
+    # Execute without TTY
+    bash -c "source ${SHELL_CONFIG} && plandex new && plandex tell ${escaped_prompt}"
+else
+    # Interactive mode: start Plandex normally
+    log_step "Starting Plandex..."
+    sleep 1
+    clear
+    interactive_session "source ${SHELL_CONFIG} && plandex"
+fi

--- a/manifest.json
+++ b/manifest.json
@@ -1198,7 +1198,7 @@
     "local/cline": "missing",
     "local/gptme": "implemented",
     "local/opencode": "implemented",
-    "local/plandex": "missing",
+    "local/plandex": "implemented",
     "local/kilocode": "missing",
     "local/continue": "implemented",
     "ramnode/claude": "implemented",


### PR DESCRIPTION
## Summary
- Implements local/plandex.sh for running Plandex on local machine
- Installs Plandex via official installer
- Injects OPENROUTER_API_KEY into shell config (zshrc or bashrc)
- Supports both interactive and prompt modes
- Updates manifest.json: "local/plandex": "implemented"

## Pattern
Follows local cloud provider pattern:
1. Source local/lib/common.sh with remote fallback
2. Ensure local machine readiness (curl, Python checks)
3. Install Plandex via `curl -sL https://plandex.ai/install.sh | bash`
4. Verify installation
5. Get OpenRouter API key (env var or OAuth)
6. Inject into shell config
7. Launch interactive session or execute prompt

## Testing
- `bash -n local/plandex.sh` passes syntax check
- Matches agent manifest env requirements (OPENROUTER_API_KEY)

Agent: gap-filler