### PR TITLE
fix: inject env vars into both .bashrc and .zshrc

### DIFF
--- a/aws-lightsail/claude.sh
+++ b/aws-lightsail/claude.sh
@@ -70,4 +70,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${LIGHTSAIL_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"
+interactive_session "${LIGHTSAIL_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"

--- a/daytona/claude.sh
+++ b/daytona/claude.sh
@@ -66,4 +66,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"
+interactive_session "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"

--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -201,8 +201,8 @@ wait_for_cloud_init() {
     run_server "apt-get update -y && apt-get install -y curl unzip git zsh" >/dev/null 2>&1 || true
     run_server "curl -fsSL https://bun.sh/install | bash" >/dev/null 2>&1 || true
     run_server "curl -fsSL https://claude.ai/install.sh | bash" >/dev/null 2>&1 || true
-    run_server 'echo "export PATH=\"${HOME}/.claude/local/bin:${HOME}/.bun/bin:${PATH}\"" >> ~/.bashrc' >/dev/null 2>&1 || true
-    run_server 'echo "export PATH=\"${HOME}/.claude/local/bin:${HOME}/.bun/bin:${PATH}\"" >> ~/.zshrc' >/dev/null 2>&1 || true
+    run_server 'echo "export PATH=\"${HOME}/.local/bin:${HOME}/.bun/bin:${PATH}\"" >> ~/.bashrc' >/dev/null 2>&1 || true
+    run_server 'echo "export PATH=\"${HOME}/.local/bin:${HOME}/.bun/bin:${PATH}\"" >> ~/.zshrc' >/dev/null 2>&1 || true
     log_info "Base tools installed"
 }
 

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -79,4 +79,4 @@ save_vm_connection "${DO_SERVER_IP}" "root" "${DO_DROPLET_ID}" "${DROPLET_NAME}"
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${DO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"
+interactive_session "${DO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"

--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -68,4 +68,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "export PATH=\$HOME/.local/bin:\$PATH && source ~/.bashrc && claude"
+interactive_session "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.bashrc && claude"

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -291,8 +291,8 @@ wait_for_cloud_init() {
     log_step "Installing base tools on Fly.io machine..."
     run_server "apt-get update -y && apt-get install -y curl unzip git zsh python3 pip" >/dev/null 2>&1 || true
     run_server "curl -fsSL https://bun.sh/install | bash" >/dev/null 2>&1 || true
-    run_server 'echo "export PATH=\"\$HOME/.bun/bin:\$PATH\"" >> ~/.bashrc' >/dev/null 2>&1 || true
-    run_server 'echo "export PATH=\"\$HOME/.bun/bin:\$PATH\"" >> ~/.zshrc' >/dev/null 2>&1 || true
+    run_server 'echo "export PATH=\"\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"" >> ~/.bashrc' >/dev/null 2>&1 || true
+    run_server 'echo "export PATH=\"\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"" >> ~/.zshrc' >/dev/null 2>&1 || true
     log_info "Base tools installed"
 }
 

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -73,4 +73,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${GCP_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"
+interactive_session "${GCP_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"

--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -75,4 +75,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${HETZNER_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"
+interactive_session "${HETZNER_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"

--- a/oracle/claude.sh
+++ b/oracle/claude.sh
@@ -73,4 +73,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${OCI_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"
+interactive_session "${OCI_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"

--- a/ovh/claude.sh
+++ b/ovh/claude.sh
@@ -77,4 +77,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${OVH_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"
+interactive_session "${OVH_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -373,8 +373,8 @@ install_base_deps() {
     run_ovh "$ip" "curl -fsSL https://claude.ai/install.sh | bash"
 
     # Configure PATH
-    run_ovh "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.claude/local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.bashrc"
-    run_ovh "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.claude/local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.zshrc"
+    run_ovh "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.bashrc"
+    run_ovh "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.zshrc"
 
     log_info "Base dependencies installed"
 }

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1090,9 +1090,9 @@ inject_env_vars_ssh() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .zshrc
+    # Upload and append to both .bashrc and .zshrc
     "${upload_func}" "${server_ip}" "${env_temp}" "/tmp/env_config"
-    "${run_func}" "${server_ip}" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    "${run_func}" "${server_ip}" "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
 
     # Note: temp file will be cleaned up by trap handler
 }
@@ -1115,9 +1115,9 @@ inject_env_vars_local() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .zshrc
+    # Upload and append to both .bashrc and .zshrc
     "${upload_func}" "${env_temp}" "/tmp/env_config"
-    "${run_func}" "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    "${run_func}" "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
 
     # Note: temp file will be cleaned up by trap handler
 }
@@ -1298,9 +1298,9 @@ runcmd:
   - echo 'export IS_SANDBOX=1' >> /root/.bashrc
   - echo 'export IS_SANDBOX=1' >> /root/.zshrc
   # Configure PATH in .bashrc
-  - echo 'export PATH="${HOME}/.claude/local/bin:${HOME}/.bun/bin:${PATH}"' >> /root/.bashrc
+  - echo 'export PATH="${HOME}/.local/bin:${HOME}/.bun/bin:${PATH}"' >> /root/.bashrc
   # Configure PATH in .zshrc
-  - echo 'export PATH="${HOME}/.claude/local/bin:${HOME}/.bun/bin:${PATH}"' >> /root/.zshrc
+  - echo 'export PATH="${HOME}/.local/bin:${HOME}/.bun/bin:${PATH}"' >> /root/.zshrc
   # Signal completion
   - touch /root/.cloud-init-complete
 CLOUD_INIT_EOF

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -74,11 +74,11 @@ if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
 
     # Execute without -tty flag
-    sprite exec -s "${SPRITE_NAME}" -- zsh -c "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude -p ${escaped_prompt}"
+    sprite exec -s "${SPRITE_NAME}" -- zsh -c "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude -p ${escaped_prompt}"
 else
     # Interactive mode: start Claude Code normally
     log_step "Starting Claude Code..."
     sleep 1
     clear 2>/dev/null || true
-    sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "export PATH=\$HOME/.local/bin:\$PATH && source ~/.zshrc && claude"
+    sprite exec -s "${SPRITE_NAME}" -tty -- zsh -c "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"
 fi

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -209,8 +209,8 @@ inject_env_vars_sprite() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .zshrc using sprite exec with -file flag
-    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    # Upload and append to both .bashrc and .zshrc using sprite exec with -file flag
+    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
     trap - EXIT
 }
 


### PR DESCRIPTION
## Summary
- **Env vars (API keys)** were only injected into `.zshrc` — bash SSH sessions couldn't find `OPENROUTER_API_KEY` or other credentials. Now `inject_env_vars_ssh`, `inject_env_vars_local`, and `inject_env_vars_sprite` all write to both `.bashrc` and `.zshrc`.
- **PATH** in cloud-init and several cloud libs referenced `~/.claude/local/bin` which doesn't exist — `claude` installs to `~/.local/bin`. Fixed in `shared/common.sh`, `daytona/lib/common.sh`, `ovh/lib/common.sh`, and `fly/lib/common.sh`.
- **Interactive session PATH** synced with cloud-init PATH across all 9 clouds (added `~/.bun/bin`).

## Test plan
- [ ] `bash -n` passes on all 14 modified files
- [ ] Deploy on Hetzner, SSH in manually with bash — verify `claude` is on PATH and `OPENROUTER_API_KEY` is set
- [ ] Deploy on Hetzner, SSH in manually with zsh — verify same
- [ ] Verify spawn interactive session still launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)