### PR TITLE
fix: add npm fallback for Claude Code install on Hetzner

### DIFF
--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -31,7 +31,7 @@ wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 log_step "Verifying Claude Code installation..."
 if ! run_server "${HETZNER_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
     log_step "Claude Code not found, installing manually..."
-    run_server "${HETZNER_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
+    run_server "${HETZNER_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash || npm install -g @anthropic-ai/claude-code"
 fi
 
 # Verify installation succeeded

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1279,12 +1279,14 @@ packages:
   - unzip
   - git
   - zsh
+  - nodejs
+  - npm
 
 runcmd:
   # Install Bun
   - su - root -c 'curl -fsSL https://bun.sh/install | bash'
-  # Install Claude Code
-  - su - root -c 'curl -fsSL https://claude.ai/install.sh | bash'
+  # Install Claude Code (npm fallback if install script returns 403 from datacenter IPs)
+  - su - root -c 'curl -fsSL https://claude.ai/install.sh | bash || npm install -g @anthropic-ai/claude-code'
   # Mark as sandbox environment (disposable cloud VM)
   - echo 'export IS_SANDBOX=1' >> /root/.bashrc
   - echo 'export IS_SANDBOX=1' >> /root/.zshrc


### PR DESCRIPTION
## Summary
- `claude.ai/install.sh` returns 403 from Hetzner datacenter IPs (likely ARM/aarch64 or GCS geo-blocking)
- Adds `|| npm install -g @anthropic-ai/claude-code` fallback to both cloud-init and `hetzner/claude.sh`
- Adds `nodejs` and `npm` to cloud-init packages so npm is available for the fallback

## Test plan
- [ ] `spawn claude hetzner` on cax11 (ARM) — should fall back to npm and succeed
- [ ] `spawn claude hetzner` on cpx11 (x86) — should use bash script if it works, npm otherwise
- [ ] `bash -n shared/common.sh` — passes
- [ ] `bash -n hetzner/claude.sh` — passes
- [ ] `bash test/run.sh` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)