### PR TITLE
fix(ux): show post-session summary after SSH sessions end

### DIFF
--- a/atlanticnet/lib/common.sh
+++ b/atlanticnet/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # ============================================================
 
 readonly ATLANTICNET_API_BASE="https://cloudapi.atlantic.net"
+SPAWN_DASHBOARD_URL="https://cloud.atlantic.net/"
 readonly ATLANTICNET_API_VERSION="2010-12-30"
 
 # Generate HMAC-SHA256 signature for Atlantic.Net API

--- a/aws-lightsail/lib/common.sh
+++ b/aws-lightsail/lib/common.sh
@@ -23,6 +23,7 @@ fi
 # AWS Lightsail specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://lightsail.aws.amazon.com/"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Configurable timeout/delay constants

--- a/binarylane/lib/common.sh
+++ b/binarylane/lib/common.sh
@@ -23,6 +23,7 @@ fi
 # ============================================================
 
 readonly BINARYLANE_API_BASE="https://api.binarylane.com.au/v2"
+SPAWN_DASHBOARD_URL="https://manage.binarylane.com.au/"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Configurable timeout/delay constants

--- a/cherry/lib/common.sh
+++ b/cherry/lib/common.sh
@@ -17,6 +17,7 @@ CHERRY_API_BASE="https://api.cherryservers.com/v1"
 CHERRY_DEFAULT_PLAN="${CHERRY_DEFAULT_PLAN:-cloud_vps_1}"
 CHERRY_DEFAULT_REGION="${CHERRY_DEFAULT_REGION:-eu_nord_1}"
 CHERRY_DEFAULT_IMAGE="${CHERRY_DEFAULT_IMAGE:-Ubuntu 24.04 64bit}"
+SPAWN_DASHBOARD_URL="https://portal.cherryservers.com/"
 
 # Configurable timeout/delay constants
 INSTANCE_STATUS_POLL_DELAY=${INSTANCE_STATUS_POLL_DELAY:-5}

--- a/civo/lib/common.sh
+++ b/civo/lib/common.sh
@@ -23,6 +23,7 @@ fi
 # ============================================================
 
 readonly CIVO_API_BASE="https://api.civo.com/v2"
+SPAWN_DASHBOARD_URL="https://dashboard.civo.com/"
 
 # Configurable timeout/delay constants
 INSTANCE_STATUS_POLL_DELAY=${INSTANCE_STATUS_POLL_DELAY:-5}

--- a/cloudsigma/lib/common.sh
+++ b/cloudsigma/lib/common.sh
@@ -22,6 +22,8 @@ fi
 # CloudSigma specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://zrh.cloudsigma.com/ui/"
+
 # CloudSigma API endpoints by region
 # Default to Zurich (zrh), can be overridden with CLOUDSIGMA_REGION env var
 readonly CLOUDSIGMA_REGION_DEFAULT="zrh"

--- a/contabo/lib/common.sh
+++ b/contabo/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # ============================================================
 
 readonly CONTABO_API_BASE="https://api.contabo.com/v1"
+SPAWN_DASHBOARD_URL="https://my.contabo.com/"
 readonly CONTABO_AUTH_URL="https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token"
 
 # Get OAuth access token from Contabo

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -23,6 +23,7 @@ fi
 # ============================================================
 
 readonly DO_API_BASE="https://api.digitalocean.com/v2"
+SPAWN_DASHBOARD_URL="https://cloud.digitalocean.com/droplets"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Configurable timeout/delay constants

--- a/exoscale/lib/common.sh
+++ b/exoscale/lib/common.sh
@@ -22,6 +22,7 @@ fi
 # Exoscale specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://portal.exoscale.com/"
 # SSH_OPTS is defined in shared/common.sh
 
 # Configurable timeout/delay constants

--- a/genesiscloud/lib/common.sh
+++ b/genesiscloud/lib/common.sh
@@ -23,6 +23,7 @@ fi
 # ============================================================
 
 readonly GENESIS_API_BASE="https://api.genesiscloud.com/compute/v1"
+SPAWN_DASHBOARD_URL="https://compute.genesiscloud.com/"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Configurable timeout/delay constants

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # ============================================================
 
 readonly HETZNER_API_BASE="https://api.hetzner.cloud/v1"
+SPAWN_DASHBOARD_URL="https://console.hetzner.cloud/"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Centralized curl wrapper for Hetzner API

--- a/hostinger/lib/common.sh
+++ b/hostinger/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # ============================================================
 
 readonly HOSTINGER_API_BASE="https://api.hostinger.com/vps/v1"
+SPAWN_DASHBOARD_URL="https://hpanel.hostinger.com/"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Centralized curl wrapper for Hostinger API

--- a/hostkey/lib/common.sh
+++ b/hostkey/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # ============================================================
 
 readonly HOSTKEY_API_BASE="https://invapi.hostkey.com"
+SPAWN_DASHBOARD_URL="https://manage.hostkey.com/"
 
 # Centralized curl wrapper for HOSTKEY API
 # Delegates to generic_cloud_api for retry logic and error handling

--- a/ionos/lib/common.sh
+++ b/ionos/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # ============================================================
 
 readonly IONOS_API_BASE="https://api.ionos.com/cloudapi/v6"
+SPAWN_DASHBOARD_URL="https://dcd.ionos.com/"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Centralized curl wrapper for IONOS API

--- a/kamatera/lib/common.sh
+++ b/kamatera/lib/common.sh
@@ -23,6 +23,7 @@ fi
 # ============================================================
 
 readonly KAMATERA_API_BASE="https://cloudcli.cloudwm.com"
