### PR TITLE
feat: Add codesandbox/kilocode

### DIFF
--- a/codesandbox/kilocode.sh
+++ b/codesandbox/kilocode.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=codesandbox/lib/common.sh
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Kilo Code on CodeSandbox"
+echo ""
+
+# 1. Ensure CodeSandbox SDK/CLI and API token
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+# 2. Get sandbox name and create sandbox
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for base tools
+wait_for_cloud_init
+
+# 4. Install Kilo Code
+log_step "Installing Kilo Code..."
+run_server "npm install -g @kilocode/cli"
+log_info "Kilo Code installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables into ~/.bashrc
+log_step "Setting up environment variables..."
+
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "CodeSandbox sandbox setup completed successfully!"
+log_info "Sandbox: ${SERVER_NAME} (ID: ${CODESANDBOX_SANDBOX_ID})"
+echo ""
+
+# 7. Start Kilo Code interactively
+log_step "Starting Kilo Code..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && kilocode"

--- a/manifest.json
+++ b/manifest.json
@@ -874,7 +874,7 @@
     "codesandbox/gptme": "implemented",
     "codesandbox/opencode": "implemented",
     "codesandbox/plandex": "implemented",
-    "codesandbox/kilocode": "missing",
+    "codesandbox/kilocode": "implemented",
     "codesandbox/continue": "implemented",
     "e2b/claude": "implemented",
     "e2b/openclaw": "implemented",


### PR DESCRIPTION
Implements Kilo Code on CodeSandbox using CodeSandbox SDK.

**Implementation details:**
- Uses CodeSandbox SDK for sandbox creation and command execution
- Installs Kilo Code via npm (@kilocode/cli)
- Injects OpenRouter-specific env vars: OPENROUTER_API_KEY, KILO_PROVIDER_TYPE, KILO_OPEN_ROUTER_API_KEY
- Launches interactive Kilo Code session

**Pattern followed:**
- Sourced codesandbox/lib/common.sh (local or remote fallback)
- Used CodeSandbox primitives: create_server, run_server, upload_file, interactive_session
- Followed agent install steps from modal/kilocode.sh reference
- Updated manifest.json matrix entry to 'implemented'

-- discovery/gap-filler-4