### PR TITLE
feat: Add codesandbox/amazonq

### DIFF
--- a/codesandbox/amazonq.sh
+++ b/codesandbox/amazonq.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Amazon Q on CodeSandbox"
+echo ""
+
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+CODESANDBOX_SANDBOX_NAME=$(get_server_name)
+create_server "${CODESANDBOX_SANDBOX_NAME}"
+wait_for_cloud_init
+
+log_step "Installing Amazon Q CLI..."
+run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+run_server 'printf "export OPENROUTER_API_KEY=\"%s\"\n" "'"${OPENROUTER_API_KEY}"'" >> ~/.bashrc'
+run_server 'printf "export OPENAI_API_KEY=\"%s\"\n" "'"${OPENROUTER_API_KEY}"'" >> ~/.bashrc'
+run_server 'printf "export OPENAI_BASE_URL=\"%s\"\n" "https://openrouter.ai/api/v1" >> ~/.bashrc'
+
+echo ""
+log_info "CodeSandbox setup completed successfully!"
+echo ""
+
+log_step "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "bash -lc 'q chat'"

--- a/manifest.json
+++ b/manifest.json
@@ -838,7 +838,7 @@
     "codesandbox/codex": "missing",
     "codesandbox/interpreter": "missing",
     "codesandbox/gemini": "missing",
-    "codesandbox/amazonq": "missing",
+    "codesandbox/amazonq": "implemented",
     "codesandbox/cline": "missing",
     "codesandbox/gptme": "missing",
     "codesandbox/opencode": "missing",


### PR DESCRIPTION
Implements the missing codesandbox/amazonq combination from the spawn matrix.

## Implementation Details

- Uses CodeSandbox SDK primitives from `codesandbox/lib/common.sh`
- Follows the Amazon Q CLI installation pattern from other clouds (curl install script from AWS)
- Injects OpenRouter credentials via environment variables:
  - `OPENROUTER_API_KEY`
  - `OPENAI_API_KEY` (set to OpenRouter key)
  - `OPENAI_BASE_URL=https://openrouter.ai/api/v1`
- Launches Amazon Q chat in interactive session via `bash -lc 'q chat'`

## Testing

- Syntax validated with `bash -n`
- Follows the standard CodeSandbox deployment pattern
- Environment variables injected to `.bashrc` for persistence

-- discovery/gap-filler-2