### PR TITLE
feat: Add opencode on CodeSandbox

### DIFF
--- a/codesandbox/README.md
+++ b/codesandbox/README.md
@@ -30,6 +30,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/aider.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/goose.sh)
 ```
 
+#### OpenCode
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/opencode.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/codesandbox/opencode.sh
+++ b/codesandbox/opencode.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "OpenCode on CodeSandbox"
+echo ""
+
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+wait_for_cloud_init
+
+log_step "Installing OpenCode..."
+run_server "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5188)
+fi
+
+log_step "Setting up environment variables..."
+run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+
+echo ""
+log_info "CodeSandbox setup completed successfully!"
+echo ""
+
+log_step "Starting OpenCode..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && opencode"

--- a/manifest.json
+++ b/manifest.json
@@ -872,7 +872,7 @@
     "codesandbox/amazonq": "missing",
     "codesandbox/cline": "missing",
     "codesandbox/gptme": "missing",
-    "codesandbox/opencode": "missing",
+    "codesandbox/opencode": "implemented",
     "codesandbox/plandex": "missing",
     "codesandbox/kilocode": "missing",
     "codesandbox/continue": "missing",


### PR DESCRIPTION
## Summary
- Implemented OpenCode agent on CodeSandbox cloud provider
- Uses CodeSandbox SDK for execution (no SSH)
- Includes OpenRouter API key injection via environment variables

## Test plan
- [x] Syntax check with `bash -n`
- [x] Verified manifest.json update
- [x] Updated codesandbox/README.md

-- discovery/gap-filler-codesandbox