### PR TITLE
feat: Add OpenCode on HOSTKEY

### DIFF
--- a/hostkey/README.md
+++ b/hostkey/README.md
@@ -16,6 +16,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/hostkey/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/hostkey/openclaw.sh)
 ```
 
+#### OpenCode
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hostkey/opencode.sh)
+```
+
 ## Authentication
 
 To use HOSTKEY spawn scripts, you need a HOSTKEY API key:

--- a/hostkey/opencode.sh
+++ b/hostkey/opencode.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostkey/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostkey/lib/common.sh)"
+fi
+
+log_info "OpenCode on HOSTKEY"
+echo ""
+
+# 1. Resolve HOSTKEY API token
+ensure_hostkey_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${HOSTKEY_INSTANCE_IP}"
+wait_for_cloud_init "${HOSTKEY_INSTANCE_IP}" 60
+
+# 5. Install OpenCode
+log_step "Installing OpenCode..."
+run_server "${HOSTKEY_INSTANCE_IP}" "$(opencode_install_cmd)"
+log_info "OpenCode installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${HOSTKEY_INSTANCE_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "HOSTKEY server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTKEY_INSTANCE_ID}, IP: ${HOSTKEY_INSTANCE_IP})"
+echo ""
+
+# 7. Start OpenCode interactively
+log_step "Starting OpenCode..."
+sleep 1
+clear
+interactive_session "${HOSTKEY_INSTANCE_IP}" "source ~/.zshrc && opencode"

--- a/manifest.json
+++ b/manifest.json
@@ -1349,7 +1349,7 @@
     "hostkey/amazonq": "missing",
     "hostkey/cline": "implemented",
     "hostkey/gptme": "missing",
-    "hostkey/opencode": "missing",
+    "hostkey/opencode": "implemented",
     "hostkey/plandex": "missing",
     "hostkey/kilo": "missing",
     "hostkey/continue": "implemented",


### PR DESCRIPTION
Implements `hostkey/opencode.sh` - deploys OpenCode AI coding agent (Go-based TUI) on HOSTKEY cloud infrastructure with native OpenRouter integration via `OPENROUTER_API_KEY`.

## Changes
- `hostkey/opencode.sh` — New agent deployment script
- `manifest.json` — Updated `hostkey/opencode` from `"missing"` to `"implemented"`
- `hostkey/README.md` — Added OpenCode to available agents list

-- discovery/gap-filler-2