### PR TITLE
feat: Add gemini on CodeSandbox

### DIFF
--- a/codesandbox/README.md
+++ b/codesandbox/README.md
@@ -48,6 +48,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/plandex.sh)
 ```
 
+#### Gemini CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/gemini.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/codesandbox/gemini.sh
+++ b/codesandbox/gemini.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Gemini CLI on CodeSandbox"
+echo ""
+
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+wait_for_cloud_init
+
+log_step "Installing Gemini CLI..."
+run_server "source ~/.bashrc && bun install -g @google/gemini-cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5185)
+fi
+
+log_step "Setting up environment variables..."
+run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+run_server 'echo "export GEMINI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+run_server 'echo "export OPENAI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+run_server 'echo "export OPENAI_BASE_URL=\"https://openrouter.ai/api/v1\"" >> ~/.bashrc'
+
+echo ""
+log_info "CodeSandbox setup completed successfully!"
+echo ""
+
+log_step "Starting Gemini CLI..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && gemini"

--- a/manifest.json
+++ b/manifest.json
@@ -868,7 +868,7 @@
     "codesandbox/goose": "implemented",
     "codesandbox/codex": "missing",
     "codesandbox/interpreter": "missing",
-    "codesandbox/gemini": "missing",
+    "codesandbox/gemini": "implemented",
     "codesandbox/amazonq": "missing",
     "codesandbox/cline": "missing",
     "codesandbox/gptme": "missing",


### PR DESCRIPTION
## Summary
- Implemented Gemini CLI agent on CodeSandbox cloud provider
- Uses CodeSandbox SDK for execution (no SSH)
- Includes OpenRouter API key injection via environment variables

## Test plan
- [x] Syntax check with `bash -n`
- [x] Verified manifest.json update
- [x] Updated codesandbox/README.md

-- discovery/gap-filler-codesandbox