### PR TITLE
fix: improve UX of error messages and status output

### DIFF
--- a/cli/src/__tests__/commands-update-download.test.ts
+++ b/cli/src/__tests__/commands-update-download.test.ts
@@ -281,8 +281,8 @@ describe("Script download and execution", () => {
     await expect(cmdRun("claude", "sprite")).rejects.toThrow("process.exit");
 
     expect(processExitSpy).toHaveBeenCalledWith(1);
-    const logErrorOutput = mockLogError.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-    expect(logErrorOutput).toContain("HTTP 500");
+    const errorOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+    expect(errorOutput).toContain("HTTP 500");
   });
 
   it("should show troubleshooting info when download throws network error", async () => {

--- a/cli/src/__tests__/dispatch-extra-args.test.ts
+++ b/cli/src/__tests__/dispatch-extra-args.test.ts
@@ -22,7 +22,7 @@ function warnExtraArgs(
 ): { warned: boolean; extra: string[]; message: string } {
   const extra = filteredArgs.slice(maxExpected);
   if (extra.length > 0) {
-    const message = `Warning: extra argument${extra.length > 1 ? "s" : ""} ignored: ${extra.join(", ")}`;
+    const message = `Extra argument${extra.length > 1 ? "s" : ""} ignored: ${extra.join(", ")}`;
     return { warned: true, extra, message };
   }
   return { warned: false, extra: [], message: "" };
@@ -118,7 +118,7 @@ describe("warnExtraArgs", () => {
       const result = warnExtraArgs(["list", "extra1"], 1);
       expect(result.warned).toBe(true);
       expect(result.extra).toEqual(["extra1"]);
-      expect(result.message).toBe("Warning: extra argument ignored: extra1");
+      expect(result.message).toBe("Extra argument ignored: extra1");
       expect(result.message).not.toContain("arguments"); // singular
     });
 
@@ -126,7 +126,7 @@ describe("warnExtraArgs", () => {
       const result = warnExtraArgs(["list", "extra1", "extra2"], 1);
       expect(result.warned).toBe(true);
       expect(result.extra).toEqual(["extra1", "extra2"]);
-      expect(result.message).toBe("Warning: extra arguments ignored: extra1, extra2");
+      expect(result.message).toBe("Extra arguments ignored: extra1, extra2");
     });
 
     it("should warn on three extra args for default handler", () => {

--- a/cli/src/__tests__/download-and-failure.test.ts
+++ b/cli/src/__tests__/download-and-failure.test.ts
@@ -279,8 +279,8 @@ describe("Download and Failure Pipeline", () => {
         // Expected
       }
 
-      const logErrorOutput = mockLogError.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-      expect(logErrorOutput).toContain("HTTP 500");
+      const errorOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+      expect(errorOutput).toContain("HTTP 500");
     });
 
     it("should mention temporary server issues on 500 errors", async () => {
@@ -312,11 +312,10 @@ describe("Download and Failure Pipeline", () => {
         // Expected
       }
 
-      // Should show HTTP error (not the "script not found" path)
-      const logErrorOutput = mockLogError.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
-      expect(logErrorOutput).toContain("HTTP 404");
-      // 500 from fallback should mention temporary issues
+      // Should show HTTP error codes in console output (not the "script not found" path)
       const errorOutput = consoleMocks.error.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+      expect(errorOutput).toContain("HTTP 404");
+      // 500 from fallback should mention temporary issues
       expect(errorOutput).toContain("temporary issues");
     });
   });

--- a/cli/src/__tests__/shared-common-ssh-helpers.test.ts
+++ b/cli/src/__tests__/shared-common-ssh-helpers.test.ts
@@ -311,7 +311,7 @@ describe("generic_ssh_wait", () => {
       { useMockPath: true }
     );
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("SSH connectivity failed after 2 attempts");
+    expect(stderr).toContain("SSH connectivity timed out after");
   });
 
   it("should succeed on the second attempt", () => {
@@ -343,8 +343,7 @@ fi
       'generic_ssh_wait root 10.0.0.1 "" "echo ok" "Connection" 3 1',
       { useMockPath: true }
     );
-    expect(stderr).toContain("Connection ready after");
-    expect(stderr).toContain("attempt 1");
+    expect(stderr).toContain("Connection ready");
   });
 
   it("should pass username and IP to SSH command", () => {
@@ -438,7 +437,7 @@ echo "IP=$TEST_SERVER_IP"
 `);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("IP=203.0.113.42");
-    expect(stderr).toContain("Test instance active: IP=203.0.113.42");
+    expect(stderr).toContain("Test instance ready (IP: 203.0.113.42)");
   });
 
   it("should poll until target status is reached", () => {
@@ -479,7 +478,7 @@ generic_wait_for_instance mock_api "/instances/1" "active" \\
   TEST_IP "Instance" 3
 `);
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("Instance did not become active after 3 attempts");
+    expect(stderr).toContain("Instance did not become active after");
   });
 
   it("should export the IP variable to the environment", () => {

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -452,7 +452,7 @@ function showDryRunPreview(manifest: Manifest, agent: string, cloud: string, pro
   printDryRunSection("Credentials", credLines);
   const allSet = credLines.every(l => l.includes("-- set"));
   if (!allSet) {
-    p.log.warn("Some credentials are missing. Set them before running without --dry-run.");
+    p.log.warn("Some credentials are missing. Set them before launching.");
     p.log.info(`Run ${pc.cyan(`spawn ${cloud}`)} for setup instructions.`);
     console.log();
   }
@@ -601,8 +601,8 @@ function reportDownloadFailure(primaryUrl: string, fallbackUrl: string, primaryS
     console.error(`  2. Try again later (the script may be deploying)`);
     console.error(`  3. Report the issue: ${pc.cyan(`https://github.com/${REPO}/issues`)}`);
   } else {
-    p.log.error(`Script download failed (HTTP ${primaryStatus}/${fallbackStatus})`);
-    console.error(`\nBoth download sources returned errors.`);
+    p.log.error(`Script download failed`);
+    console.error(`\nBoth download sources returned errors (HTTP ${primaryStatus} and ${fallbackStatus}).`);
     if (primaryStatus >= 500 || fallbackStatus >= 500) {
       console.error("The server may be experiencing temporary issues.");
     }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -301,7 +301,7 @@ const VERB_ALIASES = new Set(["run", "launch", "start", "deploy", "exec"]);
 function warnExtraArgs(filteredArgs: string[], maxExpected: number): void {
   const extra = filteredArgs.slice(maxExpected);
   if (extra.length > 0) {
-    console.error(pc.yellow(`Warning: extra argument${extra.length > 1 ? "s" : ""} ignored: ${extra.join(", ")}`));
+    console.error(pc.yellow(`Extra argument${extra.length > 1 ? "s" : ""} ignored: ${extra.join(", ")}`));
     console.error(pc.dim(`  Usage: spawn <agent> <cloud> [--prompt "..."]`));
     console.error();
   }


### PR DESCRIPTION
## Summary
- Remove redundant "Warning:" prefixes from messages where `log_warn` or yellow color already conveys warning status
- Fix incorrect `export VAR=token spawn ...` syntax in auth failure hint -- `export` creates a persistent env var, but the inline `VAR=value command` syntax shown is the intended pattern
- Replace internal attempt/retry counts with elapsed time in SSH wait and instance polling messages -- users care about how long they've waited, not the retry mechanism
- Show instance IP in friendlier "ready (IP: x.x.x.x)" format instead of "active: IP=x.x.x.x"
- Move HTTP status codes from error title to body in download failures for cleaner error headlines
- Simplify dry-run credential warning, removing confusing "without --dry-run" double-negative

## Test plan
- [x] `bash -n shared/common.sh` passes
- [x] All 269 directly related tests pass (dispatch-extra-args, shared-common-ssh-helpers, download-and-failure, commands-update-download, dry-run-preview, exec-script-errors, commands-error-paths)
- [x] Test assertions updated to match new message formats

-- refactor/ux-engineer