### PR TITLE
test: fix bun PATH resolution in subprocess execSync calls

### DIFF
--- a/cli/src/__tests__/cli-entry-edge-cases.test.ts
+++ b/cli/src/__tests__/cli-entry-edge-cases.test.ts
@@ -33,7 +33,7 @@ function runCli(
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/cmdrun-resolution.test.ts
+++ b/cli/src/__tests__/cmdrun-resolution.test.ts
@@ -30,7 +30,7 @@ function runCli(
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/index-main-routing.test.ts
+++ b/cli/src/__tests__/index-main-routing.test.ts
@@ -31,6 +31,8 @@ function runCli(
       env: {
         ...process.env,
         ...env,
+        // Ensure bun is in PATH for subprocess execution
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         // Prevent auto-update from running during tests
         SPAWN_NO_UPDATE_CHECK: "1",
         // Prevent local manifest.json from being used

--- a/cli/src/__tests__/no-cloud-error-paths.test.ts
+++ b/cli/src/__tests__/no-cloud-error-paths.test.ts
@@ -34,7 +34,7 @@ function runCli(
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/prompt-file-errors.test.ts
+++ b/cli/src/__tests__/prompt-file-errors.test.ts
@@ -39,7 +39,7 @@ function runCli(
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/show-info-or-error.test.ts
+++ b/cli/src/__tests__/show-info-or-error.test.ts
@@ -37,7 +37,7 @@ function runCli(
       cwd: PROJECT_ROOT,
       env: {
         // Start with clean env to avoid bun test's NODE_ENV=test leaking
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",


### PR DESCRIPTION
## Summary

Fixed test failures in 6 CLI test files where execSync runs 'bun run' in subprocesses without bun in PATH. This resolves 156 failing tests (54% reduction).

## Changes

- Added `${process.env.HOME}/.bun/bin` to PATH in all execSync env objects across:
  - `index-main-routing.test.ts`
  - `no-cloud-error-paths.test.ts`
  - `cli-entry-edge-cases.test.ts`
  - `prompt-file-errors.test.ts`
  - `cmdrun-resolution.test.ts`
  - `show-info-or-error.test.ts`

## Test Results

- **Before**: 287 failing tests, 0 passing in affected test suites
- **After**: 131 failing tests, 7930 passing tests
- **Shell tests**: All 80 tests pass (unchanged)

The remaining 131 failures are pre-existing and unrelated to this fix (manifest loading issues in CI environment).

## Technical Details

Root cause: When using `execSync` to spawn subprocess CLIs with `bun run src/index.ts`, the environment's PATH wasn't set correctly. Child processes couldn't find the `bun` executable at `~/.bun/bin`.

Solution: Prepend `~/.bun/bin` to PATH consistently across all subprocess test helpers, matching the pattern already used in `unicode-detect.test.ts`.

-- refactor/test-engineer