### PR TITLE
refactor: extract ensure_jq and decompose CloudSigma helpers

### DIFF
--- a/cloudsigma/lib/common.sh
+++ b/cloudsigma/lib/common.sh
@@ -79,35 +79,10 @@ test_cloudsigma_credentials() {
 }
 
 ensure_cloudsigma_credentials() {
-    # CloudSigma uses email + password for API auth
-    if [[ -z "${CLOUDSIGMA_EMAIL:-}" ]]; then
-        if [[ -f "$HOME/.config/spawn/cloudsigma.json" ]]; then
-            CLOUDSIGMA_EMAIL=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('email', ''))" "$HOME/.config/spawn/cloudsigma.json" 2>/dev/null || echo "")
-            CLOUDSIGMA_PASSWORD=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('password', ''))" "$HOME/.config/spawn/cloudsigma.json" 2>/dev/null || echo "")
-        fi
-    fi
-
-    if [[ -z "${CLOUDSIGMA_EMAIL:-}" ]] || [[ -z "${CLOUDSIGMA_PASSWORD:-}" ]]; then
-        log_warn "CloudSigma credentials not found in environment or config file"
-        echo ""
-        log_info "Get your credentials at: https://${CLOUDSIGMA_REGION:-zrh}.cloudsigma.com/"
-        echo ""
-        printf "Enter your CloudSigma email: "
-        CLOUDSIGMA_EMAIL=$(safe_read "")
-        printf "Enter your CloudSigma password: "
-        CLOUDSIGMA_PASSWORD=$(safe_read "")
-
-        # Save credentials
-        mkdir -p "$HOME/.config/spawn"
-        python3 -c "
-import json, sys
-with open(sys.argv[1], 'w') as f:
-    json.dump({'email': sys.argv[2], 'password': sys.argv[3]}, f)
-" "$HOME/.config/spawn/cloudsigma.json" "$CLOUDSIGMA_EMAIL" "$CLOUDSIGMA_PASSWORD"
-        chmod 600 "$HOME/.config/spawn/cloudsigma.json"
-    fi
-
-    test_cloudsigma_credentials
+    ensure_multi_credentials "CloudSigma" "$HOME/.config/spawn/cloudsigma.json" \
+        "https://${CLOUDSIGMA_REGION:-zrh}.cloudsigma.com/" test_cloudsigma_credentials \
+        "CLOUDSIGMA_EMAIL:email:Email" \
+        "CLOUDSIGMA_PASSWORD:password:Password"
 }
 
 # Check if SSH key is registered with CloudSigma
@@ -172,8 +147,36 @@ get_server_name() {
     get_validated_server_name "CLOUDSIGMA_SERVER_NAME" "Enter server name: "
 }
 
