### PR TITLE
fix(ux): add post-session summary to Alibaba Cloud and GCP

### DIFF
--- a/alibabacloud/lib/common.sh
+++ b/alibabacloud/lib/common.sh
@@ -22,6 +22,8 @@ fi
 # Alibaba Cloud specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://ecs.console.aliyun.com/"
+
 # Configurable timeout/delay constants
 INSTANCE_STATUS_POLL_DELAY=${INSTANCE_STATUS_POLL_DELAY:-5}  # Delay between instance status checks
 
@@ -550,32 +552,8 @@ create_server() {
     _wait_for_aliyun_instance "$instance_id" 60
 }
 
-# Upload file to instance
-# Usage: upload_file SERVER_IP LOCAL_PATH REMOTE_PATH
-upload_file() {
-    local server_ip="$1"
-    local local_path="$2"
-    local remote_path="$3"
-    # shellcheck disable=SC2086
-    scp $SSH_OPTS "$local_path" "root@${server_ip}:${remote_path}"
-}
-
-# Run command on instance
-# Usage: run_server SERVER_IP COMMAND
-run_server() {
-    local server_ip="$1"
-    shift
-    # shellcheck disable=SC2086
-    ssh $SSH_OPTS "root@${server_ip}" "$@"
-}
-
-# Start interactive session
-# Usage: interactive_session SERVER_IP [COMMAND]
-interactive_session() {
-    local server_ip="$1"
-    local command="${2:-bash}"
-    # shellcheck disable=SC2086
-    ssh $SSH_OPTS -t "root@${server_ip}" "$command"
-}
-
+# Standard SSH operations (delegates to shared helpers in shared/common.sh)
+run_server() { ssh_run_server "$@"; }
+upload_file() { ssh_upload_file "$@"; }
+interactive_session() { ssh_interactive_session "$@"; }
 verify_server_connectivity() { ssh_verify_connectivity "$@"; }


### PR DESCRIPTION
## Summary

- **Alibaba Cloud** and **GCP** both had custom `interactive_session()` functions that called `ssh` directly, bypassing the shared `ssh_interactive_session` helper which shows the post-session "your server is still running" warning
- Users ending sessions on these clouds got no reminder to delete their server, risking ongoing charges
- Both clouds were also missing `SPAWN_DASHBOARD_URL`, so even if the summary were shown, it would display a generic message instead of a clickable dashboard link

## Changes

- **alibabacloud/lib/common.sh**: Replace 3 custom SSH functions (`run_server`, `upload_file`, `interactive_session`) with shared helper delegates; add `SPAWN_DASHBOARD_URL` pointing to ECS console
- **gcp/lib/common.sh**: Set `SSH_USER="${GCP_USERNAME}"` so shared helpers use the correct username; replace 4 custom SSH functions with shared helper delegates; add `SPAWN_DASHBOARD_URL` pointing to Compute Engine console

## Test plan

- [x] `bash -n` syntax check passes on both modified files
- [x] All 105 post-session tests pass (including the `SPAWN_DASHBOARD_URL` convention tests which now auto-discover both clouds)
- [x] Pre-existing CodeSandbox test failures are unrelated (also fail on main)

-- refactor/ux-engineer