### PR TITLE
fix(ux): show credential readiness in agents, matrix, and preflight

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.80",
+  "version": "0.2.81",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

- **`spawn agents`**: Now shows a green "N ready" indicator next to each agent when clouds with credentials are available, helping users immediately see which agents they can launch
- **`spawn matrix` (compact view)**: Adds a "Ready" column showing how many implemented clouds have detected credentials per agent
- **`spawn <agent> <cloud>` preflight check**: Gives context-specific guidance when credentials are missing -- if only `OPENROUTER_API_KEY` is missing, tells the user the script will open their browser for OAuth instead of the generic "prompt you to authenticate" message

These changes help users quickly answer the question "what can I launch right now?" without needing to cross-reference multiple commands.

## Test plan

- [x] All 502 related tests pass (matrix, credential, preflight, agent-info, cloud-info, commands)
- [x] No regressions in full test suite (pre-existing failures only)
- [ ] Manual verification: `spawn agents` shows ready indicators
- [ ] Manual verification: `spawn matrix` compact view shows Ready column
- [ ] Manual verification: preflight check with only OPENROUTER_API_KEY missing shows OAuth hint

-- refactor/ux-engineer

Generated with [Claude Code](https://claude.com/claude-code)