### PR TITLE
fix: improve local script UX -- prompt support, escaping, consistent messages

### DIFF
--- a/local/aider.sh
+++ b/local/aider.sh
@@ -56,8 +56,7 @@ echo ""
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     log_step "Executing Aider with prompt..."
     source ~/.zshrc 2>/dev/null || true
-    escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
-    aider --model "openrouter/${MODEL_ID}" -m "${escaped_prompt}"
+    aider --model "openrouter/${MODEL_ID}" -m "${SPAWN_PROMPT}"
 else
     log_step "Starting Aider..."
     sleep 1

--- a/local/cline.sh
+++ b/local/cline.sh
@@ -23,6 +23,15 @@ if ! command -v npm &>/dev/null; then
 fi
 npm install -g cline
 
+# Verify installation
+if ! command -v cline &>/dev/null; then
+    log_error "Cline installation failed"
+    log_error "The 'cline' command is not available"
+    log_error "Try installing manually: npm install -g cline"
+    exit 1
+fi
+log_info "Cline installation verified"
+
 echo ""
 if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     log_info "Using OpenRouter API key from environment"
@@ -37,10 +46,18 @@ inject_env_vars_local upload_file run_server \
     "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
-log_info "Local machine setup completed successfully!"
+log_info "Local setup completed successfully!"
 echo ""
 
-log_step "Starting Cline..."
-sleep 1
-clear
-cline
+# Start Cline
+if [[ -n "${SPAWN_PROMPT:-}" ]]; then
+    log_step "Executing Cline with prompt..."
+    source ~/.zshrc 2>/dev/null || true
+    cline "${SPAWN_PROMPT}"
+else
+    log_step "Starting Cline..."
+    sleep 1
+    clear 2>/dev/null || true
+    source ~/.zshrc 2>/dev/null || true
+    exec cline
+fi

--- a/local/interpreter.sh
+++ b/local/interpreter.sh
@@ -55,8 +55,7 @@ echo ""
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     log_step "Executing Open Interpreter with prompt..."
     source ~/.zshrc 2>/dev/null || true
-    escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
-    interpreter -m "${escaped_prompt}"
+    interpreter -m "${SPAWN_PROMPT}"
 else
     log_step "Starting Open Interpreter..."
     sleep 1

--- a/local/plandex.sh
+++ b/local/plandex.sh
@@ -16,7 +16,7 @@ echo ""
 ensure_local_ready
 
 SERVER_NAME=$(get_server_name)
-log_info "Running on: ${SERVER_NAME}"
+create_server "${SERVER_NAME}"
 
 # Install Plandex
 log_step "Installing Plandex..."
@@ -51,18 +51,14 @@ echo ""
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     # Non-interactive mode: execute prompt and exit
     log_step "Executing Plandex with prompt..."
-
-    # Escape prompt for safe shell execution
-    escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
-
-    # Execute without TTY
     source ~/.zshrc 2>/dev/null || true
-    plandex new && plandex tell ${escaped_prompt}
+    plandex new
+    plandex tell "${SPAWN_PROMPT}"
 else
     # Interactive mode: start Plandex normally
     log_step "Starting Plandex..."
     sleep 1
-    clear
+    clear 2>/dev/null || true
     source ~/.zshrc 2>/dev/null || true
     exec plandex
 fi


### PR DESCRIPTION
## Summary

- **local/cline.sh**: Add missing `SPAWN_PROMPT` non-interactive mode (was the only local agent that silently ignored `--prompt`), replace manual `sed -i.bak` env var handling with `inject_env_vars_local` (eliminates leftover `.bak` files in home directory), add installation verification step
- **local/plandex.sh**: Replace manual shell config handling with `inject_env_vars_local` for consistency, fix `printf '%q'` prompt escaping that corrupted prompt text with literal backslashes
- **local/aider.sh, local/interpreter.sh**: Fix `printf '%q'` prompt escaping -- pass `SPAWN_PROMPT` directly as a quoted argument instead of shell-escaping it (which adds unwanted backslashes/`$'...'` syntax to the prompt text)
- **7 local scripts**: Standardize log message from "Appending environment variables to ~/.zshrc..." to "Setting up environment variables..." for consistency with all other cloud providers

## Test plan

- [x] `bash -n` passes on all 11 modified scripts
- [x] CLI tests pass (pre-existing failures only, no new regressions)
- [ ] Manual: `spawn cline local --prompt "test"` now works (was silently ignored)
- [ ] Manual: `spawn aider local --prompt "Fix all linter errors"` no longer adds backslashes to prompt

-- refactor/ux-engineer