+SPAWN_DASHBOARD_URL="https://console.kamatera.com/"
 
 # Configurable timeout/delay constants
 INSTANCE_STATUS_POLL_DELAY=${INSTANCE_STATUS_POLL_DELAY:-5}

--- a/latitude/lib/common.sh
+++ b/latitude/lib/common.sh
@@ -19,6 +19,7 @@ fi
 # ============================================================
 
 readonly LATITUDE_API_BASE="https://api.latitude.sh"
+SPAWN_DASHBOARD_URL="https://www.latitude.sh/dashboard"
 
 # Centralized curl wrapper for Latitude.sh API
 latitude_api() {

--- a/linode/lib/common.sh
+++ b/linode/lib/common.sh
@@ -23,6 +23,7 @@ fi
 # ============================================================
 
 readonly LINODE_API_BASE="https://api.linode.com/v4"
+SPAWN_DASHBOARD_URL="https://cloud.linode.com/"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Configurable timeout/delay constants

--- a/netcup/lib/common.sh
+++ b/netcup/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # ============================================================
 
 readonly NETCUP_API_BASE="https://ccp.netcup.net/run/webservice/servers/endpoint.php"
+SPAWN_DASHBOARD_URL="https://ccp.netcup.net/"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Check if a Netcup API response indicates success

--- a/oracle/lib/common.sh
+++ b/oracle/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # OCI specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://cloud.oracle.com/compute/instances"
 # SSH_OPTS is defined in shared/common.sh
 
 # Configurable timeout/delay constants

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # ============================================================
 
 readonly OVH_API_BASE="https://eu.api.ovh.com/1.0"
+SPAWN_DASHBOARD_URL="https://www.ovhcloud.com/manager/"
 
 # OVH API requires signature-based authentication.
 # Headers: X-Ovh-Application, X-Ovh-Consumer, X-Ovh-Timestamp, X-Ovh-Signature

--- a/ramnode/lib/common.sh
+++ b/ramnode/lib/common.sh
@@ -21,6 +21,7 @@ fi
 # ============================================================
 
 readonly RAMNODE_API_BASE="https://openstack.ramnode.com"
+SPAWN_DASHBOARD_URL="https://manage.ramnode.com/"
 readonly RAMNODE_IDENTITY_API="${RAMNODE_API_BASE}:5000/v3"
 readonly RAMNODE_COMPUTE_API="${RAMNODE_API_BASE}:8774/v2.1"
 readonly RAMNODE_NETWORK_API="${RAMNODE_API_BASE}:9696/v2.0"

--- a/scaleway/lib/common.sh
+++ b/scaleway/lib/common.sh
@@ -24,6 +24,7 @@ fi
 
 SCALEWAY_ZONE="${SCALEWAY_ZONE:-fr-par-1}"
 readonly SCALEWAY_API_BASE="https://api.scaleway.com/instance/v1/zones/${SCALEWAY_ZONE}"
+SPAWN_DASHBOARD_URL="https://console.scaleway.com/"
 readonly SCALEWAY_ACCOUNT_API="https://api.scaleway.com/account/v3"
 # SSH_OPTS is defined in shared/common.sh
 

--- a/upcloud/lib/common.sh
+++ b/upcloud/lib/common.sh
@@ -19,6 +19,7 @@ fi
 # ============================================================
 
 readonly UPCLOUD_API_BASE="https://api.upcloud.com/1.3"
+SPAWN_DASHBOARD_URL="https://hub.upcloud.com/"
 
 # Configurable timeout/delay constants
 INSTANCE_STATUS_POLL_DELAY=${INSTANCE_STATUS_POLL_DELAY:-5}

--- a/vultr/lib/common.sh
+++ b/vultr/lib/common.sh
@@ -23,6 +23,7 @@ fi
 # ============================================================
 
 readonly VULTR_API_BASE="https://api.vultr.com/v2"
+SPAWN_DASHBOARD_URL="https://my.vultr.com/"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Configurable timeout/delay constants

--- a/webdock/lib/common.sh
+++ b/webdock/lib/common.sh
@@ -23,6 +23,7 @@ fi
 # ============================================================
 
 readonly WEBDOCK_API_BASE="https://api.webdock.io/v1"
+SPAWN_DASHBOARD_URL="https://webdock.io/en/dashboard"
 # SSH_OPTS is now defined in shared/common.sh
 
 # Configurable timeout/delay constants


### PR DESCRIPTION
## Summary
- After an interactive SSH session ends, users now see a warning that their server is still running, a dashboard link to manage/delete it, and the SSH command to reconnect
- Adds `_show_post_session_summary()` to `shared/common.sh` and integrates it into `ssh_interactive_session`
- Sets `SPAWN_DASHBOARD_URL` in all 25 SSH-based cloud providers so the summary includes a direct dashboard link

## Motivation
Previously, all 486 agent scripts ended with `interactive_session` and then silently exited. Users had no feedback about whether their server was still running (and incurring charges), how to delete it, or how to reconnect. This was the single biggest UX gap -- users could unknowingly leave servers running and get billed.

## What it looks like

After exiting an agent session, users now see:
```
Session ended. Your server is still running at 203.0.113.5.

To manage or delete it, visit your dashboard:
  https://console.hetzner.cloud/

To reconnect:
  ssh root@203.0.113.5
```

## Test plan
- [x] `bash -n` syntax check passes on all 26 modified files (shared/common.sh + 25 cloud libs)
- [x] All 52 SSH helper tests pass (`shared-common-ssh-helpers.test.ts`)
- [x] All 950 cloud API surface tests pass (`cloud-lib-api-surface.test.ts`)
- [x] Post-session summary output goes to stderr (via `log_warn`), so existing stdout-based tests are unaffected
- [x] SSH exit code is preserved -- the summary displays but the original exit code is returned

-- refactor/ux-engineer