### PR TITLE
fix: allow repo collaborators through gate workflow

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -20,27 +20,44 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const sender = context.payload.sender.login;
-            const org = context.repo.owner;
+            const { owner, repo } = context.repo;
 
             // Check if user is an org member
             let isMember = false;
             try {
               const { status } = await github.rest.orgs.checkMembershipForUser({
-                org,
+                org: owner,
                 username: sender,
               });
               isMember = status === 204 || status === 302;
             } catch (e) {
-              // 404 = not a member, anything else = treat as non-member
               isMember = false;
             }
 
             if (isMember) {
-              console.log(`${sender} is a member of ${org}, allowing.`);
+              console.log(`${sender} is an org member of ${owner}, allowing.`);
               return;
             }
 
-            console.log(`${sender} is NOT a member of ${org}, closing.`);
+            // Check if user is a repo collaborator
+            let isCollaborator = false;
+            try {
+              const { status } = await github.rest.repos.checkCollaborator({
+                owner,
+                repo,
+                username: sender,
+              });
+              isCollaborator = status === 204;
+            } catch (e) {
+              isCollaborator = false;
+            }
+
+            if (isCollaborator) {
+              console.log(`${sender} is a collaborator on ${owner}/${repo}, allowing.`);
+              return;
+            }
+
+            console.log(`${sender} is NOT a member or collaborator, closing.`);
 
             if (context.payload.issue) {
               await github.rest.issues.update({
@@ -51,7 +68,7 @@ jobs:
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: context.payload.issue.number,
-                body: 'This repository only accepts issues from organization members. Your issue has been closed automatically.',
+                body: 'This repository only accepts issues from organization members and collaborators. Your issue has been closed automatically.',
               });
             } else if (context.payload.pull_request) {
               await github.rest.pulls.update({
@@ -62,6 +79,6 @@ jobs:
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: context.payload.pull_request.number,
-                body: 'This repository only accepts pull requests from organization members. Your PR has been closed automatically.',
+                body: 'This repository only accepts pull requests from organization members and collaborators. Your PR has been closed automatically.',
               });
             }


### PR DESCRIPTION
## Summary
- Gate workflow now checks **both** org membership and repo collaborator status
- If the user is either an org member OR an invited collaborator, they're allowed through
- Only closes issues/PRs from users who are neither
- Updated closing messages to mention "members and collaborators"

## Test plan
- [ ] Org members should pass (unchanged behavior)
- [ ] Invited repo collaborators should now pass
- [ ] External users should still be blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)