### PR TITLE
fix(ux): include cloud dashboard URLs in error messages

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.79",
+  "version": "0.2.80",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/exec-script-errors.test.ts
+++ b/cli/src/__tests__/exec-script-errors.test.ts
@@ -199,7 +199,7 @@ describe("execScript bash execution error handling", () => {
       const warnText = warnMessages.join("\n");
       expect(warnText).toContain("interrupted");
       expect(warnText).toContain("server");
-      expect(warnText).toContain("cloud provider dashboard");
+      expect(warnText).toContain("dashboard");
     });
   });
 

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -606,3 +606,82 @@ describe("buildRetryCommand", () => {
     expect(buildRetryCommand("aider", "vultr", "")).toBe("spawn aider vultr");
   });
 });
+
+describe("dashboard URL in guidance", () => {
+  describe("getScriptFailureGuidance with dashboardUrl", () => {
+    it("should include dashboard URL for exit code 1 when provided", () => {
+      const lines = getScriptFailureGuidance(1, "hetzner", undefined, "https://console.hetzner.cloud/");
+      const joined = lines.join("\n");
+      expect(joined).toContain("https://console.hetzner.cloud/");
+      expect(joined).toContain("dashboard");
+    });
+
+    it("should include dashboard URL for exit code 130 when provided", () => {
+      const lines = getScriptFailureGuidance(130, "sprite", undefined, "https://sprite.sh");
+      const joined = lines.join("\n");
+      expect(joined).toContain("https://sprite.sh");
+      expect(joined).toContain("dashboard");
+    });
+
+    it("should include dashboard URL for exit code 137 when provided", () => {
+      const lines = getScriptFailureGuidance(137, "vultr", undefined, "https://my.vultr.com/");
+      const joined = lines.join("\n");
+      expect(joined).toContain("https://my.vultr.com/");
+    });
+
+    it("should include dashboard URL for default exit code when provided", () => {
+      const lines = getScriptFailureGuidance(42, "digitalocean", undefined, "https://cloud.digitalocean.com/");
+      const joined = lines.join("\n");
+      expect(joined).toContain("https://cloud.digitalocean.com/");
+    });
+
+    it("should fall back to generic message when no dashboardUrl", () => {
+      const lines = getScriptFailureGuidance(130, "sprite");
+      const joined = lines.join("\n");
+      expect(joined).toContain("cloud provider dashboard");
+      expect(joined).not.toContain("https://");
+    });
+
+    it("should not add dashboard URL for exit codes 127, 126, 255, 2", () => {
+      for (const code of [127, 126, 255, 2]) {
+        const lines = getScriptFailureGuidance(code, "hetzner", undefined, "https://console.hetzner.cloud/");
+        const joined = lines.join("\n");
+        expect(joined).not.toContain("https://console.hetzner.cloud/");
+      }
+    });
+  });
+
+  describe("getSignalGuidance with dashboardUrl", () => {
+    it("should include dashboard URL for SIGKILL when provided", () => {
+      const lines = getSignalGuidance("SIGKILL", "https://console.hetzner.cloud/");
+      const joined = lines.join("\n");
+      expect(joined).toContain("https://console.hetzner.cloud/");
+      expect(joined).toContain("dashboard");
+    });
+
+    it("should include dashboard URL for SIGTERM when provided", () => {
+      const lines = getSignalGuidance("SIGTERM", "https://my.vultr.com/");
+      const joined = lines.join("\n");
+      expect(joined).toContain("https://my.vultr.com/");
+    });
+
+    it("should include dashboard URL for SIGINT when provided", () => {
+      const lines = getSignalGuidance("SIGINT", "https://cloud.digitalocean.com/");
+      const joined = lines.join("\n");
+      expect(joined).toContain("https://cloud.digitalocean.com/");
+    });
+
+    it("should fall back to generic message when no dashboardUrl", () => {
+      const lines = getSignalGuidance("SIGKILL");
+      const joined = lines.join("\n");
+      expect(joined).toContain("cloud provider dashboard");
+      expect(joined).not.toContain("https://");
+    });
+
+    it("should not add dashboard URL for SIGHUP", () => {
+      const lines = getSignalGuidance("SIGHUP", "https://example.com");
+      const joined = lines.join("\n");
+      expect(joined).not.toContain("https://example.com");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- When spawn scripts fail or are interrupted (Ctrl+C, SIGKILL, SIGTERM, etc.), error messages now include the cloud provider's actual dashboard URL instead of generic "check your cloud provider dashboard" text
- Applies to `reportScriptFailure`, `handleUserInterrupt`, `getScriptFailureGuidance`, and `getSignalGuidance`
- Before: `Check your cloud provider dashboard to stop or delete any unused servers.`
- After: `Check your dashboard: https://console.hetzner.cloud/` (uses the cloud's `url` from manifest.json)
- Bumps CLI version to 0.2.80

## Why
When a script fails or the user hits Ctrl+C, they need to check their cloud provider for orphaned servers. Telling them to "check your cloud provider dashboard" is unhelpful -- they have to remember or look up the URL. Every cloud in manifest.json already has a `url` field, so we now surface it directly in error messages.

## Changes
- `cli/src/commands.ts`: Added `dashboardUrl` parameter to `execScript`, `reportScriptFailure`, `handleUserInterrupt`, `runWithRetries`, `getScriptFailureGuidance`, and `getSignalGuidance`. Passed `manifest.clouds[cloud].url` from `cmdRun` and `cmdInteractive`.
- `cli/src/__tests__/script-failure-guidance.test.ts`: Added 11 new tests for dashboard URL behavior (with URL, without URL fallback, per exit code and signal type)
- `cli/src/__tests__/exec-script-errors.test.ts`: Updated assertion to match new format
- `cli/package.json`: Version bump 0.2.78 -> 0.2.80

## Test plan
- [x] 92 script-failure-guidance tests pass (81 existing + 11 new)
- [x] 21 exec-script-errors tests pass
- [x] 15 cmd-run tests pass
- [x] Full suite: 12,104 pass, 101 pre-existing failures (none related to this change)

-- refactor/ux-engineer