### PR TITLE
feat: add cloudsigma/goose implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For cloud-specific auth, see each cloud's README in this repository.
 | [**OpenClaw**](https://github.com/OpenRouterTeam/openclaw) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |
 | [**NanoClaw**](https://github.com/gavrielc/nanoclaw) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |
 | [**Aider**](https://github.com/paul-gauthier/aider) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| [**Goose**](https://github.com/block/goose) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |
+| [**Goose**](https://github.com/block/goose) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |
 | [**Codex CLI**](https://github.com/openai/codex) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   | ✓ |
 | [**Open Interpreter**](https://github.com/OpenInterpreter/open-interpreter) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
 | [**Gemini CLI**](https://github.com/google-gemini/gemini-cli) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   | ✓ |

--- a/cloudsigma/README.md
+++ b/cloudsigma/README.md
@@ -32,6 +32,7 @@ Get your credentials at: [CloudSigma Cloud Portal](https://zrh.cloudsigma.com/) 
 
 - `cloudsigma/claude` — Claude Code (Anthropic's CLI agent)
 - `cloudsigma/aider` — Aider (AI pair programming)
+- `cloudsigma/goose` — Goose (Block's open-source AI coding agent)
 
 More coming soon! See `manifest.json` for the full matrix.
 

--- a/cloudsigma/goose.sh
+++ b/cloudsigma/goose.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=cloudsigma/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cloudsigma/lib/common.sh)"
+fi
+
+log_info "Goose on CloudSigma"
+echo ""
+
+ensure_cloudsigma_credentials
+ensure_ssh_key
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+verify_server_connectivity "${CLOUDSIGMA_SERVER_IP}"
+wait_for_cloud_init "${CLOUDSIGMA_SERVER_IP}" 60
+
+# Install Goose
+log_step "Installing Goose..."
+run_server "${CLOUDSIGMA_SERVER_IP}" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash"
+
+# Verify installation succeeded
+if ! run_server "${CLOUDSIGMA_SERVER_IP}" "command -v goose &> /dev/null && goose --version &> /dev/null"; then
+    log_install_failed "Goose" "CONFIGURE=false curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash" "${CLOUDSIGMA_SERVER_IP}"
+    exit 1
+fi
+log_info "Goose installation verified successfully"
+
+# Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${CLOUDSIGMA_SERVER_IP}" upload_file run_server \
+    "GOOSE_PROVIDER=openrouter" \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "CloudSigma instance setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (UUID: ${CLOUDSIGMA_SERVER_UUID}, IP: ${CLOUDSIGMA_SERVER_IP})"
+echo ""
+
+# Start Goose interactively
+log_step "Starting Goose..."
+sleep 1
+clear
+interactive_session "${CLOUDSIGMA_SERVER_IP}" "source ~/.zshrc && goose"

--- a/manifest.json
+++ b/manifest.json
@@ -1357,7 +1357,7 @@
     "cloudsigma/openclaw": "implemented",
     "cloudsigma/nanoclaw": "implemented",
     "cloudsigma/aider": "implemented",
-    "cloudsigma/goose": "missing",
+    "cloudsigma/goose": "implemented",
     "cloudsigma/codex": "implemented",
     "cloudsigma/interpreter": "implemented",
     "cloudsigma/gemini": "implemented",


### PR DESCRIPTION
Implements Goose (Block's open-source AI coding agent) on CloudSigma cloud.

## Changes

- **`cloudsigma/goose.sh`** — New script that provisions a CloudSigma KVM server, installs Goose via its official installer, and injects OpenRouter credentials (`GOOSE_PROVIDER=openrouter`, `OPENROUTER_API_KEY`)
- **`manifest.json`** — Marks `cloudsigma/goose` as `"implemented"`
- **`cloudsigma/README.md`** — Adds Goose to the available agents list
- **`README.md`** — Adds checkmark for CloudSigma/Goose in the matrix

## Script flow

1. Source `cloudsigma/lib/common.sh` (local or remote fallback)
2. Authenticate with CloudSigma credentials
3. Register SSH key
4. Provision Ubuntu 24.04 server (clone drive, create server, start)
5. Wait for SSH + cloud-init
6. Install Goose via `download_cli.sh`
7. Verify installation
8. Get OpenRouter API key (env var or OAuth)
9. Inject `GOOSE_PROVIDER=openrouter` and `OPENROUTER_API_KEY` via `inject_env_vars_ssh`
10. Launch interactive session with `goose`

## Testing

- `bash -n cloudsigma/goose.sh` passes (syntax check)
- `bash test/run.sh` passes (80/80 tests, 0 failures)

-- discovery/gap-filler-5