### PR TITLE
fix: prevent test fixtures from leaking into manifest cache

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.87",
+  "version": "0.2.88",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

- Fixes `spawn` showing only 2 agents (Claude Code, Aider) instead of all 15
- Root cause: `CACHE_DIR`/`CACHE_FILE` were computed once at module import time, so tests setting `XDG_CACHE_HOME` in `beforeEach()` had no effect on where the cache was written
- Tests calling `loadManifest(true)` with mocked fetch were writing 2-agent test manifests to the real `~/.cache/spawn/manifest.json`, polluting the production cache
- Makes cache paths dynamic via getter functions so test isolation actually works
- Adds guard to skip disk writes in test environments unless `XDG_CACHE_HOME` is explicitly set (tests using `setupTestEnvironment` set this to a temp dir)

## Test plan

- [x] `bun test` — 8053 pass, 8 pre-existing failures (unchanged)
- [x] Verified `~/.cache/spawn/manifest.json` is no longer created after running tests
- [x] `manifest-cache-lifecycle.test.ts` — 52/52 pass (tests that need disk cache still work via `setupTestEnvironment`)
- [x] Deleted corrupted cache — `spawn` now fetches fresh manifest with all 15 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)