### PR TITLE
feat: add HOSTKEY cloud provider

### DIFF
--- a/hostkey/README.md
+++ b/hostkey/README.md
@@ -1,0 +1,56 @@
+# HOSTKEY
+
+HOSTKEY VPS hosting via REST API. [HOSTKEY](https://hostkey.com/)
+
+## Agents
+
+#### Claude Code
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hostkey/claude.sh)
+```
+
+#### OpenClaw
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hostkey/openclaw.sh)
+```
+
+## Authentication
+
+To use HOSTKEY spawn scripts, you need a HOSTKEY API key:
+
+1. Log in to [HOSTKEY](https://hostkey.com/)
+2. Navigate to API settings in your account
+3. Generate a new API key
+4. Set the `HOSTKEY_API_KEY` environment variable
+
+## Non-Interactive Mode
+
+```bash
+HOSTKEY_SERVER_NAME=dev-mk1 \
+HOSTKEY_API_KEY=your-api-key \
+OPENROUTER_API_KEY=sk-or-v1-xxxxx \
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/hostkey/claude.sh)
+```
+
+## Environment Variables
+
+- `HOSTKEY_API_KEY` - Your HOSTKEY API key (required)
+- `HOSTKEY_SERVER_NAME` - Server name (prompted if not set)
+- `HOSTKEY_LOCATION` - Data center location: `nl`, `de`, `fi`, `is`, `tr`, `us` (default: `nl`)
+- `HOSTKEY_INSTANCE_PRESET` - Instance preset ID (default: `1`)
+- `OPENROUTER_API_KEY` - Your OpenRouter API key (prompted via OAuth if not set)
+
+## Pricing
+
+HOSTKEY offers affordable VPS hosting starting from €1/month with hourly billing available. Check [HOSTKEY pricing](https://hostkey.com/vps/) for current rates.
+
+## Locations
+
+- `nl` - Amsterdam, Netherlands
+- `de` - Frankfurt, Germany
+- `fi` - Helsinki, Finland
+- `is` - Reykjavik, Iceland
+- `tr` - Istanbul, Turkey
+- `us` - New York, United States

--- a/hostkey/claude.sh
+++ b/hostkey/claude.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostkey/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostkey/lib/common.sh)"
+fi
+
+log_info "Claude Code on HOSTKEY"
+echo ""
+
+# 1. Resolve HOSTKEY API token
+ensure_hostkey_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${HOSTKEY_INSTANCE_IP}"
+wait_for_cloud_init "${HOSTKEY_INSTANCE_IP}" 60
+
+# 5. Verify Claude Code is installed (fallback to manual install)
+log_step "Verifying Claude Code installation..."
+if ! run_server "${HOSTKEY_INSTANCE_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
+    log_step "Claude Code not found, installing manually..."
+    run_server "${HOSTKEY_INSTANCE_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
+fi
+
+# Verify installation succeeded
+if ! run_server "${HOSTKEY_INSTANCE_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
+    log_error "Claude Code installation verification failed"
+    log_error "The 'claude' command is not available or not working properly on server ${HOSTKEY_INSTANCE_IP}"
+    exit 1
+fi
+log_info "Claude Code installation verified successfully"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${HOSTKEY_INSTANCE_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \
+    "ANTHROPIC_AUTH_TOKEN=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=" \
+    "CLAUDE_CODE_SKIP_ONBOARDING=1" \
+    "CLAUDE_CODE_ENABLE_TELEMETRY=0"
+
+# 7. Configure Claude Code settings
+setup_claude_code_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${HOSTKEY_INSTANCE_IP}" \
+    "run_server ${HOSTKEY_INSTANCE_IP}"
+
+echo ""
+log_info "HOSTKEY server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTKEY_INSTANCE_ID}, IP: ${HOSTKEY_INSTANCE_IP})"
+echo ""
+
+# 8. Start Claude Code interactively
+log_step "Starting Claude Code..."
+sleep 1
+clear
+interactive_session "${HOSTKEY_INSTANCE_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"

--- a/hostkey/lib/common.sh
+++ b/hostkey/lib/common.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+set -eo pipefail
+# Common bash functions for HOSTKEY spawn scripts
+
+# ============================================================
+# Provider-agnostic functions
+# ============================================================
+
+# Source shared provider-agnostic functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
+    source "$SCRIPT_DIR/../../shared/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+fi
+
+# Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh
+
+# ============================================================
+# HOSTKEY specific functions
+# ============================================================
+
+readonly HOSTKEY_API_BASE="https://invapi.hostkey.com"
+
+# Centralized curl wrapper for HOSTKEY API
+hostkey_api() {
+    local endpoint="$1"
+    local body="${2:-}"
+
+    if [[ -z "${HOSTKEY_API_KEY:-}" ]]; then
+        log_error "HOSTKEY_API_KEY is not set"
+        return 1
+    fi
+
+    local response
+    if [[ -n "$body" ]]; then
+        response=$(curl -s "${HOSTKEY_API_BASE}${endpoint}" \
+            -H "Authorization: Bearer ${HOSTKEY_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$body")
+    else
+        response=$(curl -s "${HOSTKEY_API_BASE}${endpoint}" \
+            -H "Authorization: Bearer ${HOSTKEY_API_KEY}")
+    fi
+
+    printf '%s' "$response"
+}
+
+# Test HOSTKEY API key validity
+test_hostkey_token() {
+    local response
+    # Try to get server list as a simple auth test
+    response=$(curl -s "${HOSTKEY_API_BASE}/v1/services" \
+        -H "Authorization: Bearer ${HOSTKEY_API_KEY:-}" 2>&1)
+
+    if echo "$response" | grep -qi "unauthorized\|invalid\|error"; then
+        log_error "API Error: Invalid or expired HOSTKEY API key"
+        log_error ""
+        log_error "How to fix:"
+        log_error "  1. Log in to HOSTKEY at: https://hostkey.com/"
+        log_error "  2. Navigate to API settings in your account"
+        log_error "  3. Generate a new API key if needed"
+        log_error "  4. Set HOSTKEY_API_KEY environment variable"
+        return 1
+    fi
+    return 0
+}
+
+# Ensure HOSTKEY_API_KEY is available (env var → config file → prompt+save)
+ensure_hostkey_token() {
+    ensure_api_token_with_provider \
+        "HOSTKEY" \
+        "HOSTKEY_API_KEY" \
+        "$HOME/.config/spawn/hostkey.json" \
+        "https://hostkey.com/documentation/apidocs/api/" \
+        "test_hostkey_token"
+}
+
+# Check if SSH key is registered with HOSTKEY
+hostkey_check_ssh_key() {
+    local fingerprint="$1"
+    local response
+    response=$(hostkey_api "/ssh_keys")
+
+    if echo "$response" | grep -q "$fingerprint"; then
+        return 0
+    fi
+    return 1
+}
+
+# Register SSH key with HOSTKEY
+hostkey_register_ssh_key() {
+    local key_name="$1"
+    local pub_path="$2"
+    local pub_key
+    pub_key=$(cat "$pub_path")
+    local json_pub_key
+    json_pub_key=$(json_escape "$pub_key")
+
+    local register_body="{\"name\":\"$key_name\",\"public_key\":$json_pub_key}"
+    local register_response
+    register_response=$(hostkey_api "/ssh_keys" "$register_body")
+
+    if echo "$register_response" | grep -qi "error"; then
+        log_error "API Error: $(echo "$register_response" | grep -o '"message":"[^"]*"' || echo "$register_response")"
+        log_error ""
+        log_error "Common causes:"
+        log_error "  - SSH key already registered with this name"
+        log_error "  - Invalid SSH key format"
+        log_error "  - API key lacks write permissions"
+        return 1
+    fi
+
+    return 0
+}
+
+# Ensure SSH key exists locally and is registered with HOSTKEY
+ensure_ssh_key() {
+    ensure_ssh_key_with_provider hostkey_check_ssh_key hostkey_register_ssh_key "HOSTKEY"
+}
+
+# Get server name from env var or prompt
+get_server_name() {
+    get_validated_server_name "HOSTKEY_SERVER_NAME" "Enter server name: "
+}
+
+# List available HOSTKEY locations
+_list_locations() {
+    printf '%s\n' "nl|Amsterdam|Netherlands"
+    printf '%s\n' "de|Frankfurt|Germany"
+    printf '%s\n' "fi|Helsinki|Finland"
+    printf '%s\n' "is|Reykjavik|Iceland"
+    printf '%s\n' "tr|Istanbul|Turkey"
+    printf '%s\n' "us|New York|United States"
+}
+
+# Interactive location picker (skipped if HOSTKEY_LOCATION is set)
+_pick_location() {
+    interactive_pick "HOSTKEY_LOCATION" "nl" "locations" _list_locations
+}
+
+# Get available instance presets for a location
+_list_instance_presets() {
+    local location="$1"
+
+    _ensure_jq || return 1
+
+    # Call HOSTKEY presets API
+    local response
+    response=$(curl -s "${HOSTKEY_API_BASE}/presets.php" -X POST \
+        --data "action=list" \
+        --data "location=${location}")
+
+    # Parse and format response
+    printf '%s' "$response" | jq -r \
+        '.[] | "\(.id)|\(.cores) vCPU|\(.ram) GB RAM|\(.storage) GB disk|€\(.price)/mo"' 2>/dev/null || {
+        log_error "Failed to fetch instance presets"
+        return 1
+    }
+}
+
+# Interactive instance preset picker
+_pick_instance_preset() {
+    local location="$1"
+    _list_presets_for_location() { _list_instance_presets "$location"; }
+    interactive_pick "HOSTKEY_INSTANCE_PRESET" "1" "instance presets" _list_presets_for_location "1"
+    unset -f _list_presets_for_location
+}
+
+# Ensure jq is installed (required for JSON parsing)
+_ensure_jq() {
+    if command -v jq &>/dev/null; then
+        return 0
+    fi
+
+    log_step "Installing jq..."
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v brew &>/dev/null; then
+            brew install jq || { log_error "Failed to install jq via Homebrew"; return 1; }
+        else
+            log_error "Install jq: brew install jq (or https://jqlang.github.io/jq/download/)"
+            return 1
+        fi
+    elif command -v apt-get &>/dev/null; then
+        sudo apt-get update -qq && sudo apt-get install -y jq || { log_error "Failed to install jq via apt"; return 1; }
+    elif command -v dnf &>/dev/null; then
+        sudo dnf install -y jq || { log_error "Failed to install jq via dnf"; return 1; }
+    elif command -v apk &>/dev/null; then
+        sudo apk add jq || { log_error "Failed to install jq via apk"; return 1; }
+    else
+        log_error "jq is required but not installed. Install from https://jqlang.github.io/jq/download/"
+        return 1
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        log_error "jq not found in PATH after installation"
+        return 1
+    fi
+
+    log_info "jq installed"
+}
+
+# Create a HOSTKEY compute instance
+create_server() {
+    local name="$1"
+
+    # Interactive location + instance preset selection (skipped if env vars are set)
+    local location
+    location=$(_pick_location)
+
+    local preset
+    preset=$(_pick_instance_preset "$location")
+
+    # Validate inputs
+    validate_resource_name "$preset" || { log_error "Invalid HOSTKEY_INSTANCE_PRESET"; return 1; }
+    validate_region_name "$location" || { log_error "Invalid HOSTKEY_LOCATION"; return 1; }
+
+    log_step "Creating HOSTKEY instance '$name' (preset: $preset, location: $location)..."
+
+    # Build order request
+    local order_body
+    order_body=$(jq -n \
+        --arg name "$name" \
+        --arg location "$location" \
+        --arg preset "$preset" \
+        '{name: $name, location: $location, preset: $preset, os: "ubuntu-24.04"}')
+
+    local response
+    response=$(hostkey_api "/eq/order_instance" "$order_body")
+
+    if echo "$response" | grep -qi "error"; then
+        log_error "Failed to create HOSTKEY instance"
+        local error_msg
+        error_msg=$(echo "$response" | jq -r '.error // .message // "Unknown error"' 2>/dev/null || echo "$response")
+        log_error "API Error: $error_msg"
+        log_error ""
+        log_error "Common issues:"
+        log_error "  - Insufficient account balance"
+        log_error "  - Instance limit reached"
+        log_error "  - Invalid location or preset"
+        log_error ""
+        log_error "Check your account status: https://hostkey.com/"
+        return 1
+    fi
+
+    # Extract instance ID and IP
+    HOSTKEY_INSTANCE_ID=$(printf '%s' "$response" | jq -r '.id // .instance_id')
+    HOSTKEY_INSTANCE_IP=$(printf '%s' "$response" | jq -r '.ip // .ipv4')
+    export HOSTKEY_INSTANCE_ID HOSTKEY_INSTANCE_IP
+
+    log_info "Instance created: ID=$HOSTKEY_INSTANCE_ID, IP=$HOSTKEY_INSTANCE_IP"
+
+    # Wait for instance to be ready
+    log_step "Waiting for instance to be ready..."
+    sleep 10
+}
+
+# SSH operations — delegates to shared helpers (SSH_USER defaults to root)
+verify_server_connectivity() { ssh_verify_connectivity "$@"; }
+run_server() { ssh_run_server "$@"; }
+upload_file() { ssh_upload_file "$@"; }
+interactive_session() { ssh_interactive_session "$@"; }
+
+# Destroy a HOSTKEY instance
+destroy_server() {
+    local instance_id="$1"
+
+    log_step "Destroying instance $instance_id..."
+    local response
+    response=$(hostkey_api "/eq/terminate" "{\"id\":\"$instance_id\"}")
+
+    if echo "$response" | grep -qi "error"; then
+        log_error "Failed to destroy instance: $response"
+        return 1
+    fi
+
+    log_info "Instance $instance_id destroyed"
+}
+
+# List all HOSTKEY instances
+list_servers() {
+    local response
+    response=$(hostkey_api "/v1/services")
+
+    local count
+    count=$(printf '%s' "$response" | jq 'length' 2>/dev/null || echo "0")
+
+    if [[ "$count" -eq 0 ]]; then
+        printf 'No instances found\n'
+        return 0
+    fi
+
+    printf '%-25s %-12s %-12s %-16s\n' "NAME" "ID" "STATUS" "IP"
+    printf '%s\n' "-----------------------------------------------------------------"
+    printf '%s' "$response" | jq -r \
+        '.[] | "\(.name // "N/A")|\(.id // "N/A")|\(.status // "N/A")|\(.ip // "N/A")"' \
+        | while IFS='|' read -r name sid status ip; do
+            printf '%-25s %-12s %-12s %-16s\n' "$name" "$sid" "$status" "$ip"
+        done
+}

--- a/hostkey/openclaw.sh
+++ b/hostkey/openclaw.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostkey/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostkey/lib/common.sh)"
+fi
+
+log_info "OpenClaw on HOSTKEY"
+echo ""
+
+# 1. Resolve HOSTKEY API token
+ensure_hostkey_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${HOSTKEY_INSTANCE_IP}"
+wait_for_cloud_init "${HOSTKEY_INSTANCE_IP}" 60
+
+# 5. Install openclaw via bun
+log_step "Installing openclaw..."
+run_server "${HOSTKEY_INSTANCE_IP}" "source ~/.bashrc && bun install -g openclaw"
+log_info "OpenClaw installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Get model preference
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${HOSTKEY_INSTANCE_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
+
+# 7. Configure openclaw
+setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" \
+    "upload_file ${HOSTKEY_INSTANCE_IP}" \
+    "run_server ${HOSTKEY_INSTANCE_IP}"
+
+echo ""
+log_info "HOSTKEY server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTKEY_INSTANCE_ID}, IP: ${HOSTKEY_INSTANCE_IP})"
+echo ""
+
+# 8. Start openclaw gateway in background and launch TUI
+log_step "Starting openclaw..."
+run_server "${HOSTKEY_INSTANCE_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+sleep 2
+interactive_session "${HOSTKEY_INSTANCE_IP}" "source ~/.zshrc && openclaw tui"

--- a/manifest.json
+++ b/manifest.json
@@ -372,7 +372,7 @@
       "defaults": {
         "template": "base"
       },
-      "notes": "No SSH \u2014 uses CodeSandbox SDK/CLI for exec. Firecracker microVMs with ~2s start. Free tier: 40 hrs/mo on Build plan. Requires npm install -g @codesandbox/sdk."
+      "notes": "No SSH — uses CodeSandbox SDK/CLI for exec. Firecracker microVMs with ~2s start. Free tier: 40 hrs/mo on Build plan. Requires npm install -g @codesandbox/sdk."
     },
     "e2b": {
       "name": "E2B",
@@ -386,7 +386,7 @@
       "defaults": {
         "template": "base"
       },
-      "notes": "No SSH \u2014 uses E2B CLI for exec. Sandboxes start in ~150ms. Requires npm install -g @e2b/cli."
+      "notes": "No SSH — uses E2B CLI for exec. Sandboxes start in ~150ms. Requires npm install -g @e2b/cli."
     },
     "modal": {
       "name": "Modal",
@@ -400,7 +400,7 @@
       "defaults": {
         "image": "debian_slim"
       },
-      "notes": "No SSH \u2014 uses Modal Python SDK for exec. Sub-second cold starts. Requires pip install modal."
+      "notes": "No SSH — uses Modal Python SDK for exec. Sub-second cold starts. Requires pip install modal."
     },
     "fly": {
       "name": "Fly.io",
@@ -656,7 +656,7 @@
         "disk_size": 20,
         "location": "us/las"
       },
-      "notes": "Budget European cloud provider with minute-based billing starting at $2/month. Requires IONOS_USERNAME (email) and IONOS_PASSWORD (API key) from https://dcd.ionos.com/ \u2192 Management \u2192 Users & Keys. Datacenters are created automatically if needed."
+      "notes": "Budget European cloud provider with minute-based billing starting at $2/month. Requires IONOS_USERNAME (email) and IONOS_PASSWORD (API key) from https://dcd.ionos.com/ → Management → Users & Keys. Datacenters are created automatically if needed."
     },
     "exoscale": {
       "name": "Exoscale",
@@ -704,7 +704,7 @@
         "location": "eu-central",
         "os_template": "ubuntu-24.04"
       },
-      "notes": "Budget VPS provider with cloud-init pre-installed. Starting at $4.95/mo. Requires HOSTINGER_API_KEY from hPanel \u2192 Profile \u2192 Account Information \u2192 API. API docs at developers.hostinger.com"
+      "notes": "Budget VPS provider with cloud-init pre-installed. Starting at $4.95/mo. Requires HOSTINGER_API_KEY from hPanel → Profile → Account Information → API. API docs at developers.hostinger.com"
     },
     "netcup": {
       "name": "Netcup",
@@ -720,7 +720,7 @@
         "datacenter": "Nuremberg",
         "image": "ubuntu-24.04"
       },
