### PR TITLE
fix: correct scaleway SSH key assertion endpoint

### DIFF
--- a/test/fixtures/scaleway/_api_assertions.sh
+++ b/test/fixtures/scaleway/_api_assertions.sh
@@ -1,2 +1,2 @@
-assert_api_called "GET" "/sshkeys" "fetches SSH keys"
+assert_api_called "GET" "/ssh-keys" "fetches SSH keys"
 assert_api_called "POST" "/servers" "creates server"


### PR DESCRIPTION
## Summary
- The mock test assertion checked for `GET /sshkeys` but Scaleway's actual API endpoint is `/ssh-keys` (with a hyphen)
- This caused all 15 scaleway agent tests to fail the "fetches SSH keys" check
- One-character fix: `/sshkeys` → `/ssh-keys` in `test/fixtures/scaleway/_api_assertions.sh`

## Test plan
- [x] `bash test/mock.sh` passes: 480 passed, 0 failed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)