### PR TITLE
fix: detect slash notation and suggest correct syntax

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -395,6 +395,17 @@ async function dispatchCommand(cmd: string, filteredArgs: string[], prompt: stri
     process.exit(1);
   }
 
+  // Handle slash notation: "spawn claude/hetzner" or "spawn hetzner/claude"
+  if (filteredArgs.length === 1 && cmd.includes("/")) {
+    const parts = cmd.split("/");
+    if (parts.length === 2 && parts[0] && parts[1]) {
+      console.error(pc.dim(`Tip: use a space instead of slash: ${pc.cyan(`spawn ${parts[0]} ${parts[1]}`)}`));
+      console.error();
+      await handleDefaultCommand(parts[0], parts[1], prompt, dryRun);
+      return;
+    }
+  }
+
   warnExtraArgs(filteredArgs, 2);
   await handleDefaultCommand(filteredArgs[0], filteredArgs[1], prompt, dryRun);
 }


### PR DESCRIPTION
## Summary
- When users type `spawn claude/hetzner` or `spawn hetzner/claude`, the CLI now splits on the slash and runs the spawn correctly, with a tip suggesting space-separated syntax
- Previously, slash notation caused a confusing "contains invalid characters" error from identifier validation, since the slash was rejected before the CLI could recognize the user's intent
- The swap detection logic in `cmdRun` still handles cloud/agent vs agent/cloud ordering automatically

## Changes
- `cli/src/index.ts`: Added slash notation detection in `dispatchCommand` — splits `a/b` into two args and forwards to `handleDefaultCommand`
- `cli/src/__tests__/index-dispatch-routing.test.ts`: Added 11 tests covering slash notation parsing, edge cases (empty parts, multiple slashes, extra args), and priority verification
- `cli/package.json`: Version bump 0.2.69 -> 0.2.70

## Test plan
- [x] All 149 dispatch routing tests pass (138 existing + 11 new)
- [x] All 250 index-related tests pass across 4 test files
- [ ] Manual: `spawn claude/hetzner` should show tip and launch correctly
- [ ] Manual: `spawn hetzner/claude` should auto-swap and launch correctly

-- refactor/ux-engineer