-      "notes": "German budget VPS provider starting at \u20ac3.86/mo. Session-based REST API launched Oct 2025. Requires NETCUP_CUSTOMER_NUMBER, NETCUP_API_KEY, and NETCUP_API_PASSWORD from https://ccp.netcup.net/ \u2192 Settings \u2192 API"
+      "notes": "German budget VPS provider starting at €3.86/mo. Session-based REST API launched Oct 2025. Requires NETCUP_CUSTOMER_NUMBER, NETCUP_API_KEY, and NETCUP_API_PASSWORD from https://ccp.netcup.net/ → Settings → API"
     },
     "local": {
       "name": "Local Machine",
@@ -746,7 +746,7 @@
         "flavor": "1GB",
         "image": "Ubuntu 24.04"
       },
-      "notes": "Budget VPS provider with OpenStack API. Hourly billing starting at $0.006/hr (~$4.38/mo). Full OpenStack compatibility. Get credentials from https://manage.ramnode.com/ \u2192 Cloud \u2192 API Users. Requires RAMNODE_USERNAME, RAMNODE_PASSWORD, and RAMNODE_PROJECT_ID."
+      "notes": "Budget VPS provider with OpenStack API. Hourly billing starting at $0.006/hr (~$4.38/mo). Full OpenStack compatibility. Get credentials from https://manage.ramnode.com/ → Cloud → API Users. Requires RAMNODE_USERNAME, RAMNODE_PASSWORD, and RAMNODE_PROJECT_ID."
     },
     "atlanticnet": {
       "name": "Atlantic.Net",
@@ -762,7 +762,22 @@
         "location": "USEAST2",
         "image": "ubuntu-24.04_64bit"
       },
