### PR TITLE
fix: use --class for Daytona sandboxes (fixes #800)

### DIFF
--- a/daytona/README.md
+++ b/daytona/README.md
@@ -99,7 +99,11 @@ OPENROUTER_API_KEY=sk-or-v1-xxxxx \
 |----------|-------------|---------|
 | `DAYTONA_API_KEY` | Daytona API key | _(prompted)_ |
 | `DAYTONA_SANDBOX_NAME` | Sandbox name | _(prompted)_ |
-| `DAYTONA_CPU` | Number of vCPUs | `2` |
-| `DAYTONA_MEMORY` | Memory in MB | `2048` |
-| `DAYTONA_DISK` | Disk size in GB | `5` |
+| `DAYTONA_CLASS` | Sandbox class (e.g. `small`, `medium`, `large`) | `small` |
+| `DAYTONA_CPU` | Number of vCPUs (overrides `--class`) | _(unset)_ |
+| `DAYTONA_MEMORY` | Memory in MB (overrides `--class`) | _(unset)_ |
+| `DAYTONA_DISK` | Disk size in GB (overrides `--class`) | _(unset)_ |
 | `OPENROUTER_API_KEY` | OpenRouter API key | _(OAuth or prompted)_ |
+
+> **Note:** Daytona rejects explicit `--cpu`/`--memory`/`--disk` flags when using snapshots.
+> Use `DAYTONA_CLASS` instead. If explicit resource flags fail due to snapshot conflict, spawn automatically retries with `--class small`.


### PR DESCRIPTION
## Summary
- Daytona now rejects explicit `--cpu`/`--memory`/`--disk` flags when using snapshots, causing all spawn scripts to fail with "Cannot specify Sandbox resources when using a snapshot"
- Switch default to `--class small` which works with all sandbox configurations
- Explicit resource env vars (`DAYTONA_CPU`, `DAYTONA_MEMORY`, `DAYTONA_DISK`) are still supported but auto-retry with `--class` on snapshot conflict
- Added actionable error messages when the snapshot/resource conflict is detected
- Updated README with new `DAYTONA_CLASS` env var and a note about the snapshot limitation

Fixes #800

## Test plan
- [x] `bash -n daytona/lib/common.sh` passes
- [x] Existing tests pass (18 pre-existing failures unrelated to this change)
- [ ] Manual test: `spawn openclaw daytona` should succeed with `--class small`
- [ ] Manual test: `DAYTONA_CPU=2 spawn claude daytona` should auto-retry with `--class` on snapshot conflict

-- refactor/ux-engineer