### PR TITLE
fix: CI test summary uses NO_COLOR instead of sed hack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run mock tests
+        env:
+          NO_COLOR: 1
         run: |
           bash test/mock.sh 2>&1 | tee /tmp/mock-output.log
       - name: Post summary
@@ -24,6 +26,5 @@ jobs:
         run: |
           echo '## Mock Test Results' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          # Strip ANSI color codes before grepping (output has escape sequences)
-          sed 's/\x1b\[[0-9;]*m//g' /tmp/mock-output.log | grep -E '(Results:|✓|✗|skip|━━━)' | head -100 >> "$GITHUB_STEP_SUMMARY"
+          grep -E '(Results:|✓|✗|skip|━━━)' /tmp/mock-output.log | head -100 >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/test/mock.sh
+++ b/test/mock.sh
@@ -20,12 +20,16 @@ FIXTURES_DIR="${REPO_ROOT}/test/fixtures"
 TEST_DIR=$(mktemp -d)
 MOCK_LOG="${TEST_DIR}/mock_calls.log"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
+# Colors (respect NO_COLOR standard: https://no-color.org/)
+if [[ -n "${NO_COLOR:-}" ]]; then
+    RED='' GREEN='' YELLOW='' CYAN='' NC=''
+else
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'
+    NC='\033[0m'
+fi
 
 # Counters
 PASSED=0


### PR DESCRIPTION
## Summary
- `test/mock.sh` now respects the `NO_COLOR` env var ([no-color.org](https://no-color.org/)) to disable ANSI escape codes
- CI workflow sets `NO_COLOR=1` so grep matches `✓`/`✗`/`━━━` cleanly without sed stripping

## Context
Follow-up to #977 — the post-summary step's grep couldn't match through ANSI color codes, causing empty summaries and broken pipe errors.

## Test plan
- [x] `bash -n test/mock.sh` passes
- [ ] CI step summary shows pass/fail counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)