-      "notes": "Budget VPS provider starting at $4/mo. Uses HMAC-SHA256 signature auth with API key + private key. Requires ATLANTICNET_API_KEY and ATLANTICNET_API_PRIVATE_KEY from https://cloud.atlantic.net/ \u2192 API Info."
+      "notes": "Budget VPS provider starting at $4/mo. Uses HMAC-SHA256 signature auth with API key + private key. Requires ATLANTICNET_API_KEY and ATLANTICNET_API_PRIVATE_KEY from https://cloud.atlantic.net/ → API Info."
+    },
+    "hostkey": {
+      "name": "HOSTKEY",
+      "description": "HOSTKEY VPS hosting via REST API",
+      "url": "https://hostkey.com/",
+      "type": "api",
+      "auth": "HOSTKEY_API_KEY",
+      "provision_method": "POST /eq/order_instance",
+      "exec_method": "ssh root@IP",
+      "interactive_method": "ssh -t root@IP",
+      "defaults": {
+        "preset": "1",
+        "location": "nl",
+        "os": "ubuntu-24.04"
+      }
     }
   },
   "matrix": {
@@ -1275,6 +1290,21 @@
     "atlanticnet/opencode": "missing",
     "atlanticnet/plandex": "missing",
     "atlanticnet/kilocode": "missing",
-    "atlanticnet/continue": "missing"
+    "atlanticnet/continue": "missing",
+    "hostkey/claude": "implemented",
+    "hostkey/openclaw": "implemented",
+    "hostkey/nanoclaw": "missing",
+    "hostkey/aider": "missing",
+    "hostkey/goose": "missing",
+    "hostkey/codex-cli": "missing",
+    "hostkey/open-interpreter": "missing",
+    "hostkey/gemini-cli": "missing",
+    "hostkey/amazonq": "missing",
+    "hostkey/cline": "missing",
+    "hostkey/gptme": "missing",
+    "hostkey/opencode": "missing",
+    "hostkey/plandex": "missing",
+    "hostkey/kilo": "missing",
+    "hostkey/continue": "missing"
   }
 }

