### PR TITLE
fix: add --delete-branch to all gh pr close commands

### DIFF
--- a/.claude/skills/setup-agent-team/discovery.sh
+++ b/.claude/skills/setup-agent-team/discovery.sh
@@ -372,7 +372,7 @@ Every teammate MUST follow this workflow using worktrees. NO exceptions.
    `gh pr edit NUMBER --repo OpenRouterTeam/spawn --add-label "needs-team-review"`
 8. **If PR cannot be created** (conflicts, etc.):
    - Comment on the PR explaining WHY
-   - Close with: `gh pr close {number} --comment "Closing: {reason}\n\n-- discovery/AGENT-NAME"`
+   - Close with: `gh pr close {number} --delete-branch --comment "Closing: {reason}\n\n-- discovery/AGENT-NAME"`
    - NEVER close a PR silently — every closed PR MUST have a comment
 9. Clean up worktree: `git worktree remove WORKTREE_BASE_PLACEHOLDER/{branch-name}`
 
@@ -398,7 +398,7 @@ You MUST remain active until ALL of the following are true:
 2. **All PRs are self-reviewed and labeled**: Run `gh pr list --repo OpenRouterTeam/spawn --state open --author @me` and confirm every PR from this cycle has a self-review comment and the `needs-team-review` label. Do NOT merge — PRs stay open for external review.
 3. **All provider PRs are labeled**: Run `gh pr list --repo OpenRouterTeam/spawn --state open --json number,title,headRefName` and check for ANY open PRs related to cloud providers. For each:
    - Ensure it has a self-review comment and `needs-team-review` label
-   - If not mergeable (conflicts) → close with comment: `gh pr close NUMBER --comment "Auto-closing: provider PR from interrupted cycle (unmergeable). Please reopen if still needed.\n\n-- discovery/team-lead"`
+   - If not mergeable (conflicts) → close with comment: `gh pr close NUMBER --delete-branch --comment "Auto-closing: provider PR from interrupted cycle (unmergeable). Please reopen if still needed.\n\n-- discovery/team-lead"`
    - If mergeable → leave open with label for external review (do NOT merge)
 4. **All worktrees are cleaned**: Run `git worktree list` and confirm only the main worktree exists. Run `rm -rf WORKTREE_BASE_PLACEHOLDER` and `git worktree prune`.
 5. **All teammates are shut down**: Send `shutdown_request` to EVERY teammate. Wait for each to confirm. Do NOT exit while any teammate is still active.
@@ -410,7 +410,7 @@ You MUST remain active until ALL of the following are true:
 3. **Sweep for leftover provider PRs**: `gh pr list --repo OpenRouterTeam/spawn --state open --json number,title,headRefName,mergeable`
    - For each PR whose title or branch references a cloud/provider:
      - If mergeable → ensure it has `needs-team-review` label and a self-review comment (do NOT merge)
-     - If not mergeable → close with `gh pr close NUMBER --comment "Auto-closing: stale provider PR (unmergeable). Please reopen if still needed.\n\n-- discovery/team-lead"`
+     - If not mergeable → close with `gh pr close NUMBER --delete-branch --comment "Auto-closing: stale provider PR (unmergeable). Please reopen if still needed.\n\n-- discovery/team-lead"`
    - Log every action taken
 4. For each teammate, send a `shutdown_request` via SendMessage
 5. Wait for all `shutdown_response` confirmations

