### PR TITLE
fix: add write permissions to gate workflow

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -6,6 +6,10 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   check-membership:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The gate workflow's default `GITHUB_TOKEN` lacked `issues: write` and `pull-requests: write` permissions
- This caused a 403 "Resource not accessible by integration" when trying to close issues/PRs from non-org members
- Adds explicit `permissions` block at the workflow level

## Test plan
- [ ] Re-test with a non-org-member issue (e.g. #1147) — should now close successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)