--- a/test/mock.sh
+++ b/test/mock.sh
@@ -257,6 +257,7 @@ _strip_api_base() {
         https://infrahub-api.nexgencloud.com/v1*) ENDPOINT="${URL#https://infrahub-api.nexgencloud.com/v1}" ;;
         *eu.api.ovh.com*)                   ENDPOINT=$(echo "$URL" | sed 's|https://eu.api.ovh.com/1.0||') ;;
         https://cloudapi.atlantic.net/*)    ENDPOINT=$(echo "$URL" | sed 's|https://cloudapi.atlantic.net/\?||') ;;
+        https://invapi.hostkey.com*)        ENDPOINT="${URL#https://invapi.hostkey.com}" ;;
     esac
     EP_CLEAN=$(echo "$ENDPOINT" | sed 's|?.*||')
 }

--- a/test/record.sh
+++ b/test/record.sh
@@ -31,7 +31,7 @@ ERRORS=0
 PROMPT_FOR_CREDS=true
 
 # All clouds with REST APIs that we can record from
-ALL_RECORDABLE_CLOUDS="hetzner digitalocean vultr linode lambda civo upcloud binarylane ovh scaleway genesiscloud kamatera latitude hyperstack atlanticnet"
+ALL_RECORDABLE_CLOUDS="hetzner digitalocean vultr linode lambda civo upcloud binarylane ovh scaleway genesiscloud kamatera latitude hyperstack atlanticnet hostkey"
 
 # --- Endpoint registry ---
 # Format: "fixture_name:endpoint"
