### PR TITLE
fix: add actionable guidance to agent installation failures across 126 scripts

### DIFF
--- a/atlanticnet/aider.sh
+++ b/atlanticnet/aider.sh
@@ -32,8 +32,7 @@ run_server "${ATLANTICNET_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip
 
 # Verify installation succeeded
 if ! run_server "${ATLANTICNET_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly on server ${ATLANTICNET_SERVER_IP}"
+    log_install_failed "Aider" "pip install aider-chat" "${ATLANTICNET_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/atlanticnet/claude.sh
+++ b/atlanticnet/claude.sh
@@ -32,8 +32,7 @@ run_server "${ATLANTICNET_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh |
 
 # Verify installation succeeded
 if ! run_server "${ATLANTICNET_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${ATLANTICNET_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${ATLANTICNET_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/atlanticnet/goose.sh
+++ b/atlanticnet/goose.sh
@@ -36,8 +36,7 @@ run_server "${ATLANTICNET_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github
 
 # Verify installation succeeded
 if ! run_server "${ATLANTICNET_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${ATLANTICNET_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/atlanticnet/gptme.sh
+++ b/atlanticnet/gptme.sh
@@ -24,7 +24,7 @@ log_step "Installing gptme..."
 run_server "${ATLANTICNET_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 if ! run_server "${ATLANTICNET_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
+    log_install_failed "gptme" "pip install gptme" "${ATLANTICNET_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/atlanticnet/plandex.sh
+++ b/atlanticnet/plandex.sh
@@ -25,7 +25,7 @@ log_step "Installing Plandex..."
 run_server "${ATLANTICNET_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 if ! run_server "${ATLANTICNET_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${ATLANTICNET_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/binarylane/aider.sh
+++ b/binarylane/aider.sh
@@ -24,7 +24,7 @@ log_step "Installing Aider..."
 run_server "${BINARYLANE_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 if ! run_server "${BINARYLANE_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
+    log_install_failed "Aider" "pip install aider-chat" "${BINARYLANE_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installed"

--- a/binarylane/goose.sh
+++ b/binarylane/goose.sh
@@ -25,7 +25,7 @@ run_server "${BINARYLANE_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.
 
 log_step "Verifying Goose installation..."
 if ! run_server "${BINARYLANE_SERVER_IP}" "command -v goose" >/dev/null 2>&1; then
-    log_error "Goose installation failed"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${BINARYLANE_SERVER_IP}"
     exit 1
 fi
 log_info "Goose is installed"

--- a/binarylane/gptme.sh
+++ b/binarylane/gptme.sh
@@ -24,7 +24,7 @@ log_step "Installing gptme..."
 run_server "${BINARYLANE_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 if ! run_server "${BINARYLANE_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
+    log_install_failed "gptme" "pip install gptme" "${BINARYLANE_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installed"

--- a/binarylane/plandex.sh
+++ b/binarylane/plandex.sh
@@ -25,7 +25,7 @@ run_server "${BINARYLANE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | b
 
 log_step "Verifying Plandex installation..."
 if ! run_server "${BINARYLANE_SERVER_IP}" "command -v plandex" >/dev/null 2>&1; then
-    log_error "Plandex installation failed"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${BINARYLANE_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex is installed"

--- a/cherry/aider.sh
+++ b/cherry/aider.sh
@@ -33,8 +33,7 @@ run_server "${CHERRY_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 ins
 
 # Verify installation succeeded
 if ! run_server "${CHERRY_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly on server ${CHERRY_SERVER_IP}"
+    log_install_failed "Aider" "pip install aider-chat" "${CHERRY_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/cherry/claude.sh
+++ b/cherry/claude.sh
@@ -33,8 +33,7 @@ run_server "${CHERRY_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash
 
 # Verify installation succeeded
 if ! run_server "${CHERRY_SERVER_IP}" "command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${CHERRY_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${CHERRY_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/cherry/goose.sh
+++ b/cherry/goose.sh
@@ -33,8 +33,7 @@ run_server "${CHERRY_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/
 
 # Verify installation succeeded
 if ! run_server "${CHERRY_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly on server ${CHERRY_SERVER_IP}"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${CHERRY_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/cherry/gptme.sh
+++ b/cherry/gptme.sh
@@ -33,8 +33,7 @@ run_server "${CHERRY_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install 
 
 # Verify installation succeeded
 if ! run_server "${CHERRY_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server ${CHERRY_SERVER_IP}"
+    log_install_failed "gptme" "pip install gptme" "${CHERRY_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/cherry/plandex.sh
+++ b/cherry/plandex.sh
@@ -33,8 +33,7 @@ run_server "${CHERRY_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_server "${CHERRY_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${CHERRY_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${CHERRY_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/civo/goose.sh
+++ b/civo/goose.sh
@@ -26,8 +26,7 @@ log_step "Installing Goose..."
 run_server "${CIVO_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 if ! run_server "${CIVO_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly on server ${CIVO_SERVER_IP}"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${CIVO_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/civo/gptme.sh
+++ b/civo/gptme.sh
@@ -27,8 +27,7 @@ run_server "${CIVO_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gp
 
 # Verify installation succeeded
 if ! run_server "${CIVO_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server ${CIVO_SERVER_IP}"
+    log_install_failed "gptme" "pip install gptme" "${CIVO_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/codesandbox/gptme.sh
+++ b/codesandbox/gptme.sh
@@ -28,8 +28,7 @@ run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation
 if ! run_server "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly"
+    log_install_failed "gptme" "pip install gptme"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/contabo/claude.sh
+++ b/contabo/claude.sh
@@ -36,8 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${CONTABO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${CONTABO_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${CONTABO_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/contabo/gemini.sh
+++ b/contabo/gemini.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${CONTABO_SERVER_IP}" "command -v gemini &> /dev/null"; then
-    log_error "Gemini CLI installation verification failed"
-    log_error "The 'gemini' command is not available on server ${CONTABO_SERVER_IP}"
+    log_install_failed "Gemini CLI" "npm install -g @google/gemini-cli" "${CONTABO_SERVER_IP}"
     exit 1
 fi
 log_info "Gemini CLI installation verified successfully"

--- a/contabo/goose.sh
+++ b/contabo/goose.sh
@@ -33,8 +33,7 @@ run_server "${CONTABO_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com
 
 # Verify installation succeeded
 if ! run_server "${CONTABO_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly on server ${CONTABO_SERVER_IP}"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${CONTABO_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/contabo/gptme.sh
+++ b/contabo/gptme.sh
@@ -32,8 +32,7 @@ run_server "$CONTABO_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install g
 
 # Verify installation succeeded
 if ! run_server "$CONTABO_SERVER_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server $CONTABO_SERVER_IP"
+    log_install_failed "gptme" "pip install gptme" "${CONTABO_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/contabo/plandex.sh
+++ b/contabo/plandex.sh
@@ -33,8 +33,7 @@ run_server "${CONTABO_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash
 
 # Verify installation succeeded
 if ! run_server "${CONTABO_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${CONTABO_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${CONTABO_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/digitalocean/aider.sh
+++ b/digitalocean/aider.sh
@@ -33,8 +33,7 @@ run_server "${DO_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install
 
 # Verify installation succeeded
 if ! run_server "${DO_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly on server ${DO_SERVER_IP}"
+    log_install_failed "Aider" "pip install aider-chat" "${DO_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -39,8 +39,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${DO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${DO_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${DO_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/digitalocean/gptme.sh
+++ b/digitalocean/gptme.sh
@@ -32,8 +32,7 @@ run_server "$DO_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
 if ! run_server "$DO_SERVER_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server $DO_SERVER_IP"
+    log_install_failed "gptme" "pip install gptme" "${DO_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/digitalocean/plandex.sh
+++ b/digitalocean/plandex.sh
@@ -33,8 +33,7 @@ run_server "${DO_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_server "${DO_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${DO_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${DO_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/exoscale/gptme.sh
+++ b/exoscale/gptme.sh
@@ -32,8 +32,7 @@ run_server "$EXOSCALE_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install 
 
 # Verify installation succeeded
 if ! run_server "$EXOSCALE_SERVER_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server $EXOSCALE_SERVER_IP"
+    log_install_failed "gptme" "pip install gptme" "${EXOSCALE_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/exoscale/plandex.sh
+++ b/exoscale/plandex.sh
@@ -33,8 +33,7 @@ run_server "${EXOSCALE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bas
 
 # Verify installation succeeded
 if ! run_server "${EXOSCALE_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${EXOSCALE_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${EXOSCALE_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -29,7 +29,7 @@ run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
 if ! run_server "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_error "Claude Code installation failed"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
     exit 1
 fi
 log_info "Claude Code installed"

--- a/fly/goose.sh
+++ b/fly/goose.sh
@@ -29,7 +29,7 @@ run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/l
 
 # Verify installation
 if ! run_server "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
     exit 1
 fi
 log_info "Goose installed"

--- a/github-codespaces/claude.sh
+++ b/github-codespaces/claude.sh
@@ -43,7 +43,7 @@ run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
 if ! run_server "command -v claude" &>/dev/null; then
-    log_error "Claude Code installation failed"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
     delete_codespace "$CODESPACE"
     exit 1
 fi

--- a/hetzner/aider.sh
+++ b/hetzner/aider.sh
@@ -33,8 +33,7 @@ run_server "${HETZNER_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 in
 
 # Verify installation succeeded
 if ! run_server "${HETZNER_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly on server ${HETZNER_SERVER_IP}"
+    log_install_failed "Aider" "pip install aider-chat" "${HETZNER_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -36,8 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${HETZNER_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${HETZNER_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${HETZNER_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/hetzner/goose.sh
+++ b/hetzner/goose.sh
@@ -33,8 +33,7 @@ run_server "${HETZNER_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com
 
 # Verify installation succeeded
 if ! run_server "${HETZNER_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly on server ${HETZNER_SERVER_IP}"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${HETZNER_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/hetzner/gptme.sh
+++ b/hetzner/gptme.sh
@@ -32,8 +32,7 @@ run_server "$HETZNER_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install g
 
 # Verify installation succeeded
 if ! run_server "$HETZNER_SERVER_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server $HETZNER_SERVER_IP"
+    log_install_failed "gptme" "pip install gptme" "${HETZNER_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/hetzner/plandex.sh
+++ b/hetzner/plandex.sh
@@ -33,8 +33,7 @@ run_server "${HETZNER_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash
 
 # Verify installation succeeded
 if ! run_server "${HETZNER_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${HETZNER_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${HETZNER_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/hostinger/aider.sh
+++ b/hostinger/aider.sh
@@ -33,8 +33,7 @@ run_server "${HOSTINGER_VPS_IP}" "pip install aider-chat 2>/dev/null || pip3 ins
 
 # Verify installation succeeded
 if ! run_server "${HOSTINGER_VPS_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly on VPS ${HOSTINGER_VPS_IP}"
+    log_install_failed "Aider" "pip install aider-chat" "${HOSTINGER_VPS_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/hostinger/claude.sh
+++ b/hostinger/claude.sh
@@ -36,8 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${HOSTINGER_VPS_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on VPS ${HOSTINGER_VPS_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${HOSTINGER_VPS_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/hostinger/gptme.sh
+++ b/hostinger/gptme.sh
@@ -32,8 +32,7 @@ run_server "$HOSTINGER_VPS_IP" "pip install gptme 2>/dev/null || pip3 install gp
 
 # Verify installation succeeded
 if ! run_server "$HOSTINGER_VPS_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server $HOSTINGER_VPS_IP"
+    log_install_failed "gptme" "pip install gptme" "${HOSTINGER_VPS_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/hostinger/plandex.sh
+++ b/hostinger/plandex.sh
@@ -33,8 +33,7 @@ run_server "${HOSTINGER_VPS_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_server "${HOSTINGER_VPS_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${HOSTINGER_VPS_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${HOSTINGER_VPS_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/hostkey/claude.sh
+++ b/hostkey/claude.sh
@@ -36,8 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${HOSTKEY_INSTANCE_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${HOSTKEY_INSTANCE_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${HOSTKEY_INSTANCE_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/hyperstack/claude.sh
+++ b/hyperstack/claude.sh
@@ -35,8 +35,7 @@ run_server "${HYPERSTACK_VM_IP}" "curl -fsSL https://claude.ai/install.sh | bash
 
 # Verify installation succeeded
 if ! run_server "${HYPERSTACK_VM_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on VM ${HYPERSTACK_VM_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${HYPERSTACK_VM_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/ionos/aider.sh
+++ b/ionos/aider.sh
@@ -36,8 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly on server ${IONOS_SERVER_IP}"
+    log_install_failed "Aider" "pip install aider-chat" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/ionos/amazonq.sh
+++ b/ionos/amazonq.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v q &> /dev/null"; then
-    log_error "Amazon Q CLI installation verification failed"
-    log_error "The 'q' command is not available on server ${IONOS_SERVER_IP}"
+    log_install_failed "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Amazon Q CLI installation verified successfully"

--- a/ionos/cline.sh
+++ b/ionos/cline.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v cline &> /dev/null"; then
-    log_error "Cline installation verification failed"
-    log_error "The 'cline' command is not available on server ${IONOS_SERVER_IP}"
+    log_install_failed "Cline" "npm install -g cline" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Cline installation verified successfully"

--- a/ionos/codex.sh
+++ b/ionos/codex.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v codex &> /dev/null"; then
-    log_error "Codex CLI installation verification failed"
-    log_error "The 'codex' command is not available on server ${IONOS_SERVER_IP}"
+    log_install_failed "Codex CLI" "npm install -g @openai/codex" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Codex CLI installation verified successfully"

--- a/ionos/continue.sh
+++ b/ionos/continue.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v cn &> /dev/null"; then
-    log_error "Continue CLI installation verification failed"
-    log_error "The 'cn' command is not available on server ${IONOS_SERVER_IP}"
+    log_install_failed "Continue" "npm install -g @continuedev/cli" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Continue CLI installation verified successfully"

--- a/ionos/gemini.sh
+++ b/ionos/gemini.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v gemini &> /dev/null"; then
-    log_error "Gemini CLI installation verification failed"
-    log_error "The 'gemini' command is not available on server ${IONOS_SERVER_IP}"
+    log_install_failed "Gemini CLI" "npm install -g @google/gemini-cli" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Gemini CLI installation verified successfully"

--- a/ionos/goose.sh
+++ b/ionos/goose.sh
@@ -36,8 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly on server ${IONOS_SERVER_IP}"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/ionos/gptme.sh
+++ b/ionos/gptme.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server ${IONOS_SERVER_IP}"
+    log_install_failed "gptme" "pip install gptme" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/ionos/interpreter.sh
+++ b/ionos/interpreter.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v interpreter &> /dev/null"; then
-    log_error "Open Interpreter installation verification failed"
-    log_error "The 'interpreter' command is not available on server ${IONOS_SERVER_IP}"
+    log_install_failed "Open Interpreter" "pip install open-interpreter" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Open Interpreter installation verified successfully"

--- a/ionos/kilocode.sh
+++ b/ionos/kilocode.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v kilocode &> /dev/null"; then
-    log_error "Kilo Code CLI installation verification failed"
-    log_error "The 'kilocode' command is not available on server ${IONOS_SERVER_IP}"
+    log_install_failed "Kilo Code" "npm install -g @kilocode/cli" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Kilo Code CLI installation verified successfully"

--- a/ionos/openclaw.sh
+++ b/ionos/openclaw.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v openclaw &> /dev/null"; then
-    log_error "openclaw installation verification failed"
-    log_error "The 'openclaw' command is not available on server ${IONOS_SERVER_IP}"
+    log_install_failed "OpenClaw" "bun install -g openclaw" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "openclaw installation verified successfully"

--- a/ionos/plandex.sh
+++ b/ionos/plandex.sh
@@ -35,8 +35,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${IONOS_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${IONOS_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${IONOS_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/kamatera/plandex.sh
+++ b/kamatera/plandex.sh
@@ -26,7 +26,7 @@ log_step "Installing Plandex..."
 run_server "${KAMATERA_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 if ! run_server "${KAMATERA_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${KAMATERA_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installed"

--- a/koyeb/claude.sh
+++ b/koyeb/claude.sh
@@ -29,7 +29,7 @@ run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
 if ! run_server "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_error "Claude Code installation failed"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
     exit 1
 fi
 log_info "Claude Code installed"

--- a/latitude/aider.sh
+++ b/latitude/aider.sh
@@ -36,8 +36,7 @@ run_server "${LATITUDE_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 i
 
 # Verify installation succeeded
 if ! run_server "${LATITUDE_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly on server ${LATITUDE_SERVER_IP}"
+    log_install_failed "Aider" "pip install aider-chat" "${LATITUDE_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/latitude/claude.sh
+++ b/latitude/claude.sh
@@ -36,8 +36,7 @@ run_server "${LATITUDE_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | ba
 
 # Verify installation succeeded
 if ! run_server "${LATITUDE_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${LATITUDE_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${LATITUDE_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/latitude/goose.sh
+++ b/latitude/goose.sh
@@ -36,8 +36,7 @@ run_server "${LATITUDE_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.co
 
 # Verify installation succeeded
 if ! run_server "${LATITUDE_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly on server ${LATITUDE_SERVER_IP}"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${LATITUDE_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/latitude/gptme.sh
+++ b/latitude/gptme.sh
@@ -36,8 +36,7 @@ run_server "${LATITUDE_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 instal
 
 # Verify installation succeeded
 if ! run_server "${LATITUDE_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server ${LATITUDE_SERVER_IP}"
+    log_install_failed "gptme" "pip install gptme" "${LATITUDE_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/latitude/plandex.sh
+++ b/latitude/plandex.sh
@@ -36,8 +36,7 @@ run_server "${LATITUDE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bas
 
 # Verify installation succeeded
 if ! run_server "${LATITUDE_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${LATITUDE_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${LATITUDE_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/linode/plandex.sh
+++ b/linode/plandex.sh
@@ -15,7 +15,7 @@ wait_for_cloud_init "${LINODE_SERVER_IP}" 60
 log_step "Installing Plandex..."
 run_server "${LINODE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 if ! run_server "${LINODE_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${LINODE_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installed"

--- a/local/aider.sh
+++ b/local/aider.sh
@@ -25,9 +25,7 @@ fi
 
 # Verify installation
 if ! command -v aider &>/dev/null || ! aider --version &>/dev/null; then
-    log_error "Aider installation failed"
-    log_error "The 'aider' command is not available or not working properly"
-    log_error "Try installing manually: pip install aider-chat"
+    log_install_failed "Aider" "pip install aider-chat"
     exit 1
 fi
 log_info "Aider installation verified"

--- a/local/amazonq.sh
+++ b/local/amazonq.sh
@@ -26,9 +26,7 @@ fi
 
 # Verify installation
 if ! command -v q &>/dev/null; then
-    log_error "Amazon Q CLI installation failed"
-    log_error "The 'q' command is not available"
-    log_error "Try installing manually: curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+    log_install_failed "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
     exit 1
 fi
 log_info "Amazon Q CLI installation verified"

--- a/local/claude.sh
+++ b/local/claude.sh
@@ -26,9 +26,7 @@ fi
 
 # Verify installation
 if ! command -v claude &>/dev/null; then
-    log_error "Claude Code installation failed"
-    log_error "The 'claude' command is not available"
-    log_error "Try installing manually: curl -fsSL https://claude.ai/install.sh | bash"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
     exit 1
 fi
 log_info "Claude Code installation verified"

--- a/local/cline.sh
+++ b/local/cline.sh
@@ -25,9 +25,7 @@ npm install -g cline
 
 # Verify installation
 if ! command -v cline &>/dev/null; then
-    log_error "Cline installation failed"
-    log_error "The 'cline' command is not available"
-    log_error "Try installing manually: npm install -g cline"
+    log_install_failed "Cline" "npm install -g cline"
     exit 1
 fi
 log_info "Cline installation verified"

--- a/local/codex.sh
+++ b/local/codex.sh
@@ -32,9 +32,7 @@ fi
 
 # Verify installation
 if ! command -v codex &>/dev/null; then
-    log_error "Codex installation failed"
-    log_error "The 'codex' command is not available"
-    log_error "Try installing manually: npm install -g @openai/codex"
+    log_install_failed "Codex CLI" "npm install -g @openai/codex"
     exit 1
 fi
 log_info "Codex installation verified"

--- a/local/continue.sh
+++ b/local/continue.sh
@@ -32,9 +32,7 @@ fi
 
 # Verify installation
 if ! command -v cn &>/dev/null; then
-    log_error "Continue installation failed"
-    log_error "The 'cn' command is not available"
-    log_error "Try installing manually: npm install -g @continuedev/cli"
+    log_install_failed "Continue" "npm install -g @continuedev/cli"
     exit 1
 fi
 log_info "Continue installation verified"

--- a/local/gemini.sh
+++ b/local/gemini.sh
@@ -26,9 +26,7 @@ fi
 
 # Verify installation
 if ! command -v gemini &>/dev/null; then
-    log_error "Gemini CLI installation failed"
-    log_error "The 'gemini' command is not available"
-    log_error "Try installing manually: npm install -g @google/gemini-cli"
+    log_install_failed "Gemini CLI" "npm install -g @google/gemini-cli"
     exit 1
 fi
 log_info "Gemini CLI installation verified"

--- a/local/goose.sh
+++ b/local/goose.sh
@@ -25,9 +25,7 @@ fi
 
 # Verify installation
 if ! command -v goose &>/dev/null; then
-    log_error "Goose installation failed"
-    log_error "The 'goose' command is not available"
-    log_error "Try installing manually: CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
     exit 1
 fi
 log_info "Goose installation verified"

--- a/local/gptme.sh
+++ b/local/gptme.sh
@@ -25,9 +25,7 @@ fi
 
 # Verify installation
 if ! command -v gptme &>/dev/null; then
-    log_error "gptme installation failed"
-    log_error "The 'gptme' command is not available"
-    log_error "Try installing manually: pip install gptme"
+    log_install_failed "gptme" "pip install gptme"
     exit 1
 fi
 log_info "gptme installation verified"

--- a/local/interpreter.sh
+++ b/local/interpreter.sh
@@ -25,9 +25,7 @@ fi
 
 # Verify installation
 if ! command -v interpreter &>/dev/null; then
-    log_error "Open Interpreter installation failed"
-    log_error "The 'interpreter' command is not available"
-    log_error "Try installing manually: pip install open-interpreter"
+    log_install_failed "Open Interpreter" "pip install open-interpreter"
     exit 1
 fi
 log_info "Open Interpreter installation verified"

--- a/local/kilocode.sh
+++ b/local/kilocode.sh
@@ -25,9 +25,7 @@ fi
 
 # Verify installation
 if ! command -v kilocode &>/dev/null; then
-    log_error "Kilo Code installation failed"
-    log_error "The 'kilocode' command is not available"
-    log_error "Try installing manually: npm install -g @kilocode/cli"
+    log_install_failed "Kilo Code" "npm install -g @kilocode/cli"
     exit 1
 fi
 log_info "Kilo Code installation verified"

--- a/local/plandex.sh
+++ b/local/plandex.sh
@@ -24,8 +24,7 @@ run_server "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_server "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/netcup/aider.sh
+++ b/netcup/aider.sh
@@ -33,8 +33,7 @@ run_server "${NETCUP_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 ins
 
 # Verify installation succeeded
 if ! run_server "${NETCUP_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly on server ${NETCUP_SERVER_IP}"
+    log_install_failed "Aider" "pip install aider-chat" "${NETCUP_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/netcup/claude.sh
+++ b/netcup/claude.sh
@@ -36,8 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${NETCUP_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${NETCUP_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${NETCUP_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/netcup/goose.sh
+++ b/netcup/goose.sh
@@ -33,8 +33,7 @@ run_server "${NETCUP_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/
 
 # Verify installation succeeded
 if ! run_server "${NETCUP_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly on server ${NETCUP_SERVER_IP}"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${NETCUP_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/netcup/gptme.sh
+++ b/netcup/gptme.sh
@@ -33,8 +33,7 @@ run_server "${NETCUP_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install 
 
 # Verify installation succeeded
 if ! run_server "${NETCUP_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server ${NETCUP_SERVER_IP}"
+    log_install_failed "gptme" "pip install gptme" "${NETCUP_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/netcup/plandex.sh
+++ b/netcup/plandex.sh
@@ -32,8 +32,7 @@ run_server "${NETCUP_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_server "${NETCUP_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${NETCUP_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${NETCUP_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/northflank/claude.sh
+++ b/northflank/claude.sh
@@ -31,7 +31,7 @@ run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
 if ! run_server "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_error "Claude Code installation failed"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
     exit 1
 fi
 log_info "Claude Code is installed"

--- a/northflank/goose.sh
+++ b/northflank/goose.sh
@@ -29,8 +29,7 @@ run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/l
 
 # Verify installation succeeded
 if ! run_server "command -v goose && goose --version"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/northflank/gptme.sh
+++ b/northflank/gptme.sh
@@ -26,8 +26,7 @@ run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation
 if ! run_server "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly"
+    log_install_failed "gptme" "pip install gptme"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/northflank/kilocode.sh
+++ b/northflank/kilocode.sh
@@ -26,8 +26,7 @@ run_server "curl -fsSL https://bun.sh/install | bash && export PATH=\"\$HOME/.bu
 
 # Verify installation
 if ! run_server "command -v kilocode &> /dev/null"; then
-    log_error "kilocode installation verification failed"
-    log_error "The 'kilocode' command is not available"
+    log_install_failed "Kilo Code" "npm install -g @kilocode/cli"
     exit 1
 fi
 log_info "Kilo Code installation verified successfully"

--- a/northflank/opencode.sh
+++ b/northflank/opencode.sh
@@ -26,8 +26,7 @@ run_server "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/re
 
 # Verify installation
 if ! run_server "command -v opencode &> /dev/null"; then
-    log_error "opencode installation verification failed"
-    log_error "The 'opencode' command is not available"
+    log_install_failed "OpenCode" "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
     exit 1
 fi
 log_info "OpenCode installation verified successfully"

--- a/northflank/plandex.sh
+++ b/northflank/plandex.sh
@@ -26,8 +26,7 @@ run_server "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation
 if ! run_server "command -v plandex &> /dev/null"; then
-    log_error "plandex installation verification failed"
-    log_error "The 'plandex' command is not available"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/oracle/gptme.sh
+++ b/oracle/gptme.sh
@@ -38,8 +38,7 @@ run_server "${OCI_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gpt
 
 # Verify installation succeeded
 if ! run_server "${OCI_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server ${OCI_SERVER_IP}"
+    log_install_failed "gptme" "pip install gptme" "${OCI_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/oracle/plandex.sh
+++ b/oracle/plandex.sh
@@ -37,8 +37,7 @@ run_server "${OCI_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_server "${OCI_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${OCI_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${OCI_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/ovh/aider.sh
+++ b/ovh/aider.sh
@@ -38,8 +38,7 @@ run_ovh "${OVH_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install a
 
 # Verify installation succeeded
 if ! run_ovh "${OVH_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly on server ${OVH_SERVER_IP}"
+    log_install_failed "Aider" "pip install aider-chat" "${OVH_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/ovh/claude.sh
+++ b/ovh/claude.sh
@@ -41,8 +41,7 @@ fi
 
 # Verify installation succeeded
 if ! run_ovh "${OVH_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${OVH_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${OVH_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/ovh/goose.sh
+++ b/ovh/goose.sh
@@ -38,8 +38,7 @@ run_ovh "${OVH_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/
 
 # Verify installation succeeded
 if ! run_ovh "${OVH_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly on server ${OVH_SERVER_IP}"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${OVH_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/ovh/gptme.sh
+++ b/ovh/gptme.sh
@@ -38,8 +38,7 @@ run_ovh "${OVH_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
 if ! run_ovh "${OVH_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server ${OVH_SERVER_IP}"
+    log_install_failed "gptme" "pip install gptme" "${OVH_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/ovh/plandex.sh
+++ b/ovh/plandex.sh
@@ -38,8 +38,7 @@ run_ovh "${OVH_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_ovh "${OVH_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly on server ${OVH_SERVER_IP}"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${OVH_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/railway/claude.sh
+++ b/railway/claude.sh
@@ -29,7 +29,7 @@ run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
 if ! run_server "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_error "Claude Code installation failed"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
     exit 1
 fi
 log_info "Claude Code installed"

--- a/railway/goose.sh
+++ b/railway/goose.sh
@@ -27,8 +27,7 @@ run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/l
 
 # Verify installation succeeded
 if ! run_server "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/ramnode/aider.sh
+++ b/ramnode/aider.sh
@@ -36,7 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${RAMNODE_SERVER_IP}" "command -v aider &> /dev/null"; then
-    log_error "Aider installation verification failed"
+    log_install_failed "Aider" "pip install aider-chat" "${RAMNODE_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/ramnode/claude.sh
+++ b/ramnode/claude.sh
@@ -36,8 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${RAMNODE_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${RAMNODE_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${RAMNODE_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/ramnode/cline.sh
+++ b/ramnode/cline.sh
@@ -36,7 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${RAMNODE_SERVER_IP}" "command -v cline &> /dev/null"; then
-    log_error "Cline installation verification failed"
+    log_install_failed "Cline" "npm install -g cline" "${RAMNODE_SERVER_IP}"
     exit 1
 fi
 log_info "Cline installation verified successfully"

--- a/ramnode/continue.sh
+++ b/ramnode/continue.sh
@@ -36,7 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${RAMNODE_SERVER_IP}" "command -v cn &> /dev/null"; then
-    log_error "Continue installation verification failed"
+    log_install_failed "Continue" "npm install -g @continuedev/cli" "${RAMNODE_SERVER_IP}"
     exit 1
 fi
 log_info "Continue installation verified successfully"

--- a/ramnode/goose.sh
+++ b/ramnode/goose.sh
@@ -36,7 +36,7 @@ fi
 
 # Verify installation succeeded
 if ! run_server "${RAMNODE_SERVER_IP}" "command -v goose &> /dev/null"; then
-    log_error "Goose installation verification failed"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${RAMNODE_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/ramnode/gptme.sh
+++ b/ramnode/gptme.sh
@@ -32,8 +32,7 @@ run_server "$RAMNODE_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install g
 
 # Verify installation succeeded
 if ! run_server "$RAMNODE_SERVER_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly on server $RAMNODE_SERVER_IP"
+    log_install_failed "gptme" "pip install gptme" "${RAMNODE_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/ramnode/plandex.sh
+++ b/ramnode/plandex.sh
@@ -25,8 +25,7 @@ run_server "${RAMNODE_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash
 
 # Verify installation
 if ! run_server "${RAMNODE_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${RAMNODE_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/render/aider.sh
+++ b/render/aider.sh
@@ -29,7 +29,7 @@ run_server "pip install aider-chat"
 
 # Verify installation
 if ! run_server "command -v aider" >/dev/null 2>&1; then
-    log_error "Aider installation failed"
+    log_install_failed "Aider" "pip install aider-chat"
     exit 1
 fi
 log_info "Aider installed"

--- a/render/amazonq.sh
+++ b/render/amazonq.sh
@@ -29,7 +29,7 @@ run_server "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/
 
 # Verify installation
 if ! run_server "command -v q" >/dev/null 2>&1; then
-    log_error "Amazon Q CLI installation failed"
+    log_install_failed "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
     exit 1
 fi
 log_info "Amazon Q CLI installed"

--- a/render/claude.sh
+++ b/render/claude.sh
@@ -29,7 +29,7 @@ run_server "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation
 if ! run_server "command -v claude" >/dev/null 2>&1; then
-    log_error "Claude Code installation failed"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
     exit 1
 fi
 log_info "Claude Code installed"

--- a/render/cline.sh
+++ b/render/cline.sh
@@ -29,7 +29,7 @@ run_server "npm install -g cline"
 
 # Verify installation
 if ! run_server "command -v cline" >/dev/null 2>&1; then
-    log_error "Cline installation failed"
+    log_install_failed "Cline" "npm install -g cline"
     exit 1
 fi
 log_info "Cline installed"

--- a/render/codex.sh
+++ b/render/codex.sh
@@ -30,7 +30,7 @@ run_server "npm install -g @openai/codex"
 
 # Verify installation
 if ! run_server "command -v codex" >/dev/null 2>&1; then
-    log_error "Codex CLI installation failed"
+    log_install_failed "Codex CLI" "npm install -g @openai/codex"
     exit 1
 fi
 log_info "Codex CLI installed"

--- a/render/gemini.sh
+++ b/render/gemini.sh
@@ -30,7 +30,7 @@ run_server "npm install -g @google/gemini-cli"
 
 # Verify installation
 if ! run_server "command -v gemini" >/dev/null 2>&1; then
-    log_error "Gemini CLI installation failed"
+    log_install_failed "Gemini CLI" "npm install -g @google/gemini-cli"
     exit 1
 fi
 log_info "Gemini CLI installed"

--- a/render/goose.sh
+++ b/render/goose.sh
@@ -29,7 +29,7 @@ run_server "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/l
 
 # Verify installation
 if ! run_server "command -v goose" >/dev/null 2>&1; then
-    log_error "Goose installation failed"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
     exit 1
 fi
 log_info "Goose installed"

--- a/render/gptme.sh
+++ b/render/gptme.sh
@@ -29,7 +29,7 @@ run_server "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation
 if ! run_server "command -v gptme && gptme --version" >/dev/null 2>&1; then
-    log_error "gptme installation failed"
+    log_install_failed "gptme" "pip install gptme"
     exit 1
 fi
 log_info "gptme installed"

--- a/render/interpreter.sh
+++ b/render/interpreter.sh
@@ -30,7 +30,7 @@ run_server "pip3 install open-interpreter"
 
 # Verify installation
 if ! run_server "command -v interpreter" >/dev/null 2>&1; then
-    log_error "Open Interpreter installation failed"
+    log_install_failed "Open Interpreter" "pip install open-interpreter"
     exit 1
 fi
 log_info "Open Interpreter installed"

--- a/render/kilocode.sh
+++ b/render/kilocode.sh
@@ -29,7 +29,7 @@ run_server "npm install -g @kilocode/cli"
 
 # Verify installation
 if ! run_server "command -v kilocode" >/dev/null 2>&1; then
-    log_error "Kilo Code CLI installation failed"
+    log_install_failed "Kilo Code" "npm install -g @kilocode/cli"
     exit 1
 fi
 log_info "Kilo Code CLI installed"

--- a/render/nanoclaw.sh
+++ b/render/nanoclaw.sh
@@ -29,7 +29,7 @@ run_server "curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get
 
 # Verify Node.js installation
 if ! run_server "command -v node" >/dev/null 2>&1; then
-    log_error "Node.js installation failed"
+    log_install_failed "NanoClaw" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
     exit 1
 fi
 log_info "Node.js installed"

--- a/render/openclaw.sh
+++ b/render/openclaw.sh
@@ -29,7 +29,7 @@ run_server "curl -fsSL https://bun.sh/install | bash"
 
 # Verify Bun installation
 if ! run_server "command -v /root/.bun/bin/bun" >/dev/null 2>&1; then
-    log_error "Bun installation failed"
+    log_install_failed "OpenClaw" "bun install -g openclaw"
     exit 1
 fi
 log_info "Bun installed"

--- a/render/opencode.sh
+++ b/render/opencode.sh
@@ -29,7 +29,7 @@ run_server "$(opencode_install_cmd)"
 
 # Verify installation
 if ! run_server "command -v opencode" >/dev/null 2>&1; then
-    log_error "OpenCode installation failed"
+    log_install_failed "OpenCode" "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
     exit 1
 fi
 log_info "OpenCode installed"

--- a/render/plandex.sh
+++ b/render/plandex.sh
@@ -29,7 +29,7 @@ run_server "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation
 if ! run_server "command -v plandex && plandex version" >/dev/null 2>&1; then
-    log_error "Plandex installation failed"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash"
     exit 1
 fi
 log_info "Plandex installed"

--- a/sprite/aider.sh
+++ b/sprite/aider.sh
@@ -31,8 +31,7 @@ run_sprite "${SPRITE_NAME}" "pip install aider-chat 2>/dev/null || pip3 install 
 
 # Verify installation succeeded
 if ! run_sprite "${SPRITE_NAME}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
-    log_error "The 'aider' command is not available or not working properly"
+    log_install_failed "Aider" "pip install aider-chat"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -31,8 +31,7 @@ run_sprite "${SPRITE_NAME}" "curl -fsSL https://claude.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_sprite "${SPRITE_NAME}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/sprite/goose.sh
+++ b/sprite/goose.sh
@@ -31,8 +31,7 @@ run_sprite "${SPRITE_NAME}" "CONFIGURE=false curl -fsSL https://github.com/block
 
 # Verify installation succeeded
 if ! run_sprite "${SPRITE_NAME}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
-    log_error "The 'goose' command is not available or not working properly"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/sprite/gptme.sh
+++ b/sprite/gptme.sh
@@ -31,8 +31,7 @@ run_sprite "$SPRITE_NAME" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 # Verify installation succeeded
 if ! run_sprite "$SPRITE_NAME" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
-    log_error "The 'gptme' command is not available or not working properly"
+    log_install_failed "gptme" "pip install gptme"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/sprite/plandex.sh
+++ b/sprite/plandex.sh
@@ -31,8 +31,7 @@ run_sprite "${SPRITE_NAME}" "curl -sL https://plandex.ai/install.sh | bash"
 
 # Verify installation succeeded
 if ! run_sprite "${SPRITE_NAME}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
-    log_error "The 'plandex' command is not available or not working properly"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/upcloud/aider.sh
+++ b/upcloud/aider.sh
@@ -23,7 +23,7 @@ log_step "Installing Aider..."
 run_server "${UPCLOUD_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
 
 if ! run_server "${UPCLOUD_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_error "Aider installation verification failed"
+    log_install_failed "Aider" "pip install aider-chat" "${UPCLOUD_SERVER_IP}"
     exit 1
 fi
 log_info "Aider installation verified successfully"

--- a/upcloud/claude.sh
+++ b/upcloud/claude.sh
@@ -33,8 +33,7 @@ run_server "${UPCLOUD_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bas
 
 # Verify installation succeeded
 if ! run_server "${UPCLOUD_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_error "Claude Code installation verification failed"
-    log_error "The 'claude' command is not available or not working properly on server ${UPCLOUD_SERVER_IP}"
+    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${UPCLOUD_SERVER_IP}"
     exit 1
 fi
 log_info "Claude Code installation verified successfully"

--- a/upcloud/goose.sh
+++ b/upcloud/goose.sh
@@ -23,7 +23,7 @@ log_step "Installing Goose..."
 run_server "${UPCLOUD_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
 
 if ! run_server "${UPCLOUD_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
-    log_error "Goose installation verification failed"
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${UPCLOUD_SERVER_IP}"
     exit 1
 fi
 log_info "Goose installation verified successfully"

--- a/upcloud/gptme.sh
+++ b/upcloud/gptme.sh
@@ -23,7 +23,7 @@ log_step "Installing gptme..."
 run_server "${UPCLOUD_SERVER_IP}" "pip install gptme 2>/dev/null || pip3 install gptme"
 
 if ! run_server "${UPCLOUD_SERVER_IP}" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_error "gptme installation verification failed"
+    log_install_failed "gptme" "pip install gptme" "${UPCLOUD_SERVER_IP}"
     exit 1
 fi
 log_info "gptme installation verified successfully"

--- a/upcloud/plandex.sh
+++ b/upcloud/plandex.sh
@@ -23,7 +23,7 @@ log_step "Installing Plandex..."
 run_server "${UPCLOUD_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 if ! run_server "${UPCLOUD_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${UPCLOUD_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installation verified successfully"

--- a/vultr/plandex.sh
+++ b/vultr/plandex.sh
@@ -24,7 +24,7 @@ log_step "Installing Plandex..."
 run_server "${VULTR_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
 
 if ! run_server "${VULTR_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_error "Plandex installation verification failed"
+    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${VULTR_SERVER_IP}"
     exit 1
 fi
 log_info "Plandex installed"


### PR DESCRIPTION
## Summary
- Add `log_install_failed` helper to `shared/common.sh` that provides structured troubleshooting when agent installation verification fails
- Update 126 agent scripts across all clouds to use the new helper instead of bare `log_error "X installation failed"` messages
- Improve SSH key registration failure message with actionable guidance

## What changed

**Before** (bare error, no guidance):
```
ERROR: Claude Code installation verification failed
```

**After** (structured causes + actionable steps):
```
ERROR: Claude Code installation verification failed

Possible causes:
  - Package manager timeout or network issue on the server
  - Insufficient disk space or memory on the server
  - The install script requires a dependency not yet available

How to fix:
  1. SSH into the server to debug:  ssh root@203.0.113.5
  2. Re-run the install manually:  curl -fsSL https://claude.ai/install.sh | bash
  3. Re-run this spawn command to try again on a fresh server
```

The helper adapts its output based on context:
- SSH-based clouds show the SSH debug command with the server IP
- All scripts show the agent-specific install command from manifest.json
- Container/local providers omit the SSH step

## Test plan
- [x] All 127 modified shell scripts pass `bash -n` syntax check
- [x] Spot-checked representative scripts from each cloud type (SSH, container, local)

-- refactor/ux-engineer