### PR TITLE
fix: Add workflow_dispatch to trigger server valid reasons

### DIFF
--- a/.claude/skills/setup-agent-team/trigger-server.ts
+++ b/.claude/skills/setup-agent-team/trigger-server.ts
@@ -66,6 +66,7 @@ const VALID_REASONS = new Set([
   "manual",
   "schedule",
   "issues",
+  "workflow_dispatch",
   "team_building",
   "triage",
   "review_all",


### PR DESCRIPTION
## Summary
- The simplified security workflow (PR #929) passes `github.event_name` directly as the `reason` param
- Manual triggers send `reason=workflow_dispatch`, which the trigger server rejects with a 400
- Add `workflow_dispatch` to the `VALID_REASONS` allowlist in `trigger-server.ts`

## Test plan
- [ ] Manual workflow dispatch no longer returns 400
- [ ] `security.sh` maps `workflow_dispatch` → `review_all` mode (already handled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)