### PR TITLE
fix: show all auth vars in agent info quick start

### DIFF
--- a/cli/src/__tests__/cloud-agent-quickstart.test.ts
+++ b/cli/src/__tests__/cloud-agent-quickstart.test.ts
@@ -578,6 +578,35 @@ describe("cmdAgentInfo - Quick start auth patterns", () => {
       const output = getOutput();
       expect(output).toContain("upcloud.com");
     });
+
+    it("should show ALL auth env vars for multi-credential clouds", async () => {
+      await setupManifest(multiAuthManifest);
+      await cmdAgentInfo("claude");
+      const output = getOutput();
+      // Both vars from "UPCLOUD_USERNAME + UPCLOUD_PASSWORD" should appear
+      expect(output).toContain("UPCLOUD_USERNAME");
+      expect(output).toContain("UPCLOUD_PASSWORD");
+    });
+
+    it("should show URL hint only on first auth var, not repeated", async () => {
+      await setupManifest(multiAuthManifest);
+      await cmdAgentInfo("claude");
+      const lines = consoleSpy.mock.calls.map((c: any[]) => c.join(" "));
+      const quickStartIdx = lines.findIndex((l: string) => l.includes("Quick start"));
+      const afterQuickStart = lines.slice(quickStartIdx + 1);
+      const usernameLine = afterQuickStart.find(
+        (l: string) => l.includes("UPCLOUD_USERNAME")
+      );
+      const passwordLine = afterQuickStart.find(
+        (l: string) => l.includes("UPCLOUD_PASSWORD")
+      );
+      expect(usernameLine).toBeDefined();
+      expect(passwordLine).toBeDefined();
+      // URL hint should appear on the first auth var line
+      expect(usernameLine).toContain("upcloud.com");
+      // URL hint should NOT be repeated on the second auth var line
+      expect(passwordLine).not.toContain("upcloud.com");
+    });
   });
 
   describe("agent where first cloud has 'none' auth", () => {

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1380,8 +1380,10 @@ export async function cmdAgentInfo(agent: string): Promise<void> {
       console.log(pc.bold("Quick start:"));
       console.log(formatAuthVarLine("OPENROUTER_API_KEY", "https://openrouter.ai/settings/keys"));
       if (authVars.length > 0) {
-        const hint = cloudDef.url ?? `${cloudDef.name} credential`;
-        console.log(formatAuthVarLine(authVars[0], hint));
+        for (let i = 0; i < authVars.length; i++) {
+          // Only show the URL hint on the first auth var to avoid repetition
+          console.log(formatAuthVarLine(authVars[i], i === 0 ? cloudDef.url : undefined));
+        }
       }
       console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
     }


### PR DESCRIPTION
## Summary
- **Bug**: `spawn <agent>` quick start only showed the first auth env var when the best cloud requires multiple credentials (e.g., UpCloud with `UPCLOUD_USERNAME + UPCLOUD_PASSWORD`). Users only saw `export UPCLOUD_USERNAME=...` and had no idea they also needed `UPCLOUD_PASSWORD`.
- **Fix**: Iterate over all auth vars in `cmdAgentInfo`, consistent with how `printCloudQuickStart` (used by `spawn <cloud>`) already works.
- **Tests**: Added 2 new tests verifying all auth vars appear and URL hint is only shown on the first var.

## Affected clouds
Multi-credential clouds where this matters: UpCloud (2 vars), Netcup (3 vars), RamNode (3 vars), Contabo (4 vars), CloudSigma (2 vars).

## Test plan
- [x] Existing 41 tests in `cloud-agent-quickstart.test.ts` pass
- [x] 2 new tests added to verify multi-auth display
- [x] Full test suite: no regressions (pre-existing failures only)

-- refactor/ux-engineer