### PR TITLE
refactor: deduplicate ensure_jq and decompose DO create_server

### DIFF
--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -105,7 +105,7 @@ get_server_name() {
 _list_server_types_for_location() {
     local location="$1"
 
-    _ensure_jq || return 1
+    ensure_jq || return 1
 
     local dc_response types_response
     dc_response=$(hetzner_api GET "/datacenters")
@@ -134,7 +134,7 @@ _list_server_types_for_location() {
 # Fetch available locations from /datacenters API
 # Outputs: "name|city|country" lines
 _list_locations() {
-    _ensure_jq || return 1
+    ensure_jq || return 1
 
     local dc_response
     dc_response=$(hetzner_api GET "/datacenters")
@@ -155,40 +155,6 @@ _pick_server_type() {
     _list_server_types_for_current_location() { _list_server_types_for_location "$location"; }
     interactive_pick "HETZNER_SERVER_TYPE" "cpx11" "server types" _list_server_types_for_current_location "cpx11"
     unset -f _list_server_types_for_current_location
-}
-
-# Ensure jq is installed (required for server type validation)
-_ensure_jq() {
-    if command -v jq &>/dev/null; then
-        return 0
-    fi
-
-    log_step "Installing jq..."
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        if command -v brew &>/dev/null; then
-            brew install jq || { log_error "Failed to install jq via Homebrew"; return 1; }
-        else
-            log_error "Install jq: brew install jq (or https://jqlang.github.io/jq/download/)"
-            return 1
-        fi
-    elif command -v apt-get &>/dev/null; then
-        sudo apt-get update -qq && sudo apt-get install -y jq || { log_error "Failed to install jq via apt"; return 1; }
-    elif command -v dnf &>/dev/null; then
-        sudo dnf install -y jq || { log_error "Failed to install jq via dnf"; return 1; }
-    elif command -v apk &>/dev/null; then
-        sudo apk add jq || { log_error "Failed to install jq via apk"; return 1; }
-    else
-        log_error "jq is required but not installed. Install from https://jqlang.github.io/jq/download/"
-        return 1
-    fi
-
-    if ! command -v jq &>/dev/null; then
-        log_error "jq not found in PATH after installation"
-        return 1
-    fi
-
-    log_info "jq installed"
 }
 
 # Find cheapest available server type matching spec constraints
@@ -276,7 +242,7 @@ _validate_server_type_for_location() {
     local server_type="$1"
     local location="$2"
 
-    _ensure_jq || return 1
+    ensure_jq || return 1
 
     local available_ids
     available_ids=$(_hetzner_get_available_ids "$location") || return 1

--- a/hostkey/lib/common.sh
+++ b/hostkey/lib/common.sh
@@ -128,7 +128,7 @@ _pick_location() {
 _list_instance_presets() {
     local location="$1"
 
-    _ensure_jq || return 1
+    ensure_jq || return 1
 
     # Call HOSTKEY presets API
     local response
@@ -150,40 +150,6 @@ _pick_instance_preset() {
     _list_presets_for_location() { _list_instance_presets "$location"; }
     interactive_pick "HOSTKEY_INSTANCE_PRESET" "1" "instance presets" _list_presets_for_location "1"
     unset -f _list_presets_for_location
-}
-
-# Ensure jq is installed (required for JSON parsing)
-_ensure_jq() {
-    if command -v jq &>/dev/null; then
-        return 0
-    fi
-
-    log_step "Installing jq..."
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        if command -v brew &>/dev/null; then
-            brew install jq || { log_error "Failed to install jq via Homebrew"; return 1; }
-        else
-            log_error "Install jq: brew install jq (or https://jqlang.github.io/jq/download/)"
-            return 1
-        fi
-    elif command -v apt-get &>/dev/null; then
-        sudo apt-get update -qq && sudo apt-get install -y jq || { log_error "Failed to install jq via apt"; return 1; }
-    elif command -v dnf &>/dev/null; then
-        sudo dnf install -y jq || { log_error "Failed to install jq via dnf"; return 1; }
-    elif command -v apk &>/dev/null; then
-        sudo apk add jq || { log_error "Failed to install jq via apk"; return 1; }
-    else
-        log_error "jq is required but not installed. Install from https://jqlang.github.io/jq/download/"
-        return 1
-    fi
-
-    if ! command -v jq &>/dev/null; then
-        log_error "jq not found in PATH after installation"
-        return 1
-    fi
-
-    log_info "jq installed"
 }
 
 # Create a HOSTKEY compute instance

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2299,6 +2299,45 @@ ensure_ssh_key_with_provider() {
 }
 
 # ============================================================
+# Tool installation helpers
+# ============================================================
+
+# Ensure jq is installed (required by some cloud providers for JSON parsing)
+# Tries brew (macOS), apt-get, dnf, apk in order.
+ensure_jq() {
+    if command -v jq &>/dev/null; then
+        return 0
+    fi
+
+    log_step "Installing jq..."
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v brew &>/dev/null; then
+            brew install jq || { log_error "Failed to install jq via Homebrew"; return 1; }
+        else
+            log_error "Install jq: brew install jq (or https://jqlang.github.io/jq/download/)"
+            return 1
+        fi
+    elif command -v apt-get &>/dev/null; then
+        sudo apt-get update -qq && sudo apt-get install -y jq || { log_error "Failed to install jq via apt"; return 1; }
+    elif command -v dnf &>/dev/null; then
+        sudo dnf install -y jq || { log_error "Failed to install jq via dnf"; return 1; }
+    elif command -v apk &>/dev/null; then
+        sudo apk add jq || { log_error "Failed to install jq via apk"; return 1; }
+    else
+        log_error "jq is required but not installed. Install from https://jqlang.github.io/jq/download/"
+        return 1
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        log_error "jq not found in PATH after installation"
+        return 1
+    fi
+
+    log_info "jq installed"
+}
+
+# ============================================================
 # Agent install commands (run remotely on provisioned servers)
 # ============================================================
 


### PR DESCRIPTION
## Summary

- **Extract `ensure_jq()` into `shared/common.sh`**: Both `hetzner/lib/common.sh` and `hostkey/lib/common.sh` had identical 32-line `_ensure_jq()` functions. Moved to shared library as `ensure_jq()`, eliminating 64 lines of duplication.
- **Decompose DigitalOcean `create_server()`**: Extracted error handling into `_do_check_create_error()` helper, consistent with other cloud providers (e.g., Hetzner's `_hetzner_check_create_error`). Replaced inline Python error parsing with the shared `extract_api_error_message` and `_extract_json_field` helpers.

Net change: -23 lines (68 added, 91 removed).

## Files changed

| File | Change |
|---|---|
| `shared/common.sh` | Added `ensure_jq()` to Tool installation helpers section |
| `hetzner/lib/common.sh` | Removed `_ensure_jq()`, calls `ensure_jq` from shared |
| `hostkey/lib/common.sh` | Removed `_ensure_jq()`, calls `ensure_jq` from shared |
| `digitalocean/lib/common.sh` | Extracted `_do_check_create_error()`, uses shared helpers |

## Test plan

- [x] `bash -n` syntax check passes on all 4 modified files
- [x] CLI tests pass (no shell-related test changes)

Agent: complexity-hunter