### PR TITLE
ux: improve CLI help examples and remove duplicate auth text

### DIFF
--- a/cli/src/__tests__/cmd-help-content.test.ts
+++ b/cli/src/__tests__/cmd-help-content.test.ts
@@ -143,7 +143,7 @@ describe("cmdHelp - content completeness", () => {
 
     it("should show direct launch example with agent and cloud", () => {
       const output = getHelpOutput();
-      expect(output).toContain("spawn claude sprite");
+      expect(output).toContain("spawn openclaw sprite");
     });
 
     it("should show --prompt example", () => {

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1786,8 +1786,6 @@ function printQuickStart(opts: {
     for (let i = 0; i < opts.authVars.length; i++) {
       console.log(formatAuthVarLine(opts.authVars[i], i === 0 ? opts.cloudUrl : undefined));
     }
-  } else if (opts.auth.toLowerCase() !== "none") {
-    console.log(`  ${pc.dim(`Auth: ${opts.auth}`)}`);
   }
   if (opts.spawnCmd) {
     console.log(`  ${pc.cyan(opts.spawnCmd)}`);
@@ -1932,18 +1930,19 @@ function getHelpUsageSection(): string {
 function getHelpExamplesSection(): string {
   return `${pc.bold("EXAMPLES")}
   spawn                              ${pc.dim("# Pick interactively")}
-  spawn claude sprite                ${pc.dim("# Launch Claude Code on Sprite")}
+  spawn openclaw sprite              ${pc.dim("# Launch OpenClaw on Sprite")}
   spawn aider hetzner                ${pc.dim("# Launch Aider on Hetzner Cloud")}
+  spawn goose digitalocean           ${pc.dim("# Launch Goose on DigitalOcean")}
   spawn claude sprite --prompt "Fix all linter errors"
                                      ${pc.dim("# Execute Claude with prompt and exit")}
   spawn aider sprite -p "Add tests"  ${pc.dim("# Short form of --prompt")}
-  spawn claude sprite -f instructions.txt
+  spawn openclaw vultr -f instructions.txt
                                      ${pc.dim("# Read prompt from file (short for --prompt-file)")}
-  spawn claude sprite --dry-run      ${pc.dim("# Preview without provisioning")}
+  spawn interpreter linode --dry-run ${pc.dim("# Preview without provisioning")}
   spawn claude                       ${pc.dim("# Show which clouds support Claude")}
   spawn hetzner                      ${pc.dim("# Show which agents run on Hetzner")}
   spawn list                         ${pc.dim("# Browse history and pick one to rerun")}
-  spawn list claude                  ${pc.dim("# Filter history by agent name")}
+  spawn list aider                   ${pc.dim("# Filter history by agent name")}
   spawn matrix                       ${pc.dim("# See the full agent x cloud matrix")}`;
 }
 


### PR DESCRIPTION
## Summary
- Diversified help command examples to showcase more agents and clouds (openclaw, goose, interpreter, vultr, digitalocean, linode instead of just claude/sprite)
- Removed duplicate "Auth: token" text in cloud info display (was appearing twice in Quick start section)
- Updated test to match new help examples

## Test plan
- [x] Run `spawn --help` and verify examples show diverse agents/clouds
- [x] Run `spawn hetzner` and verify "Auth: token" only appears once (in header, not in Quick start)
- [x] Run `bun test cmd-help-content.test.ts` and verify all tests pass
- [x] Verify swapped argument detection still works: `spawn sprite claude`

## Impact
Minor UX improvement - better showcase of spawn's capabilities in help text, cleaner cloud info display.

-- refactor/ux-engineer