### PR TITLE
refactor: remove sprite-env usage from bot scripts

### DIFF
--- a/.claude/skills/setup-agent-team/discovery.sh
+++ b/.claude/skills/setup-agent-team/discovery.sh
@@ -234,12 +234,8 @@ _handle_cycle_completion() {
 
     if [[ "${exit_code}" -eq 0 ]] || [[ "${session_ended}" = true ]]; then
         log_info "Cycle completed successfully"
-        log_info "Creating checkpoint..."
-        sprite-env checkpoint create --comment "discovery cycle complete" 2>&1 | tee -a "${LOG_FILE}" || true
     elif [[ "${idle_seconds}" -ge "${idle_timeout}" ]]; then
         log_warn "Cycle killed by activity watchdog (no output for ${idle_timeout}s)"
-        log_info "Creating checkpoint for partial work..."
-        sprite-env checkpoint create --comment "discovery cycle hung (watchdog kill)" 2>&1 | tee -a "${LOG_FILE}" || true
     else
         log_error "Cycle failed (exit_code=${exit_code})"
     fi
@@ -488,10 +484,8 @@ run_single_cycle() {
 
     if [[ "${CLAUDE_EXIT}" -eq 0 ]]; then
         log_info "Single cycle completed successfully"
-        sprite-env checkpoint create --comment "discovery single cycle complete" 2>&1 | tee -a "${LOG_FILE}" || true
     elif [[ "${IDLE_SECONDS}" -ge "${IDLE_TIMEOUT}" ]]; then
         log_warn "Single cycle killed by activity watchdog (no output for ${IDLE_TIMEOUT}s)"
-        sprite-env checkpoint create --comment "discovery single cycle hung (watchdog kill)" 2>&1 | tee -a "${LOG_FILE}" || true
     else
         log_error "Single cycle failed (exit_code=${CLAUDE_EXIT})"
     fi

--- a/.claude/skills/setup-agent-team/qa-cycle.sh
+++ b/.claude/skills/setup-agent-team/qa-cycle.sh
@@ -912,7 +912,4 @@ if [[ "${FAIL_COUNT:-0}" -gt 0 ]] && [[ "${RETRY_FAIL:-0}" -lt "${FAIL_COUNT:-0}
     log "Fixed ${FIXED} failure(s) this cycle"
 fi
 
-# Create checkpoint if available
-sprite-env checkpoint create --comment "QA cycle complete" 2>&1 | tee -a "${LOG_FILE}" || true
-
 log "=== QA Cycle Complete ==="

--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -296,7 +296,6 @@ CRITICAL: Exiting early orphans teammates. Wait for ALL shutdown confirmations.
 ## Safety
 
 - NEVER close a PR — rebase, fix, or comment instead
-- Checkpoint before risky changes: `sprite-env checkpoint create --comment 'Description'`
 - Run tests after every change. If 3 consecutive failures, pause and investigate.
 - **SIGN-OFF**: Every comment MUST end with `-- refactor/AGENT-NAME`
 
@@ -317,7 +316,7 @@ fi
 log "Hard timeout: ${HARD_TIMEOUT}s"
 
 # NOTE: VM keep-alive is handled by the trigger server streaming output back
-# to the GitHub Actions runner. The long-lived HTTP response keeps Sprite alive.
+# to the GitHub Actions runner via a long-lived HTTP response.
 
 # Activity watchdog: kill claude if no output for IDLE_TIMEOUT seconds.
 # This catches hung API calls (pre-flight check hangs, network issues) much

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -582,20 +582,10 @@ CLAUDE_EXIT=$?
 
 if [[ "${CLAUDE_EXIT}" -eq 0 ]] || [[ "${SESSION_ENDED}" = true ]]; then
     log "Cycle completed successfully"
-
-    # Create checkpoint
-    log "Creating checkpoint..."
-    sprite-env checkpoint create --comment "security ${RUN_MODE} cycle complete" 2>&1 | tee -a "${LOG_FILE}" || true
 elif [[ "${IDLE_SECONDS}" -ge "${IDLE_TIMEOUT}" ]]; then
     log "Cycle killed by activity watchdog (no output for ${IDLE_TIMEOUT}s)"
-
-    log "Creating checkpoint for partial work..."
-    sprite-env checkpoint create --comment "security ${RUN_MODE} cycle hung (watchdog kill)" 2>&1 | tee -a "${LOG_FILE}" || true
 elif [[ "${CLAUDE_EXIT}" -eq 124 ]]; then
     log "Cycle timed out after ${HARD_TIMEOUT}s — killed by hard timeout"
-
-    log "Creating checkpoint for partial work..."
-    sprite-env checkpoint create --comment "security ${RUN_MODE} cycle timed out (partial)" 2>&1 | tee -a "${LOG_FILE}" || true
 else
     log "Cycle failed (exit_code=${CLAUDE_EXIT})"
 fi

--- a/.claude/skills/setup-agent-team/trigger-server.ts
+++ b/.claude/skills/setup-agent-team/trigger-server.ts
@@ -1,5 +1,5 @@
 /**
- * Generic HTTP trigger server for Sprite services.
+ * Generic HTTP trigger server for automation services.
  *
  * Reads config from env vars:
  *   TRIGGER_SECRET  — Bearer token for auth (required)
@@ -12,10 +12,9 @@
  *   POST /trigger → validates auth, runs TARGET_SCRIPT, streams output back
  *
  * The /trigger endpoint returns a streaming text/plain response with the
- * script's stdout/stderr. The long-lived HTTP connection keeps the Sprite
- * VM alive for the entire duration of the cycle (Sprite pauses VMs with
- * no active HTTP requests). A heartbeat line is emitted every 30s during
- * silent periods to prevent proxy idle timeouts.
+ * script's stdout/stderr. The long-lived HTTP connection keeps the VM
+ * alive for the entire duration of the cycle. A heartbeat line is emitted
+ * every 30s during silent periods to prevent proxy idle timeouts.
  *
  * If the client disconnects mid-stream, the script keeps running — output
  * continues to drain to the server console.
@@ -195,8 +194,8 @@ process.on("SIGINT", () => gracefulShutdown("SIGINT"));
  * Spawn the target script and return a streaming Response.
  *
  * stdout/stderr are piped back as chunked text/plain. A heartbeat line
- * is injected every 30 seconds of silence so the Sprite proxy (and any
- * intermediaries) keep the connection alive.
+ * is injected every 30 seconds of silence so intermediary proxies
+ * keep the connection alive.
  *
  * If the HTTP client disconnects, the process keeps running — we just
  * stop writing to the response stream and continue draining to console.
@@ -449,7 +448,6 @@ const server = Bun.serve({
       server.timeout(req, 0);
 
       // Stream the script output back as the response body.
-      // The long-lived HTTP connection keeps the Sprite VM alive.
       return startStreamingRun(reason, issue);
     }
 


### PR DESCRIPTION
## Summary
- Remove all `sprite-env checkpoint create` calls from discovery.sh, security.sh, and qa-cycle.sh (were already silently failing with `|| true`)
- Remove `sprite-env checkpoint` instruction from refactor.sh prompt
- Update trigger-server.ts comments to remove Sprite-specific language
- Update SKILL.md to remove Sprite-specific service management docs and references

## Test plan
- [x] `bash -n` passes on all 4 modified shell scripts
- [x] `bash test/run.sh` passes
- [x] `grep -r "sprite-env" .claude/skills/` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)