### PR TITLE
feat: Add codesandbox/interpreter

### DIFF
--- a/codesandbox/interpreter.sh
+++ b/codesandbox/interpreter.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Open Interpreter on CodeSandbox"
+echo ""
+
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+CODESANDBOX_SANDBOX_NAME=$(get_server_name)
+create_server "${CODESANDBOX_SANDBOX_NAME}"
+wait_for_cloud_init
+
+log_step "Installing Open Interpreter..."
+run_server "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+run_server 'printf "export OPENROUTER_API_KEY=\"%s\"\n" "'"${OPENROUTER_API_KEY}"'" >> ~/.bashrc'
+run_server 'printf "export OPENAI_API_KEY=\"%s\"\n" "'"${OPENROUTER_API_KEY}"'" >> ~/.bashrc'
+run_server 'printf "export OPENAI_BASE_URL=\"%s\"\n" "https://openrouter.ai/api/v1" >> ~/.bashrc'
+
+echo ""
+log_info "CodeSandbox setup completed successfully!"
+echo ""
+
+log_step "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "bash -lc 'interpreter'"

--- a/manifest.json
+++ b/manifest.json
@@ -836,7 +836,7 @@
     "codesandbox/aider": "implemented",
     "codesandbox/goose": "missing",
     "codesandbox/codex": "missing",
-    "codesandbox/interpreter": "missing",
+    "codesandbox/interpreter": "implemented",
     "codesandbox/gemini": "missing",
     "codesandbox/amazonq": "missing",
     "codesandbox/cline": "missing",


### PR DESCRIPTION
Implements the missing codesandbox/interpreter combination from the spawn matrix.

## Implementation Details

- Uses CodeSandbox SDK primitives from `codesandbox/lib/common.sh`
- Follows the Open Interpreter installation pattern from other clouds (`pip install open-interpreter`)
- Injects OpenRouter credentials via environment variables:
  - `OPENROUTER_API_KEY`
  - `OPENAI_API_KEY` (set to OpenRouter key)
  - `OPENAI_BASE_URL=https://openrouter.ai/api/v1`
- Launches interpreter in interactive session via `bash -lc`

## Testing

- Syntax validated with `bash -n`
- Follows the standard CodeSandbox deployment pattern
- Environment variables injected to `.bashrc` for persistence

-- discovery/gap-filler-2