### PR TITLE
fix: give QA fix agents full mock test output instead of 10-line snippets

### DIFF
--- a/.claude/skills/setup-agent-team/qa-cycle.sh
+++ b/.claude/skills/setup-agent-team/qa-cycle.sh
@@ -442,6 +442,15 @@ else
         FAILED_CLOUDS=$(grep ':fail$' "${RESULTS_PHASE2}" | sed 's/:fail$//' | cut -d/ -f1 | sort -u || true)
     fi
 
+    # Capture full mock test output per-cloud for richer agent context
+    MOCK_OUTPUT_DIR="/tmp/spawn-qa-mock-output"
+    rm -rf "${MOCK_OUTPUT_DIR}"
+    mkdir -p "${MOCK_OUTPUT_DIR}"
+    for cloud in $FAILED_CLOUDS; do
+        log "Phase 3: Capturing full mock test output for ${cloud}..."
+        bash test/mock.sh "$cloud" > "${MOCK_OUTPUT_DIR}/${cloud}.log" 2>&1 || true
+    done
+
     AGENT_PIDS=""
     for cloud in $FAILED_CLOUDS; do
         check_timeout || break
@@ -450,24 +459,20 @@ else
         cloud_failures=$(printf '%s\n' $FAILURES | grep "^${cloud}/" || true)
         failing_scripts=""
         failing_agents=""
-        error_context=""
         for combo in $cloud_failures; do
             agent=$(printf '%s' "$combo" | cut -d/ -f2)
             script_path="${cloud}/${agent}.sh"
             failing_scripts="${failing_scripts} ${script_path}"
             failing_agents="${failing_agents} ${agent}"
-            if [[ -f "${LOG_FILE}" ]]; then
-                ctx=$(grep -A 10 "test ${script_path}" "${LOG_FILE}" | tail -10 || true)
-                if [[ -n "$ctx" ]]; then
-                    error_context="${error_context}
---- ${script_path} ---
-${ctx}
-"
-                fi
-            fi
         done
         failing_scripts=$(printf '%s' "$failing_scripts" | sed 's/^ //')
         failing_agents=$(printf '%s' "$failing_agents" | sed 's/^ //')
+
+        # Use full mock test output as error context (not just 10 lines from log)
+        error_context=""
+        if [[ -f "${MOCK_OUTPUT_DIR}/${cloud}.log" ]]; then
+            error_context=$(cat "${MOCK_OUTPUT_DIR}/${cloud}.log")
+        fi
 
         fail_count=$(printf '%s\n' $cloud_failures | wc -l | tr -d ' ')
         log "Phase 3: Spawning teammate to fix ${fail_count} failing script(s) in ${cloud}"
@@ -575,6 +580,9 @@ FIXEOF
         git branch -D "qa/fix-${cloud}" 2>/dev/null || true
     done
     git worktree prune 2>/dev/null || true
+
+    # Clean up per-cloud mock output
+    rm -rf "${MOCK_OUTPUT_DIR}" 2>/dev/null || true
 
     log "Phase 3: Fix teammates complete"
 fi


### PR DESCRIPTION
## Summary
- Phase 3 fix agents now get complete mock test output per cloud, not just 10 lines grepped from the log
- Runs `bash test/mock.sh {cloud}` for each failing cloud and captures full output to a temp file
- Cleans up temp files after all fix agents complete

Previously, the error context was often too truncated for agents to diagnose root causes — they'd get the tail of one assertion failure but miss the setup context or earlier errors that caused the cascade.

## Changes
- `.claude/skills/setup-agent-team/qa-cycle.sh`: Replace per-script 10-line log grep with per-cloud full mock test capture

## Test plan
- [ ] Verify `bash -n` passes on modified script
- [ ] Confirm mock output dir is created, populated, and cleaned up
- [ ] Verify fix agents receive the full test output in their prompt

Extracted from #833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)