### PR TITLE
fix: show cloud URL for missing credentials in dry-run and add spawn list --clear

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.72",
+  "version": "0.2.73",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/history.ts
+++ b/cli/src/history.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -43,6 +43,17 @@ export function saveSpawnRecord(record: SpawnRecord): void {
     history = history.slice(history.length - MAX_HISTORY_ENTRIES);
   }
   writeFileSync(getHistoryPath(), JSON.stringify(history, null, 2) + "\n");
+}
+
+export function clearHistory(): number {
+  const path = getHistoryPath();
+  if (!existsSync(path)) return 0;
+  const records = loadHistory();
+  const count = records.length;
+  if (count > 0) {
+    unlinkSync(path);
+  }
+  return count;
 }
 
 export function filterHistory(

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3,6 +3,7 @@ import {
   cmdInteractive,
   cmdRun,
   cmdList,
+  cmdListClear,
   cmdMatrix,
   cmdAgents,
   cmdClouds,
@@ -64,6 +65,7 @@ const KNOWN_FLAGS = new Set([
   "--prompt", "-p", "--prompt-file", "-f",
   "--dry-run", "-n",
   "-a", "-c", "--agent", "--cloud",
+  "--clear",
 ]);
 
 /** Expand --flag=value into --flag value so all flag parsing works uniformly */
@@ -368,6 +370,10 @@ async function dispatchCommand(cmd: string, filteredArgs: string[], prompt: stri
 
   if (LIST_COMMANDS.has(cmd)) {
     if (hasTrailingHelpFlag(filteredArgs)) { cmdHelp(); return; }
+    if (filteredArgs.slice(1).includes("--clear")) {
+      cmdListClear();
+      return;
+    }
     const { agentFilter, cloudFilter } = parseListFilters(filteredArgs.slice(1));
     await cmdList(agentFilter, cloudFilter);
     return;


### PR DESCRIPTION
## Summary

Two UX improvements to the spawn CLI:

- **Dry-run credential hints**: `spawn <agent> <cloud> --dry-run` now shows the cloud provider's URL next to missing cloud-specific auth vars (e.g., `HCLOUD_TOKEN -- not set  https://console.hetzner.cloud/`), helping users find where to create their credentials. Previously only `OPENROUTER_API_KEY` showed a URL hint.

- **`spawn list --clear`**: New command to clear spawn history. Previously there was no way to reset the 100-entry history file without manually finding and deleting `~/.spawn/history.json`.

## Changed files

- `cli/src/commands.ts` - Enhanced `buildCredentialStatusLines` to pass cloud URL to missing vars; added `cmdListClear` function; updated help text
- `cli/src/history.ts` - Added `clearHistory()` function
- `cli/src/index.ts` - Added `--clear` to known flags, dispatch for `spawn list --clear`
- `cli/package.json` - Version bump 0.2.72 -> 0.2.73

## Test plan

- [x] All existing tests pass (10404 pass, 86 pre-existing failures unrelated to changes)
- [x] Dry-run preview tests pass
- [x] Credential hint tests pass
- [x] History tests pass
- [x] Index parsing and unknown flag tests pass

-- refactor/ux-engineer