### PR TITLE
fix: validate provider name in invalidate_cloud_key and improve key validation

### DIFF
--- a/.claude/skills/setup-agent-team/key-server.ts
+++ b/.claude/skills/setup-agent-team/key-server.ts
@@ -301,7 +301,12 @@ function saveKeys(provider: string, vars: Record<string, string>) {
 }
 
 function validKeyVal(v: string) {
-  return !/[;&'"<>|$`\\(){}]/.test(v);
+  if (v.length === 0 || v.length > 4096) return false;
+  // Block control characters (U+0000–U+001F, U+007F–U+009F)
+  if (/[\x00-\x1f\x7f-\x9f]/.test(v)) return false;
+  // Block shell metacharacters
+  if (/[;&'"<>|$`\\(){}]/.test(v)) return false;
+  return true;
 }
 
 // --- Security headers for HTML responses ---

--- a/shared/key-request.sh
+++ b/shared/key-request.sh
@@ -202,6 +202,13 @@ print(json.dumps(providers))
 # Usage: invalidate_cloud_key CLOUD_KEY
 invalidate_cloud_key() {
     local provider="${1}"
+
+    # Validate provider name to prevent path traversal
+    if [[ ! "${provider}" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]]; then
+        log "invalidate_cloud_key: invalid provider name: ${provider}"
+        return 1
+    fi
+
     local config_file="${HOME}/.config/spawn/${provider}.json"
 
     if [[ -f "${config_file}" ]]; then


### PR DESCRIPTION
## Summary

- **Path traversal fix** (`shared/key-request.sh:202-211`): `invalidate_cloud_key()` now validates the `provider` parameter against `^[a-z0-9][a-z0-9._-]{0,63}$` before constructing a file path, preventing path traversal attacks that could delete arbitrary files (e.g., `../../etc/passwd`). This matches the same `SAFE_PROVIDER_RE` regex already used in `key-server.ts`.

- **Key validation hardening** (`.claude/skills/setup-agent-team/key-server.ts:303`): `validKeyVal()` now blocks control characters (U+0000-U+001F, U+007F-U+009F) and enforces a 4096-byte max length. Previously it only blocked shell metacharacters, allowing null bytes, newlines, and arbitrarily long values through.

Fixes #1013

## Test plan

- [x] `bash -n shared/key-request.sh` passes
- [x] `bun test` passes (7654 pass, 185 pre-existing failures unrelated to these changes)
- [ ] Verify `invalidate_cloud_key "../../../tmp/test"` returns 1 and logs error
- [ ] Verify `validKeyVal("key-with-\x00-null")` returns false
- [ ] Verify `validKeyVal("")` returns false (empty)
- [ ] Verify `validKeyVal("sk-valid-key-12345")` returns true

-- refactor/security-auditor