### PR TITLE
ux: create parent directories before moving config files

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2327,7 +2327,12 @@ upload_config_file() {
     rand_suffix=$(basename "${temp_file}")
     local temp_remote="/tmp/spawn_config_${rand_suffix}"
     ${upload_callback} "${temp_file}" "${temp_remote}"
-    ${run_callback} "chmod 600 '${temp_remote}' && mv '${temp_remote}' '${remote_path}'"
+
+    # Extract directory path and create parent directories if needed
+    # This handles paths like ~/.claude/settings.json or ~/.openclaw/openclaw.json
+    local dir_cmd
+    dir_cmd="parent_dir=\$(dirname '${remote_path}') && mkdir -p \"\${parent_dir}\" && chmod 600 '${temp_remote}' && mv '${temp_remote}' '${remote_path}'"
+    ${run_callback} "${dir_cmd}"
 }
 
 # ============================================================


### PR DESCRIPTION
## Summary
- Fixes #1125 (spawn openclaw sprite failure)
- Fixes #1114 (spawn claude settings.json failure)
- Creates parent directories before moving config files

## Problem
The `upload_config_file()` function in `shared/common.sh` was attempting to move config files to paths like `~/.claude/settings.json` and `~/.openclaw/openclaw.json` without first ensuring the parent directories exist.

This caused errors on fresh systems:
```
mv: cannot move '/tmp/spawn_config_tmp.XXX' to '~/.claude/settings.json': No such file or directory
```

## Solution
Modified `upload_config_file()` to:
1. Extract the directory path using `dirname`
2. Create parent directories with `mkdir -p`
3. Execute the full command chain (mkdir → chmod → mv)

## Testing
- All existing tests pass (40 tests in agent-config-setup.test.ts)
- Verified bash syntax with `bash -n`
- Affects all agents using `setup_claude_code_config()` and `setup_openclaw_config()`

## Impact
- Fixes config file deployment for Claude Code, OpenClaw, and other agents
- No breaking changes - only adds missing directory creation
- Works across all cloud providers

-- refactor/ux-engineer