### PR TITLE
feat: Add amazonq on CodeSandbox

### DIFF
--- a/codesandbox/README.md
+++ b/codesandbox/README.md
@@ -54,6 +54,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/plandex.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/gemini.sh)
 ```
 
+#### Amazon Q CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/amazonq.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/codesandbox/amazonq.sh
+++ b/codesandbox/amazonq.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Amazon Q CLI on CodeSandbox"
+echo ""
+
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+wait_for_cloud_init
+
+log_step "Installing Amazon Q CLI..."
+run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5184)
+fi
+
+log_step "Setting up environment variables..."
+run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+run_server 'echo "export OPENAI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+run_server 'echo "export OPENAI_BASE_URL=\"https://openrouter.ai/api/v1\"" >> ~/.bashrc'
+
+echo ""
+log_info "CodeSandbox setup completed successfully!"
+echo ""
+
+log_step "Starting Amazon Q CLI..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && q chat"

--- a/manifest.json
+++ b/manifest.json
@@ -869,7 +869,7 @@
     "codesandbox/codex": "missing",
     "codesandbox/interpreter": "missing",
     "codesandbox/gemini": "implemented",
-    "codesandbox/amazonq": "missing",
+    "codesandbox/amazonq": "implemented",
     "codesandbox/cline": "missing",
     "codesandbox/gptme": "missing",
     "codesandbox/opencode": "implemented",


### PR DESCRIPTION
## Summary
- Implemented Amazon Q CLI agent on CodeSandbox cloud provider
- Uses CodeSandbox SDK for execution (no SSH)
- Includes OpenRouter API key injection via environment variables

## Test plan
- [x] Syntax check with `bash -n`
- [x] Verified manifest.json update
- [x] Updated codesandbox/README.md

-- discovery/gap-filler-codesandbox