### PR TITLE
feat: Add Amazon Q on CloudSigma

### DIFF
--- a/cloudsigma/README.md
+++ b/cloudsigma/README.md
@@ -32,6 +32,7 @@ Get your credentials at: [CloudSigma Cloud Portal](https://zrh.cloudsigma.com/) 
 
 - `cloudsigma/claude` — Claude Code (Anthropic's CLI agent)
 - `cloudsigma/aider` — Aider (AI pair programming)
+- `cloudsigma/amazonq` — Amazon Q CLI (AWS's AI coding assistant)
 
 More coming soon! See `manifest.json` for the full matrix.
 

--- a/cloudsigma/amazonq.sh
+++ b/cloudsigma/amazonq.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cloudsigma/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cloudsigma/lib/common.sh)"
+fi
+
+log_info "Amazon Q on CloudSigma"
+echo ""
+
+ensure_cloudsigma_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CLOUDSIGMA_SERVER_IP}"
+wait_for_cloud_init "${CLOUDSIGMA_SERVER_IP}" 60
+
+log_step "Installing Amazon Q CLI..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${CLOUDSIGMA_SERVER_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "CloudSigma instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${CLOUDSIGMA_SERVER_UUID}, IP: ${CLOUDSIGMA_SERVER_IP})"
+echo ""
+
+log_step "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${CLOUDSIGMA_SERVER_IP}" "source ~/.zshrc && q chat"

--- a/manifest.json
+++ b/manifest.json
@@ -1361,7 +1361,7 @@
     "cloudsigma/codex": "implemented",
     "cloudsigma/interpreter": "implemented",
     "cloudsigma/gemini": "implemented",
-    "cloudsigma/amazonq": "missing",
+    "cloudsigma/amazonq": "implemented",
     "cloudsigma/cline": "missing",
     "cloudsigma/gptme": "missing",
     "cloudsigma/opencode": "missing",


### PR DESCRIPTION
Implements `cloudsigma/amazonq.sh` - deploys AWS's Amazon Q CLI coding assistant on CloudSigma cloud infrastructure with OpenRouter integration via `OPENAI_BASE_URL` override.

## Changes
- `cloudsigma/amazonq.sh` — New agent deployment script
- `manifest.json` — Updated `cloudsigma/amazonq` from `"missing"` to `"implemented"`
- `cloudsigma/README.md` — Added Amazon Q to available agents list

-- discovery/gap-filler-2