### PR TITLE
feat: Add amazonq on Atlantic.Net

### DIFF
--- a/atlanticnet/README.md
+++ b/atlanticnet/README.md
@@ -62,6 +62,10 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/atlanticnet/opencode.sh)
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/atlanticnet/plandex.sh)
+#### Amazon Q
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/atlanticnet/amazonq.sh)
 ```
 
 ## Non-Interactive Mode

--- a/atlanticnet/amazonq.sh
+++ b/atlanticnet/amazonq.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+    source "$SCRIPT_DIR/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/atlanticnet/lib/common.sh)"
+fi
+
+log_info "Amazon Q on Atlantic.Net Cloud"
+echo ""
+
+ensure_atlanticnet_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+log_step "Waiting for server to be ready..."
+verify_server_connectivity "${ATLANTICNET_SERVER_IP}"
+
+log_step "Installing Amazon Q CLI..."
+run_server "${ATLANTICNET_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+run_server "${ATLANTICNET_SERVER_IP}" "cat >> ~/.bashrc << 'EOF'
+export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+export OPENAI_API_KEY=${OPENROUTER_API_KEY}
+export OPENAI_BASE_URL=https://openrouter.ai/api/v1
+EOF"
+
+echo ""
+log_info "Server setup completed successfully!"
+echo ""
+
+log_step "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.bashrc && q chat"

--- a/manifest.json
+++ b/manifest.json
@@ -1284,7 +1284,7 @@
     "atlanticnet/codex": "implemented",
     "atlanticnet/interpreter": "missing",
     "atlanticnet/gemini": "implemented",
-    "atlanticnet/amazonq": "missing",
+    "atlanticnet/amazonq": "implemented",
     "atlanticnet/cline": "missing",
     "atlanticnet/gptme": "implemented",
     "atlanticnet/opencode": "implemented",


### PR DESCRIPTION
Implements Amazon Q agent on Atlantic.Net Cloud provider.

## Changes
- Created `atlanticnet/amazonq.sh` deployment script
- Updated `manifest.json` to mark `atlanticnet/amazonq` as implemented
- Updated `atlanticnet/README.md` with Amazon Q usage instructions

## Testing
- Syntax validation passed: `bash -n atlanticnet/amazonq.sh`
- Follows Atlantic.Net common.sh pattern
- OpenRouter environment variables properly injected

-- discovery/gap-filler-atlantic