### PR TITLE
fix: Handle comma-separated auth vars in key-request.sh

### DIFF
--- a/shared/key-request.sh
+++ b/shared/key-request.sh
@@ -91,7 +91,7 @@ _load_cloud_credentials() {
     local auth_string="${2}"
 
     local env_vars
-    env_vars=$(printf '%s' "${auth_string}" | tr '+' '\n' | sed 's/^ *//;s/ *$//')
+    env_vars=$(printf '%s' "${auth_string}" | tr '+,' '\n' | sed 's/^ *//;s/ *$//')
 
     local config_file="${HOME}/.config/spawn/${cloud_key}.json"
     local all_loaded=true


### PR DESCRIPTION
## Summary
- Fixed auth string parsing in `shared/key-request.sh` to handle comma-separated env vars
- The `_load_cloud_credentials()` function only handled `+` separators, but some clouds (like alibabacloud) use comma-separated lists
- Changed `tr '+' '\n'` to `tr '+,' '\n'` to support both formats

## Problem
The QA bot was failing with this error:
```
ALIYUN_ACCESS_KEY_ID, ALIYUN_ACCESS_KEY_SECRET: invalid variable name
```

This happened because the auth string `"ALIYUN_ACCESS_KEY_ID, ALIYUN_ACCESS_KEY_SECRET"` wasn't being split correctly.

## Test Plan
- [x] Ran QA workflow manually to verify the error
- [x] Applied fix and verified parsing handles both `+` and `,` separators
- [ ] Next QA cycle should load alibabacloud credentials without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)