### PR TITLE
fix: remove duplicate ensure_jq and fix help text alias placement

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1562,12 +1562,11 @@ ${pc.bold("USAGE")}
                                      Execute agent with prompt from file
   spawn <agent>                      Show available clouds for agent
   spawn <cloud>                      Show available agents for cloud
-  spawn list                         Browse and rerun previous spawns
+  spawn list                         Browse and rerun previous spawns (aliases: ls, history)
   spawn list <filter>                Filter history by agent or cloud name
   spawn list -a <agent>              Filter spawn history by agent (or --agent)
   spawn list -c <cloud>              Filter spawn history by cloud (or --cloud)
   spawn list --clear                 Clear all spawn history
-                                     Aliases: ls, history
   spawn matrix                       Full availability matrix (alias: m)
   spawn agents                       List all agents with descriptions
   spawn clouds                       List all cloud providers

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2333,45 +2333,6 @@ ensure_ssh_key_with_provider() {
 }
 
 # ============================================================
-# Tool installation helpers
-# ============================================================
-
-# Ensure jq is installed (required by some cloud providers for JSON parsing)
-# Tries brew (macOS), apt-get, dnf, apk in order.
-ensure_jq() {
-    if command -v jq &>/dev/null; then
-        return 0
-    fi
-
-    log_step "Installing jq..."
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        if command -v brew &>/dev/null; then
-            brew install jq || { log_error "Failed to install jq via Homebrew"; return 1; }
-        else
-            log_error "Install jq: brew install jq (or https://jqlang.github.io/jq/download/)"
-            return 1
-        fi
-    elif command -v apt-get &>/dev/null; then
-        sudo apt-get update -qq && sudo apt-get install -y jq || { log_error "Failed to install jq via apt"; return 1; }
-    elif command -v dnf &>/dev/null; then
-        sudo dnf install -y jq || { log_error "Failed to install jq via dnf"; return 1; }
-    elif command -v apk &>/dev/null; then
-        sudo apk add jq || { log_error "Failed to install jq via apk"; return 1; }
-    else
-        log_error "jq is required but not installed. Install from https://jqlang.github.io/jq/download/"
-        return 1
-    fi
-
-    if ! command -v jq &>/dev/null; then
-        log_error "jq not found in PATH after installation"
-        return 1
-    fi
-
-    log_info "jq installed"
-}
-
-# ============================================================
 # Agent install commands (run remotely on provisioned servers)
 # ============================================================
 


### PR DESCRIPTION
## Summary

- **Remove duplicate `ensure_jq()` function** in `shared/common.sh` — the function was defined twice (at line 91 and again at line 2341) after the refactoring in #946 extracted it to the shared lib but left the original copy in place. The second definition silently shadowed the first; removing it eliminates confusion and ~30 lines of dead code.

- **Fix help text alias placement** — "Aliases: ls, history" was on its own continuation line directly after `spawn list --clear`, making it appear as if those were aliases for `--clear`. Moved the aliases inline with `spawn list` where they belong.

## Test plan

- [x] `bash -n shared/common.sh` passes
- [x] `bun test cmd-help-content` (37 tests pass)
- [x] `bun test commands-helpers commands commands-internal-helpers` (120 tests pass)
- [x] `bun test script-conventions` (82 tests pass)
- [x] Verified `ensure_jq` now appears exactly once in shared/common.sh

Agent: ux-engineer