### PR TITLE
fix: use safe inject_env_vars helpers for API key injection

### DIFF
--- a/atlanticnet/codex.sh
+++ b/atlanticnet/codex.sh
@@ -31,11 +31,10 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${ATLANTICNET_SERVER_IP}" "cat >> ~/.bashrc << 'EOF'
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_BASE_URL=https://openrouter.ai/api/v1
-EOF"
+inject_env_vars_ssh "${ATLANTICNET_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "Server setup completed successfully!"
@@ -44,4 +43,4 @@ echo ""
 log_step "Starting Codex..."
 sleep 1
 clear
-interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.bashrc && codex"
+interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.zshrc && codex"

--- a/atlanticnet/continue.sh
+++ b/atlanticnet/continue.sh
@@ -31,9 +31,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${ATLANTICNET_SERVER_IP}" "cat >> ~/.bashrc << 'EOF'
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-EOF"
+inject_env_vars_ssh "${ATLANTICNET_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 setup_continue_config "${OPENROUTER_API_KEY}" \
     "upload_file ${ATLANTICNET_SERVER_IP}" \
@@ -46,4 +45,4 @@ echo ""
 log_step "Starting Continue CLI in TUI mode..."
 sleep 1
 clear
-interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.bashrc && cn"
+interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.zshrc && cn"

--- a/atlanticnet/gemini.sh
+++ b/atlanticnet/gemini.sh
@@ -31,12 +31,11 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${ATLANTICNET_SERVER_IP}" "cat >> ~/.bashrc << 'EOF'
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-export GEMINI_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_API_KEY=${OPENROUTER_API_KEY}
-export OPENAI_BASE_URL=https://openrouter.ai/api/v1
-EOF"
+inject_env_vars_ssh "${ATLANTICNET_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "Server setup completed successfully!"
@@ -45,4 +44,4 @@ echo ""
 log_step "Starting Gemini..."
 sleep 1
 clear
-interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.bashrc && gemini"
+interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/atlanticnet/gptme.sh
+++ b/atlanticnet/gptme.sh
@@ -39,9 +39,8 @@ fi
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
 log_step "Setting up environment variables..."
-run_server "${ATLANTICNET_SERVER_IP}" "cat >> ~/.bashrc << 'EOF'
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-EOF"
+inject_env_vars_ssh "${ATLANTICNET_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""
 log_info "Server setup completed successfully!"
@@ -50,4 +49,4 @@ echo ""
 log_step "Starting gptme..."
 sleep 1
 clear
-interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.bashrc && gptme -m openrouter/${MODEL_ID}"
+interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/atlanticnet/kilocode.sh
+++ b/atlanticnet/kilocode.sh
@@ -31,11 +31,10 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${ATLANTICNET_SERVER_IP}" "cat >> ~/.bashrc << 'EOF'
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-export KILO_PROVIDER_TYPE=openrouter
-export KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}
-EOF"
+inject_env_vars_ssh "${ATLANTICNET_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "KILO_PROVIDER_TYPE=openrouter" \
+    "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""
 log_info "Server setup completed successfully!"
@@ -44,4 +43,4 @@ echo ""
 log_step "Starting Kilo Code..."
 sleep 1
 clear
-interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.bashrc && kilocode"
+interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.zshrc && kilocode"

--- a/atlanticnet/opencode.sh
+++ b/atlanticnet/opencode.sh
@@ -32,9 +32,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${ATLANTICNET_SERVER_IP}" "cat >> ~/.bashrc << 'EOF'
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-EOF"
+inject_env_vars_ssh "${ATLANTICNET_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""
 log_info "Server setup completed successfully!"
@@ -43,4 +42,4 @@ echo ""
 log_step "Starting OpenCode..."
 sleep 1
 clear
-interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.bashrc && opencode"
+interactive_session "${ATLANTICNET_SERVER_IP}" "source ~/.zshrc && opencode"

--- a/codesandbox/amazonq.sh
+++ b/codesandbox/amazonq.sh
@@ -29,9 +29,10 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_BASE_URL=\"https://openrouter.ai/api/v1\"" >> ~/.bashrc'
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "CodeSandbox setup completed successfully!"

--- a/codesandbox/gemini.sh
+++ b/codesandbox/gemini.sh
@@ -29,10 +29,11 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export GEMINI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_BASE_URL=\"https://openrouter.ai/api/v1\"" >> ~/.bashrc'
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "CodeSandbox setup completed successfully!"

--- a/codesandbox/goose.sh
+++ b/codesandbox/goose.sh
@@ -29,8 +29,9 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export GOOSE_PROVIDER=\"openrouter\"" >> ~/.bashrc'
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GOOSE_PROVIDER=openrouter"
 
 echo ""
 log_info "CodeSandbox setup completed successfully!"

--- a/codesandbox/opencode.sh
+++ b/codesandbox/opencode.sh
@@ -29,7 +29,8 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""
 log_info "CodeSandbox setup completed successfully!"

--- a/codesandbox/plandex.sh
+++ b/codesandbox/plandex.sh
@@ -29,9 +29,10 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_BASE_URL=\"https://openrouter.ai/api/v1\"" >> ~/.bashrc'
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "CodeSandbox setup completed successfully!"


### PR DESCRIPTION
## Summary

- Replace unsafe heredoc/echo patterns with `inject_env_vars_ssh` (Atlantic.Net) and `inject_env_vars_local` (CodeSandbox) for API key injection in 11 agent scripts
- The previous patterns embedded `OPENROUTER_API_KEY` values directly into shell command strings without escaping, allowing potential command injection if the API key contained shell metacharacters (`"`, `` ` ``, `$`, `\`)
- The safe helpers (`generate_env_config`) properly single-quote all values and escape embedded single quotes, preventing shell interpretation of special characters

## Affected scripts (11)

**Atlantic.Net** (6 scripts using unsafe heredoc pattern):
- `codex.sh`, `continue.sh`, `gemini.sh`, `gptme.sh`, `kilocode.sh`, `opencode.sh`

**CodeSandbox** (5 scripts using unsafe double-quote echo pattern):
- `amazonq.sh`, `gemini.sh`, `goose.sh`, `opencode.sh`, `plandex.sh`

## Test plan

- [x] `bash -n` syntax check passes on all 11 modified scripts
- [x] Fixes 11 pre-existing test failures that were already asserting the safe pattern:
  - 6x `should call inject_env_vars_ssh for env var setup` (Atlantic.Net)
  - 5x `should call inject_env_vars_local for sandbox env setup` (CodeSandbox)

-- refactor/security-auditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)