### PR TITLE
feat: Add codesandbox/continue

### DIFF
--- a/codesandbox/continue.sh
+++ b/codesandbox/continue.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=codesandbox/lib/common.sh
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Continue on CodeSandbox"
+echo ""
+
+# 1. Ensure CodeSandbox SDK/CLI and API token
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+# 2. Get sandbox name and create sandbox
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 3. Wait for base tools
+wait_for_cloud_init
+
+# 4. Install Continue CLI
+log_step "Installing Continue CLI..."
+run_server "npm install -g @continuedev/cli"
+log_info "Continue installed"
+
+# 5. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 6. Inject environment variables into ~/.bashrc
+log_step "Setting up environment variables..."
+
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+# 7. Setup Continue config file
+setup_continue_config "${OPENROUTER_API_KEY}" "upload_file" "run_server"
+
+echo ""
+log_info "CodeSandbox sandbox setup completed successfully!"
+log_info "Sandbox: ${SERVER_NAME} (ID: ${CODESANDBOX_SANDBOX_ID})"
+echo ""
+
+# 8. Start Continue CLI in TUI mode
+log_step "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && cn"

--- a/manifest.json
+++ b/manifest.json
@@ -844,7 +844,7 @@
     "codesandbox/opencode": "missing",
     "codesandbox/plandex": "missing",
     "codesandbox/kilocode": "missing",
-    "codesandbox/continue": "missing",
+    "codesandbox/continue": "implemented",
     "e2b/claude": "implemented",
     "e2b/openclaw": "implemented",
     "e2b/nanoclaw": "implemented",


### PR DESCRIPTION
Implements Continue CLI on CodeSandbox using CodeSandbox SDK.

**Implementation details:**
- Uses CodeSandbox SDK for sandbox creation and command execution
- Installs Continue CLI via npm (@continuedev/cli)
- Injects OPENROUTER_API_KEY into ~/.bashrc
- Uses setup_continue_config helper from shared/common.sh to write ~/.continue/config.json
- Launches Continue in TUI mode (cn command)

**Pattern followed:**
- Sourced codesandbox/lib/common.sh (local or remote fallback)
- Used CodeSandbox primitives: create_server, run_server, upload_file, interactive_session
- Followed agent install steps from e2b/continue.sh reference
- Used shared setup_continue_config helper for config file generation
- Updated manifest.json matrix entry to 'implemented'

-- discovery/gap-filler-4