### PR TITLE
refactor: decompose cmdAgentInfo and generic_wait_for_instance

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1380,30 +1380,8 @@ export async function cmdAgentInfo(agent: string): Promise<void> {
   // Prioritize clouds where the user already has credentials
   const { sortedClouds, credCount } = prioritizeCloudsByCredentials(implClouds, manifest);
 
-  // Show quick-start with best available cloud (prefer one with credentials)
   if (sortedClouds.length > 0) {
-    const exampleCloud = sortedClouds[0];
-    const cloudDef = manifest.clouds[exampleCloud];
-    const authVars = parseAuthEnvVars(cloudDef.auth);
-    const hasCreds = hasCloudCredentials(cloudDef.auth);
-    const hasOpenRouterKey = !!process.env.OPENROUTER_API_KEY;
-    const allReady = hasOpenRouterKey && (hasCreds || authVars.length === 0);
-
-    console.log();
-    if (allReady) {
-      console.log(pc.bold("Quick start:") + "  " + pc.green("credentials detected -- ready to go"));
-      console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
-    } else {
-      console.log(pc.bold("Quick start:"));
-      console.log(formatAuthVarLine("OPENROUTER_API_KEY", "https://openrouter.ai/settings/keys"));
-      if (authVars.length > 0) {
-        for (let i = 0; i < authVars.length; i++) {
-          // Only show the URL hint on the first auth var to avoid repetition
-          console.log(formatAuthVarLine(authVars[i], i === 0 ? cloudDef.url : undefined));
-        }
-      }
-      console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
-    }
+    printAgentQuickStart(manifest, agentKey, sortedClouds[0]);
   }
 
   console.log();
@@ -1429,6 +1407,31 @@ export async function cmdAgentInfo(agent: string): Promise<void> {
     }
   );
   console.log();
+}
+
+/** Print quick-start instructions for an agent, using the best available cloud */
+function printAgentQuickStart(manifest: Manifest, agentKey: string, exampleCloud: string): void {
+  const cloudDef = manifest.clouds[exampleCloud];
+  const authVars = parseAuthEnvVars(cloudDef.auth);
+  const hasCreds = hasCloudCredentials(cloudDef.auth);
+  const hasOpenRouterKey = !!process.env.OPENROUTER_API_KEY;
+  const allReady = hasOpenRouterKey && (hasCreds || authVars.length === 0);
+
+  console.log();
+  if (allReady) {
+    console.log(pc.bold("Quick start:") + "  " + pc.green("credentials detected -- ready to go"));
+    console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
+  } else {
+    console.log(pc.bold("Quick start:"));
+    console.log(formatAuthVarLine("OPENROUTER_API_KEY", "https://openrouter.ai/settings/keys"));
+    if (authVars.length > 0) {
+      for (let i = 0; i < authVars.length; i++) {
+        // Only show the URL hint on the first auth var to avoid repetition
+        console.log(formatAuthVarLine(authVars[i], i === 0 ? cloudDef.url : undefined));
+      }
+    }
+    console.log(`  ${pc.cyan(`spawn ${agentKey} ${exampleCloud}`)}`);
+  }
 }
 
 // ── Cloud Info ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extract `printAgentQuickStart` from `cmdAgentInfo` (63 -> 43 lines) in `cli/src/commands.ts`, paralleling the existing `printCloudQuickStart` helper used by `cmdCloudInfo`
- Extract `_poll_instance_once` and `_report_instance_timeout` from `generic_wait_for_instance` (52 -> 20 lines) in `shared/common.sh`, eliminating duplicated elapsed-time logging, sleep, and increment code in the polling loop

## Test plan
- [x] `bash -n shared/common.sh` passes
- [x] All 128 CLI command tests pass (commands.test.ts, commands-info-details.test.ts, commands-display.test.ts, cloud-agent-quickstart.test.ts)
- [x] All 42 polling/error tests pass (shared-common-error-polling.test.ts) -- 2 pre-existing failures unrelated to this change
- [x] No regressions introduced (verified by running tests against both original and modified code)

-- refactor/complexity-hunter