### PR TITLE
fix(security): harden nanoclaw API key handling and remote temp file permissions

### DIFF
--- a/cloudsigma/nanoclaw.sh
+++ b/cloudsigma/nanoclaw.sh
@@ -46,7 +46,7 @@ chmod 600 "${DOTENV_TEMP}"
 printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${CLOUDSIGMA_SERVER_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
-run_server "${CLOUDSIGMA_SERVER_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
+run_server "${CLOUDSIGMA_SERVER_IP}" "chmod 600 /tmp/nanoclaw_env && mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "CloudSigma instance setup completed successfully!"

--- a/github-codespaces/nanoclaw.sh
+++ b/github-codespaces/nanoclaw.sh
@@ -69,7 +69,7 @@ track_temp_file "${DOTENV_TEMP}"
 printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
-run_server "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
+run_server "chmod 600 /tmp/nanoclaw_env && mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "GitHub Codespace setup completed successfully!"

--- a/hostinger/nanoclaw.sh
+++ b/hostinger/nanoclaw.sh
@@ -56,7 +56,7 @@ chmod 600 "${DOTENV_TEMP}"
 printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${HOSTINGER_VPS_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
-run_server "${HOSTINGER_VPS_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
+run_server "${HOSTINGER_VPS_IP}" "chmod 600 /tmp/nanoclaw_env && mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "Hostinger VPS setup completed successfully!"

--- a/hostkey/nanoclaw.sh
+++ b/hostkey/nanoclaw.sh
@@ -58,7 +58,7 @@ chmod 600 "${DOTENV_TEMP}"
 printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${HOSTKEY_INSTANCE_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
-run_server "${HOSTKEY_INSTANCE_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
+run_server "${HOSTKEY_INSTANCE_IP}" "chmod 600 /tmp/nanoclaw_env && mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "HOSTKEY server setup completed successfully!"

--- a/ionos/nanoclaw.sh
+++ b/ionos/nanoclaw.sh
@@ -56,7 +56,7 @@ chmod 600 "${DOTENV_TEMP}"
 printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${IONOS_SERVER_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
-run_server "${IONOS_SERVER_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
+run_server "${IONOS_SERVER_IP}" "chmod 600 /tmp/nanoclaw_env && mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "IONOS server setup completed successfully!"

--- a/koyeb/nanoclaw.sh
+++ b/koyeb/nanoclaw.sh
@@ -51,7 +51,14 @@ inject_env_vars \
 
 # 8. Create NanoClaw .env file
 log_step "Configuring NanoClaw..."
-run_server "printf 'ANTHROPIC_API_KEY=%s\n' '${OPENROUTER_API_KEY}' > ~/nanoclaw/.env"
+
+DOTENV_TEMP=$(mktemp)
+chmod 600 "${DOTENV_TEMP}"
+track_temp_file "${DOTENV_TEMP}"
+printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
+
+upload_file "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
+run_server "chmod 600 /tmp/nanoclaw_env && mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "Koyeb service setup completed successfully!"

--- a/northflank/nanoclaw.sh
+++ b/northflank/nanoclaw.sh
@@ -59,7 +59,7 @@ track_temp_file "${DOTENV_TEMP}"
 printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
-run_server "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
+run_server "chmod 600 /tmp/nanoclaw_env && mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "Northflank setup completed successfully!"

--- a/ramnode/nanoclaw.sh
+++ b/ramnode/nanoclaw.sh
@@ -58,7 +58,7 @@ chmod 600 "${DOTENV_TEMP}"
 printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
 upload_file "${RAMNODE_SERVER_IP}" "${DOTENV_TEMP}" "/tmp/nanoclaw_env"
-run_server "${RAMNODE_SERVER_IP}" "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
+run_server "${RAMNODE_SERVER_IP}" "chmod 600 /tmp/nanoclaw_env && mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "RamNode server setup completed successfully!"

--- a/sprite/nanoclaw.sh
+++ b/sprite/nanoclaw.sh
@@ -55,7 +55,7 @@ trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
 printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
 
-sprite exec -s "${SPRITE_NAME}" -file "${DOTENV_TEMP}:/tmp/nanoclaw_env" -- bash -c "mv /tmp/nanoclaw_env ~/nanoclaw/.env"
+sprite exec -s "${SPRITE_NAME}" -file "${DOTENV_TEMP}:/tmp/nanoclaw_env" -- bash -c "chmod 600 /tmp/nanoclaw_env && mv /tmp/nanoclaw_env ~/nanoclaw/.env"
 
 echo ""
 log_info "Sprite setup completed successfully!"


### PR DESCRIPTION
## Summary
- **MEDIUM: Fix command injection in `koyeb/nanoclaw.sh`** — the API key was embedded directly in a `run_server` shell command string using single quotes. A key containing `'` could break out and execute arbitrary commands. Replaced with the safe `mktemp` + `upload_file` pattern used by all other nanoclaw scripts.
- **LOW: Add `chmod 600` to remote `/tmp/nanoclaw_env`** before `mv` in 8 nanoclaw scripts (ramnode, ionos, hostinger, hostkey, cloudsigma, northflank, github-codespaces, sprite). This restricts permissions on the credential file during the brief transfer window on the remote server.

## Files changed (9)
- `koyeb/nanoclaw.sh` — replaced inline API key injection with safe mktemp+upload pattern
- `ramnode/nanoclaw.sh`, `ionos/nanoclaw.sh`, `hostinger/nanoclaw.sh`, `hostkey/nanoclaw.sh`, `cloudsigma/nanoclaw.sh`, `northflank/nanoclaw.sh`, `github-codespaces/nanoclaw.sh`, `sprite/nanoclaw.sh` — added `chmod 600` before `mv` on remote temp file

## Test plan
- [x] `bash -n` syntax check passes on all 9 modified scripts
- [x] `bun test` passes (pre-existing failures in codesandbox tests are unrelated)
- [x] Verified the test assertion in `test/run.sh:227` still matches the updated sprite pattern

## Related
- Addresses findings from issue #763 (nanoclaw .env security)
- Follows the security hardening pattern established in PR #1039

-- refactor/security-auditor