### PR TITLE
feat: Add goose on Atlantic.Net

### DIFF
--- a/atlanticnet/README.md
+++ b/atlanticnet/README.md
@@ -62,10 +62,18 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/atlanticnet/opencode.sh)
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/atlanticnet/plandex.sh)
+```
+
 #### Amazon Q
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/atlanticnet/amazonq.sh)
+```
+
+#### Goose
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/atlanticnet/goose.sh)
 ```
 
 ## Non-Interactive Mode

--- a/atlanticnet/goose.sh
+++ b/atlanticnet/goose.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/atlanticnet/lib/common.sh)"
+fi
+
+log_info "Goose on Atlantic.Net Cloud"
+echo ""
+
+# Authenticate with Atlantic.Net
+ensure_atlanticnet_credentials
+
+# Setup SSH key
+ensure_ssh_key
+
+# Get or prompt for server name
+SERVER_NAME=$(get_server_name)
+
+# Create server
+create_server "${SERVER_NAME}"
+
+# Wait for SSH connectivity
+log_step "Waiting for server to be ready..."
+verify_server_connectivity "${ATLANTICNET_SERVER_IP}"
+
+log_step "Setting up server environment..."
+
+# Install Goose
+log_step "Installing Goose..."
+run_server "${ATLANTICNET_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${ATLANTICNET_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
+    log_error "Goose installation verification failed"
+    log_error "The 'goose' command is not available or not working properly"
+    exit 1
+fi
+log_info "Goose installation verified successfully"
+
+# Get OpenRouter API key via OAuth
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+run_server "${ATLANTICNET_SERVER_IP}" "cat >> ~/.bashrc << 'EOF'
+export GOOSE_PROVIDER=openrouter
+export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+EOF"
+
+echo ""
+log_info "Server setup completed successfully!"
+echo ""
+
+# Start interactive session
+log_step "Starting Goose..."
+sleep 1
+clear
+interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.bashrc && goose"

--- a/manifest.json
+++ b/manifest.json
@@ -1280,7 +1280,7 @@
     "atlanticnet/openclaw": "implemented",
     "atlanticnet/nanoclaw": "implemented",
     "atlanticnet/aider": "implemented",
-    "atlanticnet/goose": "missing",
+    "atlanticnet/goose": "implemented",
     "atlanticnet/codex": "implemented",
     "atlanticnet/interpreter": "missing",
     "atlanticnet/gemini": "implemented",


### PR DESCRIPTION
Implements Goose agent on Atlantic.Net Cloud provider.

## Changes
- Created `atlanticnet/goose.sh` deployment script
- Updated `manifest.json` to mark `atlanticnet/goose` as implemented
- Updated `atlanticnet/README.md` with Goose usage instructions

## Testing
- Syntax validation passed: `bash -n atlanticnet/goose.sh`
- Follows Atlantic.Net common.sh pattern
- OpenRouter environment variables properly injected

-- discovery/gap-filler-atlantic