### PR TITLE
fix: stop refactor team from deferring issues to future cycles

### DIFF
--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -186,6 +186,17 @@ You are the Team Lead for the spawn continuous refactoring service.
 
 Mission: Spawn specialized teammates to maintain and improve the spawn codebase.
 
+## Issue-First Policy (MANDATORY)
+
+Before doing ANY refactoring work, check open issues:
+```bash
+gh issue list --repo OpenRouterTeam/spawn --state open --json number,title,labels --jq 'length'
+```
+
+If there are **10 or fewer open issues**: there is NO "deferring to next cycle." Every open issue is YOUR problem to solve NOW. Assign issues to teammates, plan fixes, and deliver PRs. Refactoring is secondary — issues come first.
+
+**NEVER** comment on an issue saying "we'll look at this in a future cycle" or "deferring." You have a full team of capable agents — use them. Pick up the issue, plan a fix, and execute it.
+
 ## Time Budget
 
 Complete within 15 minutes. At 10 min tell teammates to wrap up, at 12 min send shutdown_request, at 15 min force shutdown.
@@ -248,9 +259,11 @@ Refactor team **creates PRs** — security team **reviews and merges** them.
    - **NEVER** post "interim updates", "status checks", or acknowledgment-only follow-ups
 
    - Acknowledge issues briefly and casually (only if NO prior `-- refactor/community-coordinator` comment exists)
-   - Categorize (bug/feature/question) and delegate to relevant teammate
+   - Categorize (bug/feature/question) and **immediately assign to a teammate for fixing** — do NOT just acknowledge and move on
+   - Every issue should result in a PR, not just a comment. If an issue is actionable, get a teammate working on it NOW.
    - Link PRs: `gh issue comment NUMBER --body "Fix in PR_URL. [explanation].\n\n-- refactor/community-coordinator"`
    - Do NOT close issues — PRs with `Fixes #NUMBER` auto-close on merge
+   - **NEVER** defer an issue to "next cycle" or say "we'll look into this later"
    - **SIGN-OFF**: Every comment MUST end with `-- refactor/community-coordinator`
 
 ## Issue Fix Workflow


### PR DESCRIPTION
## Summary
- Added **Issue-First Policy** to refactor team lead prompt: when ≤10 issues are open, every issue must be picked up and worked on immediately — no deferring
- Updated community-coordinator instructions to **assign issues to teammates for fixing**, not just acknowledge them
- Explicitly banned "we'll look at this in a future cycle" type responses

Addresses the pattern seen in #1144 where issues were acknowledged but not acted on.

## Test plan
- [ ] Next refactor cycle should pick up open issues and create PRs for them
- [ ] Community-coordinator should assign work to teammates, not just comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)