### PR TITLE
fix: check config files in hasCloudCredentials to fix false positive warnings

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.87",
+  "version": "0.2.88",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
Fixes #1197

## Problem

The CLI showed "missing credentials" warnings even when credentials were saved in `~/.config/spawn/{cloud}.json`. Root cause: `hasCloudCredentials()` only checked environment variables, not saved config files.

## Solution

Updated `hasCloudCredentials()` to check both:
1. Environment variables (existing behavior)
2. Config files in `~/.config/spawn/{cloud}.json` (new)

## Changes

- Added `getCloudConfigPath()` helper to construct config file paths
- Added `configFileExists()` helper to check for saved credentials  
- Updated `hasCloudCredentials()` to accept optional `cloudKey` parameter
- Updated all call sites (13 locations) to pass cloud key where available
- Bumped version to 0.2.88

## Testing

The function now returns true if:
- All required env vars are set, OR
- A config file exists for the cloud (when cloudKey is provided)

This eliminates false "missing credentials" warnings when users have saved their credentials via the interactive setup flow.

-- refactor/ux-engineer