### PR TITLE
feat: Add PR comment triage to security and refactor teams

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ refactor.yml        — GitHub Actions workflow that POSTs to the trigger server
 | | Issue Mode | Refactor Mode |
 |---|---|---|
 | **Trigger** | `?reason=issues&issue=N` | `?reason=schedule` |
-| **Agents** | 2 (issue-fixer, issue-tester) | 6 (security, ux, complexity, test, branch, community) |
+| **Teammates** | 2 (issue-fixer, issue-tester) | 6 (security, ux, complexity, test, branch, community) |
 | **Prompt timeout** | 15 min | 30 min |
 | **Hard timeout** | 20 min | 40 min |
 | **Worktree** | `/tmp/spawn-worktrees/issue-N/` | `/tmp/spawn-worktrees/refactor/` |


### PR DESCRIPTION
## Summary

- Security team's **pr-reviewer** now reads all PR comments before passing verdict — closes PRs that are superseded, duplicate, or abandoned based on comment signals
- Refactor team's **pr-maintainer** now reads PR comments first and can close PRs when comments clearly justify it (previously had a blanket "NEVER close" rule)
- CLAUDE.md: `Agents` → `Teammates` in the dual-mode table

### Security reviewer changes (new step 2):
- Fetches both conversation comments (`gh pr view --json comments`) and inline review comments (`gh api pulls/N/comments`)
- Checks for: superseded by another PR, duplicate work, author abandonment, previous reviewer flagged as stale
- If found, closes with comment + deletes branch, skips further review
- Remaining steps renumbered (3→4 through 11→12)

### Refactor pr-maintainer changes:
- Reads PR comments before evaluating each PR
- New comment-based triage block with same close signals
- Rule updated: "NEVER close a PR" → "Only close when comments clearly indicate superseded/duplicate/abandoned"

## Test plan

- [x] `bash -n` syntax check on both modified scripts
- [ ] Next security review_all cycle should read comments and close stale/duplicate PRs
- [ ] Next refactor cycle pr-maintainer should do the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)