### PR TITLE
fix: improve CLI UX with better error messages and help text

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.74",
+  "version": "0.2.75",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1177,6 +1177,8 @@ async function resolveListFilters(
 
 /** Show interactive picker to select and rerun a previous spawn */
 async function interactiveListPicker(records: SpawnRecord[], manifest: Manifest | null): Promise<void> {
+  p.log.info(pc.dim(`Filter: ${pc.cyan("spawn list -a <agent>")} or ${pc.cyan("spawn list -c <cloud>")}  |  Clear: ${pc.cyan("spawn list --clear")}`));
+
   const options = records.map((r, i) => ({
     value: i,
     label: buildRecordLabel(r, manifest),
@@ -1630,12 +1632,14 @@ ${pc.bold("TROUBLESHOOTING")}
   ${pc.dim("*")} Missing credentials: Run ${pc.cyan("spawn <cloud>")} to see setup instructions
   ${pc.dim("*")} Update issues: Try ${pc.cyan("spawn update")} or reinstall manually
   ${pc.dim("*")} Garbled unicode: Set ${pc.cyan("SPAWN_NO_UNICODE=1")} for ASCII-only output
+  ${pc.dim("*")} Missing unicode over SSH: Set ${pc.cyan("SPAWN_UNICODE=1")} to force unicode on
   ${pc.dim("*")} Slow startup: Set ${pc.cyan("SPAWN_NO_UPDATE_CHECK=1")} to skip auto-update
 
 ${pc.bold("ENVIRONMENT VARIABLES")}
   ${pc.cyan("OPENROUTER_API_KEY")}        OpenRouter API key (all agents require this)
   ${pc.cyan("SPAWN_NO_UPDATE_CHECK=1")}   Skip auto-update check on startup
   ${pc.cyan("SPAWN_NO_UNICODE=1")}        Force ASCII output (no unicode symbols)
+  ${pc.cyan("SPAWN_UNICODE=1")}           Force unicode output (override SSH auto-detection)
   ${pc.cyan("SPAWN_HOME")}                Override spawn data directory (default: ~/.spawn)
   ${pc.cyan("SPAWN_DEBUG=1")}             Show debug output (unicode detection, etc.)
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -95,6 +95,11 @@ function checkUnknownFlags(args: string[]): void {
       console.error(`    ${pc.cyan("--help, -h")}          Show help information`);
       console.error(`    ${pc.cyan("--version, -v")}       Show version`);
       console.error();
+      console.error(`  For ${pc.cyan("spawn list")}:`);
+      console.error(`    ${pc.cyan("-a, --agent")}         Filter history by agent`);
+      console.error(`    ${pc.cyan("-c, --cloud")}         Filter history by cloud`);
+      console.error(`    ${pc.cyan("--clear")}             Clear all spawn history`);
+      console.error();
       console.error(`  Run ${pc.cyan("spawn help")} for full usage information.`);
       process.exit(1);
     }
@@ -235,6 +240,12 @@ async function resolvePrompt(args: string[]): Promise<[string | undefined, strin
       prompt = readFileSync(promptFile, "utf-8");
     } catch (err) {
       handlePromptFileError(promptFile, err);
+    }
+
+    if (prompt !== undefined && prompt.trim() === "") {
+      console.error(pc.red(`Prompt file is empty: ${pc.bold(promptFile)}`));
+      console.error(`\nThe file exists but contains no text. Add your prompt to the file and try again.`);
+      process.exit(1);
     }
   }
 


### PR DESCRIPTION
## Summary
- Show list-specific flags (`-a`, `-c`, `--clear`) in the unknown flag error message so users discover `spawn list` filtering options
- Add a specific error when `--prompt-file` points to an empty file, instead of the generic "Prompt cannot be empty" validation error
- Document `SPAWN_UNICODE=1` env var in both help text and troubleshooting section for users who want to force unicode on in SSH sessions
- Show filter and clear hints in the interactive list picker so users know about `spawn list -a <agent>` and `spawn list --clear`

## Test plan
- [x] All 266 related tests pass (unknown-flags, prompt-file-errors, resolve-prompt, cmd-help-content, list-display, cmdlist-integration, index-parsing)
- [x] No new test failures introduced
- [x] CLI version bumped to 0.2.75

-- refactor/ux-engineer