### PR TITLE
fix: eliminate duplicate Loading manifest spinner

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.77",
+  "version": "0.2.78",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1418,8 +1418,10 @@ function printGroupedList(
 
 // ── Agent Info ─────────────────────────────────────────────────────────────────
 
-export async function cmdAgentInfo(agent: string): Promise<void> {
-  const [manifest, agentKey] = await validateAndGetEntity(agent, "agent");
+export async function cmdAgentInfo(agent: string, preloadedManifest?: Manifest): Promise<void> {
+  const [manifest, agentKey] = preloadedManifest
+    ? [preloadedManifest, agent]
+    : await validateAndGetEntity(agent, "agent");
 
   const agentDef = manifest.agents[agentKey];
   printInfoHeader(agentDef);
@@ -1544,8 +1546,10 @@ function printAgentList(
   }
 }
 
-export async function cmdCloudInfo(cloud: string): Promise<void> {
-  const [manifest, cloudKey] = await validateAndGetEntity(cloud, "cloud");
+export async function cmdCloudInfo(cloud: string, preloadedManifest?: Manifest): Promise<void> {
+  const [manifest, cloudKey] = preloadedManifest
+    ? [preloadedManifest, cloud]
+    : await validateAndGetEntity(cloud, "cloud");
 
   const c = manifest.clouds[cloudKey];
   printInfoHeader(c);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -129,15 +129,15 @@ function showUnknownCommandError(name: string, manifest: { agents: Record<string
 async function showInfoOrError(name: string): Promise<void> {
   const manifest = await loadManifestWithSpinner();
 
-  // Direct key match
-  if (manifest.agents[name]) { await cmdAgentInfo(name); return; }
-  if (manifest.clouds[name]) { await cmdCloudInfo(name); return; }
+  // Direct key match — pass pre-loaded manifest to avoid a redundant spinner
+  if (manifest.agents[name]) { await cmdAgentInfo(name, manifest); return; }
+  if (manifest.clouds[name]) { await cmdCloudInfo(name, manifest); return; }
 
   // Try resolving display names and case-insensitive matches
   const resolvedAgent = resolveAgentKey(manifest, name);
-  if (resolvedAgent) { await cmdAgentInfo(resolvedAgent); return; }
+  if (resolvedAgent) { await cmdAgentInfo(resolvedAgent, manifest); return; }
   const resolvedCloud = resolveCloudKey(manifest, name);
-  if (resolvedCloud) { await cmdCloudInfo(resolvedCloud); return; }
+  if (resolvedCloud) { await cmdCloudInfo(resolvedCloud, manifest); return; }
 
   showUnknownCommandError(name, manifest);
 }


### PR DESCRIPTION
## Summary
- Fixed a UX papercut where `spawn <agent>` and `spawn <cloud>` showed the "Loading manifest..." spinner **twice** -- once in `showInfoOrError()` and again in `cmdAgentInfo`/`cmdCloudInfo` via `validateAndGetEntity()`
- Added optional `preloadedManifest` parameter to `cmdAgentInfo` and `cmdCloudInfo` so callers that already have the manifest can skip the redundant load
- Bumped CLI version to 0.2.78

## Test plan
- [x] All 1,067 command-related tests pass (commands-display, commands-cloud-info, commands-error-paths, index-parsing, agent-info)
- [x] Manually verified `spawn claude` shows one spinner (was two)
- [x] Manually verified `spawn hetzner` shows one spinner (was two)
- [x] Direct calls without preloaded manifest (`spawn agents claude`) still work normally

-- refactor/ux-engineer