### PR TITLE
refactor: reduce complexity in test/mock.sh and test/record.sh

### DIFF
--- a/test/mock.sh
+++ b/test/mock.sh
@@ -210,17 +210,8 @@ MOCK
     done
 }
 
-setup_mock_agents() {
-    # Agent binaries
-    _create_logging_mock claude aider goose codex interpreter gemini amazonq cline gptme opencode plandex kilocode openclaw nanoclaw q
-
-    # Tools used during agent install
-    _create_logging_mock pip pip3 npm npx bun node openssl shred cargo go git
-
-    # Silent mocks (no logging needed)
-    _create_silent_mock clear sleep
-
-    # Mock 'ssh-keygen' — returns MD5 fingerprint matching fixture data
+# Create the ssh-keygen mock script
+_create_ssh_keygen_mock() {
     cat > "${TEST_DIR}/ssh-keygen" << 'MOCK'
 #!/bin/bash
 echo "ssh-keygen $*" >> "${MOCK_LOG}"
@@ -247,6 +238,20 @@ fi
 exit 0
 MOCK
     chmod +x "${TEST_DIR}/ssh-keygen"
+}
+
+setup_mock_agents() {
+    # Agent binaries
+    _create_logging_mock claude aider goose codex interpreter gemini amazonq cline gptme opencode plandex kilocode openclaw nanoclaw q
+
+    # Tools used during agent install
+    _create_logging_mock pip pip3 npm npx bun node openssl shred cargo go git
+
+    # Silent mocks (no logging needed)
+    _create_silent_mock clear sleep
+
+    # Mock 'ssh-keygen' — returns MD5 fingerprint matching fixture data
+    _create_ssh_keygen_mock
 }
 
 setup_fake_home() {


### PR DESCRIPTION
## Summary

Extracted three sets of functions from complex test utilities to improve readability and maintainability:

- **test/mock.sh**: Extracted `_create_ssh_keygen_mock()` from `setup_mock_agents()`
  - Reduces `setup_mock_agents()` from 38 to 13 lines
  
- **test/record.sh**: Extracted validation and response handling
  - `_validate_endpoint_response()`: handles empty/invalid/error responses (1 line per check → dedicated function)
  - `_save_endpoint_fixture()`: saves fixture and updates metadata
  - Reduces `_record_endpoint()` from 43 to 17 lines
  
- **test/record.sh**: Extracted ID/response handling
  - `_extract_resource_id()`: extracts ID from create response with validation
  - `_handle_delete_response()`: handles fallback for empty delete responses
  - Reduces `_live_create_delete_cycle()` from 44 to 28 lines

## Test Plan

- [x] All 79 tests pass
- [x] Bash syntax check passes on all modified files
- [x] No functionality changes, only refactoring

🤖 Generated with refactor/complexity-hunter