### PR TITLE
fix: enforce strict dedup rules to prevent duplicate agent comments

### DIFF
--- a/.claude/skills/setup-agent-team/discovery-team-prompt.txt
+++ b/.claude/skills/setup-agent-team/discovery-team-prompt.txt
@@ -92,8 +92,10 @@ For each linked PR: `gh pr view PR_NUM --repo OpenRouterTeam/spawn --comments`
 
 Read ALL comments — prior discussion contains decisions, rejected approaches, and scope changes.
 
-**DEDUP**: Check `--json comments --jq '.comments[] | "\(.author.login): \(.body[-40:])"'` — skip if `-- discovery/issue-responder` already exists.
-If actionable, implement and create PR (self-review + label, do NOT merge). If already implemented, close with comment.
+**STRICT DEDUP — MANDATORY**: Check `--json comments --jq '.comments[] | "\(.author.login): \(.body[-40:])"'`
+- If `-- discovery/issue-responder` already exists in ANY comment → **SKIP this issue entirely** unless you have a concrete PR link or fix to report
+- **NEVER** post acknowledgment-only comments on issues that have already been acknowledged by any team (check for any `-- ` sign-off pattern)
+If actionable AND not already claimed, implement and create PR (self-review + label, do NOT merge). If already implemented, close with comment.
 **SIGN-OFF**: Every comment MUST end with `-- discovery/issue-responder`.
 
 ### Gap Filler (spawn remaining)

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -394,10 +394,10 @@ Spawn **branch-cleaner** (model=haiku):
 Spawn **issue-checker** (model=haiku):
 - \`gh issue list --repo OpenRouterTeam/spawn --state open --json number,title,labels,updatedAt,comments\`
 - For each issue, fetch full context: \`gh issue view NUMBER --repo OpenRouterTeam/spawn --comments\`
-- DEDUP before any comment: check for existing similar comments
-- For stale issues (>1h no activity) with security labels: re-evaluate and nudge if needed
-- For issues with no status label: add \`pending-review\`
-- Verify label consistency: every issue needs exactly ONE status label
+- **STRICT DEDUP — MANDATORY**: Check comments for \`-- security/issue-checker\`. If that sign-off already exists in ANY comment on the issue → **SKIP this issue entirely** (do NOT comment again) UNLESS there are new human comments posted AFTER the last \`-- security/issue-checker\` comment
+- **NEVER** post "status update", "re-triage", "triage update", or "status check" comments that restate existing information
+- For issues with no status label: silently add \`pending-review\` (no comment needed)
+- Verify label consistency silently: every issue needs exactly ONE status label — fix labels without commenting
 - **SIGN-OFF**: \`-- security/issue-checker\`
 
 ## Step 4.5 — Lightweight Repo Scan (if ≤5 open PRs)


### PR DESCRIPTION
## Summary

- **security/issue-checker**: Replace vague "check for existing similar comments" with strict rule — skip issues entirely if `-- security/issue-checker` sign-off already exists (unless new human comments appeared). Label fixes are now silent (no comment needed).
- **refactor/community-coordinator**: Only re-comment when linking a NEW PR or reporting a concrete resolution. Removed "post interim updates" and "re-scan every 5 min" instructions that caused redundant posts.
- **refactor/issue-fixer** (issue mode): Check for ANY `-- ` sign-off from any team before posting acknowledgment, not just own team's comments.
- **discovery/issue-responder**: Skip issues entirely if already commented unless linking a concrete PR or fix. Added cross-team sign-off check.

## Test plan

- [x] `bash -n security.sh` passes
- [x] `bash -n refactor.sh` passes
- [ ] Monitor next few agent cycles to confirm reduced duplicate comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)