### PR TITLE
feat: Add Amazon Q CLI on local machine

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -16,7 +16,13 @@ spawn aider local
 spawn goose local
 spawn codex local
 spawn interpreter local
+spawn gemini local
+spawn amazonq local
+spawn cline local
 spawn gptme local
+spawn opencode local
+spawn plandex local
+spawn kilocode local
 spawn continue local
 ```
 
@@ -30,7 +36,13 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/aider.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/goose.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/codex.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/interpreter.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/gemini.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/amazonq.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/cline.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/gptme.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/opencode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/kilocode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/continue.sh)
 ```
 

--- a/local/amazonq.sh
+++ b/local/amazonq.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "Amazon Q CLI on local machine"
+echo ""
+
+# 1. Ensure local prerequisites
+ensure_local_ready
+
+# 2. Install Amazon Q CLI if not already installed
+if command -v q &>/dev/null; then
+    log_info "Amazon Q CLI already installed"
+else
+    log_step "Installing Amazon Q CLI..."
+    curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash
+fi
+
+# Verify installation
+if ! command -v q &>/dev/null; then
+    log_error "Amazon Q CLI installation failed"
+    log_error "The 'q' command is not available"
+    log_error "Try installing manually: curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+    exit 1
+fi
+log_info "Amazon Q CLI installation verified"
+
+# 3. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 4. Inject environment variables
+log_step "Setting up environment variables..."
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "Local setup completed successfully!"
+echo ""
+
+# 5. Start Amazon Q
+log_step "Starting Amazon Q..."
+sleep 1
+clear 2>/dev/null || true
+source ~/.zshrc 2>/dev/null || source ~/.bashrc 2>/dev/null || true
+exec q chat

--- a/manifest.json
+++ b/manifest.json
@@ -1239,7 +1239,7 @@
     "local/codex": "implemented",
     "local/interpreter": "implemented",
     "local/gemini": "implemented",
-    "local/amazonq": "missing",
+    "local/amazonq": "implemented",
     "local/cline": "implemented",
     "local/gptme": "implemented",
     "local/opencode": "implemented",


### PR DESCRIPTION
Implemented local/amazonq.sh to run Amazon Q CLI directly on the user's local machine.

**Changes**:
- Created `local/amazonq.sh` with standard local provider pattern
- Updated `manifest.json` to mark `local/amazonq` as `implemented`
- Updated `local/README.md` with amazonq usage examples

**Implementation details**:
- Uses `inject_env_vars_local` to set `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, and `OPENAI_BASE_URL`
- Follows the same pattern as other local scripts (aider, goose, etc.)
- Installs Amazon Q CLI via the official installer if not present
- Launches `q chat` after setup

**Testing**:
- ✅ Syntax check passed (`bash -n local/amazonq.sh`)
- ✅ Follows local provider conventions
- ✅ OpenRouter injection is mandatory and present

-- discovery/gap-filler-local