### PR TITLE
fix(security): use single-quoted heredocs with sed substitution in issue/team prompts

### DIFF
--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -119,21 +119,21 @@ PROMPT_FILE=$(mktemp /tmp/refactor-prompt-XXXXXX.md)
 
 if [[ "${RUN_MODE}" == "issue" ]]; then
     # --- Issue mode: lightweight 2-teammate fix ---
-    cat > "${PROMPT_FILE}" << ISSUE_PROMPT_EOF
+    cat > "${PROMPT_FILE}" << 'ISSUE_PROMPT_EOF'
 You are the Team Lead for a focused issue-fix cycle on the spawn codebase.
 
 ## Target Issue
 
-Fix GitHub issue #${SPAWN_ISSUE}.
+Fix GitHub issue #SPAWN_ISSUE_PLACEHOLDER.
 
 ## Context Gathering (MANDATORY)
 
 Fetch the COMPLETE issue thread before starting:
-\`\`\`bash
-gh issue view ${SPAWN_ISSUE} --repo OpenRouterTeam/spawn --comments
-gh pr list --repo OpenRouterTeam/spawn --search "${SPAWN_ISSUE}" --json number,title,url
-\`\`\`
-For each linked PR: \`gh pr view PR_NUM --repo OpenRouterTeam/spawn --comments\`
+```bash
+gh issue view SPAWN_ISSUE_PLACEHOLDER --repo OpenRouterTeam/spawn --comments
+gh pr list --repo OpenRouterTeam/spawn --search "SPAWN_ISSUE_PLACEHOLDER" --json number,title,url
+```
+For each linked PR: `gh pr view PR_NUM --repo OpenRouterTeam/spawn --comments`
 
 Read ALL comments — prior discussion contains decisions, rejected approaches, and scope changes.
 
@@ -143,37 +143,41 @@ Complete within 10 minutes. At 7 min stop new work, at 9 min shutdown teammates,
 
 ## Team Structure
 
-1. **issue-fixer** (Sonnet) — Diagnose root cause, implement fix in worktree, run tests, create PR with \`Fixes #${SPAWN_ISSUE}\`
-2. **issue-tester** (Haiku) — Review fix for correctness/edge cases, run \`bun test\` + \`bash -n\` on modified .sh files, report results
+1. **issue-fixer** (Sonnet) — Diagnose root cause, implement fix in worktree, run tests, create PR with `Fixes #SPAWN_ISSUE_PLACEHOLDER`
+2. **issue-tester** (Haiku) — Review fix for correctness/edge cases, run `bun test` + `bash -n` on modified .sh files, report results
 
 ## Label Management
 
-Track lifecycle: "pending-review" → "under-review" → "in-progress". Check labels first: \`gh issue view ${SPAWN_ISSUE} --repo OpenRouterTeam/spawn --json labels --jq '.labels[].name'\`
-- Start: \`gh issue edit ${SPAWN_ISSUE} --repo OpenRouterTeam/spawn --remove-label "pending-review" --remove-label "under-review" --add-label "in-progress"\`
-- After merge: \`gh issue edit ${SPAWN_ISSUE} --repo OpenRouterTeam/spawn --remove-label "in-progress"\`
+Track lifecycle: "pending-review" → "under-review" → "in-progress". Check labels first: `gh issue view SPAWN_ISSUE_PLACEHOLDER --repo OpenRouterTeam/spawn --json labels --jq '.labels[].name'`
+- Start: `gh issue edit SPAWN_ISSUE_PLACEHOLDER --repo OpenRouterTeam/spawn --remove-label "pending-review" --remove-label "under-review" --add-label "in-progress"`
+- After merge: `gh issue edit SPAWN_ISSUE_PLACEHOLDER --repo OpenRouterTeam/spawn --remove-label "in-progress"`
 
 ## Workflow
 
 1. Create team, fetch issue, transition label to "in-progress"
-2. DEDUP: \`gh issue view ${SPAWN_ISSUE} --repo OpenRouterTeam/spawn --json comments --jq '.comments[].author.login'\` — only post acknowledgment if no automated comments exist
-3. Post acknowledgment (if needed): \`gh issue comment ${SPAWN_ISSUE} --repo OpenRouterTeam/spawn --body "Thanks for flagging this! Looking into it now.\n\n-- refactor/issue-fixer"\`
-4. Create worktree: \`git worktree add ${WORKTREE_BASE} -b fix/issue-${SPAWN_ISSUE} origin/main\`
+2. DEDUP: `gh issue view SPAWN_ISSUE_PLACEHOLDER --repo OpenRouterTeam/spawn --json comments --jq '.comments[].author.login'` — only post acknowledgment if no automated comments exist
+3. Post acknowledgment (if needed): `gh issue comment SPAWN_ISSUE_PLACEHOLDER --repo OpenRouterTeam/spawn --body "Thanks for flagging this! Looking into it now.\n\n-- refactor/issue-fixer"`
+4. Create worktree: `git worktree add WORKTREE_BASE_PLACEHOLDER -b fix/issue-SPAWN_ISSUE_PLACEHOLDER origin/main`
 5. Spawn issue-fixer + issue-tester
-6. When fix is ready: push, create PR with \`Fixes #${SPAWN_ISSUE}\` in body, post update comment linking PR
-7. Do NOT close the issue — \`Fixes #${SPAWN_ISSUE}\` auto-closes on merge
-8. Clean up: \`git worktree remove ${WORKTREE_BASE}\`, shutdown teammates
+6. When fix is ready: push, create PR with `Fixes #SPAWN_ISSUE_PLACEHOLDER` in body, post update comment linking PR
+7. Do NOT close the issue — `Fixes #SPAWN_ISSUE_PLACEHOLDER` auto-closes on merge
+8. Clean up: `git worktree remove WORKTREE_BASE_PLACEHOLDER`, shutdown teammates
 
 ## Commit Markers
 
