### PR TITLE
ux: add spawn last command to instantly rerun most recent spawn

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.82",
+  "version": "0.2.83",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1560,6 +1560,29 @@ export async function cmdList(agentFilter?: string, cloudFilter?: string): Promi
   showListFooter(records, agentFilter, cloudFilter);
 }
 
+export async function cmdLast(): Promise<void> {
+  const records = filterHistory();
+
+  if (records.length === 0) {
+    p.log.info("No spawn history found.");
+    p.log.info(`Run ${pc.cyan("spawn <agent> <cloud>")} to create your first spawn.`);
+    return;
+  }
+
+  const latest = records[0];
+  let manifest: Manifest | null = null;
+  try {
+    manifest = await loadManifest();
+  } catch {
+    // Manifest unavailable -- show raw keys
+  }
+
+  const label = buildRecordLabel(latest, manifest);
+  const hint = buildRecordHint(latest);
+  p.log.step(`Rerunning last spawn: ${pc.bold(label)} ${pc.dim(hint)}`);
+  await cmdRun(latest.agent, latest.cloud, latest.prompt);
+}
+
 // ── Agents ─────────────────────────────────────────────────────────────────────
 
 export function getImplementedAgents(manifest: Manifest, cloud: string): string[] {
@@ -1919,6 +1942,7 @@ function getHelpUsageSection(): string {
   spawn list -a <agent>              Filter spawn history by agent (or --agent)
   spawn list -c <cloud>              Filter spawn history by cloud (or --cloud)
   spawn list --clear                 Clear all spawn history
+  spawn last                         Instantly rerun the most recent spawn (alias: rerun)
   spawn matrix                       Full availability matrix (alias: m)
   spawn agents                       List all agents with descriptions
   spawn clouds                       List all cloud providers
@@ -1943,6 +1967,7 @@ function getHelpExamplesSection(): string {
   spawn hetzner                      ${pc.dim("# Show which agents run on Hetzner")}
   spawn list                         ${pc.dim("# Browse history and pick one to rerun")}
   spawn list aider                   ${pc.dim("# Filter history by agent name")}
+  spawn last                         ${pc.dim("# Instantly rerun the most recent spawn")}
   spawn matrix                       ${pc.dim("# See the full agent x cloud matrix")}`;
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,6 +4,7 @@ import {
   cmdRun,
   cmdList,
   cmdListClear,
+  cmdLast,
   cmdMatrix,
   cmdAgents,
   cmdClouds,
@@ -336,6 +337,7 @@ const SUBCOMMANDS: Record<string, () => Promise<void>> = {
   "agents": cmdAgents,
   "clouds": cmdClouds,
   "update": cmdUpdate,
+  "last": cmdLast, "rerun": cmdLast,
 };
 
 // list/ls/history handled separately for -a/-c flag parsing


### PR DESCRIPTION
## Summary
Adds a new `spawn last` command (alias: `rerun`) that instantly reruns the most recent spawn from history without requiring the interactive picker.

## Motivation
Users frequently want to restart their last session quickly. The current flow requires running `spawn list` and selecting from the picker, which is slower for this common use case.

## Changes
- Added `cmdLast()` function in `commands.ts`
- Added `last` and `rerun` aliases to command dispatcher in `index.ts`
- Updated help text to document the new command
- Added example to help examples section
- Bumped version to 0.2.83

## Behavior
```bash
# Instantly rerun the most recent spawn
$ spawn last

# Also works with the rerun alias
$ spawn rerun
```

Shows descriptive output before rerunning:
```
Rerunning last spawn: Claude Code on Sprite (5 min ago)
```

Handles empty history gracefully:
```
No spawn history found.
Run spawn <agent> <cloud> to create your first spawn.
```

## Test plan
- [x] Manually tested `spawn last` with existing history
- [x] Manually tested with empty history
- [x] Verified help text updates appear correctly
- [x] Ran existing test suite (all passing)

## Related
Partially addresses #1144 by improving the UX for rerunning previous spawns. Left a comment on the issue asking for clarification on what other improvements are needed.

-- refactor/ux-engineer