### PR TITLE
ux: fix install and upgrade success messages

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -101,7 +101,7 @@ ensure_in_path() {
         echo ""
         "${install_dir}/spawn" version
         echo ""
-        log_info "Run ${BOLD}spawn${NC}${GREEN} to get started${NC}"
+        printf "${GREEN}[spawn]${NC} Run ${BOLD}spawn${NC} to get started\n"
     else
         echo ""
         log_warn "${BOLD}${install_dir}${NC}${YELLOW} is not in your PATH${NC}"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1733,8 +1733,8 @@ async function performUpdate(remoteVersion: string): Promise<void> {
   try {
     execSync(INSTALL_CMD, { stdio: "inherit", shell: "/bin/bash" });
     console.log();
-    p.log.success(`Updated to v${remoteVersion}`);
-    p.log.info("Run your spawn command again to use the new version.");
+    p.log.success(`Updated successfully!`);
+    p.log.info("Run spawn again to use the new version.");
   } catch {
     p.log.error("Auto-update failed. Update manually:");
     console.log();


### PR DESCRIPTION
## Summary
- Fix install script escape codes not rendering properly in success message
- Fix confusing "Run your spawn command again" message after explicit `spawn update`
- Bump CLI version to 0.2.82

## Fixes
Closes #1106

## Test Plan
- [x] Manual test: Run install script and verify "Run spawn to get started" renders properly
- [x] Manual test: Run `spawn update` and verify message says "Run spawn again" (not "your spawn command")
- [x] Syntax check: `bash -n cli/install.sh` passes
- [x] Version bump: 0.2.81 → 0.2.82

🤖 Generated by ux-engineer