@@ -130,6 +130,11 @@ get_endpoints() {
                 "ssh_keys:list-sshkeys" \
                 "plans:describe-plan"
             ;;
+        hostkey)
+            printf '%s\n' \
+                "services:/v1/services" \
+                "ssh_keys:/ssh_keys"
+            ;;
     esac
 }
 
@@ -152,6 +157,7 @@ get_auth_env_var() {
         latitude)      printf "LATITUDE_API_KEY" ;;
         hyperstack)    printf "HYPERSTACK_API_KEY" ;;
         atlanticnet)   printf "ATLANTICNET_API_KEY" ;;
+        hostkey)       printf "HOSTKEY_API_KEY" ;;
     esac
 }
 
@@ -360,6 +366,7 @@ call_api() {
         latitude)      latitude_api GET "$endpoint" ;;
         hyperstack)    hyperstack_api GET "$endpoint" ;;
         atlanticnet)   atlanticnet_api "$endpoint" ;;
+        hostkey)       hostkey_api "$endpoint" ;;
     esac
 }
 
@@ -399,6 +406,8 @@ elif cloud == 'kamatera':
 elif cloud == 'latitude':
     sys.exit(0 if 'error' in d or ('errors' in d and d['errors']) else 1)
 elif cloud == 'atlanticnet':
