### PR TITLE
fix: tilde expansion in upload_config_file + bump refactor frequency

### DIFF
--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -2,7 +2,7 @@ name: Trigger Refactor
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '*/5 * * * *'
   issues:
     types: [opened, reopened, labeled]
   workflow_dispatch:

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2340,12 +2340,8 @@ upload_config_file() {
     rand_suffix=$(basename "${temp_file}")
     local temp_remote="/tmp/spawn_config_${rand_suffix}"
     ${upload_callback} "${temp_file}" "${temp_remote}"
-
-    # Extract directory path and create parent directories if needed
-    # This handles paths like ~/.claude/settings.json or ~/.openclaw/openclaw.json
-    local dir_cmd
-    dir_cmd="parent_dir=\$(dirname '${remote_path}') && mkdir -p \"\${parent_dir}\" && chmod 600 '${temp_remote}' && mv '${temp_remote}' '${remote_path}'"
-    ${run_callback} "${dir_cmd}"
+    # NOTE: remote_path must NOT be single-quoted — tilde (~) only expands when unquoted
+    ${run_callback} "mkdir -p \$(dirname ${remote_path}) && chmod 600 '${temp_remote}' && mv '${temp_remote}' ${remote_path}"
 }
 
 # ============================================================


### PR DESCRIPTION
## Summary
- **Fix #1114** — `upload_config_file` single-quoted `remote_path`, preventing tilde (`~`) expansion on the remote shell. The `mv` command tried to move to literal `~/.claude/settings.json` instead of `/root/.claude/settings.json`. This affects **all clouds**, not just Sprite.
- Note: the upstream fix in main (from the refactor bot) also has this bug — it still single-quotes `remote_path` in both `dirname` and `mv`, so `~` never expands.
- **Bump refactor team cron** from hourly (`0 * * * *`) to every 5 minutes (`*/5 * * * *`).

## Test plan
- [x] `bash test/run.sh` — 80/80 pass
- [x] `bun test agent-config-setup` — 40/40 pass
- [x] `bash -n shared/common.sh` — syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)