### PR TITLE
feat: rename /cleanup-branches to /pcl

### DIFF
--- a/.claude/skills/pcl/SKILL.md
+++ b/.claude/skills/pcl/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cleanup-branches
+name: pcl
 description: Delete stale git branches (local + remote) that have no open PR, and prune worktrees.
 argument-hint: "[--dry-run]"
 allowed-tools: Bash


### PR DESCRIPTION
## Summary

- Renames the cleanup-branches skill from `/cleanup-branches` to `/pcl` for quicker invocation

## Test plan

- [ ] `/pcl` shows up in slash command autocomplete after restart
- [ ] `/pcl --dry-run` lists stale branches without deleting

🤖 Generated with [Claude Code](https://claude.com/claude-code)