### PR TITLE
ux: remove unnecessary 'Tip' messages for cleaner output

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -427,8 +427,6 @@ async function dispatchSubcommand(cmd: string, filteredArgs: string[]): Promise<
   if ((cmd === "agents" || cmd === "clouds") && filteredArgs.length > 1 && !filteredArgs[1].startsWith("-")) {
     const name = filteredArgs[1];
     warnExtraArgs(filteredArgs, 2);
-    console.error(pc.dim(`Tip: next time you can just run ${pc.cyan(`spawn ${name}`)}`));
-    console.error();
     await showInfoOrError(name);
     return;
   }
@@ -455,8 +453,6 @@ async function dispatchVerbAlias(cmd: string, filteredArgs: string[], prompt: st
 async function dispatchSlashNotation(cmd: string, prompt: string | undefined, dryRun: boolean, debug: boolean): Promise<boolean> {
   const parts = cmd.split("/");
   if (parts.length === 2 && parts[0] && parts[1]) {
-    console.error(pc.dim(`Tip: use a space instead of slash: ${pc.cyan(`spawn ${parts[0]} ${parts[1]}`)}`));
-    console.error();
     await handleDefaultCommand(parts[0], parts[1], prompt, dryRun, debug);
     return true;
   }


### PR DESCRIPTION
## Summary

Removes unnecessary "Tip:" messages that appeared when users ran certain command variations. These messages added visual clutter and made it seem like something went wrong, when in fact the commands worked perfectly.

## Changes

**Removed tip messages from:**
1. `spawn agents <name>` / `spawn clouds <name>` 
   - Before: Shows "Tip: next time you can just run spawn <name>" then the info
   - After: Just shows the info (same behavior, no noise)

2. `spawn <agent>/<cloud>` (slash notation)
   - Before: Shows "Tip: use a space instead of slash" then runs
   - After: Just runs (slash notation works, no explanation needed)

## UX Improvement

**Before:**
```
$ spawn agents claude
Tip: next time you can just run spawn claude

Claude Code -- AI coding agent with autonomous capabilities
...
```

**After:**
```
$ spawn agents claude

Claude Code -- AI coding agent with autonomous capabilities
...
```

## Why This Improves UX

- **Less clutter**: Commands "just work" without patronizing messages
- **Consistent**: Other spawn commands don't show tips - why should these?
- **Natural discovery**: Users learn shortcuts through usage, not interruptions
- **Professional**: Tools should be helpful, not chatty

## Version Bump

- 0.2.83 → 0.2.84 (patch: UX improvement)

-- refactor/ux-engineer