### PR TITLE
feat: Add hostkey/amazonq implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For cloud-specific auth, see each cloud's README in this repository.
 | [**Codex CLI**](https://github.com/openai/codex) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   | ✓ |
 | [**Open Interpreter**](https://github.com/OpenInterpreter/open-interpreter) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
 | [**Gemini CLI**](https://github.com/google-gemini/gemini-cli) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   | ✓ |
-| [**Amazon Q CLI**](https://aws.amazon.com/q/developer/) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   |
+| [**Amazon Q CLI**](https://aws.amazon.com/q/developer/) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |
 | [**Cline**](https://github.com/cline/cline) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |
 | [**gptme**](https://github.com/gptme/gptme) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   |
 | [**OpenCode**](https://github.com/opencode-ai/opencode) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   |

--- a/hostkey/README.md
+++ b/hostkey/README.md
@@ -1,0 +1,50 @@
+# HOSTKEY
+
+HOSTKEY VPS hosting via REST API. [HOSTKEY](https://hostkey.com/)
+
+## Agents
+
+#### Amazon Q CLI
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hostkey/amazonq.sh)
+```
+
+## Authentication
+
+To use HOSTKEY spawn scripts, you need a HOSTKEY API key:
+
+1. Log in to [HOSTKEY](https://hostkey.com/)
+2. Navigate to API settings in your account
+3. Generate a new API key
+4. Set the `HOSTKEY_API_KEY` environment variable
+
+## Non-Interactive Mode
+
+```bash
+HOSTKEY_SERVER_NAME=dev-mk1 \
+HOSTKEY_API_KEY=your-api-key \
+OPENROUTER_API_KEY=sk-or-v1-xxxxx \
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/hostkey/amazonq.sh)
+```
+
+## Environment Variables
+
+- `HOSTKEY_API_KEY` - Your HOSTKEY API key (required)
+- `HOSTKEY_SERVER_NAME` - Server name (prompted if not set)
+- `HOSTKEY_LOCATION` - Data center location: `nl`, `de`, `fi`, `is`, `tr`, `us` (default: `nl`)
+- `HOSTKEY_INSTANCE_PRESET` - Instance preset ID (default: `1`)
+- `OPENROUTER_API_KEY` - Your OpenRouter API key (prompted via OAuth if not set)
+
+## Pricing
+
+HOSTKEY offers affordable VPS hosting starting from EUR 1/month with hourly billing available. Check [HOSTKEY pricing](https://hostkey.com/vps/) for current rates.
+
+## Locations
+
+- `nl` - Amsterdam, Netherlands
+- `de` - Frankfurt, Germany
+- `fi` - Helsinki, Finland
+- `is` - Reykjavik, Iceland
+- `tr` - Istanbul, Turkey
+- `us` - New York, United States

--- a/hostkey/amazonq.sh
+++ b/hostkey/amazonq.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# shellcheck disable=SC2154
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# shellcheck source=hostkey/lib/common.sh
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/hostkey/lib/common.sh)"
+fi
+
+log_info "Amazon Q CLI on HOSTKEY"
+echo ""
+
+# 1. Resolve HOSTKEY API token
+ensure_hostkey_token
+
+# 2. Generate + register SSH key
+ensure_ssh_key
+
+# 3. Get server name and create server
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# 4. Wait for SSH and cloud-init
+verify_server_connectivity "${HOSTKEY_INSTANCE_IP}"
+wait_for_cloud_init "${HOSTKEY_INSTANCE_IP}" 60
+
+# 5. Install Amazon Q CLI
+log_step "Installing Amazon Q CLI..."
+run_server "${HOSTKEY_INSTANCE_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
+log_info "Amazon Q CLI installed"
+
+# 6. Get OpenRouter API key
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# 7. Inject environment variables
+log_step "Setting up environment variables..."
+inject_env_vars_ssh "${HOSTKEY_INSTANCE_IP}" upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
+    "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+
+echo ""
+log_info "HOSTKEY server setup completed successfully!"
+log_info "Server: ${SERVER_NAME} (ID: ${HOSTKEY_INSTANCE_ID}, IP: ${HOSTKEY_INSTANCE_IP})"
+echo ""
+
+# 8. Start Amazon Q CLI interactively
+log_step "Starting Amazon Q..."
+sleep 1
+clear
+interactive_session "${HOSTKEY_INSTANCE_IP}" "source ~/.zshrc && q chat"

--- a/hostkey/lib/common.sh
+++ b/hostkey/lib/common.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+set -eo pipefail
+# Common bash functions for HOSTKEY spawn scripts
+
+# ============================================================
+# Provider-agnostic functions
+# ============================================================
+
+# Source shared provider-agnostic functions (local or remote fallback)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
+    source "$SCRIPT_DIR/../../shared/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+fi
+
+# Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh
+
+# ============================================================
+# HOSTKEY specific functions
+# ============================================================
+
+readonly HOSTKEY_API_BASE="https://invapi.hostkey.com"
+SPAWN_DASHBOARD_URL="https://manage.hostkey.com/"
+
+# Centralized curl wrapper for HOSTKEY API
+# Delegates to generic_cloud_api for retry logic and error handling
+# Usage: hostkey_api METHOD ENDPOINT [BODY]
+hostkey_api() {
+    local method="$1"
+    local endpoint="$2"
+    local body="${3:-}"
+
+    generic_cloud_api "$HOSTKEY_API_BASE" "$HOSTKEY_API_KEY" "$method" "$endpoint" "$body"
+}
+
+# Test HOSTKEY API key validity
+test_hostkey_token() {
+    local response
+    response=$(hostkey_api GET "/v1/services" 2>&1) || true
+
+    if echo "$response" | grep -qi "unauthorized\|invalid\|error"; then
+        log_error "API Error: Invalid or expired HOSTKEY API key"
+        log_error ""
+        log_error "How to fix:"
+        log_error "  1. Log in to HOSTKEY at: https://hostkey.com/"
+        log_error "  2. Navigate to API settings in your account"
+        log_error "  3. Generate a new API key if needed"
+        log_error "  4. Set HOSTKEY_API_KEY environment variable"
+        return 1
+    fi
+    return 0
+}
+
+# Ensure HOSTKEY_API_KEY is available (env var → config file → prompt+save)
+ensure_hostkey_token() {
+    ensure_api_token_with_provider \
+        "HOSTKEY" \
+        "HOSTKEY_API_KEY" \
+        "$HOME/.config/spawn/hostkey.json" \
+        "https://hostkey.com/documentation/apidocs/api/" \
+        "test_hostkey_token"
+}
+
+# Check if SSH key is registered with HOSTKEY
+hostkey_check_ssh_key() {
+    local fingerprint="$1"
+    local response
+    response=$(hostkey_api GET "/ssh_keys")
+
+    if echo "$response" | grep -q "$fingerprint"; then
+        return 0
+    fi
+    return 1
+}
+
+# Register SSH key with HOSTKEY
+hostkey_register_ssh_key() {
+    local key_name="$1"
+    local pub_path="$2"
+    local pub_key
+    pub_key=$(cat "$pub_path")
+    local json_pub_key json_name
+    json_pub_key=$(json_escape "$pub_key")
+    json_name=$(json_escape "$key_name")
+
+    local register_body="{\"name\":$json_name,\"public_key\":$json_pub_key}"
+    local register_response
+    register_response=$(hostkey_api POST "/ssh_keys" "$register_body")
+
+    if echo "$register_response" | grep -qi "error"; then
+        log_error "API Error: $(echo "$register_response" | grep -o '"message":"[^"]*"' || echo "$register_response")"
+        log_error ""
+        log_error "Common causes:"
+        log_error "  - SSH key already registered with this name"
+        log_error "  - Invalid SSH key format"
+        log_error "  - API key lacks write permissions"
+        return 1
+    fi
+
+    return 0
+}
+
+# Ensure SSH key exists locally and is registered with HOSTKEY
+ensure_ssh_key() {
+    ensure_ssh_key_with_provider hostkey_check_ssh_key hostkey_register_ssh_key "HOSTKEY"
+}
+
+# Get server name from env var or prompt
+get_server_name() {
+    get_validated_server_name "HOSTKEY_SERVER_NAME" "Enter server name: "
+}
+
+# List available HOSTKEY locations
+_list_locations() {
+    printf '%s\n' "nl|Amsterdam|Netherlands"
+    printf '%s\n' "de|Frankfurt|Germany"
+    printf '%s\n' "fi|Helsinki|Finland"
+    printf '%s\n' "is|Reykjavik|Iceland"
+    printf '%s\n' "tr|Istanbul|Turkey"
+    printf '%s\n' "us|New York|United States"
+}
+
+# Interactive location picker (skipped if HOSTKEY_LOCATION is set)
+_pick_location() {
+    interactive_pick "HOSTKEY_LOCATION" "nl" "locations" _list_locations
+}
+
+# Get available instance presets for a location
+_list_instance_presets() {
+    local location="$1"
+
+    ensure_jq || return 1
+
+    # Call HOSTKEY presets API
+    local response
+    response=$(curl -s "${HOSTKEY_API_BASE}/presets.php" -X POST \
+        --data "action=list" \
+        --data "location=${location}")
+
+    # Parse and format response
+    printf '%s' "$response" | jq -r \
+        '.[] | "\(.id)|\(.cores) vCPU|\(.ram) GB RAM|\(.storage) GB disk|€\(.price)/mo"' 2>/dev/null || {
+        log_error "Failed to fetch instance presets"
+        return 1
+    }
+}
+
+# Interactive instance preset picker
+_pick_instance_preset() {
+    local location="$1"
+    _list_presets_for_location() { _list_instance_presets "$location"; }
+    interactive_pick "HOSTKEY_INSTANCE_PRESET" "1" "instance presets" _list_presets_for_location "1"
+    unset -f _list_presets_for_location
+}
+
+# Build JSON order body for HOSTKEY instance creation
+# Usage: _hostkey_build_order_body NAME LOCATION PRESET
+_hostkey_build_order_body() {
+    local name="$1" location="$2" preset="$3"
+    jq -n \
+        --arg name "$name" \
+        --arg location "$location" \
+        --arg preset "$preset" \
+        '{name: $name, location: $location, preset: $preset, os: "ubuntu-24.04"}'
+}
+
+# Check HOSTKEY API response for errors and log diagnostics
+# Returns 0 if error detected, 1 if no error
+_hostkey_check_create_error() {
+    local response="$1"
+
+    if ! echo "$response" | grep -qi "error"; then
+        return 1
+    fi
+
+    log_error "Failed to create HOSTKEY instance"
+    local error_msg
+    error_msg=$(printf '%s' "$response" | jq -r '.error // .message // "Unknown error"' 2>/dev/null || echo "$response")
+    log_error "API Error: $error_msg"
+    log_error ""
+    log_error "Common issues:"
+    log_error "  - Insufficient account balance"
+    log_error "  - Instance limit reached"
+    log_error "  - Invalid location or preset"
+    log_error ""
+    log_error "Check your account status: https://hostkey.com/"
+    return 0
+}
+
+# Parse instance ID and IP from HOSTKEY order response
+# Sets HOSTKEY_INSTANCE_ID and HOSTKEY_INSTANCE_IP on success
+_hostkey_parse_instance_response() {
+    local response="$1"
+    HOSTKEY_INSTANCE_ID=$(printf '%s' "$response" | jq -r '.id // .instance_id')
+    HOSTKEY_INSTANCE_IP=$(printf '%s' "$response" | jq -r '.ip // .ipv4')
+    export HOSTKEY_INSTANCE_ID HOSTKEY_INSTANCE_IP
+}
+
+# Create a HOSTKEY compute instance
+create_server() {
+    local name="$1"
+
+    # Interactive location + instance preset selection (skipped if env vars are set)
+    local location
+    location=$(_pick_location)
+    # Validate location before using it in API calls (preset listing)
+    validate_region_name "$location" || { log_error "Invalid HOSTKEY_LOCATION"; return 1; }
+
+    local preset
+    preset=$(_pick_instance_preset "$location")
+    validate_resource_name "$preset" || { log_error "Invalid HOSTKEY_INSTANCE_PRESET"; return 1; }
+
+    log_step "Creating HOSTKEY instance '$name' (preset: $preset, location: $location)..."
+
+    local order_body
+    order_body=$(_hostkey_build_order_body "$name" "$location" "$preset")
+
+    local response
+    response=$(hostkey_api POST "/eq/order_instance" "$order_body")
+
+    if _hostkey_check_create_error "$response"; then
+        return 1
+    fi
+
+    _hostkey_parse_instance_response "$response"
+
+    log_info "Instance created: ID=$HOSTKEY_INSTANCE_ID, IP=$HOSTKEY_INSTANCE_IP"
+
+    # Wait for instance to be ready
+    log_step "Waiting for instance to be ready..."
+    sleep 10
+}
+
+# SSH operations — delegates to shared helpers (SSH_USER defaults to root)
+verify_server_connectivity() { ssh_verify_connectivity "$@"; }
+run_server() { ssh_run_server "$@"; }
+upload_file() { ssh_upload_file "$@"; }
+interactive_session() { ssh_interactive_session "$@"; }
+
+# Destroy a HOSTKEY instance
+destroy_server() {
+    local instance_id="$1"
+
+    log_step "Destroying instance $instance_id..."
+    local response
+    local json_id
+    json_id=$(json_escape "$instance_id")
+    response=$(hostkey_api POST "/eq/terminate" "{\"id\":$json_id}")
+
+    if echo "$response" | grep -qi "error"; then
+        log_error "Failed to destroy instance $instance_id"
+        log_error "API Error: $(extract_api_error_message "$response" "$response")"
+        log_error ""
+        log_error "The instance may still be running and incurring charges."
+        log_error "Delete it manually at: https://manage.hostkey.com/"
+        return 1
+    fi
+
+    log_info "Instance $instance_id destroyed"
+}
+
+# List all HOSTKEY instances
+list_servers() {
+    local response
+    response=$(hostkey_api GET "/v1/services")
+
+    local count
+    count=$(printf '%s' "$response" | jq 'length' 2>/dev/null || echo "0")
+
+    if [[ "$count" -eq 0 ]]; then
+        printf 'No instances found\n'
+        return 0
+    fi
+
+    printf '%-25s %-12s %-12s %-16s\n' "NAME" "ID" "STATUS" "IP"
+    printf '%s\n' "-----------------------------------------------------------------"
+    printf '%s' "$response" | jq -r \
+        '.[] | "\(.name // "N/A")|\(.id // "N/A")|\(.status // "N/A")|\(.ip // "N/A")"' \
+        | while IFS='|' read -r name sid status ip; do
+            printf '%-25s %-12s %-12s %-16s\n' "$name" "$sid" "$status" "$ip"
+        done
+}

--- a/manifest.json
+++ b/manifest.json
@@ -388,6 +388,21 @@
       "provision_method": "sprite create",
       "exec_method": "sprite exec",
       "interactive_method": "sprite exec -tty"
+    },
+    "hostkey": {
+      "name": "HOSTKEY",
+      "description": "HOSTKEY VPS hosting via REST API",
+      "url": "https://hostkey.com/",
+      "type": "api",
+      "auth": "HOSTKEY_API_KEY",
+      "provision_method": "POST /eq/order_instance",
+      "exec_method": "ssh root@IP",
+      "interactive_method": "ssh -t root@IP",
+      "defaults": {
+        "preset": "1",
+        "location": "nl",
+        "os": "ubuntu-24.04"
+      }
     }
   },
   "matrix": {
@@ -540,6 +555,21 @@
     "local/opencode": "missing",
     "local/plandex": "implemented",
     "local/kilocode": "implemented",
-    "local/continue": "implemented"
+    "local/continue": "implemented",
+    "hostkey/claude": "missing",
+    "hostkey/openclaw": "missing",
+    "hostkey/nanoclaw": "missing",
+    "hostkey/aider": "missing",
+    "hostkey/goose": "missing",
+    "hostkey/codex": "missing",
+    "hostkey/interpreter": "missing",
+    "hostkey/gemini": "missing",
+    "hostkey/amazonq": "implemented",
+    "hostkey/cline": "missing",
+    "hostkey/gptme": "missing",
+    "hostkey/opencode": "missing",
+    "hostkey/plandex": "missing",
+    "hostkey/kilocode": "missing",
+    "hostkey/continue": "missing"
   }
 }


### PR DESCRIPTION
## Summary

- Re-adds HOSTKEY as a cloud provider with `hostkey/lib/common.sh` (API primitives for server provisioning, SSH, instance management)
- Implements `hostkey/amazonq.sh` deploying Amazon Q CLI on HOSTKEY VPS
- Adds HOSTKEY cloud entry and matrix entries to `manifest.json` (amazonq implemented, other agents marked missing)
- Updates root README.md matrix to show HOSTKEY/Amazon Q checkmark
- Adds `hostkey/README.md` with usage instructions

## OpenRouter injection

The script injects `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, and `OPENAI_BASE_URL=https://openrouter.ai/api/v1` per the amazonq agent manifest spec.

## Test plan

- [ ] `bash -n hostkey/amazonq.sh` passes syntax check
- [ ] `python3 -c "import json; json.load(open('manifest.json'))"` validates JSON
- [ ] Manual: `HOSTKEY_API_KEY=xxx bash hostkey/amazonq.sh` provisions server and launches `q chat`

-- discovery/gap-filler-1