### PR TITLE
fix: use safe single-quoted env injection in cline.sh and plandex.sh

### DIFF
--- a/local/cline.sh
+++ b/local/cline.sh
@@ -31,32 +31,10 @@ else
 fi
 
 log_step "Setting up environment variables..."
-# Export env vars for current session
-export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
-export OPENAI_API_KEY="${OPENROUTER_API_KEY}"
-export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
-
-# Persist to shell config
-SHELL_CONFIG=""
-if [[ -f "${HOME}/.zshrc" ]]; then
-    SHELL_CONFIG="${HOME}/.zshrc"
-elif [[ -f "${HOME}/.bashrc" ]]; then
-    SHELL_CONFIG="${HOME}/.bashrc"
-fi
-
-if [[ -n "${SHELL_CONFIG}" ]]; then
-    # Remove old entries if they exist
-    sed -i.bak '/^export OPENROUTER_API_KEY=/d' "${SHELL_CONFIG}" 2>/dev/null || true
-    sed -i.bak '/^export OPENAI_API_KEY=/d' "${SHELL_CONFIG}" 2>/dev/null || true
-    sed -i.bak '/^export OPENAI_BASE_URL=/d' "${SHELL_CONFIG}" 2>/dev/null || true
-
-    # Add new entries
-    printf '\nexport OPENROUTER_API_KEY="%s"\n' "${OPENROUTER_API_KEY}" >> "${SHELL_CONFIG}"
-    printf 'export OPENAI_API_KEY="%s"\n' "${OPENROUTER_API_KEY}" >> "${SHELL_CONFIG}"
-    printf 'export OPENAI_BASE_URL="https://openrouter.ai/api/v1"\n' >> "${SHELL_CONFIG}"
-
-    log_info "Environment variables persisted to ${SHELL_CONFIG}"
-fi
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "Local machine setup completed successfully!"

--- a/local/plandex.sh
+++ b/local/plandex.sh
@@ -40,25 +40,8 @@ fi
 
 # Inject environment variables
 log_step "Setting up environment variables..."
-
-# Add to shell config
-SHELL_CONFIG=""
-if [[ -f "${HOME}/.zshrc" ]]; then
-    SHELL_CONFIG="${HOME}/.zshrc"
-elif [[ -f "${HOME}/.bashrc" ]]; then
-    SHELL_CONFIG="${HOME}/.bashrc"
-else
-    SHELL_CONFIG="${HOME}/.bashrc"
-    touch "${SHELL_CONFIG}"
-fi
-
-# Check if already configured
-if ! grep -q "export OPENROUTER_API_KEY=" "${SHELL_CONFIG}" 2>/dev/null; then
-    printf '\n# OpenRouter API Key for Plandex\nexport OPENROUTER_API_KEY="%s"\n' "${OPENROUTER_API_KEY}" >> "${SHELL_CONFIG}"
-fi
-
-# Export for current session
-export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""
 log_info "Local setup completed successfully!"
@@ -73,11 +56,13 @@ if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
 
     # Execute without TTY
-    bash -c "source ${SHELL_CONFIG} && plandex new && plandex tell ${escaped_prompt}"
+    source ~/.zshrc 2>/dev/null || true
+    plandex new && plandex tell ${escaped_prompt}
 else
     # Interactive mode: start Plandex normally
     log_step "Starting Plandex..."
     sleep 1
     clear
-    interactive_session "source ${SHELL_CONFIG} && plandex"
+    source ~/.zshrc 2>/dev/null || true
+    exec plandex
 fi


### PR DESCRIPTION
## Security Fix

`local/cline.sh` and `local/plandex.sh` were writing API keys to shell config (`~/.zshrc` / `~/.bashrc`) using double-quoted printf format strings:

```bash
printf '\nexport OPENROUTER_API_KEY="%s"\n' "${OPENROUTER_API_KEY}" >> "${SHELL_CONFIG}"
```

If an API key contained shell metacharacters (`"`, `$`, backtick), sourcing the shell config on the next login could execute arbitrary code. For example, an API key like `sk-or-v1-foo"$(id)"bar` would execute the `id` command.

### Fix

Replace manual printf with `inject_env_vars_local` which delegates to the existing safe `generate_env_config` helper. This helper uses single-quoted values with proper escaping (replacing `'` with `'\''`), preventing all shell interpretation.

Both scripts now follow the same pattern as all other local/ agent scripts (claude.sh, codex.sh, gemini.sh, kilocode.sh, etc.).

### Files Changed

- `local/cline.sh` — replaced 16 lines of manual shell config management with `inject_env_vars_local`
- `local/plandex.sh` — replaced manual printf + SHELL_CONFIG with `inject_env_vars_local`, updated interactive/non-interactive launch to source `~/.zshrc` directly (matching other local scripts)

### Testing

- `bash -n` passes on both modified scripts
- `bun test` passes (18 pre-existing failures unrelated to this change)

-- refactor/security-auditor