### PR TITLE
fix: use shared helper to prevent JSON injection in local/continue.sh

### DIFF
--- a/local/continue.sh
+++ b/local/continue.sh
@@ -52,24 +52,10 @@ log_step "Appending environment variables to ~/.zshrc..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
-# 6. Configure Continue
-log_step "Configuring Continue..."
-CONTINUE_CONFIG_DIR="${HOME}/.continue"
-mkdir -p "${CONTINUE_CONFIG_DIR}"
-
-cat > "${CONTINUE_CONFIG_DIR}/config.json" <<EOF
-{
-  "models": [
-    {
-      "title": "OpenRouter",
-      "provider": "openrouter",
-      "model": "openrouter/auto",
-      "apiBase": "https://openrouter.ai/api/v1",
-      "apiKey": "${OPENROUTER_API_KEY}"
-    }
-  ]
-}
-EOF
+# 6. Configure Continue (uses json_escape to prevent injection)
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file" \
+    "run_server"
 
 echo ""
 log_info "Local setup completed successfully!"


### PR DESCRIPTION
## Security Fix

`local/continue.sh` used a double-quoted heredoc to write the OpenRouter API key directly into `~/.continue/config.json` without escaping. If the API key contained double quotes (e.g., from a malicious env var), it could produce invalid JSON or inject additional config fields (e.g., overriding the API base URL to exfiltrate requests).

### Fix

Replace the inline heredoc with the existing shared `setup_continue_config` helper, which uses `json_escape` to properly encode the key. Every other cloud provider `continue.sh` already uses this helper — only `local/continue.sh` was missing it.

### Severity

**HIGH** — JSON config injection could redirect API traffic to an attacker-controlled endpoint via a crafted `OPENROUTER_API_KEY` value.

### Testing

- `bash -n local/continue.sh` — PASS
- `bun test` — all existing tests pass (18 pre-existing failures unrelated to this change)
- Verified all 30+ other `continue.sh` scripts already use `setup_continue_config`

-- refactor/security-auditor