### PR TITLE
ux: add interactive VM deletion to spawn ls command

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/history.ts
+++ b/cli/src/history.ts
@@ -80,6 +80,21 @@ export function clearHistory(): number {
   return count;
 }
 
+/** Delete a specific spawn record from history */
+export function deleteSpawnRecord(recordToDelete: SpawnRecord): void {
+  const history = loadHistory();
+  const filtered = history.filter((r) =>
+    !(r.agent === recordToDelete.agent &&
+      r.cloud === recordToDelete.cloud &&
+      r.timestamp === recordToDelete.timestamp)
+  );
+
+  if (filtered.length < history.length) {
+    // Record was found and removed
+    writeFileSync(getHistoryPath(), JSON.stringify(filtered, null, 2) + "\n");
+  }
+}
+
 /** Check for pending connection data and merge it into the last history entry.
  *  Bash scripts write connection info to last-connection.json after successful spawn.
  *  This function merges that data into the history and persists it. */


### PR DESCRIPTION
Fixes #1178

## Feature

Users can now delete VMs directly from the `spawn ls` interactive picker. When selecting a VM with a `server_id`, a "Delete VM" option (displayed in red) appears alongside "Reconnect" and "Rerun".

## Implementation

- Added `deleteVM()` function that:
  - Confirms deletion with user (defaults to No)
  - Sources the cloud's `lib/common.sh` to call `destroy_server()`
  - Removes the record from history after successful deletion
  - Shows appropriate error handling if deletion fails

- Added `deleteSpawnRecord()` to history.ts for removing records from history

- Updated `handleRecordAction()` to include delete option when `server_id` is available

## UX Flow

When you run `spawn ls` and select a VM:

```
What would you like to do?
> Reconnect to existing VM          ssh root@203.0.113.5
  Spawn a new VM                    Create a fresh instance
  Delete VM                         Destroy my-claude-vm on hetzner
```

Confirmation prompt (defaults to No for safety):
```
Delete my-claude-vm on Hetzner Cloud? [y/N]
```

After successful deletion, the VM is destroyed on the cloud provider and removed from history.

## Changes

- `cli/src/commands.ts`: Added `deleteVM()` and updated `handleRecordAction()`
- `cli/src/history.ts`: Added `deleteSpawnRecord()` function
- `cli/package.json`: Bumped version to 0.2.89

This supersedes PR #1188 which had merge conflicts. Clean implementation from main branch.

-- refactor/ux-engineer