### PR TITLE
fix: standardize CloudSigma auth field format

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -784,7 +784,7 @@
       "description": "Flexible cloud compute with API-first architecture",
       "url": "https://www.cloudsigma.com/",
       "type": "api",
-      "auth": "CLOUDSIGMA_EMAIL and CLOUDSIGMA_PASSWORD (HTTP Basic Auth)",
+      "auth": "CLOUDSIGMA_EMAIL + CLOUDSIGMA_PASSWORD",
       "provision_method": "POST /api/2.0/servers/ with drives and SSH keys",
       "exec_method": "ssh cloudsigma@IP",
       "interactive_method": "ssh -t cloudsigma@IP",


### PR DESCRIPTION
## Summary
- Changed CloudSigma auth field from `"CLOUDSIGMA_EMAIL and CLOUDSIGMA_PASSWORD (HTTP Basic Auth)"` to `"CLOUDSIGMA_EMAIL + CLOUDSIGMA_PASSWORD"`
- The `and` separator caused `key-request.sh` to crash during QA cycle Phase 0 (tried to use the whole string as a variable name)

## Test plan
- [ ] Trigger QA workflow and verify Phase 0 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)