### PR TITLE
fix: show 'ready to go' in quick start when all credentials are set

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.70",
+  "version": "0.2.71",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1315,14 +1315,22 @@ export async function cmdAgentInfo(agent: string): Promise<void> {
     const cloudDef = manifest.clouds[exampleCloud];
     const authVars = parseAuthEnvVars(cloudDef.auth);
     const hasCreds = hasCloudCredentials(cloudDef.auth);
+    const hasOpenRouterKey = !!process.env.OPENROUTER_API_KEY;
+    const allReady = hasOpenRouterKey && (hasCreds || authVars.length === 0);
+
     console.log();
-    console.log(pc.bold("Quick start:"));
-    console.log(formatAuthVarLine("OPENROUTER_API_KEY", "https://openrouter.ai/settings/keys"));
-    if (authVars.length > 0) {
-      const hint = cloudDef.url ?? `${cloudDef.name} credential`;
-      console.log(formatAuthVarLine(authVars[0], hint));
+    if (allReady) {
+      console.log(pc.bold("Quick start:") + "  " + pc.green("credentials detected -- ready to go"));
+      console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
+    } else {
+      console.log(pc.bold("Quick start:"));
+      console.log(formatAuthVarLine("OPENROUTER_API_KEY", "https://openrouter.ai/settings/keys"));
+      if (authVars.length > 0) {
+        const hint = cloudDef.url ?? `${cloudDef.name} credential`;
+        console.log(formatAuthVarLine(authVars[0], hint));
+      }
+      console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
     }
-    console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
   }
 
   console.log();
@@ -1360,7 +1368,16 @@ function printCloudQuickStart(
   cloudKey: string
 ): void {
   const hasCreds = hasCloudCredentials(cloud.auth);
+  const hasOpenRouterKey = !!process.env.OPENROUTER_API_KEY;
+  const allReady = hasOpenRouterKey && (hasCreds || authVars.length === 0);
+
   console.log();
+  if (allReady && exampleAgent) {
+    console.log(pc.bold("Quick start:") + "  " + pc.green("credentials detected -- ready to go"));
+    console.log(`  ${pc.cyan(`spawn ${exampleAgent} ${cloudKey}`)}`);
+    return;
+  }
+
   console.log(pc.bold("Quick start:"));
   console.log(formatAuthVarLine("OPENROUTER_API_KEY", "https://openrouter.ai/settings/keys"));
   if (authVars.length > 0) {


### PR DESCRIPTION
## Summary
- When all required credentials are already set, `spawn <agent>` and `spawn <cloud>` Quick start sections now show **"credentials detected -- ready to go"** with just the launch command, instead of redundant export instructions
- The `hasCreds` variable was previously computed but unused in both `printCloudQuickStart` and `cmdAgentInfo` -- this puts it to use
- Adds 10 new tests covering the ready/not-ready states for both cloud info and agent info views

## Before
```
Quick start:
  OPENROUTER_API_KEY -- set
  HCLOUD_TOKEN -- set
  spawn claude hetzner
```

## After
```
Quick start:  credentials detected -- ready to go
  spawn claude hetzner
```

When credentials are missing, the behavior is unchanged (shows export instructions as before).

## Test plan
- [x] 41 tests pass in cloud-agent-quickstart.test.ts (31 existing + 10 new)
- [x] 138 tests pass across related test files (cloud-info, commands-cloud-info, commands-info-details, commands-display)
- [x] All existing behavior preserved when credentials are NOT fully set

-- refactor/ux-engineer