--- a/.claude/skills/setup-agent-team/qa-cycle.sh
+++ b/.claude/skills/setup-agent-team/qa-cycle.sh
@@ -178,7 +178,7 @@ STALE_PRS=$(gh pr list --state open --label '' --json number,headRefName,updated
 for pr_num in $STALE_PRS; do
     if [[ -n "$pr_num" ]]; then
         log "Closing stale QA PR #${pr_num}..."
-        gh pr close "$pr_num" --comment "Auto-closing: stale QA PR from a previous cycle.
+        gh pr close "$pr_num" --delete-branch --comment "Auto-closing: stale QA PR from a previous cycle.
 
 -- qa/cycle" 2>&1 | tee -a "${LOG_FILE}" || true
     fi

--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -294,11 +294,10 @@ Create these teammates:
      * A previous reviewer flagged it as stale, duplicate, or no-longer-relevant
      If any of these apply:
      ```
-     gh pr close NUMBER --repo OpenRouterTeam/spawn --comment "Closing: [reason — e.g., superseded by #NNN / duplicate of #NNN / author abandoned].
+     gh pr close NUMBER --repo OpenRouterTeam/spawn --delete-branch --comment "Closing: [reason — e.g., superseded by #NNN / duplicate of #NNN / author abandoned].
 
 -- refactor/pr-maintainer"
      ```
-     Delete the branch: `git push origin --delete "$(gh pr view NUMBER --repo OpenRouterTeam/spawn --json headRefName --jq '.headRefName')" 2>/dev/null || true`
      Report to team lead and move on to the next PR.
    - For EACH remaining open PR, evaluate and take the appropriate action:
      * **Has merge conflicts**: rebase the PR branch onto main to resolve

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -467,11 +467,10 @@ Each pr-reviewer teammate must:
    * A previous reviewer flagged the PR as stale, duplicate, or no-longer-relevant
    If any of these apply, close the PR with a comment explaining why:
    \`\`\`bash
-   gh pr close NUMBER --repo OpenRouterTeam/spawn --comment "Closing: [reason — e.g., superseded by #NNN / duplicate of #NNN / author abandoned].
+   gh pr close NUMBER --repo OpenRouterTeam/spawn --delete-branch --comment "Closing: [reason — e.g., superseded by #NNN / duplicate of #NNN / author abandoned].
 
 -- security/pr-reviewer"
    \`\`\`
-   Delete the branch: \`git push origin --delete "\$(gh pr view NUMBER --repo OpenRouterTeam/spawn --json headRefName --jq '.headRefName')" 2>/dev/null || true\`
    Report to team lead and STOP — skip further review.
 
 3. **Staleness check** — Before doing security review, check:
@@ -503,20 +502,15 @@ PR #NUMBER was auto-closed due to staleness + merge conflicts, but the change it
        \`\`\`
      - Then close the PR with a comment referencing the new issue:
        \`\`\`bash
-       gh pr close NUMBER --repo OpenRouterTeam/spawn --comment "Auto-closing: this PR has been stale for >48h with merge conflicts. The change is still valid — filed ISSUE_URL to track re-implementation.
+       gh pr close NUMBER --repo OpenRouterTeam/spawn --delete-branch --comment "Auto-closing: this PR has been stale for >48h with merge conflicts. The change is still valid — filed ISSUE_URL to track re-implementation.
 
 -- security/pr-reviewer"
        \`\`\`
      - **If the PR is trivial, outdated, or no longer relevant**, close without filing an issue:
        \`\`\`bash
-       gh pr close NUMBER --repo OpenRouterTeam/spawn --comment "Auto-closing: this PR has been stale for >48h with merge conflicts and the changes are no longer relevant. Please reopen or create a fresh PR if still needed.
+       gh pr close NUMBER --repo OpenRouterTeam/spawn --delete-branch --comment "Auto-closing: this PR has been stale for >48h with merge conflicts and the changes are no longer relevant. Please reopen or create a fresh PR if still needed.
 
 -- security/pr-reviewer"
-       \`\`\`
-     - Then delete the branch:
-       \`\`\`bash
-       BRANCH=\$(gh pr view NUMBER --repo OpenRouterTeam/spawn --json headRefName --jq '.headRefName')
-       git push origin --delete "\${BRANCH}" 2>/dev/null || true
        \`\`\`
      - Report to team lead: "PR #NUMBER closed (stale+conflicts), follow-up issue filed: ISSUE_URL" (or "no follow-up needed") and STOP — skip security review.
    * Is \`updatedAt\` > 48 hours ago but NO conflicts?


### PR DESCRIPTION
## Summary

- Adds `--delete-branch` flag to all `gh pr close` commands across team scripts (refactor.sh, security.sh, discovery.sh, qa-cycle.sh)
- Removes redundant manual `git push origin --delete` calls that were previously used as a separate step after closing

This ensures closing a PR also deletes its associated remote branch, consistent with how `gh pr merge` already uses `--delete-branch`.

**Files changed:**
- `.claude/skills/setup-agent-team/refactor.sh` — 1 `gh pr close` updated, 1 manual branch delete removed
- `.claude/skills/setup-agent-team/security.sh` — 3 `gh pr close` updated, 2 manual branch delete blocks removed
- `.claude/skills/setup-agent-team/discovery.sh` — 3 `gh pr close` updated
- `.claude/skills/setup-agent-team/qa-cycle.sh` — 1 `gh pr close` updated

Fixes #942

-- refactor/pr-maintainer