### PR TITLE
feat: Add codesandbox/goose

### DIFF
--- a/codesandbox/goose.sh
+++ b/codesandbox/goose.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Goose on CodeSandbox"
+echo ""
+
+# Setup CodeSandbox environment
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+SANDBOX_NAME=$(get_server_name)
+create_server "${SANDBOX_NAME}"
+wait_for_cloud_init
+
+# Install Goose
+log_step "Installing Goose..."
+run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+
+# Verify installation succeeded
+log_step "Verifying Goose installation..."
+if ! run_server "command -v goose && goose --version"; then
+    log_error "Goose installation verification failed"
+    log_error "The 'goose' command is not available or not working properly"
+    exit 1
+fi
+log_info "Goose installation verified successfully"
+
+# Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+run_server "echo 'export GOOSE_PROVIDER=openrouter' >> ~/.bashrc"
+run_server "echo 'export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}' >> ~/.bashrc"
+
+echo ""
+log_info "CodeSandbox setup completed successfully!"
+echo ""
+
+# Start Goose interactively
+log_step "Starting Goose..."
+sleep 1
+interactive_session "source ~/.bashrc && goose"

--- a/manifest.json
+++ b/manifest.json
@@ -834,7 +834,7 @@
     "codesandbox/openclaw": "implemented",
     "codesandbox/nanoclaw": "missing",
     "codesandbox/aider": "implemented",
-    "codesandbox/goose": "missing",
+    "codesandbox/goose": "implemented",
     "codesandbox/codex": "missing",
     "codesandbox/interpreter": "missing",
     "codesandbox/gemini": "missing",


### PR DESCRIPTION
## Summary
Implements Block's Goose AI coding agent on CodeSandbox.

## Changes
- Created `codesandbox/goose.sh` using CodeSandbox SDK primitives
- Updated `manifest.json` matrix entry from "missing" to "implemented"

## Implementation Details
- Uses CodeSandbox SDK for sandbox creation and command execution
- Installs Goose via official GitHub release download script
- Configures OpenRouter as provider via `GOOSE_PROVIDER` env var
- Sets `OPENROUTER_API_KEY` for authentication
- Verifies installation success before proceeding

## Testing
- Syntax validated with `bash -n`
- Follows established CodeSandbox pattern from other agents

---
discovery/gap-filler-1