### PR TITLE
refactor: decompose Atlantic.Net and HOSTKEY create_server into focused helpers

### DIFF
--- a/cli/src/__tests__/atlanticnet-provider.test.ts
+++ b/cli/src/__tests__/atlanticnet-provider.test.ts
@@ -393,36 +393,35 @@ describe("Atlantic.Net SSH delegation", () => {
 
 describe("Atlantic.Net server lifecycle", () => {
   it("should extract instance ID from run-instance response", () => {
-    const createFunc = extractFunctionBody(libContent, "create_server");
-    expect(createFunc).toContain("instanceid");
+    const parseFunc = extractFunctionBody(libContent, "_atlanticnet_parse_instance_response");
+    expect(parseFunc).toContain("instanceid");
   });
 
   it("should extract IP address from run-instance response", () => {
-    const createFunc = extractFunctionBody(libContent, "create_server");
-    expect(createFunc).toContain("ip_address");
+    const parseFunc = extractFunctionBody(libContent, "_atlanticnet_parse_instance_response");
+    expect(parseFunc).toContain("ip_address");
   });
 
   it("should export ATLANTICNET_SERVER_ID after creation", () => {
-    const createFunc = extractFunctionBody(libContent, "create_server");
-    expect(createFunc).toContain("export ATLANTICNET_SERVER_ID");
+    const parseFunc = extractFunctionBody(libContent, "_atlanticnet_parse_instance_response");
+    expect(parseFunc).toContain("export ATLANTICNET_SERVER_ID");
   });
 
   it("should export ATLANTICNET_SERVER_IP after creation", () => {
-    const createFunc = extractFunctionBody(libContent, "create_server");
-    // May be combined export: "export ATLANTICNET_SERVER_ID ATLANTICNET_SERVER_IP"
-    expect(createFunc).toContain("ATLANTICNET_SERVER_IP");
-    expect(createFunc).toContain("export");
+    const parseFunc = extractFunctionBody(libContent, "_atlanticnet_parse_instance_response");
+    expect(parseFunc).toContain("ATLANTICNET_SERVER_IP");
+    expect(parseFunc).toContain("export");
   });
 
   it("should check for empty instance ID or IP", () => {
-    const createFunc = extractFunctionBody(libContent, "create_server");
-    expect(createFunc).toContain('-z "$instance_id"');
-    expect(createFunc).toContain('-z "$ip_address"');
+    const parseFunc = extractFunctionBody(libContent, "_atlanticnet_parse_instance_response");
+    expect(parseFunc).toContain('-z "$instance_id"');
+    expect(parseFunc).toContain('-z "$ip_address"');
   });
 
   it("should check for API errors in response", () => {
-    const createFunc = extractFunctionBody(libContent, "create_server");
-    expect(createFunc).toContain('"error"');
+    const checkFunc = extractFunctionBody(libContent, "_atlanticnet_check_create_error");
+    expect(checkFunc).toContain('"error"');
   });
 
   it("should call terminate-instance in destroy_server", () => {
@@ -800,7 +799,8 @@ describe("Atlantic.Net error handling", () => {
 
   it("should check for API errors in create_server", () => {
     const createFunc = extractFunctionBody(libContent, "create_server");
-    expect(createFunc).toContain('"error"');
+    // Error checking is delegated to _atlanticnet_check_create_error helper
+    expect(createFunc).toContain("_atlanticnet_check_create_error");
     expect(createFunc).toContain("return 1");
   });
 


### PR DESCRIPTION
## Summary
- Decompose Atlantic.Net `create_server()` (59 -> 30 lines) by extracting `_atlanticnet_extract_error`, `_atlanticnet_check_create_error`, and `_atlanticnet_parse_instance_response` helpers; replace inline python3 with shared `_extract_json_field`
- Decompose HOSTKEY `create_server()` (52 -> 24 lines) by extracting `_hostkey_build_order_body`, `_hostkey_check_create_error`, and `_hostkey_parse_instance_response` helpers
- Update atlanticnet-provider.test.ts to check extracted helper functions instead of monolithic create_server body

## Test plan
- [x] `bash -n` passes on all modified .sh files
- [x] `bun test atlanticnet-provider.test.ts` passes (338 pass, 7 pre-existing fail unchanged)
- [x] No new test regressions

-- refactor/complexity-hunter