### PR TITLE
fix: defense-in-depth for SPAWN_HOME and manifest JSON sanitization

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.73",
+  "version": "0.2.74",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/history.test.ts
+++ b/cli/src/__tests__/history.test.ts
@@ -42,6 +42,26 @@ describe("history", () => {
       const { homedir } = require("os");
       expect(getSpawnDir()).toBe(join(homedir(), ".spawn"));
     });
+
+    it("throws for relative SPAWN_HOME path", () => {
+      process.env.SPAWN_HOME = "relative/path";
+      expect(() => getSpawnDir()).toThrow("must be an absolute path");
+    });
+
+    it("throws for dot-relative SPAWN_HOME path", () => {
+      process.env.SPAWN_HOME = "./local/dir";
+      expect(() => getSpawnDir()).toThrow("must be an absolute path");
+    });
+
+    it("resolves .. segments in absolute SPAWN_HOME", () => {
+      process.env.SPAWN_HOME = "/tmp/foo/../bar";
+      expect(getSpawnDir()).toBe("/tmp/bar");
+    });
+
+    it("accepts normal absolute SPAWN_HOME", () => {
+      process.env.SPAWN_HOME = "/home/user/.spawn";
+      expect(getSpawnDir()).toBe("/home/user/.spawn");
+    });
   });
 
   // ── getHistoryPath ──────────────────────────────────────────────────────

--- a/cli/src/__tests__/security-encoding.test.ts
+++ b/cli/src/__tests__/security-encoding.test.ts
@@ -160,3 +160,67 @@ describe("Security Encoding Edge Cases", () => {
     });
   });
 });
+
+// ── stripDangerousKeys (prototype pollution defense) ─────────────────────────
+
+import { stripDangerousKeys } from "../manifest";
+
+describe("stripDangerousKeys", () => {
+  it("strips __proto__ from parsed JSON", () => {
+    // JSON.parse produces an own-property __proto__ key (not inherited)
+    const input = JSON.parse('{"agents":{},"clouds":{},"matrix":{},"__proto__":{"polluted":true}}');
+    expect(Object.prototype.hasOwnProperty.call(input, "__proto__")).toBe(true);
+    const result = stripDangerousKeys(input);
+    expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(false);
+    expect(result.agents).toEqual({});
+  });
+
+  it("strips constructor key", () => {
+    const input = Object.assign(Object.create(null), { name: "test", constructor: { evil: true } });
+    const result = stripDangerousKeys(input);
+    expect(Object.keys(result)).toEqual(["name"]);
+    expect(result.name).toBe("test");
+  });
+
+  it("strips prototype key", () => {
+    const input = Object.assign(Object.create(null), { data: 1, prototype: { inject: true } });
+    const result = stripDangerousKeys(input);
+    expect(Object.keys(result)).toEqual(["data"]);
+    expect(result.data).toBe(1);
+  });
+
+  it("strips dangerous keys from nested objects", () => {
+    const input = { agents: { claude: { __proto__: { evil: true }, name: "Claude" } } };
+    const result = stripDangerousKeys(input);
+    expect(result.agents.claude.name).toBe("Claude");
+    expect(Object.keys(result.agents.claude)).toEqual(["name"]);
+  });
+
+  it("handles arrays correctly", () => {
+    const input = { items: [{ name: "a" }, { name: "b", __proto__: {} }] };
+    const result = stripDangerousKeys(input);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].name).toBe("a");
+    expect(result.items[1].name).toBe("b");
+  });
+
+  it("passes through primitives unchanged", () => {
+    expect(stripDangerousKeys("hello")).toBe("hello");
+    expect(stripDangerousKeys(42)).toBe(42);
+    expect(stripDangerousKeys(true)).toBe(true);
+    expect(stripDangerousKeys(null)).toBe(null);
+  });
+
+  it("preserves normal keys", () => {
+    const input = { agents: { a: 1 }, clouds: { b: 2 }, matrix: { c: 3 } };
+    const result = stripDangerousKeys(input);
+    expect(result).toEqual(input);
+  });
+
+  it("handles deeply nested dangerous keys", () => {
+    const input = { a: { b: { c: { constructor: "bad", value: "good" } } } };
+    const result = stripDangerousKeys(input);
+    expect(result.a.b.c.value).toBe("good");
+    expect(Object.keys(result.a.b.c)).toEqual(["value"]);
+  });
+});


### PR DESCRIPTION
## Summary
- **SPAWN_HOME validation** (Fixes #980): Validate that `SPAWN_HOME` env var is an absolute path. Relative paths are rejected with a clear error message. The resolved path collapses `..` segments to canonical form.
- **Manifest JSON sanitization** (Fixes #979): Strip `__proto__`, `constructor`, and `prototype` keys from parsed manifest JSON to prevent prototype pollution. Applied to all ingestion paths (GitHub fetch, disk cache, local dev manifest).
- Adds 12 new tests covering both fixes.
- Bumps CLI version to 0.2.74.

## Severity Assessment
Both issues are **MEDIUM** severity (not HIGH/CRITICAL):
- **#980**: `SPAWN_HOME` is a user-controlled local env var (like `HOME`, `XDG_CACHE_HOME`). An attacker who can set env vars already has code execution. The fix is defense-in-depth.
- **#979**: Modern JS engines (V8, JSC/Bun) handle `__proto__` safely in `JSON.parse()`. Manifest comes over HTTPS from GitHub. The fix is defense-in-depth.

## Test plan
- [x] All 83 history tests pass
- [x] All 208 manifest + security tests pass
- [x] All 257 SPAWN_HOME-dependent tests pass (list, cmdrun, etc.)
- [x] Pre-existing manifest-type-contracts failures unchanged

-- refactor/security-auditor