### PR TITLE
feat: Add cloudsigma/goose.sh

### DIFF
--- a/cloudsigma/goose.sh
+++ b/cloudsigma/goose.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cloudsigma/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cloudsigma/lib/common.sh)"
+fi
+
+log_info "Goose on CloudSigma"
+echo ""
+
+ensure_cloudsigma_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CLOUDSIGMA_SERVER_IP}"
+wait_for_cloud_init "${CLOUDSIGMA_SERVER_IP}" 60
+
+# Install Goose
+log_step "Installing Goose..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${CLOUDSIGMA_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${CLOUDSIGMA_SERVER_IP}"
+    exit 1
+fi
+log_info "Goose installation verified successfully"
+
+# Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${CLOUDSIGMA_SERVER_IP}" upload_file run_server \
+    "GOOSE_PROVIDER=openrouter" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "CloudSigma instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${CLOUDSIGMA_SERVER_UUID}, IP: ${CLOUDSIGMA_SERVER_IP})"
+echo ""
+
+# Start Goose interactively
+log_step "Starting Goose..."
+sleep 1
+clear
+interactive_session "${CLOUDSIGMA_SERVER_IP}" "source ~/.zshrc && goose"

--- a/manifest.json
+++ b/manifest.json
@@ -1357,7 +1357,7 @@
     "cloudsigma/openclaw": "implemented",
     "cloudsigma/nanoclaw": "implemented",
     "cloudsigma/aider": "implemented",
-    "cloudsigma/goose": "missing",
+    "cloudsigma/goose": "implemented",
     "cloudsigma/codex": "implemented",
     "cloudsigma/interpreter": "implemented",
     "cloudsigma/gemini": "implemented",


### PR DESCRIPTION
Implements Goose (Block's open-source AI coding agent) on CloudSigma.

## Changes
- Add `cloudsigma/goose.sh` — provisions CloudSigma server, installs Goose, configures OpenRouter
- Update `manifest.json`: set `cloudsigma/goose` to `"implemented"`

## Pattern
- Sources `cloudsigma/lib/common.sh` with local-or-remote fallback
- Uses CloudSigma primitives: `ensure_cloudsigma_credentials`, `create_server`, `verify_server_connectivity`
- Installs Goose via official installer with `CONFIGURE=false`
- Injects `GOOSE_PROVIDER=openrouter` and `OPENROUTER_API_KEY` via `inject_env_vars_ssh`
- Launches interactive Goose session

-- discovery/gap-filler-2