### PR TITLE
fix(security): prevent shell expansion in nanoclaw .env heredocs

### DIFF
--- a/atlanticnet/nanoclaw.sh
+++ b/atlanticnet/nanoclaw.sh
@@ -57,9 +57,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${ATLANTICNET_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/aws-lightsail/nanoclaw.sh
+++ b/aws-lightsail/nanoclaw.sh
@@ -57,9 +57,7 @@ inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
 log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${LIGHTSAIL_SERVER_IP}" "${DOTENV_TEMP}" "/home/ubuntu/nanoclaw/.env"
 

--- a/binarylane/nanoclaw.sh
+++ b/binarylane/nanoclaw.sh
@@ -44,9 +44,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${BINARYLANE_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/cherry/nanoclaw.sh
+++ b/cherry/nanoclaw.sh
@@ -55,9 +55,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${CHERRY_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/civo/nanoclaw.sh
+++ b/civo/nanoclaw.sh
@@ -47,9 +47,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${CIVO_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/cloudsigma/nanoclaw.sh
+++ b/cloudsigma/nanoclaw.sh
@@ -43,9 +43,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${CLOUDSIGMA_SERVER_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
 run_server "${CLOUDSIGMA_SERVER_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"

--- a/codesandbox/nanoclaw.sh
+++ b/codesandbox/nanoclaw.sh
@@ -57,9 +57,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${DOTENV_TEMP}" ~/nanoclaw/.env
 run_server "chmod 600 ~/nanoclaw/.env"

--- a/contabo/nanoclaw.sh
+++ b/contabo/nanoclaw.sh
@@ -55,9 +55,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${CONTABO_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/daytona/nanoclaw.sh
+++ b/daytona/nanoclaw.sh
@@ -54,9 +54,7 @@ log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${DOTENV_TEMP}" ~/nanoclaw/.env
 

--- a/digitalocean/nanoclaw.sh
+++ b/digitalocean/nanoclaw.sh
@@ -55,9 +55,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${DO_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/e2b/nanoclaw.sh
+++ b/e2b/nanoclaw.sh
@@ -54,9 +54,7 @@ log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${DOTENV_TEMP}" ~/nanoclaw/.env
 

--- a/exoscale/nanoclaw.sh
+++ b/exoscale/nanoclaw.sh
@@ -55,9 +55,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${EXOSCALE_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/fly/nanoclaw.sh
+++ b/fly/nanoclaw.sh
@@ -53,9 +53,7 @@ log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 chmod 600 "$DOTENV_TEMP"
-cat > "$DOTENV_TEMP" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "$DOTENV_TEMP" "/root/nanoclaw/.env"
 rm "$DOTENV_TEMP"

--- a/gcp/nanoclaw.sh
+++ b/gcp/nanoclaw.sh
@@ -60,9 +60,7 @@ inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
 log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${GCP_SERVER_IP}" "${DOTENV_TEMP}" "${HOME}/nanoclaw/.env"
 

--- a/github-codespaces/nanoclaw.sh
+++ b/github-codespaces/nanoclaw.sh
@@ -66,9 +66,7 @@ DOTENV_TEMP=$(mktemp)
 chmod 600 "${DOTENV_TEMP}"
 track_temp_file "${DOTENV_TEMP}"
 
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
 run_server "mv /tmp/nanoclaw_env ~/nanoclaw/.env"

--- a/github-codespaces/openclaw.sh
+++ b/github-codespaces/openclaw.sh
@@ -65,12 +65,7 @@ CONFIG_TEMP=$(mktemp)
 chmod 600 "${CONFIG_TEMP}"
 track_temp_file "${CONFIG_TEMP}"
 
-cat > "${CONFIG_TEMP}" << EOF
-{
-  "modelId": "${MODEL_ID}",
-  "provider": "anthropic"
-}
-EOF
+printf '{\n  "modelId": "%s",\n  "provider": "anthropic"\n}\n' "${MODEL_ID}" > "${CONFIG_TEMP}"
 
 upload_file "${CONFIG_TEMP}" "/tmp/openclaw_config.json"
 run_server "mkdir -p ~/.config/openclaw && mv /tmp/openclaw_config.json ~/.config/openclaw/config.json"

--- a/hetzner/nanoclaw.sh
+++ b/hetzner/nanoclaw.sh
@@ -55,9 +55,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${HETZNER_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/hostinger/nanoclaw.sh
+++ b/hostinger/nanoclaw.sh
@@ -53,9 +53,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${HOSTINGER_VPS_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
 run_server "${HOSTINGER_VPS_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"

--- a/hostkey/nanoclaw.sh
+++ b/hostkey/nanoclaw.sh
@@ -55,9 +55,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${HOSTKEY_INSTANCE_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
 run_server "${HOSTKEY_INSTANCE_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"

--- a/ionos/nanoclaw.sh
+++ b/ionos/nanoclaw.sh
@@ -53,9 +53,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${IONOS_SERVER_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
 run_server "${IONOS_SERVER_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"

--- a/koyeb/nanoclaw.sh
+++ b/koyeb/nanoclaw.sh
@@ -51,9 +51,7 @@ inject_env_vars \
 
 # 8. Create NanoClaw .env file
 log_step "Configuring NanoClaw..."
-run_server "cat > ~/nanoclaw/.env << 'EOF'
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF"
+run_server "printf 'ANTHROPIC_API_KEY=%s\n' '${OPENROUTER_API_KEY}' > ~/nanoclaw/.env"
 
 echo ""
 log_info "Koyeb service setup completed successfully!"

--- a/latitude/nanoclaw.sh
+++ b/latitude/nanoclaw.sh
@@ -58,9 +58,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 track_temp_file "${DOTENV_TEMP}"
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${LATITUDE_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/linode/nanoclaw.sh
+++ b/linode/nanoclaw.sh
@@ -29,9 +29,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 upload_file "${LINODE_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 echo ""
 log_info "Linode setup completed successfully!"

--- a/modal/nanoclaw.sh
+++ b/modal/nanoclaw.sh
@@ -60,9 +60,7 @@ log_step "Configuring nanoclaw..."
 
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${DOTENV_TEMP}" ~/nanoclaw/.env
 

--- a/netcup/nanoclaw.sh
+++ b/netcup/nanoclaw.sh
@@ -55,9 +55,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${NETCUP_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/northflank/nanoclaw.sh
+++ b/northflank/nanoclaw.sh
@@ -56,9 +56,7 @@ DOTENV_TEMP=$(mktemp)
 chmod 600 "${DOTENV_TEMP}"
 track_temp_file "${DOTENV_TEMP}"
 
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
 run_server "mv /tmp/nanoclaw_env ~/nanoclaw/.env"

--- a/oracle/nanoclaw.sh
+++ b/oracle/nanoclaw.sh
@@ -61,9 +61,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${OCI_SERVER_IP}" "${DOTENV_TEMP}" "/home/ubuntu/nanoclaw/.env"
 

--- a/ovh/nanoclaw.sh
+++ b/ovh/nanoclaw.sh
@@ -60,9 +60,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file_ovh "${OVH_SERVER_IP}" "${DOTENV_TEMP}" "/home/ubuntu/nanoclaw/.env"
 

--- a/railway/nanoclaw.sh
+++ b/railway/nanoclaw.sh
@@ -56,9 +56,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "$DOTENV_TEMP" "/root/nanoclaw/.env"
 

--- a/ramnode/nanoclaw.sh
+++ b/ramnode/nanoclaw.sh
@@ -55,9 +55,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${RAMNODE_SERVER_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
 run_server "${RAMNODE_SERVER_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"

--- a/scaleway/nanoclaw.sh
+++ b/scaleway/nanoclaw.sh
@@ -43,9 +43,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 upload_file "${SCALEWAY_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 
 echo ""

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2095,7 +2095,7 @@ upload_config_file() {
 
     local temp_remote="/tmp/spawn_config_${RANDOM}_${RANDOM}_$(basename "${remote_path}")"
     ${upload_callback} "${temp_file}" "${temp_remote}"
-    ${run_callback} "mv ${temp_remote} ${remote_path}"
+    ${run_callback} "mv '${temp_remote}' '${remote_path}'"
 }
 
 # ============================================================

--- a/sprite/nanoclaw.sh
+++ b/sprite/nanoclaw.sh
@@ -53,9 +53,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 sprite exec -s "${SPRITE_NAME}" -file "${DOTENV_TEMP}:/tmp/nanoclaw_env" -- bash -c "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 

--- a/upcloud/nanoclaw.sh
+++ b/upcloud/nanoclaw.sh
@@ -43,9 +43,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${UPCLOUD_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 

--- a/vultr/nanoclaw.sh
+++ b/vultr/nanoclaw.sh
@@ -43,9 +43,7 @@ log_step "Configuring nanoclaw..."
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
-cat > "${DOTENV_TEMP}" << EOF
-ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}
-EOF
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 upload_file "${VULTR_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 
 echo ""


### PR DESCRIPTION
## Summary

- Replace unquoted `<< EOF` heredocs with `printf` in 33 nanoclaw scripts across all cloud providers to prevent shell expansion of API key values
- Fix unquoted variable expansion in `upload_config_file()` mv command in `shared/common.sh`
- Fix unquoted heredoc in `github-codespaces/openclaw.sh` config file creation

## Problem

All nanoclaw scripts used unquoted heredocs to write the .env file, which causes bash to perform shell expansion before writing. If an API key contains dollar signs, backticks, or backslashes, the value is silently corrupted or could trigger command execution.

## Fix

Replace with printf which safely writes the value without shell interpretation. This matches the pattern already used by kamatera, local, and render nanoclaw scripts.

Also quote paths in upload_config_file() mv command to prevent word splitting.

## Test plan

- All 35 modified scripts pass bash -n syntax check
- Full test suite passes (101 pre-existing failures, 0 new failures)
- Pattern matches existing safe implementations

Relates to #763 (nanoclaw heredoc medium finding)

-- refactor/security-auditor
