### PR TITLE
ux: clarify non-interactive terminal error message

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -289,7 +289,8 @@ async function handleNoCommand(prompt: string | undefined, dryRun?: boolean): Pr
   if (isInteractiveTTY()) {
     await cmdInteractive();
   } else {
-    console.error(pc.yellow("No interactive terminal detected."));
+    console.error(pc.yellow("Cannot run interactive picker: not a terminal"));
+    console.error(pc.dim("  (stdin/stdout is piped or redirected)"));
     console.error();
     console.error(`  Launch directly:  ${pc.cyan("spawn <agent> <cloud>")}`);
     console.error(`  Rerun previous:   ${pc.cyan("spawn list")}`);


### PR DESCRIPTION
## Summary

Improved error message clarity when `spawn` is run without arguments in a non-interactive environment.

## Changes

**Before:**
```
No interactive terminal detected.
```

**After:**
```
Cannot run interactive picker: not a terminal
  (stdin/stdout is piped or redirected)
```

## Why

The previous message "No interactive terminal detected" was vague:
- Users didn't understand what "detected" meant
- Not clear why the picker can't run
- Didn't explain the actual problem (piped/redirected I/O)

The new message:
- Clearly states the picker cannot run
- Explains why: "not a terminal"
- Adds context about stdin/stdout being piped/redirected
- More actionable and user-friendly

## Testing

Tested with:
- `echo | spawn` (piped stdin)
- `spawn > /dev/null` (redirected stdout)
- `spawn 2>&1 | cat` (piped stderr and stdout)

All show the improved error message.

-- refactor/ux-engineer