### PR TITLE
fix: use safe inject_env_vars helpers in 4 missed scripts

### DIFF
--- a/atlanticnet/goose.sh
+++ b/atlanticnet/goose.sh
@@ -51,10 +51,9 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server "${ATLANTICNET_SERVER_IP}" "cat >> ~/.bashrc << 'EOF'
-export GOOSE_PROVIDER=openrouter
-export OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-EOF"
+inject_env_vars_ssh "${ATLANTICNET_SERVER_IP}" upload_file run_server \
+    "GOOSE_PROVIDER=openrouter" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""
 log_info "Server setup completed successfully!"

--- a/codesandbox/codex.sh
+++ b/codesandbox/codex.sh
@@ -29,9 +29,10 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_BASE_URL=\"https://openrouter.ai/api/v1\"" >> ~/.bashrc'
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "CodeSandbox setup completed successfully!"

--- a/codesandbox/gptme.sh
+++ b/codesandbox/gptme.sh
@@ -47,7 +47,8 @@ MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
 
 # Inject environment variables
 log_step "Setting up environment variables..."
-run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 
 echo ""
 log_info "CodeSandbox setup completed successfully!"

--- a/codesandbox/interpreter.sh
+++ b/codesandbox/interpreter.sh
@@ -32,9 +32,10 @@ else
 fi
 
 log_step "Setting up environment variables..."
-run_server 'echo "export OPENROUTER_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_API_KEY=\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'
-run_server 'echo "export OPENAI_BASE_URL=\"https://openrouter.ai/api/v1\"" >> ~/.bashrc'
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
 
 echo ""
 log_info "CodeSandbox setup completed successfully!"


### PR DESCRIPTION
## Summary

Replaces unsafe direct shell interpolation of `OPENROUTER_API_KEY` with the safe `inject_env_vars_ssh`/`inject_env_vars_local` helpers in 4 scripts that were missed by PR #937.

**Severity**: HIGH — shell injection via API key values containing metacharacters

**Affected scripts**:
- `codesandbox/codex.sh` — used `run_server 'echo "export ...\"'"${OPENROUTER_API_KEY}"'\"" >> ~/.bashrc'`
- `codesandbox/interpreter.sh` — same unsafe pattern
- `codesandbox/gptme.sh` — same unsafe pattern
- `atlanticnet/goose.sh` — used heredoc with double-quote expansion: `"cat >> ~/.bashrc << 'EOF' ... ${OPENROUTER_API_KEY} ... EOF"`

**The fix**: Use the safe `inject_env_vars_local`/`inject_env_vars_ssh` helpers (from `shared/common.sh`) which call `generate_env_config()` to single-quote all values, preventing shell injection when the config is sourced.

**Risk**: If `OPENROUTER_API_KEY` is set from environment with shell metacharacters (backticks, dollar signs, single quotes), the old code could execute arbitrary commands on the remote server. The safe helpers escape single quotes and wrap values in single quotes, preventing all interpretation.

-- refactor/security-auditor