+# Find Ubuntu 24.04 image UUID from the CloudSigma library
+_find_ubuntu_image_uuid() {
+    local response
+    response=$(cloudsigma_api GET "/libdrives/?limit=1000")
+
+    _extract_json_field "$response" \
+        "next(d['uuid'] for d in d.get('objects',[]) if 'ubuntu' in d.get('name','').lower() and ('24.04' in d.get('name','') or '24-04' in d.get('name','')))"
+}
+
+# Clone a library drive and return the new drive UUID
+_clone_drive() {
+    local image_uuid="$1"
+    local name="$2"
+    local size_bytes="$3"
+
+    local clone_body
+    clone_body=$(python3 -c "
+import json, sys
+print(json.dumps({'name': sys.argv[1] + '-disk', 'size': int(sys.argv[2]), 'media': 'disk'}))
+" "$name" "$size_bytes")
+
+    local response
+    response=$(cloudsigma_api POST "/libdrives/${image_uuid}/action/?do=clone" "$clone_body")
+
+    _extract_json_field "$response" \
+        "next(obj['uuid'] for obj in d.get('objects',[d]) if 'uuid' in obj)"
+}
+
 # Create a CloudSigma drive (disk) for the server
-# Returns the drive UUID in CLOUDSIGMA_DRIVE_UUID
+# Sets: CLOUDSIGMA_DRIVE_UUID
 create_cloudsigma_drive() {
     local name="$1"
     local size_gb="${CLOUDSIGMA_DISK_SIZE_GB:-20}"
@@ -181,54 +184,18 @@ create_cloudsigma_drive() {
 
     log_step "Creating drive '${name}-disk' (${size_gb}GB)..."
 
-    # Clone from Ubuntu 24.04 image
-    # First, find the Ubuntu 24.04 image UUID
-    local image_response
-    image_response=$(cloudsigma_api GET "/libdrives/?limit=1000")
-
     local ubuntu_image_uuid
-    ubuntu_image_uuid=$(echo "$image_response" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for drive in data.get('objects', []):
-    name = drive.get('name', '').lower()
-    if 'ubuntu' in name and ('24.04' in name or '24-04' in name):
-        print(drive['uuid'])
-        break
-" 2>/dev/null || echo "")
-
+    ubuntu_image_uuid=$(_find_ubuntu_image_uuid)
     if [[ -z "$ubuntu_image_uuid" ]]; then
         log_error "Could not find Ubuntu 24.04 image in CloudSigma library"
         return 1
     fi
 
     log_step "Cloning Ubuntu 24.04 image: $ubuntu_image_uuid"
-
-    # Clone the image to create a new drive
-    local clone_body
-    clone_body=$(python3 -c "
-import json, sys
-print(json.dumps({
-    'name': sys.argv[1] + '-disk',
-    'size': int(sys.argv[2]),
-    'media': 'disk'
-}))
-" "$name" "$size_bytes")
-
-    local clone_response
-    clone_response=$(cloudsigma_api POST "/libdrives/${ubuntu_image_uuid}/action/?do=clone" "$clone_body")
-
-    CLOUDSIGMA_DRIVE_UUID=$(echo "$clone_response" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for obj in data.get('objects', [data]):
-    if 'uuid' in obj:
-        print(obj['uuid'])
-        break
-" 2>/dev/null || echo "")
+    CLOUDSIGMA_DRIVE_UUID=$(_clone_drive "$ubuntu_image_uuid" "$name" "$size_bytes")
 
     if [[ -z "$CLOUDSIGMA_DRIVE_UUID" ]]; then
-        log_error "Failed to create drive: $clone_response"
+        log_error "Failed to clone drive"
         return 1
     fi
 
@@ -281,70 +248,51 @@ print(json.dumps(body))
 " "$name" "$cpu_mhz" "$mem_bytes" "$drive_uuid" "$ssh_key_uuid" "$(openssl rand -hex 8)"
 }
 
+# Resolve a CloudSigma IP reference (may be a UUID) to an actual IP address
+_resolve_cloudsigma_ip() {
+    local ip="$1"
+    # If it looks like a UUID, fetch the actual IP from the /ips/ endpoint
+    if [[ "$ip" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+        _extract_json_field "$(cloudsigma_api GET "/ips/${ip}/")" "d.get('uuid','')"
+    else
+        echo "$ip"
+    fi
+}
+
 # Wait for CloudSigma server to become running and get its IP
 # Sets: CLOUDSIGMA_SERVER_IP
 _wait_for_cloudsigma_server() {
     local server_uuid="$1"
-    local max_attempts=${2:-60}
 
-    log_step "Waiting for server to get IP address..."
+    # IP extraction: get first NIC's IPv4 address (may be a UUID reference)
+    local ip_py="next((ic.get('ip',{}).get('uuid','') if isinstance(ic.get('ip'),dict) else ic.get('ip','')) for n in d.get('nics',[]) for ic in [n.get('ip_v4_conf',{})] if ic) if d.get('nics') else ''"
 
-    local attempt=0
-    while [[ $attempt -lt $max_attempts ]]; do
-        attempt=$((attempt + 1))
+    generic_wait_for_instance cloudsigma_api "/servers/${server_uuid}/" \
+        "running" "d.get('status','unknown')" "$ip_py" \
+        CLOUDSIGMA_SERVER_IP "Server" 60
 
-        local response
-        response=$(cloudsigma_api GET "/servers/${server_uuid}/")
+    # Resolve UUID-style IP references to actual IP addresses
+    if [[ -n "${CLOUDSIGMA_SERVER_IP:-}" ]]; then
+        CLOUDSIGMA_SERVER_IP=$(_resolve_cloudsigma_ip "$CLOUDSIGMA_SERVER_IP")
+        export CLOUDSIGMA_SERVER_IP
+    fi
+}
 
-        local status
-        status=$(echo "$response" | python3 -c "
+# Look up the UUID of the registered SSH key by fingerprint
+_get_ssh_key_uuid() {
+    local fingerprint="$1"
+    local response
+    response=$(cloudsigma_api GET "/keypairs/")
+
+    printf '%s' "$response" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
-print(data.get('status', 'unknown'))
-" 2>/dev/null || echo "unknown")
-
-        local ip
-        ip=$(echo "$response" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for nic in data.get('nics', []):
-    ip_conf = nic.get('ip_v4_conf', {})
-    ip = ip_conf.get('ip', {})
-    if isinstance(ip, dict):
-        uuid = ip.get('uuid', '')
-        if uuid:
-            print(uuid)
-            break
-    elif ip:
-        print(ip)
+fp = sys.argv[1].replace(':', '').lower()
+for kp in data.get('objects', []):
+    if kp.get('fingerprint', '').replace(':', '').lower() == fp:
+        print(kp['uuid'])
         break
-" 2>/dev/null || echo "")
-
-        if [[ "$status" == "running" && -n "$ip" ]]; then
-            # If IP is a UUID, we need to fetch the actual IP address
-            if [[ "$ip" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-                local ip_response
-                ip_response=$(cloudsigma_api GET "/ips/${ip}/")
-                ip=$(echo "$ip_response" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-# CloudSigma IP resources use 'uuid' as the IP address string
-addr = data.get('uuid', '')
-print(addr)
-" 2>/dev/null || echo "")
-            fi
-
-            CLOUDSIGMA_SERVER_IP="$ip"
-            log_info "Server is running with IP: $ip"
-            return 0
-        fi
-
-        log_step "Server status: $status (attempt $attempt/$max_attempts)"
-        sleep "$INSTANCE_STATUS_POLL_DELAY"
-    done
-
-    log_error "Server did not become ready within expected time"
-    return 1
+" "$fingerprint" 2>/dev/null || echo ""
 }
 
 create_server() {
@@ -356,29 +304,11 @@ create_server() {
     log_step "Creating CloudSigma server '$name'..."
     log_step "  CPU: ${cpu_mhz} MHz, Memory: ${mem_gb}GB"
 
-    # Create drive first
     create_cloudsigma_drive "$name"
 
-    # Get SSH key UUID
-    local ssh_key_uuid=""
-    local keypairs_response
-    keypairs_response=$(cloudsigma_api GET "/keypairs/")
+    local ssh_key_uuid
+    ssh_key_uuid=$(_get_ssh_key_uuid "$(get_ssh_fingerprint "$HOME/.ssh/id_ed25519.pub")")
 
-    local fingerprint
-    fingerprint=$(get_ssh_fingerprint "$HOME/.ssh/id_ed25519.pub")
-
-    ssh_key_uuid=$(echo "$keypairs_response" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-fingerprint = sys.argv[1].replace(':', '').lower()
-for kp in data.get('objects', []):
-    kp_fp = kp.get('fingerprint', '').replace(':', '').lower()
-    if kp_fp == fingerprint:
-        print(kp['uuid'])
-        break
-" "$fingerprint" 2>/dev/null || echo "")
-
-    # Build server creation request
     local server_body
     server_body=$(_cloudsigma_build_server_body "$name" "$cpu_mhz" "$mem_bytes" "$CLOUDSIGMA_DRIVE_UUID" "$ssh_key_uuid")
 
@@ -386,11 +316,7 @@ for kp in data.get('objects', []):
     local create_response
     create_response=$(cloudsigma_api POST "/servers/" "$server_body")
 
-    CLOUDSIGMA_SERVER_UUID=$(echo "$create_response" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-print(data.get('uuid', ''))
-" 2>/dev/null || echo "")
+    CLOUDSIGMA_SERVER_UUID=$(_extract_json_field "$create_response" "d.get('uuid','')")
 
     if [[ -z "$CLOUDSIGMA_SERVER_UUID" ]]; then
         log_error "Failed to create server: $create_response"
@@ -399,65 +325,15 @@ print(data.get('uuid', ''))
 
     log_info "Server created: $CLOUDSIGMA_SERVER_UUID"
 
-    # Start the server
     log_step "Starting server..."
     cloudsigma_api POST "/servers/${CLOUDSIGMA_SERVER_UUID}/action/?do=start" "{}"
 
     _wait_for_cloudsigma_server "$CLOUDSIGMA_SERVER_UUID"
 }
 
-# Upload file to CloudSigma server via SCP
-upload_file() {
-    local server_ip="$1"
-    local local_path="$2"
-    local remote_path="${3:-$(basename "$local_path")}"
-
-    # CloudSigma uses cloudsigma user by default for SSH keys
-    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        "$local_path" "cloudsigma@${server_ip}:${remote_path}"
-}
-
-# Run command on CloudSigma server via SSH
-run_server() {
-    local server_ip="$1"
-    shift
-    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        "cloudsigma@${server_ip}" "$@"
-}
-
-# Start interactive SSH session on CloudSigma server
-interactive_session() {
-    local server_ip="$1"
-    local command="${2:-bash}"
-
-    log_step "Connecting to CloudSigma server..."
-    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        -t "cloudsigma@${server_ip}" "$command"
-}
-
-# Verify SSH connectivity to the server
-verify_server_connectivity() {
-    local server_ip="$1"
-    generic_ssh_wait "cloudsigma@${server_ip}" 60
-}
-
-# Wait for cloud-init to complete on the server
-wait_for_cloud_init() {
-    local server_ip="$1"
-    local max_wait="${2:-300}"
-
-    log_step "Waiting for cloud-init to complete..."
-
-    local elapsed=0
-    while [[ $elapsed -lt $max_wait ]]; do
-        if run_server "$server_ip" "cloud-init status --wait" 2>/dev/null; then
-            log_info "Cloud-init completed"
-            return 0
-        fi
-        sleep 5
-        elapsed=$((elapsed + 5))
-    done
-
-    log_warn "Cloud-init did not complete within ${max_wait}s, continuing anyway"
-    return 0
-}
+# SSH operations — CloudSigma uses 'cloudsigma' user for SSH keys
+SSH_USER="cloudsigma"
+verify_server_connectivity() { ssh_verify_connectivity "$@"; }
+run_server() { ssh_run_server "$@"; }
+upload_file() { ssh_upload_file "$@"; }
+interactive_session() { ssh_interactive_session "$@"; }

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -105,7 +105,7 @@ get_server_name() {
 _list_server_types_for_location() {
     local location="$1"
 
-    _ensure_jq || return 1
+    ensure_jq || return 1
 
     local dc_response types_response
     dc_response=$(hetzner_api GET "/datacenters")
@@ -134,7 +134,7 @@ _list_server_types_for_location() {
 # Fetch available locations from /datacenters API
 # Outputs: "name|city|country" lines
 _list_locations() {
-    _ensure_jq || return 1
+    ensure_jq || return 1
 
     local dc_response
     dc_response=$(hetzner_api GET "/datacenters")
@@ -155,40 +155,6 @@ _pick_server_type() {
     _list_server_types_for_current_location() { _list_server_types_for_location "$location"; }
     interactive_pick "HETZNER_SERVER_TYPE" "cpx11" "server types" _list_server_types_for_current_location "cpx11"
     unset -f _list_server_types_for_current_location
-}
-
-# Ensure jq is installed (required for server type validation)
-_ensure_jq() {
-    if command -v jq &>/dev/null; then
-        return 0
-    fi
-
-    log_step "Installing jq..."
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        if command -v brew &>/dev/null; then
-            brew install jq || { log_error "Failed to install jq via Homebrew"; return 1; }
-        else
-            log_error "Install jq: brew install jq (or https://jqlang.github.io/jq/download/)"
-            return 1
-        fi
-    elif command -v apt-get &>/dev/null; then
-        sudo apt-get update -qq && sudo apt-get install -y jq || { log_error "Failed to install jq via apt"; return 1; }
-    elif command -v dnf &>/dev/null; then
-        sudo dnf install -y jq || { log_error "Failed to install jq via dnf"; return 1; }
-    elif command -v apk &>/dev/null; then
-        sudo apk add jq || { log_error "Failed to install jq via apk"; return 1; }
-    else
-        log_error "jq is required but not installed. Install from https://jqlang.github.io/jq/download/"
-        return 1
-    fi
-
-    if ! command -v jq &>/dev/null; then
-        log_error "jq not found in PATH after installation"
-        return 1
-    fi
-
-    log_info "jq installed"
 }
 
 # Find cheapest available server type matching spec constraints
@@ -276,7 +242,7 @@ _validate_server_type_for_location() {
     local server_type="$1"
     local location="$2"
 
-    _ensure_jq || return 1
+    ensure_jq || return 1
 
     local available_ids
     available_ids=$(_hetzner_get_available_ids "$location") || return 1

--- a/hostkey/lib/common.sh
+++ b/hostkey/lib/common.sh
@@ -128,7 +128,7 @@ _pick_location() {
 _list_instance_presets() {
     local location="$1"
 
-    _ensure_jq || return 1
+    ensure_jq || return 1
 
     # Call HOSTKEY presets API
     local response
@@ -150,40 +150,6 @@ _pick_instance_preset() {
     _list_presets_for_location() { _list_instance_presets "$location"; }
     interactive_pick "HOSTKEY_INSTANCE_PRESET" "1" "instance presets" _list_presets_for_location "1"
     unset -f _list_presets_for_location
-}
-
-# Ensure jq is installed (required for JSON parsing)
-_ensure_jq() {
-    if command -v jq &>/dev/null; then
-        return 0
-    fi
-
-    log_step "Installing jq..."
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        if command -v brew &>/dev/null; then
-            brew install jq || { log_error "Failed to install jq via Homebrew"; return 1; }
-        else
-            log_error "Install jq: brew install jq (or https://jqlang.github.io/jq/download/)"
-            return 1
-        fi
-    elif command -v apt-get &>/dev/null; then
-        sudo apt-get update -qq && sudo apt-get install -y jq || { log_error "Failed to install jq via apt"; return 1; }
-    elif command -v dnf &>/dev/null; then
-        sudo dnf install -y jq || { log_error "Failed to install jq via dnf"; return 1; }
-    elif command -v apk &>/dev/null; then
-        sudo apk add jq || { log_error "Failed to install jq via apk"; return 1; }
-    else
-        log_error "jq is required but not installed. Install from https://jqlang.github.io/jq/download/"
-        return 1
-    fi
-
-    if ! command -v jq &>/dev/null; then
-        log_error "jq not found in PATH after installation"
-        return 1
-    fi
-
-    log_info "jq installed"
 }
 
 # Create a HOSTKEY compute instance

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -87,6 +87,40 @@ check_python_available() {
     return 0
 }
 
+# Install jq if not already present (required by some cloud providers)
+ensure_jq() {
+    if command -v jq &>/dev/null; then
+        return 0
+    fi
+
+    log_step "Installing jq..."
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v brew &>/dev/null; then
+            brew install jq || { log_error "Failed to install jq via Homebrew"; return 1; }
+        else
+            log_error "Install jq: brew install jq (or https://jqlang.github.io/jq/download/)"
+            return 1
+        fi
+    elif command -v apt-get &>/dev/null; then
+        sudo apt-get update -qq && sudo apt-get install -y jq || { log_error "Failed to install jq via apt"; return 1; }
+    elif command -v dnf &>/dev/null; then
+        sudo dnf install -y jq || { log_error "Failed to install jq via dnf"; return 1; }
+    elif command -v apk &>/dev/null; then
+        sudo apk add jq || { log_error "Failed to install jq via apk"; return 1; }
+    else
+        log_error "jq is required but not installed. Install from https://jqlang.github.io/jq/download/"
+        return 1
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        log_error "jq not found in PATH after installation"
+        return 1
+    fi
+
+    log_info "jq installed"
+}
+
 # ============================================================
 # Input handling
 # ============================================================


### PR DESCRIPTION
## Summary
- Extract duplicated `_ensure_jq` from hetzner and hostkey into shared `ensure_jq` in `shared/common.sh` (removes ~60 lines of duplication)
- Decompose CloudSigma `cloudsigma/lib/common.sh` to use shared helpers:
  - `ensure_multi_credentials` instead of hand-rolled credential loading
  - `generic_wait_for_instance` + `_resolve_cloudsigma_ip` instead of custom 63-line polling loop
  - Extracted `_find_ubuntu_image_uuid`, `_clone_drive`, `_get_ssh_key_uuid` helpers
  - Shared SSH helpers (`SSH_USER=cloudsigma`) instead of 4 hand-rolled SSH functions
- **Net reduction: ~158 lines across 4 files**

## Test plan
- [x] `bash -n` passes on all 4 modified .sh files
- [x] `bun test` — no new failures (pre-existing failures in CodeSandbox tests unrelated)
- [x] `bash test/run.sh` — 79/79 shell tests pass, 0 failures

-- refactor/complexity-hunter