### PR TITLE
fix: improve error messages for GCP, AWS Lightsail, Cherry, and Oracle

### DIFF
--- a/cherry/lib/common.sh
+++ b/cherry/lib/common.sh
@@ -96,8 +96,8 @@ cherry_register_ssh_key() {
     if printf '%s' "$register_response" | grep -q '"id"'; then
         return 0
     else
-        log_error "Failed to register SSH key"
-        log_error "Response: $register_response"
+        log_error "Failed to register SSH key with Cherry Servers"
+        log_error "API Error: $(extract_api_error_message "$register_response" "$register_response")"
         return 1
     fi
 }
@@ -190,8 +190,12 @@ print(json.dumps(data))
     server_id=$(_extract_json_field "$response" "d.get('id','')")
 
     if [[ -z "$server_id" ]]; then
-        log_error "Failed to create server"
-        log_error "Response: $response"
+        log_error "Failed to create Cherry Servers server"
+        log_error "API Error: $(extract_api_error_message "$response" "$response")"
+        log_warn "Common issues:"
+        log_warn "  - Insufficient account balance"
+        log_warn "  - Plan unavailable in region (try different CHERRY_DEFAULT_PLAN or CHERRY_DEFAULT_REGION)"
+        log_warn "  - Server limit reached for your account"
         return 1
     fi
 


### PR DESCRIPTION
## Summary

Improves error messages across 4 cloud providers that had the least actionable failure output when server creation fails:

- **GCP**: `create_server` was swallowing stderr with `>/dev/null 2>&1`, so users never saw why gcloud failed (quota, billing, zone). Now captures stderr and displays it. Also upgrades `ensure_gcloud` errors to use `_log_diagnostic` with structured causes and fix steps.
- **AWS Lightsail**: `create_server` had a bare "Failed to create Lightsail instance" with no guidance. Now shows common issues (instance limits, bundle/region, IAM). Also upgrades `ensure_aws_cli` to `_log_diagnostic` and improves the instance polling timeout message.
- **Cherry Servers**: Was dumping raw JSON response on failure (`log_error "Response: $response"`). Now uses `extract_api_error_message` (shared helper) and adds common issues.
- **Oracle Cloud**: Instance launch was swallowing stderr. Now captures OCI CLI error output and shows common issues (quota, permissions, shape availability, capacity). Also adds guidance for VCN and subnet creation failures.

## Test plan

- [x] `bash -n` passes on all 4 modified files
- [ ] Manual: verify error messages render correctly on actual provisioning failures

-- refactor/ux-engineer