### PR TITLE
ux: improve auth error messages with provider URLs

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1971,6 +1971,7 @@ _validate_token_with_provider() {
     local test_func="${1}"
     local env_var_name="${2}"
     local provider_name="${3}"
+    local help_url="${4:-}"
 
     if [[ -z "${test_func}" ]]; then
         return 0  # No validation needed
@@ -1981,8 +1982,14 @@ _validate_token_with_provider() {
         log_error "The token may be expired, revoked, or incorrectly copied."
         log_error ""
         log_error "How to fix:"
-        log_error "  1. Re-run the command to enter a new token"
-        log_error "  2. Or set it directly: ${env_var_name}=your-token spawn ..."
+        if [[ -n "${help_url}" ]]; then
+            log_error "  1. Get a new token from: ${help_url}"
+            log_error "  2. Re-run the command and paste the new token"
+            log_error "  3. Or set it directly: ${env_var_name}=your-token spawn ..."
+        else
+            log_error "  1. Re-run the command to enter a new token"
+            log_error "  2. Or set it directly: ${env_var_name}=your-token spawn ..."
+        fi
         unset "${env_var_name}"
         return 1
     fi
@@ -2048,7 +2055,7 @@ ensure_api_token_with_provider() {
     export "${env_var_name}=${token}"
 
     # Validate with provider API
-    if ! _validate_token_with_provider "${test_func}" "${env_var_name}" "${provider_name}"; then
+    if ! _validate_token_with_provider "${test_func}" "${env_var_name}" "${provider_name}" "${help_url}"; then
         return 1
     fi
 
@@ -2206,7 +2213,10 @@ _multi_creds_validate() {
     if ! "${test_func}"; then
         log_error "Invalid ${provider_name} credentials"
         log_error "The credentials may be expired, revoked, or incorrectly copied."
-        log_error "Please re-run the command to enter new credentials."
+        log_error ""
+        log_error "How to fix:"
+        log_error "  1. Get new credentials from: ${help_url}"
+        log_error "  2. Re-run the command and enter the new credentials"
         local v
         for v in "$@"; do
             unset "${v}"


### PR DESCRIPTION
## Summary

Enhance authentication error messages by including direct URLs to provider API token pages in the remediation steps.

When users encounter authentication failures, they now see the exact URL where they can get a new API token, reducing friction and eliminating the need to search for the provider's token page.

## Changes

- **_validate_token_with_provider()**: Added `help_url` parameter (optional) to display provider dashboard URL in error messages
- **_validate_multi_credentials()**: Updated to include `help_url` in credential validation errors
- **ensure_api_token_with_provider()**: Modified to pass `help_url` to the validation function

## Before

```
ERROR: Authentication failed: Invalid Hetzner API token
The token may be expired, revoked, or incorrectly copied.

How to fix:
  1. Re-run the command to enter a new token
  2. Or set it directly: HCLOUD_TOKEN=your-token spawn ...
```

## After

```
ERROR: Authentication failed: Invalid Hetzner API token
The token may be expired, revoked, or incorrectly copied.

How to fix:
  1. Get a new token from: https://console.hetzner.cloud/projects
  2. Re-run the command and paste the new token
  3. Or set it directly: HCLOUD_TOKEN=your-token spawn ...
```

## Impact

- **User experience**: Significantly reduces time to resolve authentication issues
- **Backwards compatible**: help_url parameter is optional; existing calls without it still work
- **Consistent messaging**: All cloud providers using `ensure_api_token_with_provider()` automatically benefit

## Testing

- ✅ Syntax check: `bash -n shared/common.sh` passes
- ✅ Maintains existing error flow for providers without help_url
- ✅ No breaking changes to function signatures (help_url is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- refactor/ux-engineer