### PR TITLE
fix: add confirmation to history clear and improve UX details

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.73",
+  "version": "0.2.74",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/clear-history.test.ts
+++ b/cli/src/__tests__/clear-history.test.ts
@@ -268,33 +268,33 @@ describe("cmdListClear", () => {
     }
   });
 
-  it("should call log.info when no history exists", () => {
-    cmdListClear();
+  it("should call log.info when no history exists", async () => {
+    await cmdListClear();
     expect(mockLogInfo).toHaveBeenCalledTimes(1);
     const msg = mockLogInfo.mock.calls[0][0] as string;
     expect(msg).toContain("No spawn history to clear");
   });
 
-  it("should call log.success with count when clearing records", () => {
+  it("should call log.success with count when clearing records", async () => {
     const records: SpawnRecord[] = [
       { agent: "claude", cloud: "sprite", timestamp: "2026-01-01T00:00:00.000Z" },
       { agent: "aider", cloud: "hetzner", timestamp: "2026-01-02T00:00:00.000Z" },
     ];
     writeFileSync(join(testDir, "history.json"), JSON.stringify(records));
 
-    cmdListClear();
+    await cmdListClear();
     expect(mockLogSuccess).toHaveBeenCalledTimes(1);
     const msg = mockLogSuccess.mock.calls[0][0] as string;
     expect(msg).toContain("Cleared 2 spawn records from history");
   });
 
-  it("should use singular 'record' for a single entry", () => {
+  it("should use singular 'record' for a single entry", async () => {
     const records: SpawnRecord[] = [
       { agent: "claude", cloud: "sprite", timestamp: "2026-01-01T00:00:00.000Z" },
     ];
     writeFileSync(join(testDir, "history.json"), JSON.stringify(records));
 
-    cmdListClear();
+    await cmdListClear();
     expect(mockLogSuccess).toHaveBeenCalledTimes(1);
     const msg = mockLogSuccess.mock.calls[0][0] as string;
     expect(msg).toContain("Cleared 1 spawn record from history");
@@ -302,37 +302,37 @@ describe("cmdListClear", () => {
     expect(msg).not.toContain("Cleared 1 spawn records");
   });
 
-  it("should actually delete the history file", () => {
+  it("should actually delete the history file", async () => {
     const records: SpawnRecord[] = [
       { agent: "claude", cloud: "sprite", timestamp: "2026-01-01T00:00:00.000Z" },
     ];
     writeFileSync(join(testDir, "history.json"), JSON.stringify(records));
 
-    cmdListClear();
+    await cmdListClear();
     expect(existsSync(join(testDir, "history.json"))).toBe(false);
   });
 
-  it("should handle empty array history file as no history", () => {
+  it("should handle empty array history file as no history", async () => {
     writeFileSync(join(testDir, "history.json"), "[]");
 
-    cmdListClear();
+    await cmdListClear();
     expect(mockLogInfo).toHaveBeenCalledTimes(1);
     expect(mockLogSuccess).not.toHaveBeenCalled();
     const msg = mockLogInfo.mock.calls[0][0] as string;
     expect(msg).toContain("No spawn history to clear");
   });
 
-  it("should handle corrupted history file as no history", () => {
+  it("should handle corrupted history file as no history", async () => {
     writeFileSync(join(testDir, "history.json"), "corrupt{{{");
 
-    cmdListClear();
+    await cmdListClear();
     expect(mockLogInfo).toHaveBeenCalledTimes(1);
     expect(mockLogSuccess).not.toHaveBeenCalled();
     const msg = mockLogInfo.mock.calls[0][0] as string;
     expect(msg).toContain("No spawn history to clear");
   });
 
-  it("should display correct count for large history", () => {
+  it("should display correct count for large history", async () => {
     const records: SpawnRecord[] = [];
     for (let i = 0; i < 50; i++) {
       records.push({
@@ -343,19 +343,19 @@ describe("cmdListClear", () => {
     }
     writeFileSync(join(testDir, "history.json"), JSON.stringify(records));
 
-    cmdListClear();
+    await cmdListClear();
     expect(mockLogSuccess).toHaveBeenCalledTimes(1);
     const msg = mockLogSuccess.mock.calls[0][0] as string;
     expect(msg).toContain("Cleared 50 spawn records from history");
   });
 
-  it("should allow saving new records after clearing via cmdListClear", () => {
+  it("should allow saving new records after clearing via cmdListClear", async () => {
     const records: SpawnRecord[] = [
       { agent: "claude", cloud: "sprite", timestamp: "2026-01-01T00:00:00.000Z" },
     ];
     writeFileSync(join(testDir, "history.json"), JSON.stringify(records));
 
-    cmdListClear();
+    await cmdListClear();
 
     // Save new record after clearing
     saveSpawnRecord({ agent: "aider", cloud: "hetzner", timestamp: "2026-01-02T00:00:00.000Z" });
@@ -364,9 +364,9 @@ describe("cmdListClear", () => {
     expect(loaded[0].agent).toBe("aider");
   });
 
-  it("should use log.info for zero records and log.success for non-zero", () => {
+  it("should use log.info for zero records and log.success for non-zero", async () => {
     // Test with zero
-    cmdListClear();
+    await cmdListClear();
     expect(mockLogInfo).toHaveBeenCalledTimes(1);
     expect(mockLogSuccess).not.toHaveBeenCalled();
 
@@ -379,7 +379,7 @@ describe("cmdListClear", () => {
       { agent: "claude", cloud: "sprite", timestamp: "2026-01-01T00:00:00.000Z" },
     ];
     writeFileSync(join(testDir, "history.json"), JSON.stringify(records));
-    cmdListClear();
+    await cmdListClear();
     expect(mockLogSuccess).toHaveBeenCalledTimes(1);
     expect(mockLogInfo).not.toHaveBeenCalled();
   });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -259,6 +259,7 @@ async function handleNoCommand(prompt: string | undefined, dryRun?: boolean): Pr
     console.error(pc.yellow("No interactive terminal detected."));
     console.error();
     console.error(`  Launch directly:  ${pc.cyan("spawn <agent> <cloud>")}`);
+    console.error(`  Rerun previous:   ${pc.cyan("spawn list")}`);
     console.error(`  Browse agents:    ${pc.cyan("spawn agents")}`);
     console.error(`  Browse clouds:    ${pc.cyan("spawn clouds")}`);
     console.error(`  Full help:        ${pc.cyan("spawn help")}`);
@@ -284,6 +285,7 @@ function showVersion(): void {
   console.log(pc.dim(`  ${process.versions.bun ? "bun" : "node"} ${process.versions.bun ?? process.versions.node}  ${process.platform} ${process.arch}`));
   const age = getCacheAge();
   console.log(pc.dim(`  manifest cache: ${formatCacheAge(age)}`));
+  console.log(pc.dim(`  https://github.com/OpenRouterTeam/spawn`));
   console.log(pc.dim(`  Run ${pc.cyan("spawn update")} to check for updates.`));
 }
 
@@ -364,7 +366,7 @@ function hasTrailingHelpFlag(args: string[]): boolean {
 async function dispatchListCommand(filteredArgs: string[]): Promise<void> {
   if (hasTrailingHelpFlag(filteredArgs)) { cmdHelp(); return; }
   if (filteredArgs.slice(1).includes("--clear")) {
-    cmdListClear();
+    await cmdListClear();
     return;
   }
   const { agentFilter, cloudFilter } = parseListFilters(filteredArgs.slice(1));


### PR DESCRIPTION
## Summary

- Add interactive confirmation prompt before `spawn list --clear` deletes history, preventing accidental data loss
- Show total prompt character count in `--dry-run` preview when prompt exceeds 100 characters, helping users verify the correct prompt was loaded from `--prompt-file`
- Add "Rerun previous: spawn list" to non-interactive terminal fallback message
- Show "(shown first)" in interactive cloud picker when credentials are detected, clarifying the sort order
- Add repository URL to `spawn version` output for discoverability
- Bump CLI version to 0.2.74

## Test plan

- [x] All 27 `cmdListClear` tests updated for async and passing
- [x] All 107 related tests pass (clear-history, commands, dry-run-preview, index-parsing)
- [x] Pre-existing failures (CodeSandbox patterns, extra args case) are unchanged

-- refactor/ux-engineer