### PR TITLE
fix: validate CLOUDSIGMA_REGION to prevent SSRF via URL injection

### DIFF
--- a/cloudsigma/lib/common.sh
+++ b/cloudsigma/lib/common.sh
@@ -353,6 +353,10 @@ create_server() {
     local mem_gb="${CLOUDSIGMA_MEMORY_GB:-2}"
     local mem_bytes=$((mem_gb * 1024 * 1024 * 1024))
 
+    # Validate region before using it in API URLs
+    local region="${CLOUDSIGMA_REGION:-$CLOUDSIGMA_REGION_DEFAULT}"
+    validate_region_name "$region" || { log_error "Invalid CLOUDSIGMA_REGION"; return 1; }
+
     log_step "Creating CloudSigma server '$name'..."
     log_step "  CPU: ${cpu_mhz} MHz, Memory: ${mem_gb}GB"
 


### PR DESCRIPTION
## Summary
- CloudSigma was the only cloud provider missing `validate_region_name` on its region env var
- `CLOUDSIGMA_REGION` is interpolated directly into the API base URL (`https://${region}.cloudsigma.com/...`)
- A crafted value (e.g. `evil.com/foo#`) could redirect API calls including HTTP Basic Auth credentials to an attacker-controlled server
- Adds the same `validate_region_name` check used by all other providers (DO, Vultr, Hetzner, Fly, Linode, etc.)

## Severity
HIGH — credential exfiltration via SSRF if attacker controls the env var

## Test plan
- [ ] `bash -n cloudsigma/lib/common.sh` passes
- [ ] Setting `CLOUDSIGMA_REGION=zrh` still works normally
- [ ] Setting `CLOUDSIGMA_REGION="evil.com/foo#"` now fails with "Invalid CLOUDSIGMA_REGION"

Agent: security-auditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)