### PR TITLE
fix: UX improvements -- macOS compat, clearer messages

### DIFF
--- a/atlanticnet/lib/common.sh
+++ b/atlanticnet/lib/common.sh
@@ -31,7 +31,7 @@ atlanticnet_sign() {
     local private_key="${ATLANTICNET_API_PRIVATE_KEY}"
 
     local string_to_sign="${timestamp}${rndguid}"
-    printf '%s' "$string_to_sign" | openssl dgst -sha256 -hmac "$private_key" -binary | base64 -w 0
+    printf '%s' "$string_to_sign" | openssl dgst -sha256 -hmac "$private_key" -binary | (base64 -w 0 2>/dev/null || base64)
 }
 
 # Generate random GUID for request deduplication

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.71",
+  "version": "0.2.72",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -523,7 +523,7 @@ export async function preflightCredentialCheck(manifest: Manifest, cloud: string
 
   if (isInteractiveTTY()) {
     const shouldContinue = await p.confirm({
-      message: "Continue anyway? The script will likely prompt for credentials or fail.",
+      message: "Continue anyway? The script will prompt you to authenticate.",
       initialValue: true,
     });
     if (p.isCancel(shouldContinue) || !shouldContinue) {

--- a/codesandbox/lib/common.sh
+++ b/codesandbox/lib/common.sh
@@ -213,7 +213,7 @@ upload_file() {
 
 interactive_session() {
     log_info "Starting interactive session..."
-    log_warn "Note: Use 'csb' CLI dashboard for full terminal experience"
+    log_step "For a full terminal, open your sandbox at: https://codesandbox.io/dashboard"
     run_server "$1"
 }
 


### PR DESCRIPTION
## Summary

- **Fix macOS compatibility bug** in Atlantic.Net API signature: `base64 -w 0` fails on macOS (no `-w` flag); adds fallback pattern used by all other providers
- **Fix misleading "csb" CLI reference** in CodeSandbox `interactive_session`: replaced with link to the actual web terminal at codesandbox.io/dashboard
- **Soften preflight credential prompt**: changed from "will likely prompt for credentials or fail" (alarming) to "will prompt you to authenticate" (accurate -- scripts have built-in auth flows)
- Bump CLI version to 0.2.72

## Test plan

- [x] `bash -n atlanticnet/lib/common.sh` passes
- [x] `bash -n codesandbox/lib/common.sh` passes
- [x] `bun test src/__tests__/exec-script-errors.test.ts` -- 21/21 pass
- [x] `bun test src/__tests__/run-path-credential-display.test.ts` -- 85/85 pass
- [x] `bun test src/__tests__/commands-exported-utils.test.ts` -- 68/68 pass
- [x] Pre-existing failures (5 codesandbox inject_env_vars_local tests) are unchanged

-- refactor/ux-engineer