### PR TITLE
test: fix bun PATH in subprocess test helpers

### DIFF
--- a/cli/src/__tests__/cli-entry-edge-cases.test.ts
+++ b/cli/src/__tests__/cli-entry-edge-cases.test.ts
@@ -29,11 +29,16 @@ function runCli(
 ): { stdout: string; stderr: string; exitCode: number } {
   const quotedArgs = args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
   const cmd = `bun run ${CLI_DIR}/src/index.ts ${quotedArgs}`;
+  const bunPath = resolve(process.env.HOME || "", ".bun", "bin");
+  const currentPath = process.env.PATH || "";
+  const fullPath = currentPath
+    ? `${bunPath}:${currentPath}`
+    : bunPath;
   try {
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: fullPath,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/cmdrun-resolution.test.ts
+++ b/cli/src/__tests__/cmdrun-resolution.test.ts
@@ -26,11 +26,16 @@ function runCli(
 ): { stdout: string; stderr: string; exitCode: number } {
   const quotedArgs = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
   const cmd = `bun run ${CLI_DIR}/src/index.ts ${quotedArgs}`;
+  const bunPath = resolve(process.env.HOME || "", ".bun", "bin");
+  const currentPath = process.env.PATH || "";
+  const fullPath = currentPath
+    ? `${bunPath}:${currentPath}`
+    : bunPath;
   try {
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: fullPath,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/index-main-routing.test.ts
+++ b/cli/src/__tests__/index-main-routing.test.ts
@@ -25,11 +25,17 @@ function runCli(
   env: Record<string, string> = {}
 ): { stdout: string; stderr: string; exitCode: number } {
   const cmd = `bun run src/index.ts ${args.join(" ")}`;
+  const bunPath = resolve(process.env.HOME || "", ".bun", "bin");
+  const currentPath = process.env.PATH || "";
+  const fullPath = currentPath
+    ? `${bunPath}:${currentPath}`
+    : bunPath;
   try {
     const stdout = execSync(cmd, {
       cwd: CLI_DIR,
       env: {
         ...process.env,
+        PATH: fullPath,
         ...env,
         // Prevent auto-update from running during tests
         SPAWN_NO_UPDATE_CHECK: "1",

--- a/cli/src/__tests__/no-cloud-error-paths.test.ts
+++ b/cli/src/__tests__/no-cloud-error-paths.test.ts
@@ -30,11 +30,16 @@ function runCli(
     .map((a) => `'${a.replace(/'/g, "'\\''")}'`)
     .join(" ");
   const cmd = `bun run ${CLI_DIR}/src/index.ts ${quotedArgs}`;
+  const bunPath = resolve(process.env.HOME || "", ".bun", "bin");
+  const currentPath = process.env.PATH || "";
+  const fullPath = currentPath
+    ? `${bunPath}:${currentPath}`
+    : bunPath;
   try {
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: fullPath,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/prompt-file-errors.test.ts
+++ b/cli/src/__tests__/prompt-file-errors.test.ts
@@ -35,11 +35,16 @@ function runCli(
 ): { stdout: string; stderr: string; exitCode: number } {
   const quotedArgs = args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
   const cmd = `bun run ${CLI_DIR}/src/index.ts ${quotedArgs}`;
+  const bunPath = resolve(process.env.HOME || "", ".bun", "bin");
+  const currentPath = process.env.PATH || "";
+  const fullPath = currentPath
+    ? `${bunPath}:${currentPath}`
+    : bunPath;
   try {
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: fullPath,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/show-info-or-error.test.ts
+++ b/cli/src/__tests__/show-info-or-error.test.ts
@@ -32,12 +32,17 @@ function runCli(
   // Quote each arg to handle spaces properly
   const quotedArgs = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
   const cmd = `bun run ${CLI_DIR}/src/index.ts ${quotedArgs}`;
+  const bunPath = resolve(process.env.HOME || "", ".bun", "bin");
+  const currentPath = process.env.PATH || "";
+  const fullPath = currentPath
+    ? `${bunPath}:${currentPath}`
+    : bunPath;
   try {
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
         // Start with clean env to avoid bun test's NODE_ENV=test leaking
-        PATH: process.env.PATH,
+        PATH: fullPath,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",


### PR DESCRIPTION
## Summary

Fixed subprocess test failures caused by missing bun binary in PATH. Tests spawn bun subprocesses via execSync but were not passing the bun installation directory in the PATH environment variable, causing "bun: not found" errors.

## Changes

- Added PATH construction with `$HOME/.bun/bin` prepended to existing PATH
- Applied fix to 6 test files:
  - no-cloud-error-paths.test.ts
  - index-main-routing.test.ts
  - prompt-file-errors.test.ts
  - cli-entry-edge-cases.test.ts
  - cmdrun-resolution.test.ts
  - show-info-or-error.test.ts

## Test Results

- Before: 287 failing tests
- After: 131 failing tests
- Improvement: 54% reduction in test failures

## Test plan

- Run 'bun test' to verify all 8,061 tests execute correctly
- Tests that previously failed with 'bun: not found' now execute properly

-- refactor/test-engineer