### PR TITLE
fix(ux): add post-session summary to 10 exec-based cloud providers

### DIFF
--- a/codesandbox/lib/common.sh
+++ b/codesandbox/lib/common.sh
@@ -25,6 +25,8 @@ fi
 # CodeSandbox specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://codesandbox.io/dashboard"
+
 ensure_codesandbox_cli() {
     if ! command -v node &>/dev/null; then
         log_step "Installing Node.js..."
@@ -226,7 +228,10 @@ upload_file() {
 interactive_session() {
     log_info "Starting interactive session..."
     log_step "For a full terminal, open your sandbox at: https://codesandbox.io/dashboard"
-    run_server "$1"
+    local session_exit=0
+    run_server "$1" || session_exit=$?
+    SERVER_NAME="${CODESANDBOX_SANDBOX_ID:-}" _show_exec_post_session_summary
+    return "${session_exit}"
 }
 
 destroy_server() {

--- a/e2b/lib/common.sh
+++ b/e2b/lib/common.sh
@@ -25,6 +25,8 @@ fi
 # E2B specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://e2b.dev/dashboard"
+
 ensure_e2b_cli() {
     if ! command -v e2b &>/dev/null; then
         log_step "Installing E2B CLI..."
@@ -142,7 +144,10 @@ interactive_session() {
     local cmd="${1}"
     local escaped_cmd
     escaped_cmd=$(printf '%q' "${cmd}")
-    e2b sandbox exec "${E2B_SANDBOX_ID}" -- bash -c "${escaped_cmd}"
+    local session_exit=0
+    e2b sandbox exec "${E2B_SANDBOX_ID}" -- bash -c "${escaped_cmd}" || session_exit=$?
+    SERVER_NAME="${E2B_SANDBOX_ID:-}" _show_exec_post_session_summary
+    return "${session_exit}"
 }
 
 destroy_server() {

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -24,6 +24,7 @@ fi
 # ============================================================
 
 readonly FLY_API_BASE="https://api.machines.dev/v1"
+SPAWN_DASHBOARD_URL="https://fly.io/dashboard"
 
 # Centralized curl wrapper for Fly.io Machines API
 fly_api() {
@@ -328,7 +329,11 @@ interactive_session() {
     # SECURITY: Properly escape command to prevent injection
     local escaped_cmd
     escaped_cmd=$(printf '%q' "$cmd")
-    "$(_get_fly_cmd)" ssh console -a "$FLY_APP_NAME" -C "bash -c $escaped_cmd"
+    local session_exit=0
+    "$(_get_fly_cmd)" ssh console -a "$FLY_APP_NAME" -C "bash -c $escaped_cmd" || session_exit=$?
+    SERVER_NAME="${FLY_APP_NAME:-}" SPAWN_RECONNECT_CMD="fly ssh console -a ${FLY_APP_NAME:-}" \
+        _show_exec_post_session_summary
+    return "${session_exit}"
 }
 
 # Destroy a Fly.io machine and app

--- a/github-codespaces/lib/common.sh
+++ b/github-codespaces/lib/common.sh
@@ -23,6 +23,8 @@ fi
 # GitHub Codespaces specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://github.com/codespaces"
+
 # Ensure gh CLI is installed
 ensure_gh_cli() {
     if command -v gh &>/dev/null; then
@@ -174,7 +176,11 @@ copy_to_codespace() {
 ssh_to_codespace() {
     local codespace="$1"
     log_step "Opening SSH session to codespace..."
-    gh codespace ssh --codespace "$codespace"
+    local session_exit=0
+    gh codespace ssh --codespace "$codespace" || session_exit=$?
+    SERVER_NAME="${codespace}" SPAWN_RECONNECT_CMD="gh codespace ssh --codespace ${codespace}" \
+        _show_exec_post_session_summary
+    return "${session_exit}"
 }
 
 # Delete a codespace

--- a/koyeb/lib/common.sh
+++ b/koyeb/lib/common.sh
@@ -23,6 +23,8 @@ fi
 # Koyeb specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://app.koyeb.com/"
+
 # Detect OS name for binary downloads (darwin or linux)
 # Outputs the OS name to stdout; returns 1 on unsupported OS
 _koyeb_detect_os() {
@@ -329,7 +331,10 @@ interactive_session() {
     # SECURITY: Properly escape command to prevent injection
     local escaped_cmd
     escaped_cmd=$(printf '%q' "$launch_cmd")
-    koyeb instances exec "$KOYEB_INSTANCE_ID" -- bash -c "$escaped_cmd"
+    local session_exit=0
+    koyeb instances exec "$KOYEB_INSTANCE_ID" -- bash -c "$escaped_cmd" || session_exit=$?
+    SERVER_NAME="${KOYEB_SERVICE_NAME:-}" _show_exec_post_session_summary
+    return "${session_exit}"
 }
 
 # Cleanup: delete the service and app

--- a/northflank/lib/common.sh
+++ b/northflank/lib/common.sh
@@ -25,6 +25,8 @@ fi
 # Northflank specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://app.northflank.com/"
+
 ensure_northflank_cli() {
     if ! command -v northflank &>/dev/null; then
         log_step "Installing Northflank CLI..."
@@ -206,10 +208,13 @@ interactive_session() {
     escaped_cmd=$(printf '%q' "${cmd}")
 
     # Use northflank exec for interactive shell
+    local session_exit=0
     northflank exec \
         --project "${project}" \
         --service "${service}" \
-        --command "bash -c ${escaped_cmd}"
+        --command "bash -c ${escaped_cmd}" || session_exit=$?
+    SERVER_NAME="${service}" _show_exec_post_session_summary
+    return "${session_exit}"
 }
 
 # Destroy a Northflank service

--- a/railway/lib/common.sh
+++ b/railway/lib/common.sh
@@ -23,6 +23,8 @@ fi
 # Railway specific functions
 # ============================================================
 
+SPAWN_DASHBOARD_URL="https://railway.com/dashboard"
+
 # Ensure Railway CLI is installed
 ensure_railway_cli() {
     if command -v railway &>/dev/null; then
@@ -237,7 +239,10 @@ interactive_session() {
     log_step "Starting interactive session..."
 
     # Railway CLI has a shell command for interactive sessions
-    railway shell
+    local session_exit=0
+    railway shell || session_exit=$?
+    SERVER_NAME="${RAILWAY_SERVICE_NAME:-}" _show_exec_post_session_summary
+    return "${session_exit}"
 }
 
 # Cleanup: delete the project

--- a/render/lib/common.sh
+++ b/render/lib/common.sh
@@ -24,6 +24,7 @@ fi
 # ============================================================
 
 RENDER_API_BASE="https://api.render.com/v1"
+SPAWN_DASHBOARD_URL="https://dashboard.render.com/"
 
 # Centralized API wrapper for Render — delegates to generic_cloud_api
 # for automatic retry with exponential backoff on 429/503/network errors.
@@ -269,7 +270,10 @@ interactive_session() {
     # SECURITY: Properly escape command to prevent injection
     local escaped_cmd
     escaped_cmd=$(printf '%q' "$launch_cmd")
-    render ssh --service "$RENDER_SERVICE_ID" -- bash -c "$escaped_cmd"
+    local session_exit=0
+    render ssh --service "$RENDER_SERVICE_ID" -- bash -c "$escaped_cmd" || session_exit=$?
+    SERVER_NAME="${RENDER_SERVICE_NAME:-}" _show_exec_post_session_summary
+    return "${session_exit}"
 }
 
 # Cleanup: delete the service

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1626,6 +1626,39 @@ _show_post_session_summary() {
     log_info "  ssh ${SSH_USER:-root}@${ip}"
 }
 
+# Show a post-session summary for exec-based (non-SSH) cloud providers.
+# These use CLI exec commands instead of direct SSH, so the reconnect
+# hint differs from the SSH variant.
+# Uses optional env vars for richer output:
+#   SPAWN_DASHBOARD_URL  - Cloud provider dashboard URL for managing services
+#   SERVER_NAME          - Service/sandbox name
+#   SPAWN_RECONNECT_CMD  - CLI command to reconnect (shown as reconnect hint)
+_show_exec_post_session_summary() {
+    local dashboard_url="${SPAWN_DASHBOARD_URL:-}"
+    local server_name="${SERVER_NAME:-}"
+    local reconnect_cmd="${SPAWN_RECONNECT_CMD:-}"
+
+    printf '\n'
+    if [[ -n "${server_name}" ]]; then
+        log_warn "Session ended. Your service '${server_name}' is still running."
+    else
+        log_warn "Session ended. Your service is still running."
+    fi
+    log_warn "Remember to delete it when you're done to avoid ongoing charges."
+    log_warn ""
+    if [[ -n "${dashboard_url}" ]]; then
+        log_warn "Manage or delete it in your dashboard:"
+        log_warn "  ${dashboard_url}"
+    else
+        log_warn "Check your cloud provider dashboard to stop or delete the service."
+    fi
+    if [[ -n "${reconnect_cmd}" ]]; then
+        log_warn ""
+        log_info "To reconnect:"
+        log_info "  ${reconnect_cmd}"
+    fi
+}
+
 # Start an interactive SSH session
 # Usage: ssh_interactive_session IP COMMAND
 # Requires: SSH_USER (default: root), SSH_OPTS


### PR DESCRIPTION
## Summary

- Users on exec-based clouds (Fly, Render, Koyeb, Northflank, Railway, Modal, Daytona, E2B, CodeSandbox, GitHub Codespaces) got no warning when their session ended that their service was still running and incurring charges
- Added `_show_exec_post_session_summary()` to `shared/common.sh` -- a variant of `_show_post_session_summary` designed for non-SSH providers that use CLI exec commands instead of direct SSH
- Added `SPAWN_DASHBOARD_URL` to all 10 exec-based clouds so users get actionable dashboard links
- Each cloud's `interactive_session()` now captures the session exit code and calls `_show_exec_post_session_summary` after the session ends
- Clouds with CLI reconnect support (Fly, Daytona, GitHub Codespaces) also set `SPAWN_RECONNECT_CMD` to show a reconnect hint

## Clouds updated

| Cloud | Dashboard URL | Reconnect hint |
|---|---|---|
| Fly.io | https://fly.io/dashboard | `fly ssh console -a APP` |
| Render | https://dashboard.render.com/ | -- |
| Koyeb | https://app.koyeb.com/ | -- |
| Northflank | https://app.northflank.com/ | -- |
| Railway | https://railway.com/dashboard | -- |
| Modal | https://modal.com/apps | -- |
| Daytona | https://app.daytona.io/ | `daytona ssh ID` |
| E2B | https://e2b.dev/dashboard | -- |
| CodeSandbox | https://codesandbox.io/dashboard | -- |
| GitHub Codespaces | https://github.com/codespaces | `gh codespace ssh --codespace NAME` |

## Test plan

- [x] `bash -n` syntax check passes on all 11 modified `.sh` files
- [x] All 138 post-session tests pass (33 new tests added)
- [x] Pre-existing CodeSandbox test failures are unrelated (also fail on main)

-- refactor/ux-engineer