### PR TITLE
security: add JSON escaping to save_vm_connection()

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2907,13 +2907,22 @@ save_vm_connection() {
 
     local conn_file="${spawn_dir}/last-connection.json"
 
+    # SECURITY: Use json_escape to prevent JSON injection attacks.
+    # Even though upstream validation restricts server_name to alphanumeric+dash,
+    # defense-in-depth requires proper escaping at the point of JSON construction.
+    local escaped_ip escaped_user escaped_server_id escaped_server_name
+    escaped_ip=$(json_escape "${ip}")
+    escaped_user=$(json_escape "${user}")
+
     # Build JSON (handle optional fields)
-    local json="{\"ip\":\"${ip}\",\"user\":\"${user}\""
+    local json="{\"ip\":${escaped_ip},\"user\":${escaped_user}"
     if [[ -n "${server_id}" ]]; then
-        json="${json},\"server_id\":\"${server_id}\""
+        escaped_server_id=$(json_escape "${server_id}")
+        json="${json},\"server_id\":${escaped_server_id}"
     fi
     if [[ -n "${server_name}" ]]; then
-        json="${json},\"server_name\":\"${server_name}\""
+        escaped_server_name=$(json_escape "${server_name}")
+        json="${json},\"server_name\":${escaped_server_name}"
     fi
     json="${json}}"
 


### PR DESCRIPTION
## Summary
Defense-in-depth fix for potential JSON injection vulnerability in `save_vm_connection()` function.

## Issue
The function builds JSON by string concatenation without escaping:
```bash
local json="{\"ip\":\"${ip}\",\"user\":\"${user}\""
```

If any of these variables contain quotes or backslashes, the JSON would be malformed and could potentially be exploited.

## Impact
**LOW severity** - Upstream validation already protects against exploitation:
- `validate_server_name()` restricts names to `^[a-zA-Z0-9-]+$`
- This prevents quotes, backslashes, and other JSON-breaking characters
- No actual exploit path exists with current code

However, this violates defense-in-depth principles and could become exploitable if:
1. Someone refactors and removes the upstream validation
2. New code paths bypass validation
3. IP addresses from cloud APIs contain unexpected characters

## Fix
Use the existing `json_escape()` helper for all fields:
```bash
escaped_ip=$(json_escape "${ip}")
local json="{\"ip\":${escaped_ip},\"user\":${escaped_user}..."
```

This ensures:
- Proper JSON encoding at the point of construction
- Protection against future refactoring
- Consistency with other JSON-building code in the codebase

## Testing
- ✅ Syntax check: `bash -n shared/common.sh`
- ✅ Full test suite: `bash test/run.sh` (80 passed, 0 failed)
- ✅ No behavioral changes - only adds escaping layer

## Related
This follows the pattern used elsewhere in the codebase:
- `shared/common.sh:2103` - Uses `json_escape` for API tokens
- `shared/common.sh:2216` - Uses `json_escape` for config files
- `fly/lib/common.sh:160` - Uses `json_escape` for app names

-- refactor/security-auditor