### PR TITLE
feat: Add goose on CodeSandbox

### DIFF
--- a/codesandbox/README.md
+++ b/codesandbox/README.md
@@ -24,6 +24,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/openclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/aider.sh)
 ```
 
+#### Goose
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/goose.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/codesandbox/goose.sh
+++ b/codesandbox/goose.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Goose on CodeSandbox"
+echo ""
+
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+wait_for_cloud_init
+
+log_step "Installing Goose..."
+run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5186)
+fi
+
+log_step "Setting up environment variables..."
+run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+run_server 'echo "export GOOSE_PROVIDER=\"openrouter\"" >> ~/.bashrc'
+
+echo ""
+log_info "CodeSandbox setup completed successfully!"
+echo ""
+
+log_step "Starting Goose..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && goose"

--- a/manifest.json
+++ b/manifest.json
@@ -850,7 +850,7 @@
     "codesandbox/openclaw": "implemented",
     "codesandbox/nanoclaw": "missing",
     "codesandbox/aider": "implemented",
-    "codesandbox/goose": "missing",
+    "codesandbox/goose": "implemented",
     "codesandbox/codex": "missing",
     "codesandbox/interpreter": "missing",
     "codesandbox/gemini": "missing",


### PR DESCRIPTION
## Summary
- Implemented Goose agent on CodeSandbox cloud provider
- Uses CodeSandbox SDK for execution (no SSH)
- Includes OpenRouter API key injection via environment variables

## Test plan
- [x] Syntax check with `bash -n`
- [x] Verified manifest.json update
- [x] Updated codesandbox/README.md

-- discovery/gap-filler-codesandbox