### PR TITLE
security: fix path traversal in key-server POST /request-batch

### DIFF
--- a/.claude/skills/setup-agent-team/key-server.ts
+++ b/.claude/skills/setup-agent-team/key-server.ts
@@ -372,6 +372,11 @@ const server = Bun.serve({
       const skipped: string[] = [];
 
       for (const pk of body.providers as string[]) {
+        // SECURITY: Validate provider name to prevent path traversal
+        if (!SAFE_PROVIDER_RE.test(pk)) {
+          console.warn(`[key-server] Rejected invalid provider name: ${pk}`);
+          continue;
+        }
         if (
           d.batches.some(
             (b) =>


### PR DESCRIPTION
## Summary
Fixes HIGH severity path traversal vulnerability in key-server.ts by adding provider name validation.

## Issue
Missing SAFE_PROVIDER_RE validation in POST /request-batch endpoint allowed authenticated attackers to submit malicious provider names like `../../malicious`. These names would later be used in `join(CONFIG_DIR, \`${provider}.json\`)` at line 291, enabling arbitrary file writes within filesystem permissions.

## Attack Vector
1. Authenticated attacker sends POST /request-batch with `{"providers": ["../../malicious"]}`
2. No validation applied - only checked against recent requests, not format
3. Provider name stored in batch without sanitization
4. When form submitted, saveKeys() does: `join(CONFIG_DIR, '${provider}.json')`
5. Attacker can write arbitrary files: `~/.config/spawn/../../malicious.json`

## Fix
Apply SAFE_PROVIDER_RE validation (regex: `^[a-z0-9][a-z0-9._-]{0,63}$`) at line 376 before accepting provider names. Invalid names are logged as warnings and skipped.

## Impact
- Prevents authenticated path traversal (HIGH severity)
- Requires authentication (SECRET env var), so not publicly exploitable
- Defense in depth: same regex already used for DELETE /key/:provider (line 433) and GET /status (line 536)

## Test plan
- [ ] Verify normal provider requests still work
- [ ] Verify malicious provider names are rejected (`../../etc/passwd`, `../config`, etc.)
- [ ] Check logs show warning for rejected names
- [ ] Confirm existing key-server tests pass

🤖 Generated by security-auditor (spawn refactor team)