### PR TITLE
ux: improve progress feedback and post-session guidance

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1405,7 +1405,7 @@ async function suggestFilterCorrection(
 async function showEmptyListMessage(agentFilter?: string, cloudFilter?: string): Promise<void> {
   if (!agentFilter && !cloudFilter) {
     p.log.info("No spawns recorded yet.");
-    p.log.info(`Run ${pc.cyan("spawn <agent> <cloud>")} to launch your first agent.`);
+    p.log.info(`Run ${pc.cyan("spawn")} to pick interactively, or ${pc.cyan("spawn <agent> <cloud>")} to launch directly.`);
     return;
   }
 
@@ -2117,6 +2117,7 @@ function getHelpExamplesSection(): string {
   spawn openclaw vultr -f instructions.txt
                                      ${pc.dim("# Read prompt from file (short for --prompt-file)")}
   spawn interpreter linode --dry-run ${pc.dim("# Preview without provisioning")}
+  spawn claude sprite --debug        ${pc.dim("# Show all commands being executed")}
   spawn claude                       ${pc.dim("# Show which clouds support Claude")}
   spawn hetzner                      ${pc.dim("# Show which agents run on Hetzner")}
   spawn list                         ${pc.dim("# Browse history and pick one to rerun")}

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1674,6 +1674,7 @@ _log_ssh_wait_progress() {
         log_step "Waiting for ${description}... (${elapsed_time}s elapsed, taking longer than usual)"
     else
         log_warn "Still waiting for ${description}... (${elapsed_time}s elapsed, this is unusually slow)"
+        log_warn "  Tip: check your cloud dashboard for server status, or press Ctrl+C to abort"
     fi
 }
 
@@ -1814,6 +1815,9 @@ _show_post_session_summary() {
     log_warn ""
     log_info "To reconnect:"
     log_info "  ssh ${SSH_USER:-root}@${ip}"
+    log_info ""
+    log_info "To see your spawn history:"
+    log_info "  spawn list"
 }
 
 # Show a post-session summary for exec-based (non-SSH) cloud providers.
@@ -1847,6 +1851,9 @@ _show_exec_post_session_summary() {
         log_info "To reconnect:"
         log_info "  ${reconnect_cmd}"
     fi
+    log_info ""
+    log_info "To see your spawn history:"
+    log_info "  spawn list"
 }
 
 # Start an interactive SSH session
@@ -1949,7 +1956,12 @@ _poll_instance_once() {
     status=$(_extract_json_field "${response}" "${status_py}" "unknown")
 
     if [[ "${status}" != "${target_status}" ]]; then
-        log_step "${description} status: ${status} ($((attempt * poll_delay))s elapsed)"
+        local elapsed=$((attempt * poll_delay))
+        if [[ ${elapsed} -lt 60 ]]; then
+            log_step "${description} status: ${status} (${elapsed}s elapsed, typically takes 30-90s)"
+        else
+            log_step "${description} status: ${status} (${elapsed}s elapsed, taking longer than usual)"
+        fi
         return 2
     fi
 


### PR DESCRIPTION
## Summary
- Add actionable tip during unusually slow SSH waits (>120s) suggesting users check their cloud dashboard or press Ctrl+C to abort
- Show expected timing context during instance polling progress ("typically takes 30-90s" vs "taking longer than usual") so users know what to expect
- Add `spawn list` hint to both SSH and exec-based post-session summaries so users discover history management after their session ends
- Add `--debug` flag example to CLI help output (was documented in flags but missing from examples)
- Improve empty list state to mention the interactive picker alongside the direct `spawn <agent> <cloud>` command

## Test plan
- [x] `bash -n shared/common.sh` syntax check passes
- [x] `bash test/run.sh` -- 80/80 tests pass
- [x] `bun test` -- all list-related tests pass (171/171), no new failures introduced (diff against main shows only pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)