### PR TITLE
improve(ux): show server name and billing reminder in post-session summary

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1599,24 +1599,30 @@ ssh_upload_file() {
 # Called automatically by ssh_interactive_session after the SSH session ends.
 # Uses optional env vars for richer output:
 #   SPAWN_DASHBOARD_URL - Cloud provider dashboard URL for managing servers
+#   SERVER_NAME         - Server name (set by individual cloud scripts)
 # Arguments: IP
 _show_post_session_summary() {
     local ip="${1}"
     local dashboard_url="${SPAWN_DASHBOARD_URL:-}"
+    local server_name="${SERVER_NAME:-}"
 
     printf '\n'
-    log_warn "Session ended. Your server is still running at ${ip}."
+    if [[ -n "${server_name}" ]]; then
+        log_warn "Session ended. Your server '${server_name}' is still running at ${ip}."
+    else
+        log_warn "Session ended. Your server is still running at ${ip}."
+    fi
+    log_warn "Remember to delete it when you're done to avoid ongoing charges."
     log_warn ""
     if [[ -n "${dashboard_url}" ]]; then
-        log_warn "To manage or delete it, visit your dashboard:"
+        log_warn "Manage or delete it in your dashboard:"
         log_warn "  ${dashboard_url}"
     else
-        log_warn "Check your cloud provider dashboard to stop or delete the server"
-        log_warn "if you no longer need it."
+        log_warn "Check your cloud provider dashboard to stop or delete the server."
     fi
     log_warn ""
-    log_warn "To reconnect:"
-    log_warn "  ssh ${SSH_USER:-root}@${ip}"
+    log_info "To reconnect:"
+    log_info "  ssh ${SSH_USER:-root}@${ip}"
 }
 
 # Start an interactive SSH session


### PR DESCRIPTION
## Summary
- Post-session summary now shows the server name (e.g., "Your server 'spawn-claude-abc' is still running at 1.2.3.4") so users can identify and find their server in the cloud dashboard
- Adds explicit billing reminder: "Remember to delete it when you're done to avoid ongoing charges"
- Reconnect instructions now use green (log_info) instead of yellow (log_warn), since it's helpful guidance, not a warning

## Details
The `_show_post_session_summary()` function in `shared/common.sh` runs after every SSH session ends. Previously it only showed the IP address, making it hard for users with multiple servers to know which one to manage. All cloud scripts already set `SERVER_NAME` before calling `interactive_session`, so this change works across all 25+ SSH-based cloud providers with zero changes to individual scripts.

**Before:**
```
Session ended. Your server is still running at 1.2.3.4.

To manage or delete it, visit your dashboard:
  https://console.hetzner.cloud/

To reconnect:
  ssh root@1.2.3.4
```

**After:**
```
Session ended. Your server 'spawn-claude-h3x7' is still running at 1.2.3.4.
Remember to delete it when you're done to avoid ongoing charges.

Manage or delete it in your dashboard:
  https://console.hetzner.cloud/

To reconnect:
  ssh root@1.2.3.4
```

## Test plan
- [x] `bash -n shared/common.sh` passes
- [x] `bash test/run.sh` -- 79/79 shell tests pass
- [x] `bun test` -- all tests pass (2 pre-existing CodeSandbox test failures unrelated to this change)

-- refactor/ux-engineer