### PR TITLE
fix: HIGH severity security issues (command injection + weak VNC password)

### DIFF
--- a/cloudsigma/lib/common.sh
+++ b/cloudsigma/lib/common.sh
@@ -263,7 +263,7 @@ if ssh_key_uuid:
     body['pubkeys'] = [{'uuid': ssh_key_uuid}]
 
 print(json.dumps(body))
-" "$name" "$cpu_mhz" "$mem_bytes" "$drive_uuid" "$ssh_key_uuid" "$(openssl rand -hex 8)"
+" "$name" "$cpu_mhz" "$mem_bytes" "$drive_uuid" "$ssh_key_uuid" "$(openssl rand -hex 16)"
 }
 
 # Resolve a CloudSigma IP reference (may be a UUID) to an actual IP address

--- a/shared/key-request.sh
+++ b/shared/key-request.sh
@@ -83,7 +83,10 @@ v = data.get(sys.argv[2], '') or data.get('api_key', '') or data.get('token', ''
 print(v)
 " "${config_file}" "${var_name}" 2>/dev/null)
         if [[ -n "${val}" ]]; then
-            export "${var_name}=${val}"
+            # SECURITY: Use printf to safely assign value without command injection risk
+            # Direct export with = operator doesn't quote the value, allowing injection via $()
+            printf -v "${var_name}" '%s' "${val}"
+            export "${var_name}"
             return 0
         fi
     fi


### PR DESCRIPTION
Fixes #1120

Fixes two HIGH severity security issues identified in the security audit:

## 1. Command Injection in shared/key-request.sh:86

**Before:**
```bash
export "${var_name}=${val}"
```

**Issue:** The value is not properly quoted, allowing command injection via crafted API key values containing `$(...)` or backticks.

**After:**
```bash
printf -v "${var_name}" '%s' "${val}"
export "${var_name}"
```

**Impact:** Prevents arbitrary command execution when loading cloud API keys from config files.

## 2. Weak VNC Password in cloudsigma/lib/common.sh:266

**Before:**
```bash
openssl rand -hex 8  # 64 bits of entropy
```

**Issue:** Only 16 hex characters (64 bits) makes the VNC password vulnerable to brute force attacks.

**After:**
```bash
openssl rand -hex 16  # 128 bits of entropy
```

**Impact:** Doubles entropy to 128 bits, significantly strengthening VNC password security.

---

-- refactor/security-auditor