### PR TITLE
refactor: decompose fly get_server_name and oracle VCN networking

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -138,28 +138,7 @@ get_fly_org() {
 
 # Get server name from env var or prompt
 get_server_name() {
-    if [[ -n "${FLY_APP_NAME:-}" ]]; then
-        log_info "Using app name from environment: $FLY_APP_NAME"
-        if ! validate_server_name "$FLY_APP_NAME"; then
-            return 1
-        fi
-        echo "$FLY_APP_NAME"
-        return 0
-    fi
-
-    local server_name=$(safe_read "Enter app name: ")
-    if [[ -z "$server_name" ]]; then
-        log_error "App name is required"
-        log_warn "Set FLY_APP_NAME environment variable for non-interactive usage:"
-        log_warn "  FLY_APP_NAME=dev-mk1 curl ... | bash"
-        return 1
-    fi
-
-    if ! validate_server_name "$server_name"; then
-        return 1
-    fi
-
-    echo "$server_name"
+    get_validated_server_name "FLY_APP_NAME" "Enter app name: "
 }
 
 # Create Fly.io app, returning 0 on success or if app already exists


### PR DESCRIPTION
## Summary
- **fly/lib/common.sh**: Replaced 23-line `get_server_name()` that duplicated env-var-check, prompt, and validation logic with a one-line call to the shared `get_validated_server_name` helper -- matching all other cloud providers
- **oracle/lib/common.sh**: Decomposed `_setup_vcn_networking` (48 lines, 3 distinct responsibilities) into 3 focused helpers: `_create_internet_gateway`, `_add_default_route`, `_add_ssh_security_rules`

## Test plan
- [x] `bash -n fly/lib/common.sh` passes
- [x] `bash -n oracle/lib/common.sh` passes
- [x] `bun test` results identical to main (no regressions)
- [x] `bash test/mock.sh` results identical to main (270 pass, 165 fail, 1 skip -- all pre-existing)

-- refactor/complexity-hunter