### PR TITLE
fix: prevent sensitive file exfiltration via --prompt-file

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.77",
+  "version": "0.2.78",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/prompt-file-errors.test.ts
+++ b/cli/src/__tests__/prompt-file-errors.test.ts
@@ -245,9 +245,9 @@ describe("--prompt-file EISDIR (path is a directory)", () => {
     mkdirSync(dirPath, { recursive: true });
   });
 
-  it("should show 'is a directory, not a file' for a directory path", () => {
+  it("should show 'is not a regular file' for a directory path", () => {
     const result = runCli(["claude", "sprite", "--prompt-file", dirPath]);
-    expect(output(result)).toContain("is a directory, not a file");
+    expect(output(result)).toContain("is not a regular file");
     expect(result.exitCode).not.toBe(0);
   });
 

--- a/cli/src/__tests__/prompt-file-security.test.ts
+++ b/cli/src/__tests__/prompt-file-security.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "bun:test";
+import { validatePromptFilePath, validatePromptFileStats } from "../security.js";
+
+describe("validatePromptFilePath", () => {
+  it("should accept normal text file paths", () => {
+    expect(() => validatePromptFilePath("prompt.txt")).not.toThrow();
+    expect(() => validatePromptFilePath("./prompt.txt")).not.toThrow();
+    expect(() => validatePromptFilePath("prompts/task.md")).not.toThrow();
+    expect(() => validatePromptFilePath("/home/user/prompt.txt")).not.toThrow();
+    expect(() => validatePromptFilePath("/tmp/instructions.md")).not.toThrow();
+  });
+
+  it("should reject empty paths", () => {
+    expect(() => validatePromptFilePath("")).toThrow("cannot be empty");
+    expect(() => validatePromptFilePath("   ")).toThrow("cannot be empty");
+  });
+
+  it("should reject SSH private key files", () => {
+    expect(() => validatePromptFilePath("/home/user/.ssh/id_rsa")).toThrow("SSH");
+    expect(() => validatePromptFilePath("/home/user/.ssh/id_ed25519")).toThrow("SSH");
+    expect(() => validatePromptFilePath("~/.ssh/config")).toThrow("SSH directory");
+    expect(() => validatePromptFilePath("/root/.ssh/authorized_keys")).toThrow("SSH directory");
+  });
+
+  it("should reject AWS credential files", () => {
+    expect(() => validatePromptFilePath("/home/user/.aws/credentials")).toThrow("AWS");
+    expect(() => validatePromptFilePath("/home/user/.aws/config")).toThrow("AWS");
+  });
+
+  it("should reject Google Cloud credential files", () => {
+    expect(() => validatePromptFilePath("/home/user/.config/gcloud/application_default_credentials.json")).toThrow("Google Cloud");
+  });
+
+  it("should reject Azure credential files", () => {
+    expect(() => validatePromptFilePath("/home/user/.azure/accessTokens.json")).toThrow("Azure");
+  });
+
+  it("should reject Kubernetes config files", () => {
+    expect(() => validatePromptFilePath("/home/user/.kube/config")).toThrow("Kubernetes");
+  });
+
+  it("should reject Docker credential files", () => {
+    expect(() => validatePromptFilePath("/home/user/.docker/config.json")).toThrow("Docker");
+  });
+
+  it("should reject .env files", () => {
+    expect(() => validatePromptFilePath(".env")).toThrow("environment file");
+    expect(() => validatePromptFilePath(".env.local")).toThrow("environment file");
+    expect(() => validatePromptFilePath(".env.production")).toThrow("environment file");
+    expect(() => validatePromptFilePath("/app/.env")).toThrow("environment file");
+  });
+
+  it("should reject npm credential files", () => {
+    expect(() => validatePromptFilePath("/home/user/.npmrc")).toThrow("npm");
+  });
+
+  it("should reject netrc files", () => {
+    expect(() => validatePromptFilePath("/home/user/.netrc")).toThrow("netrc");
+  });
+
+  it("should reject git credential files", () => {
+    expect(() => validatePromptFilePath("/home/user/.git-credentials")).toThrow("Git credentials");
+  });
+
+  it("should reject /etc/shadow", () => {
+    expect(() => validatePromptFilePath("/etc/shadow")).toThrow("password hashes");
+  });
+
+  it("should reject /etc/master.passwd", () => {
+    expect(() => validatePromptFilePath("/etc/master.passwd")).toThrow("password hashes");
+  });
+
+  it("should accept /etc/hosts (non-sensitive system file)", () => {
+    expect(() => validatePromptFilePath("/etc/hosts")).not.toThrow();
+  });
+
+  it("should accept normal config-directory paths that are not sensitive", () => {
+    expect(() => validatePromptFilePath("/home/user/.config/spawn/prompt.txt")).not.toThrow();
+  });
+
+  it("should include helpful error message about exfiltration risk", () => {
+    try {
+      validatePromptFilePath("/home/user/.ssh/id_rsa");
+      throw new Error("Expected to throw");
+    } catch (e: any) {
+      expect(e.message).toContain("sent to remote agents");
+      expect(e.message).toContain("dedicated text file");
+    }
+  });
+
+  it("should reject SSH key files by filename pattern anywhere in path", () => {
+    expect(() => validatePromptFilePath("/tmp/id_rsa")).toThrow("SSH key");
+    expect(() => validatePromptFilePath("/backup/id_ed25519")).toThrow("SSH key");
+    expect(() => validatePromptFilePath("id_ecdsa")).toThrow("SSH key");
+    expect(() => validatePromptFilePath("/tmp/id_rsa.pub")).toThrow("SSH key");
+  });
+});
+
+describe("validatePromptFileStats", () => {
+  it("should accept regular files within size limit", () => {
+    const stats = { isFile: () => true, size: 100 };
+    expect(() => validatePromptFileStats("prompt.txt", stats)).not.toThrow();
+  });
+
+  it("should accept files at the 1MB limit", () => {
+    const stats = { isFile: () => true, size: 1024 * 1024 };
+    expect(() => validatePromptFileStats("prompt.txt", stats)).not.toThrow();
+  });
+
+  it("should reject non-regular files", () => {
+    const stats = { isFile: () => false, size: 100 };
+    expect(() => validatePromptFileStats("/dev/urandom", stats)).toThrow("not a regular file");
+  });
+
+  it("should reject files over 1MB", () => {
+    const stats = { isFile: () => true, size: 1024 * 1024 + 1 };
+    expect(() => validatePromptFileStats("huge.txt", stats)).toThrow("too large");
+  });
+
+  it("should reject empty files", () => {
+    const stats = { isFile: () => true, size: 0 };
+    expect(() => validatePromptFileStats("empty.txt", stats)).toThrow("empty");
+  });
+
+  it("should show file size in MB for large files", () => {
+    const stats = { isFile: () => true, size: 5 * 1024 * 1024 };
+    try {
+      validatePromptFileStats("large.bin", stats);
+      throw new Error("Expected to throw");
+    } catch (e: any) {
+      expect(e.message).toContain("5.0MB");
+      expect(e.message).toContain("Maximum size is 1MB");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `validatePromptFilePath()` to block reading sensitive files (SSH keys, AWS/GCP/Azure credentials, `.env` files, Docker/npm/git credentials, `/etc/shadow`) via `--prompt-file`
- Add `validatePromptFileStats()` to enforce regular file check and 1MB size limit
- Add 24 tests for path validation and stat validation
- Bump CLI version to 0.2.78

Fixes #991

## What changed

**`cli/src/security.ts`**: New exported functions:
- `validatePromptFilePath(path)` - checks path against sensitive path patterns (SSH, AWS, GCloud, Azure, Kube, Docker, npm, netrc, .env, git-credentials, /etc/shadow, SSH key filenames)
- `validatePromptFileStats(path, stats)` - validates regular file, size <= 1MB, non-empty

**`cli/src/index.ts`**: `resolvePrompt()` now calls both validators before `readFileSync()`

**`cli/src/__tests__/prompt-file-security.test.ts`**: 24 new tests covering all sensitive path patterns, edge cases, and stat validation

**`cli/src/__tests__/prompt-file-errors.test.ts`**: Updated directory error message assertion to match new stat-based check

## Test plan

- [x] All 24 new security tests pass
- [x] Existing prompt-file-errors tests pass (1 assertion updated)
- [x] Security test suite passes
- [x] Index routing tests pass

-- refactor/security-auditor