### PR TITLE
Add CloudSigma support for openclaw, nanoclaw, interpreter, continue, gemini, codex

### DIFF
--- a/cloudsigma/codex.sh
+++ b/cloudsigma/codex.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cloudsigma/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cloudsigma/lib/common.sh)"
+fi
+
+log_info "Codex CLI on CloudSigma"
+echo ""
+
+ensure_cloudsigma_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CLOUDSIGMA_SERVER_IP}"
+wait_for_cloud_init "${CLOUDSIGMA_SERVER_IP}" 60
+
+log_step "Installing Node.js and Codex CLI..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs && npm install -g @openai/codex"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${CLOUDSIGMA_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "CloudSigma instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${CLOUDSIGMA_SERVER_UUID}, IP: ${CLOUDSIGMA_SERVER_IP})"
+echo ""
+
+log_step "Starting Codex..."
+sleep 1
+clear
+interactive_session "${CLOUDSIGMA_SERVER_IP}" "source ~/.zshrc && codex"

--- a/cloudsigma/continue.sh
+++ b/cloudsigma/continue.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cloudsigma/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cloudsigma/lib/common.sh)"
+fi
+
+log_info "Continue on CloudSigma"
+echo ""
+
+ensure_cloudsigma_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CLOUDSIGMA_SERVER_IP}"
+wait_for_cloud_init "${CLOUDSIGMA_SERVER_IP}" 60
+
+log_step "Installing Node.js and Continue CLI..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs && npm install -g @continuedev/cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${CLOUDSIGMA_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+setup_continue_config "${OPENROUTER_API_KEY}" \
+    "upload_file ${CLOUDSIGMA_SERVER_IP}" \
+    "run_server ${CLOUDSIGMA_SERVER_IP}"
+
+echo ""
+log_info "CloudSigma instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${CLOUDSIGMA_SERVER_UUID}, IP: ${CLOUDSIGMA_SERVER_IP})"
+echo ""
+
+log_step "Starting Continue CLI in TUI mode..."
+sleep 1
+clear
+interactive_session "${CLOUDSIGMA_SERVER_IP}" "source ~/.zshrc && cn"

--- a/cloudsigma/gemini.sh
+++ b/cloudsigma/gemini.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cloudsigma/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cloudsigma/lib/common.sh)"
+fi
+
+log_info "Gemini CLI on CloudSigma"
+echo ""
+
+ensure_cloudsigma_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CLOUDSIGMA_SERVER_IP}"
+wait_for_cloud_init "${CLOUDSIGMA_SERVER_IP}" 60
+
+log_step "Installing Node.js and Gemini CLI..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs && npm install -g @google/gemini-cli"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${CLOUDSIGMA_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "CloudSigma instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${CLOUDSIGMA_SERVER_UUID}, IP: ${CLOUDSIGMA_SERVER_IP})"
+echo ""
+
+log_step "Starting Gemini..."
+sleep 1
+clear
+interactive_session "${CLOUDSIGMA_SERVER_IP}" "source ~/.zshrc && gemini"

--- a/cloudsigma/interpreter.sh
+++ b/cloudsigma/interpreter.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cloudsigma/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cloudsigma/lib/common.sh)"
+fi
+
+log_info "Open Interpreter on CloudSigma"
+echo ""
+
+ensure_cloudsigma_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CLOUDSIGMA_SERVER_IP}"
+wait_for_cloud_init "${CLOUDSIGMA_SERVER_IP}" 60
+
+log_step "Installing Open Interpreter..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${CLOUDSIGMA_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "CloudSigma instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${CLOUDSIGMA_SERVER_UUID}, IP: ${CLOUDSIGMA_SERVER_IP})"
+echo ""
+
+log_step "Starting Open Interpreter..."
+sleep 1
+clear
+interactive_session "${CLOUDSIGMA_SERVER_IP}" "source ~/.zshrc && interpreter"

