### PR TITLE
fix: validate Alibaba Cloud image ID and fix HOSTKEY input validation order

### DIFF
--- a/alibabacloud/lib/common.sh
+++ b/alibabacloud/lib/common.sh
@@ -329,6 +329,7 @@ create_server() {
     # Validate inputs to prevent injection
     validate_resource_name "$instance_type" || { log_error "Invalid ALIYUN_INSTANCE_TYPE"; return 1; }
     validate_region_name "$region" || { log_error "Invalid ALIYUN_REGION"; return 1; }
+    validate_resource_name "$image_id" || { log_error "Invalid ALIYUN_IMAGE_ID"; return 1; }
 
     # Get or create VPC
     log_step "Checking for VPC in region $region..."

--- a/hostkey/lib/common.sh
+++ b/hostkey/lib/common.sh
@@ -203,13 +203,12 @@ create_server() {
     # Interactive location + instance preset selection (skipped if env vars are set)
     local location
     location=$(_pick_location)
+    # Validate location before using it in API calls (preset listing)
+    validate_region_name "$location" || { log_error "Invalid HOSTKEY_LOCATION"; return 1; }
 
     local preset
     preset=$(_pick_instance_preset "$location")
-
-    # Validate inputs
     validate_resource_name "$preset" || { log_error "Invalid HOSTKEY_INSTANCE_PRESET"; return 1; }
-    validate_region_name "$location" || { log_error "Invalid HOSTKEY_LOCATION"; return 1; }
 
     log_step "Creating HOSTKEY instance '$name' (preset: $preset, location: $location)..."
 


### PR DESCRIPTION
## Summary
- Add `validate_resource_name` check for `ALIYUN_IMAGE_ID` env var in Alibaba Cloud `create_server`, consistent with other providers (Contabo, Webdock, BinaryLane) that validate user-controllable image identifiers
- Move HOSTKEY `validate_region_name` for location before `_pick_instance_preset()` call, which passes the location to an API request — input should be validated before use, not after

## Findings

### Fixed in this PR (MEDIUM)
1. **Alibaba Cloud `ALIYUN_IMAGE_ID` not validated**: The env var was passed directly to the `aliyun` CLI without `validate_resource_name` validation. While not exploitable for command injection (properly quoted CLI argument), this is inconsistent with other providers.
2. **HOSTKEY location used before validation**: `_pick_instance_preset()` calls `_list_instance_presets()` which makes an API request with the unvalidated `location` parameter. Validation happened afterward in `create_server`. Now validation occurs before the API call.

### Already addressed
- Path traversal in `invalidate_cloud_key()` — fixed in PR #1017
- Key validation in `key-server.ts` — fixed in PR #1017

### No NEW HIGH/CRITICAL issues found
Scanned all recently added/modified files including:
- Alibaba Cloud provider (PR #1002) 
- Webdock provider (PR #1001)
- CloudSigma agent scripts (PR #998)
- HOSTKEY agent scripts (PR #999)
- Vultr/Koyeb decomposition (PR #1016)
- CLI changes (PRs #1012, #1003, #1014)

## Test plan
- [x] `bash -n alibabacloud/lib/common.sh` passes
- [x] `bash -n hostkey/lib/common.sh` passes
- [ ] Verify Alibaba Cloud default image ID (`ubuntu_24_04_x64_20G_alibase_20240812.vhd`) passes `validate_resource_name`

-- refactor/security-auditor