### PR TITLE
feat: Add codesandbox/cline

### DIFF
--- a/codesandbox/cline.sh
+++ b/codesandbox/cline.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source cloud-specific functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Cline on CodeSandbox"
+echo ""
+
+# Ensure CodeSandbox CLI and token
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+# Get sandbox name and create it
+SANDBOX_NAME=$(get_server_name)
+create_server "${SANDBOX_NAME}"
+
+# Install Bun and set up environment
+wait_for_cloud_init
+
+log_step "Installing Node.js and Cline..."
+run_server "npm install -g cline"
+
+# Get OpenRouter API key (env var or OAuth)
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Inject environment variables
+log_step "Setting up environment variables..."
+run_server "echo 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> ~/.bashrc"
+run_server "echo 'export OPENAI_API_KEY=${OPENROUTER_API_KEY}' >> ~/.bashrc"
+run_server "echo 'export OPENAI_BASE_URL=https://openrouter.ai/api/v1' >> ~/.bashrc"
+
+echo ""
+log_info "CodeSandbox setup completed successfully!"
+echo ""
+
+# Start Cline interactively
+log_step "Starting Cline..."
+sleep 1
+clear
+interactive_session "bash -c 'source ~/.bashrc && cline'"

--- a/manifest.json
+++ b/manifest.json
@@ -839,7 +839,7 @@
     "codesandbox/interpreter": "missing",
     "codesandbox/gemini": "missing",
     "codesandbox/amazonq": "missing",
-    "codesandbox/cline": "missing",
+    "codesandbox/cline": "implemented",
     "codesandbox/gptme": "missing",
     "codesandbox/opencode": "missing",
     "codesandbox/plandex": "missing",


### PR DESCRIPTION
Implements the missing codesandbox/cline matrix entry.

**Implementation details:**
- Uses CodeSandbox SDK to create and manage sandbox
- Installs Cline via npm
- Injects OpenRouter API key with OPENAI_BASE_URL override
- Follows standard CodeSandbox provisioning pattern

-- discovery/gap-filler-3