--- a/cloudsigma/nanoclaw.sh
+++ b/cloudsigma/nanoclaw.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cloudsigma/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cloudsigma/lib/common.sh)"
+fi
+
+log_info "NanoClaw on CloudSigma"
+echo ""
+
+ensure_cloudsigma_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CLOUDSIGMA_SERVER_IP}"
+wait_for_cloud_init "${CLOUDSIGMA_SERVER_IP}" 60
+
+log_step "Installing Node.js and dependencies..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs && sudo npm install -g tsx"
+
+log_step "Cloning and building nanoclaw..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${CLOUDSIGMA_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
+
+log_step "Configuring nanoclaw..."
+DOTENV_TEMP=$(mktemp)
+trap 'rm -f "${DOTENV_TEMP}"' EXIT
+chmod 600 "${DOTENV_TEMP}"
+cat > "${DOTENV_TEMP}" << EOF
+ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
+EOF
+
+upload_file "${CLOUDSIGMA_SERVER_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
+run_server "${CLOUDSIGMA_SERVER_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
+
+echo ""
+log_info "CloudSigma instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${CLOUDSIGMA_SERVER_UUID}, IP: ${CLOUDSIGMA_SERVER_IP})"
+echo ""
+
+log_step "Starting nanoclaw..."
+log_info "You will need to scan a WhatsApp QR code to authenticate."
+echo ""
+interactive_session "${CLOUDSIGMA_SERVER_IP}" "cd ~/nanoclaw && source ~/.zshrc && npm run dev"

--- a/cloudsigma/openclaw.sh
+++ b/cloudsigma/openclaw.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cloudsigma/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cloudsigma/lib/common.sh)"
+fi
+
+log_info "OpenClaw on CloudSigma"
+echo ""
+
+ensure_cloudsigma_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CLOUDSIGMA_SERVER_IP}"
+wait_for_cloud_init "${CLOUDSIGMA_SERVER_IP}" 60
+
+log_step "Installing openclaw..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "curl -fsSL https://bun.sh/install | bash && export PATH=\$HOME/.bun/bin:\$PATH && bun install -g openclaw"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${CLOUDSIGMA_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
+    "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
+
+setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" \
+    "upload_file ${CLOUDSIGMA_SERVER_IP}" \
+    "run_server ${CLOUDSIGMA_SERVER_IP}"
+
+echo ""
+log_info "CloudSigma instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${CLOUDSIGMA_SERVER_UUID}, IP: ${CLOUDSIGMA_SERVER_IP})"
+echo ""
+
+log_step "Starting openclaw gateway and TUI..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "export PATH=\$HOME/.bun/bin:\$PATH && source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+sleep 2
+interactive_session "${CLOUDSIGMA_SERVER_IP}" "export PATH=\$HOME/.bun/bin:\$PATH && source ~/.zshrc && openclaw tui"

--- a/manifest.json
+++ b/manifest.json
@@ -1324,19 +1324,19 @@
     "hostkey/kilo": "missing",
     "hostkey/continue": "implemented",
     "cloudsigma/claude": "implemented",
-    "cloudsigma/openclaw": "missing",
-    "cloudsigma/nanoclaw": "missing",
+    "cloudsigma/openclaw": "implemented",
+    "cloudsigma/nanoclaw": "implemented",
     "cloudsigma/aider": "implemented",
     "cloudsigma/goose": "missing",
-    "cloudsigma/codex": "missing",
-    "cloudsigma/interpreter": "missing",
-    "cloudsigma/gemini": "missing",
+    "cloudsigma/codex": "implemented",
+    "cloudsigma/interpreter": "implemented",
+    "cloudsigma/gemini": "implemented",
     "cloudsigma/amazonq": "missing",
     "cloudsigma/cline": "missing",
     "cloudsigma/gptme": "missing",
     "cloudsigma/opencode": "missing",
     "cloudsigma/plandex": "missing",
     "cloudsigma/kilocode": "missing",
-    "cloudsigma/continue": "missing"
+    "cloudsigma/continue": "implemented"
   }
 }


### PR DESCRIPTION
Implements 6 missing CloudSigma matrix entries:
- cloudsigma/openclaw
- cloudsigma/nanoclaw
- cloudsigma/interpreter
- cloudsigma/continue
- cloudsigma/gemini
- cloudsigma/codex

All scripts follow the CloudSigma pattern:
- Use CloudSigma lib/common.sh primitives
- OpenRouter API key injection via env vars
- Proper error handling and logging
- Syntax validated with bash -n

-- discovery/gap-filler-cloudsigma