### PR TITLE
feat: implement ramnode gaps for gemini, amazonq, plandex, kilocode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1206,15 +1206,15 @@
     "ramnode/nanoclaw": "implemented",
     "ramnode/aider": "implemented",
     "ramnode/goose": "implemented",
-    "ramnode/codex": "missing",
+    "ramnode/codex": "implemented",
     "ramnode/interpreter": "implemented",
-    "ramnode/gemini": "missing",
-    "ramnode/amazonq": "missing",
+    "ramnode/gemini": "implemented",
+    "ramnode/amazonq": "implemented",
     "ramnode/cline": "implemented",
     "ramnode/gptme": "implemented",
     "ramnode/opencode": "implemented",
-    "ramnode/plandex": "missing",
-    "ramnode/kilocode": "missing",
+    "ramnode/plandex": "implemented",
+    "ramnode/kilocode": "implemented",
     "ramnode/continue": "implemented"
   }
 }

--- a/ramnode/amazonq.sh
+++ b/ramnode/amazonq.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=ramnode/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ramnode/lib/common.sh)"
+fi
+
+log_info "Amazon Q CLI on RamNode Cloud"
+echo ""
+
+ensure_ramnode_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${RAMNODE_SERVER_IP}"
+wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
+
+log_step "Installing Amazon Q CLI..."
+run_server "${RAMNODE_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "RamNode server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
+echo ""
+
+log_step "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/ramnode/gemini.sh
+++ b/ramnode/gemini.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=ramnode/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ramnode/lib/common.sh)"
+fi
+
+log_info "Gemini CLI on RamNode Cloud"
+echo ""
+
+ensure_ramnode_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${RAMNODE_SERVER_IP}"
+wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
+
+log_step "Installing Gemini CLI..."
+run_server "${RAMNODE_SERVER_IP}" "npm install -g @google/gemini-cli"
+log_info "Gemini CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "RamNode server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
+echo ""
+
+log_step "Starting Gemini..."
+sleep 1
+clear
+interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/ramnode/kilocode.sh
+++ b/ramnode/kilocode.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=ramnode/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ramnode/lib/common.sh)"
+fi
+
+log_info "Kilo Code on RamNode Cloud"
+echo ""
+
+ensure_ramnode_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${RAMNODE_SERVER_IP}"
+wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
+
+log_step "Installing Kilo Code CLI..."
+run_server "${RAMNODE_SERVER_IP}" "npm install -g @kilocode/cli"
+log_info "Kilo Code CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "RamNode server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
+echo ""
+
+log_step "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/ramnode/plandex.sh
+++ b/ramnode/plandex.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=ramnode/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/ramnode/lib/common.sh)"
+fi
+
+log_info "Plandex on RamNode Cloud"
+echo ""
+
+ensure_ramnode_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${RAMNODE_SERVER_IP}"
+wait_for_cloud_init "${RAMNODE_SERVER_IP}" 60
+
+log_step "Installing Plandex..."
+run_server "${RAMNODE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+
+# Verify installation
+if ! run_server "${RAMNODE_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
+    log_error "Plandex installation verification failed"
+    log_error "The 'plandex' command is not available or not working properly"
+    exit 1
+fi
+log_info "Plandex installation verified successfully"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${RAMNODE_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "RamNode server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${RAMNODE_SERVER_ID}, IP: ${RAMNODE_SERVER_IP})"
+echo ""
+
+# Check if running in non-interactive mode
+if [[ -n "${SPAWN_PROMPT:-}" ]]; then
+    # Non-interactive mode: execute prompt and exit
+    log_step "Executing Plandex with prompt..."
+
+    # Escape prompt for safe shell execution
+    escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
+
+    # Execute without interactive session
+    run_server "${RAMNODE_SERVER_IP}" "source ~/.zshrc && plandex new && plandex tell ${escaped_prompt}"
+else
+    # Interactive mode: start Plandex normally
+    log_step "Starting Plandex..."
+    sleep 1
+    clear
+    interactive_session "${RAMNODE_SERVER_IP}" "source ~/.zshrc && plandex"
+fi


### PR DESCRIPTION
## Summary

- Implement `ramnode/gemini.sh` - Gemini CLI with OpenRouter via OPENAI_BASE_URL override
- Implement `ramnode/amazonq.sh` - Amazon Q CLI with OpenRouter support
- Implement `ramnode/plandex.sh` - Plandex agent with native OpenRouter support
- Implement `ramnode/kilocode.sh` - Kilo Code CLI with OpenRouter provider
- Fix manifest.json to mark `ramnode/codex` as implemented (script existed but was marked missing)

All scripts follow the RamNode pattern:
1. Source `ramnode/lib/common.sh` (OpenStack API functions)
2. Authenticate with RamNode credentials (RAMNODE_USERNAME, RAMNODE_PASSWORD, RAMNODE_PROJECT_ID)
3. Create Ubuntu 24.04 server via OpenStack Compute API
4. Wait for cloud-init readiness
5. Install agent via npm/curl
6. Inject `OPENROUTER_API_KEY` and agent-specific env vars
7. Launch interactive session via SSH

**OpenRouter injection (MANDATORY):**
- `gemini.sh`: Sets GEMINI_API_KEY, OPENAI_API_KEY, OPENAI_BASE_URL
- `amazonq.sh`: Sets OPENAI_API_KEY, OPENAI_BASE_URL
- `plandex.sh`: Sets OPENROUTER_API_KEY (native support)
- `kilocode.sh`: Sets KILO_PROVIDER_TYPE=openrouter, KILO_OPEN_ROUTER_API_KEY

## Test plan

- [x] `bash -n` syntax check passed for all 5 scripts
- [ ] Manual test: `bash ramnode/gemini.sh` (requires RAMNODE credentials)
- [ ] Manual test: `bash ramnode/amazonq.sh` (requires RAMNODE credentials)
- [ ] Manual test: `bash ramnode/plandex.sh` (requires RAMNODE credentials)
- [ ] Manual test: `bash ramnode/kilocode.sh` (requires RAMNODE credentials)
- [ ] Verify manifest.json matrix correctly shows all 5 as "implemented"

🤖 Generated with [Claude Code](https://claude.com/claude-code)