### PR TITLE
fix: use consistent progress message in local/ scripts

### DIFF
--- a/local/claude.sh
+++ b/local/claude.sh
@@ -42,7 +42,7 @@ else
 fi
 
 # 4. Inject environment variables
-log_step "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api" \

--- a/local/codex.sh
+++ b/local/codex.sh
@@ -48,7 +48,7 @@ else
 fi
 
 # 5. Inject environment variables
-log_step "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_BASE_URL=https://openrouter.ai/api/v1" \

--- a/local/continue.sh
+++ b/local/continue.sh
@@ -48,7 +48,7 @@ else
 fi
 
 # 5. Inject environment variables
-log_step "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 

--- a/local/gemini.sh
+++ b/local/gemini.sh
@@ -42,7 +42,7 @@ else
 fi
 
 # 4. Inject environment variables
-log_step "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \

--- a/local/goose.sh
+++ b/local/goose.sh
@@ -41,7 +41,7 @@ else
 fi
 
 # 4. Inject environment variables
-log_step "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "GOOSE_PROVIDER=openrouter" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/local/kilocode.sh
+++ b/local/kilocode.sh
@@ -41,7 +41,7 @@ else
 fi
 
 # 4. Inject environment variables
-log_step "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \

--- a/local/nanoclaw.sh
+++ b/local/nanoclaw.sh
@@ -52,7 +52,7 @@ else
 fi
 
 # 6. Inject environment variables
-log_step "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \

--- a/local/openclaw.sh
+++ b/local/openclaw.sh
@@ -42,7 +42,7 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
 
 # 6. Inject environment variables
-log_step "Appending environment variables to ~/.zshrc..."
+log_step "Setting up environment variables..."
 inject_env_vars_local upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \


### PR DESCRIPTION
## Summary
- Replace misleading "Appending environment variables to ~/.zshrc..." with "Setting up environment variables..." in all 8 local/ agent scripts
- The old message incorrectly hard-coded `~/.zshrc`, confusing users who run bash (the `inject_env_vars_local` function writes to `.zshrc` internally, but the progress message shouldn't expose this implementation detail)
- All other cloud providers already use the neutral "Setting up environment variables..." pattern -- this brings local/ scripts into consistency

## Files changed
- `local/claude.sh`, `local/codex.sh`, `local/continue.sh`, `local/gemini.sh`, `local/goose.sh`, `local/kilocode.sh`, `local/nanoclaw.sh`, `local/openclaw.sh`

## Test plan
- [x] All 8 modified scripts pass `bash -n` syntax check
- [x] No remaining instances of the old message pattern
- [x] Verified other local/ scripts (aider, cline, gptme, interpreter, plandex) already use the correct pattern

-- refactor/ux-engineer