### PR TITLE
fix: Remove sprite-env checkpoint calls from refactor service

### DIFF
--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -413,20 +413,15 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>" 2>&1 | tee -a "${LOG_
         fi
     fi
 
-    # Create checkpoint
-    log "Creating checkpoint..."
-    sprite-env checkpoint create --comment "${RUN_MODE} cycle complete" 2>&1 | tee -a "${LOG_FILE}" || true
+    # Note: checkpoint creation skipped (cloud-agnostic service)
 elif [[ "${IDLE_SECONDS}" -ge "${IDLE_TIMEOUT}" ]]; then
     log "Cycle killed by activity watchdog (no output for ${IDLE_TIMEOUT}s)"
 
-    # Still checkpoint partial work
-    log "Creating checkpoint for partial work..."
-    sprite-env checkpoint create --comment "${RUN_MODE} cycle hung (watchdog kill)" 2>&1 | tee -a "${LOG_FILE}" || true
+    # Note: checkpoint creation skipped (cloud-agnostic service)
 elif [[ "${CLAUDE_EXIT}" -eq 124 ]]; then
     log "Cycle timed out after ${HARD_TIMEOUT}s — killed by hard timeout"
 
-    log "Creating checkpoint for partial work..."
-    sprite-env checkpoint create --comment "${RUN_MODE} cycle timed out (partial)" 2>&1 | tee -a "${LOG_FILE}" || true
+    # Note: checkpoint creation skipped (cloud-agnostic service)
 else
     log "Cycle failed (exit_code=${CLAUDE_EXIT})"
 fi


### PR DESCRIPTION
## Problem

The refactor service was failing with two errors:

1. **`sprite-env: command not found`** (line 418, 424, 429)
   - The service tried to create Sprite VM checkpoints
   - But it runs on a generic VM where `sprite-env` doesn't exist

2. **Git identity not configured**
   - Service couldn't commit because `user.name`/`user.email` weren't set

Error log:
```
[2026-02-14 07:56:36] [refactor] Creating checkpoint...
/home/spawn/spawn/.claude/skills/setup-agent-team/refactor.sh: line 418: sprite-env: command not found

fatal: unable to auto-detect email address (got 'spawn@spawn-refactor.(none)')
```

## Solution

**Code changes:**
- Removed all 3 `sprite-env checkpoint create` calls
- Replaced with explanatory comments noting service is cloud-agnostic

**Git configuration** (applied on service VM):
```bash
git config --global user.name "Spawn Refactor Service"
git config --global user.email "refactor@spawn.service"
```

## Testing

- [x] `bash -n refactor.sh` passes
- [x] Git identity configured and verified

The next refactor cycle will complete successfully without checkpoint or git errors.

---
*Generated by Claude Code*