### PR TITLE
refactor: replace hand-rolled credential/polling with shared helpers

### DIFF
--- a/atlanticnet/lib/common.sh
+++ b/atlanticnet/lib/common.sh
@@ -104,58 +104,10 @@ test_atlanticnet_credentials() {
 
 # Ensure Atlantic.Net API credentials are available
 ensure_atlanticnet_credentials() {
-    local config_file="$HOME/.config/spawn/atlanticnet.json"
-
-    # Try environment variables first
-    if [[ -n "${ATLANTICNET_API_KEY:-}" && -n "${ATLANTICNET_API_PRIVATE_KEY:-}" ]]; then
-        if test_atlanticnet_credentials; then
-            return 0
-        fi
-        log_warn "Environment variables set but authentication failed"
-    fi
-
-    # Try config file
-    if [[ -f "$config_file" ]]; then
-        log_step "Loading Atlantic.Net credentials from $config_file"
-        ATLANTICNET_API_KEY=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('api_key',''))" "$config_file")
-        ATLANTICNET_API_PRIVATE_KEY=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('api_private_key',''))" "$config_file")
-        export ATLANTICNET_API_KEY ATLANTICNET_API_PRIVATE_KEY
-
-        if [[ -n "${ATLANTICNET_API_KEY}" && -n "${ATLANTICNET_API_PRIVATE_KEY}" ]]; then
-            if test_atlanticnet_credentials; then
-                return 0
-            fi
-            log_warn "Saved credentials are invalid"
-        fi
-    fi
-
-    # Prompt for credentials
-    log_info ""
-    log_info "Atlantic.Net Cloud API credentials required"
-    log_info ""
-    log_info "Get your credentials at: https://cloud.atlantic.net/ → API Info"
-    log_info ""
-
-    ATLANTICNET_API_KEY=$(safe_read "API Access Key ID: ")
-    ATLANTICNET_API_PRIVATE_KEY=$(safe_read "API Private Key: ")
-    export ATLANTICNET_API_KEY ATLANTICNET_API_PRIVATE_KEY
-
-    log_step "Testing credentials..."
-    if ! test_atlanticnet_credentials; then
-        log_error "Invalid credentials"
-        return 1
-    fi
-
-    log_info "Credentials valid!"
-
-    # Save to config file
-    mkdir -p "$(dirname "$config_file")"
-    python3 -c "import json,sys; json.dump({'api_key': sys.argv[1], 'api_private_key': sys.argv[2]}, open(sys.argv[3], 'w'), indent=2)" \
-        "$ATLANTICNET_API_KEY" "$ATLANTICNET_API_PRIVATE_KEY" "$config_file"
-    chmod 600 "$config_file"
-    log_info "Credentials saved to $config_file"
-
-    return 0
+    ensure_multi_credentials "Atlantic.Net" "$HOME/.config/spawn/atlanticnet.json" \
+        "https://cloud.atlantic.net/ -> API Info" test_atlanticnet_credentials \
+        "ATLANTICNET_API_KEY:api_key:API Access Key ID" \
+        "ATLANTICNET_API_PRIVATE_KEY:api_private_key:API Private Key"
 }
 
 # Check if SSH key is registered with Atlantic.Net


### PR DESCRIPTION
## Summary
- **atlanticnet**: Replace 54-line hand-rolled `ensure_atlanticnet_credentials` with `ensure_multi_credentials` from `shared/common.sh` -- the last remaining cloud not using the shared credential helper
- **ramnode**: Replace 35-line hand-rolled `_ramnode_wait_for_ip` polling loop with `generic_wait_for_instance` from `shared/common.sh`

Net: **-86 lines**, both functions now delegate to battle-tested shared helpers that handle env var lookup, config file persistence, interactive prompting, validation, and retry/polling consistently.

## Test plan
- [x] `bash -n` passes on both modified files
- [x] `bash test/run.sh` -- all 79 shell tests pass
- [x] `bun test` -- 8042 pass, 17 fail (all pre-existing, unrelated to this change)

-- refactor/complexity-hunter