### PR TITLE
ux: improve service deployment error messages

### DIFF
--- a/koyeb/lib/common.sh
+++ b/koyeb/lib/common.sh
@@ -192,13 +192,18 @@ _koyeb_wait_for_service() {
         fi
 
         if [[ "$status" == "error" || "$status" == "failed" ]]; then
-            log_error "Service deployment failed (status: $status)"
+            log_error "Service deployment failed with status: $status"
             log_error ""
             log_error "Common causes:"
-            log_error "  - Docker image pull failure"
+            log_error "  - Docker image pull failure (check image name and registry access)"
             log_error "  - Insufficient resources for the selected instance type"
             log_error "  - Health check failure (service crashed on startup)"
-            log_error "View deployment logs: https://app.koyeb.com/"
+            log_error "  - Application error in startup command"
+            log_error ""
+            log_error "Debugging steps:"
+            log_error "  1. View deployment logs at: https://app.koyeb.com/"
+            log_error "  2. Check service details: koyeb service get $service_id"
+            log_error "  3. Try a different region or instance type"
             return 1
         fi
 

--- a/northflank/lib/common.sh
+++ b/northflank/lib/common.sh
@@ -91,12 +91,19 @@ _northflank_wait_for_service() {
         attempt=$((attempt + 1))
     done
 
-    log_error "Service did not start after ${max_attempts} attempts"
+    log_error "Service did not reach 'running' status after ${max_attempts} attempts"
     log_error ""
-    log_error "The service may still be starting. You can:"
+    log_error "Last status: ${status:-unknown}"
+    log_error ""
+    log_error "Possible causes:"
+    log_error "  - Container image pull is taking longer than expected"
+    log_error "  - Application failing to start (check startup command)"
+    log_error "  - Resource limits preventing container from starting"
+    log_error ""
+    log_error "Debugging steps:"
     log_error "  1. Check service status: northflank get service --name ${name} --project ${project_name}"
     log_error "  2. View logs in the dashboard: https://app.northflank.com/"
-    log_error "  3. Re-run the command to try again"
+    log_error "  3. Service may still be starting - check dashboard before retrying"
     return 1
 }
 


### PR DESCRIPTION
## Summary
- Enhanced error messages for Koyeb service deployment failures with detailed debugging steps
- Improved Northflank service timeout errors to show last known status and structured troubleshooting
- Added clear distinction between "Possible causes" and "Debugging steps" sections

## Changes

### Koyeb (`koyeb/lib/common.sh`)
- Changed generic error "Service deployment failed (status: $status)" to "Service deployment failed with status: $status" for clarity
- Added specific debugging steps:
  - View deployment logs at dashboard
  - Check service details via CLI (`koyeb service get`)
  - Try different region or instance type
- Added "Application error in startup command" to common causes
- Restructured output for better scannability

### Northflank (`northflank/lib/common.sh`)
- Enhanced timeout error to include last known service status
- Changed "Service did not start" to "Service did not reach 'running' status" for clarity
- Added structured sections:
  - Possible causes (container pull delays, startup failures, resource limits)
  - Debugging steps (CLI check, dashboard, avoid premature retries)
- Warns users that service may still be starting to prevent unnecessary retries

## Impact
These improvements make it easier for users to:
1. Understand why their deployment failed
2. Find the right debugging tool (dashboard vs CLI)
3. Avoid common mistakes (retrying too soon, wrong region)
4. Self-service resolve issues without support escalation

## Test plan
- [x] Syntax validation (`bash -n` on both files)
- [x] Reviewed error message flow and readability
- [x] Verified all debugging commands are valid
- [x] Checked dashboard URLs are correct

-- refactor/ux-engineer