+    sys.exit(0 if 'error' in d and d['error'] else 1)
+elif cloud == 'hostkey':
     sys.exit(0 if 'error' in d and d['error'] else 1)
 else:
     sys.exit(1)
@@ -763,6 +772,13 @@ print(d.get('run-instanceresponse',{}).get('instancesSet',{}).get('item',{}).get
 
     _save_live_fixture "$fixture_dir" "delete_server" "terminate-instance" "$delete_response"
     printf '%b\n' "  ${CYAN}live${NC} Instance ${instance_id} deleted"
+}
+
+_live_hostkey() {
+    local fixture_dir="$1"
+    # HOSTKEY live testing not implemented yet - requires instance creation via eq/order_instance
+    # Skipping live fixtures for now
+    return 0
 }
 
 # --- Record one cloud ---


### PR DESCRIPTION
## Summary

Add HOSTKEY (https://hostkey.com/) as a new cloud provider to the spawn matrix. HOSTKEY offers affordable VPS hosting starting from €1/month with hourly billing available, making it an excellent option for running AI agents that use remote API inference.

## Implementation

**Cloud Provider:**
- Name: HOSTKEY
- API Base: `https://invapi.hostkey.com`
- Authentication: Bearer token (`HOSTKEY_API_KEY`)
- Provisioning: REST API (`/eq/order_instance`)
- Locations: Amsterdam, Frankfurt, Helsinki, Reykjavik, Istanbul, New York

**Implemented Agents (2/15):**
- ✅ Claude Code (`hostkey/claude.sh`)
- ✅ OpenClaw (`hostkey/openclaw.sh`)

**Remaining Agents (13/15):**
- ⏳ NanoClaw, Aider, Goose, Codex CLI, Open Interpreter, Gemini CLI, Amazon Q CLI, Cline, gptme, OpenCode, Plandex, Kilo Code, Continue

## Changes

- Created `hostkey/lib/common.sh` with HOSTKEY API wrappers and cloud-specific primitives
- Implemented `hostkey/claude.sh` and `hostkey/openclaw.sh` agent scripts
- Added HOSTKEY to `manifest.json` clouds section with provider metadata
- Added matrix entries for all 15 agents (2 implemented, 13 marked as missing)
- Updated `test/record.sh` with HOSTKEY endpoints, auth vars, API calls, and live test stub
- Updated `test/mock.sh` with HOSTKEY URL stripping pattern
- Created `hostkey/README.md` with usage instructions and environment variables

## Test Plan

- [x] Syntax check: `bash -n` passes on all `.sh` files
- [ ] Live test with real HOSTKEY account (requires `HOSTKEY_API_KEY`)
- [ ] Mock test: `bash test/run.sh hostkey/claude.sh`

## Pricing & Availability

- **Entry price:** €1/month
- **Hourly billing:** Available
- **API access:** REST API with session-based JWT auth
- **SSH support:** Yes (root access)
- **Data centers:** 6 locations across Europe and US

-- discovery/cloud-scout-1