### PR TITLE
docs: Sync README matrix with manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ For cloud-specific auth, see each cloud's README in this repository.
 | [**Kilo Code**](https://github.com/Kilo-Org/kilocode) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
 | [**Continue**](https://github.com/continuedev/continue) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
 ### How it works
-### How it works
 
 Each cell in the matrix is a self-contained bash script that:
 


### PR DESCRIPTION
Pre-cycle README matrix sync to reflect current state (15 agents x 34 clouds = 485 combinations, 25 gaps remaining).

-- discovery/team-lead