### PR TITLE
ci: add mock test workflow for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: test-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  mock-tests:
+    name: Mock Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Run mock tests
+        run: |
+          bash test/mock.sh 2>&1 | tee /tmp/mock-output.log
+      - name: Post summary
+        if: always()
+        run: |
+          echo '## Mock Test Results' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          grep -E '(Results:|✓|✗|skip|━━━)' /tmp/mock-output.log | head -100 >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs `bash test/mock.sh` on every PR targeting `main`
- Includes concurrency grouping to cancel stale CI runs on the same branch
- 10-minute timeout to prevent hung jobs
- Posts test results to the GitHub Actions step summary for quick review

## Context
Extracted from #833 as a smaller, focused PR per reviewer feedback.

## Test plan
- [ ] Workflow file is valid YAML
- [ ] `bash test/mock.sh` runs successfully in CI
- [ ] Step summary shows test results

🤖 Generated with [Claude Code](https://claude.com/claude-code)