### PR TITLE
feat: Add plandex on CodeSandbox

### DIFF
--- a/codesandbox/README.md
+++ b/codesandbox/README.md
@@ -36,6 +36,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/goose.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/opencode.sh)
 ```
 
+#### Plandex
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/codesandbox/plandex.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/codesandbox/plandex.sh
+++ b/codesandbox/plandex.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/codesandbox/lib/common.sh)"
+fi
+
+log_info "Plandex on CodeSandbox"
+echo ""
+
+ensure_codesandbox_cli
+ensure_codesandbox_token
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+wait_for_cloud_init
+
+log_step "Installing Plandex..."
+run_server "curl -sL https://plandex.ai/install.sh | bash"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5189)
+fi
+
+log_step "Setting up environment variables..."
+run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+run_server 'echo "export OPENAI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+run_server 'echo "export OPENAI_BASE_URL=\"https://openrouter.ai/api/v1\"" >> ~/.bashrc'
+
+echo ""
+log_info "CodeSandbox setup completed successfully!"
+echo ""
+
+log_step "Starting Plandex..."
+sleep 1
+clear
+interactive_session "source ~/.bashrc && plandex"

--- a/manifest.json
+++ b/manifest.json
@@ -873,7 +873,7 @@
     "codesandbox/cline": "missing",
     "codesandbox/gptme": "missing",
     "codesandbox/opencode": "implemented",
-    "codesandbox/plandex": "missing",
+    "codesandbox/plandex": "implemented",
     "codesandbox/kilocode": "missing",
     "codesandbox/continue": "missing",
     "e2b/claude": "implemented",


### PR DESCRIPTION
## Summary
- Implemented Plandex agent on CodeSandbox cloud provider
- Uses CodeSandbox SDK for execution (no SSH)
- Includes OpenRouter API key injection via environment variables

## Test plan
- [x] Syntax check with `bash -n`
- [x] Verified manifest.json update
- [x] Updated codesandbox/README.md

-- discovery/gap-filler-codesandbox