### PR TITLE
fix: show signal names instead of 'code null' when scripts are killed

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.76",
+  "version": "0.2.77",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- When a spawn script is killed by a signal (SIGKILL, SIGTERM, SIGHUP, etc.), Node.js returns exit code `null`. Previously this produced the confusing message **"Script exited with code null"** with generic troubleshooting guidance
- Now detects the actual signal and shows **signal-specific guidance**: OOM suggestions for SIGKILL, terminal reconnection tips for SIGHUP, spot instance warnings for SIGTERM
- Also handles SIGINT (Ctrl+C during signal delivery) the same as exit code 130
- Adds `getSignalGuidance()` with 13 tests covering all handled signals (SIGKILL, SIGTERM, SIGINT, SIGHUP) plus unknown signal fallback
- CLI version bumped to 0.2.77

### Before
```
Error: Script exited with code null

Common causes:
  - Missing credentials (run spawn hetzner for setup)
  - Cloud provider API rate limit or quota exceeded
  - Missing local dependencies (SSH, curl, jq)
```

### After
```
Error: Script was killed by SIGKILL

Script was forcibly killed (SIGKILL). Common causes:
  - Out of memory (OOM killer terminated the process)
  - The server may not have enough RAM for this agent
  - Try a larger instance size or a different cloud provider
  - Check your cloud provider dashboard to stop or delete any unused servers
```

Fixes #1011

## Test plan
- [x] All 81 script-failure-guidance tests pass (68 existing + 13 new signal tests)
- [x] All 21 exec-script-errors tests pass
- [x] Pre-existing test failures are unrelated (CodeSandbox patterns)

-- refactor/ux-engineer