-Every commit: \`Agent: issue-fixer\` + \`Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>\`
+Every commit: `Agent: issue-fixer` + `Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>`
 
 ## Safety
 
 - Run tests after every change
 - If fix is not straightforward (>10 min), comment on issue explaining complexity and exit
 
-Begin now. Fix issue #${SPAWN_ISSUE}.
+Begin now. Fix issue #SPAWN_ISSUE_PLACEHOLDER.
 ISSUE_PROMPT_EOF
+
+    # Substitute placeholders with validated values (safe — no shell expansion)
+    sed -i "s|SPAWN_ISSUE_PLACEHOLDER|${SPAWN_ISSUE}|g" "${PROMPT_FILE}"
+    sed -i "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
 
 else
     # --- Refactor mode: full 6-teammate team ---

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -157,21 +157,21 @@ PROMPT_FILE=$(mktemp /tmp/security-prompt-XXXXXX.md)
 
 if [[ "${RUN_MODE}" == "team_building" ]]; then
     # --- Team Building mode: implement changes to agent team scripts ---
-    cat > "${PROMPT_FILE}" << TEAM_PROMPT_EOF
+    cat > "${PROMPT_FILE}" << 'TEAM_PROMPT_EOF'
 You are the Team Lead for a team-building cycle on the spawn codebase.
 
 ## Target Issue
 
-Implement changes from GitHub issue #${ISSUE_NUM}.
+Implement changes from GitHub issue #ISSUE_NUM_PLACEHOLDER.
 
 ## Context Gathering (MANDATORY)
 
 Fetch the COMPLETE issue thread before starting:
-\`\`\`bash
-gh issue view ${ISSUE_NUM} --repo OpenRouterTeam/spawn --comments
-gh pr list --repo OpenRouterTeam/spawn --search "${ISSUE_NUM}" --json number,title,url
-\`\`\`
-For each linked PR: \`gh pr view PR_NUM --repo OpenRouterTeam/spawn --comments\`
+```bash
+gh issue view ISSUE_NUM_PLACEHOLDER --repo OpenRouterTeam/spawn --comments
+gh pr list --repo OpenRouterTeam/spawn --search "ISSUE_NUM_PLACEHOLDER" --json number,title,url
+```
+For each linked PR: `gh pr view PR_NUM --repo OpenRouterTeam/spawn --comments`
 
 Read ALL comments — prior discussion contains decisions, rejected approaches, and scope changes.
 
@@ -183,16 +183,16 @@ Complete within 12 minutes. At 9 min wrap up, at 11 min shutdown, at 12 min forc
 
 ## Team Structure
 
-1. **implementer** (Opus) — Identify target script (\`.claude/skills/setup-agent-team/{team}.sh\`), implement changes in worktree, update workflows if needed, run \`bash -n\`, create PR: \`gh pr create --title "feat: [desc]" --body "Implements #${ISSUE_NUM}\n\n-- security/implementer"\`
-2. **reviewer** (Opus) — Wait for PR, review for security/correctness/macOS compat/consistency. Approve or request-changes. If approved, merge: \`gh pr merge NUMBER --repo OpenRouterTeam/spawn --squash --delete-branch\`
+1. **implementer** (Opus) — Identify target script (`.claude/skills/setup-agent-team/{team}.sh`), implement changes in worktree, update workflows if needed, run `bash -n`, create PR: `gh pr create --title "feat: [desc]" --body "Implements #ISSUE_NUM_PLACEHOLDER\n\n-- security/implementer"`
+2. **reviewer** (Opus) — Wait for PR, review for security/correctness/macOS compat/consistency. Approve or request-changes. If approved, merge: `gh pr merge NUMBER --repo OpenRouterTeam/spawn --squash --delete-branch`
 
 ## Workflow
 
 1. Create team, fetch issue, transition label to "in-progress":
-   \`gh issue edit ${ISSUE_NUM} --repo OpenRouterTeam/spawn --remove-label "pending-review" --remove-label "under-review" --add-label "in-progress"\`
-2. Set up worktree: \`git worktree add ${WORKTREE_BASE} -b team-building/issue-${ISSUE_NUM} origin/main\`
+   `gh issue edit ISSUE_NUM_PLACEHOLDER --repo OpenRouterTeam/spawn --remove-label "pending-review" --remove-label "under-review" --add-label "in-progress"`
+2. Set up worktree: `git worktree add WORKTREE_BASE_PLACEHOLDER -b team-building/issue-ISSUE_NUM_PLACEHOLDER origin/main`
 3. Spawn implementer (opus) → spawn reviewer (opus)
-4. Monitor: \`TaskList\` → \`Bash("sleep 5")\` → repeat. EVERY iteration MUST call TaskList.
+4. Monitor: `TaskList` → `Bash("sleep 5")` → repeat. EVERY iteration MUST call TaskList.
 5. When both report: if merged, close issue; if issues found, comment on issue
 6. Shutdown teammates, clean up worktree, TeamDelete, exit
 
@@ -203,12 +203,16 @@ Complete within 12 minutes. At 9 min wrap up, at 11 min shutdown, at 12 min forc
 ## Safety
 
 - Only modify the specific team script(s) mentioned in the issue
-- Run \`bash -n\` on every modified .sh file
+- Run `bash -n` on every modified .sh file
 - Never break existing functionality
 - If request is unclear, comment on issue asking for clarification and exit
 
-Begin now. Implement the team building request from issue #${ISSUE_NUM}.
+Begin now. Implement the team building request from issue #ISSUE_NUM_PLACEHOLDER.
 TEAM_PROMPT_EOF
+
+    # Substitute placeholders with validated values (safe — no shell expansion)
+    sed -i "s|ISSUE_NUM_PLACEHOLDER|${ISSUE_NUM}|g" "${PROMPT_FILE}"
+    sed -i "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
 
 elif [[ "${RUN_MODE}" == "triage" ]]; then
     # --- Triage mode: single-agent issue safety check ---


### PR DESCRIPTION
## Summary

- **refactor.sh (issue mode)**: Convert unquoted heredoc to single-quoted with `SPAWN_ISSUE_PLACEHOLDER` and `WORKTREE_BASE_PLACEHOLDER` sed substitution — prevents shell expansion of `$SPAWN_ISSUE` and `$WORKTREE_BASE` in prompt templates
- **security.sh (team_building mode)**: Same pattern — convert to single-quoted heredoc with `ISSUE_NUM_PLACEHOLDER` and `WORKTREE_BASE_PLACEHOLDER` sed substitution

This standardizes all prompt heredocs on Pattern B (single-quoted + sed), matching the existing `WORKTREE_BASE_PLACEHOLDER` pattern already used in refactor mode. Eliminates the inconsistency where some heredocs used direct variable expansion (Pattern A) and others used the safer sed approach (Pattern B).

Fixes #1058
Fixes #1047
Fixes #1048

## Test plan

- [x] `bash -n .claude/skills/setup-agent-team/refactor.sh` — syntax check passes
- [x] `bash -n .claude/skills/setup-agent-team/security.sh` — syntax check passes
- [ ] Manual: trigger an issue-mode refactor cycle and verify prompt has correct issue number
- [ ] Manual: trigger a team-building security cycle and verify prompt has correct issue number

-- refactor/security-auditor