### PR TITLE
security: fix path traversal and timeout issues in key-request.sh

### DIFF
--- a/cli/src/__tests__/shared-key-request.test.ts
+++ b/cli/src/__tests__/shared-key-request.test.ts
@@ -595,7 +595,7 @@ describe("invalidate_cloud_key", () => {
     expect(result.stdout).toContain("invalid provider name");
   });
 
-  it("should accept valid provider names with dots, hyphens, underscores", () => {
+  it("should accept valid provider names with hyphens and underscores", () => {
     const configDir = join(testDir, ".config", "spawn");
     mkdirSync(configDir, { recursive: true });
     const configFile = join(configDir, "my-cloud_v2.json");
@@ -604,6 +604,18 @@ describe("invalidate_cloud_key", () => {
     const result = runBash(`invalidate_cloud_key "my-cloud_v2" 2>&1`);
     expect(result.exitCode).toBe(0);
     expect(existsSync(configFile)).toBe(false);
+  });
+
+  it("should reject provider names with dots to prevent path traversal", () => {
+    const result = runBash(`invalidate_cloud_key "foo..bar" 2>&1`);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("invalid provider name");
+  });
+
+  it("should reject provider names with single dots", () => {
+    const result = runBash(`invalidate_cloud_key "foo.bar" 2>&1`);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("invalid provider name");
   });
 
   it("should accept exactly 64-character provider names", () => {


### PR DESCRIPTION
## Summary

This PR addresses two MEDIUM severity findings from security issue #763:

### M1: Path Traversal Validation Incomplete
**File:** `shared/key-request.sh:217`

The provider name regex `^[a-z0-9][a-z0-9._-]{0,63}$` allowed dots, which could permit sequences like `foo..bar` to potentially escape the config directory boundary.

**Fix:** Removed dots from the allowed character set: `^[a-z0-9][a-z0-9_-]{0,63}$`

**Safety Check:** Verified no current cloud provider names in `manifest.json` contain dots.

### M2: No Timeout on Background Key Request Process
**File:** `shared/key-request.sh:194-208`

The fire-and-forget background curl process had `--max-time 10` but ran in an unmonitored subshell that could hang indefinitely if curl itself hung or the process became blocked.

**Fix:** Wrapped the entire background operation in a `timeout 15 bash -c` command to ensure the subprocess is reaped after 15 seconds maximum.

## Test Coverage

- All existing tests pass (`bash test/run.sh`)
- Updated test expectations to reflect new validation (dots now rejected)
- Added explicit tests for `foo..bar` and `foo.bar` rejection

## Related Issue

Closes partial findings from #763

-- refactor/security-auditor