### PR TITLE
ux: improve prompt file error messages with actionable examples

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -206,16 +206,26 @@ function handlePromptFileError(promptFile: string, err: unknown): never {
   const code = err && typeof err === "object" && "code" in err ? err.code : "";
   if (code === "ENOENT") {
     console.error(pc.red(`Prompt file not found: ${pc.bold(promptFile)}`));
-    console.error(`\nCheck the path and try again.`);
+    console.error(`\nCreate a text file with your prompt and try again:`);
+    console.error(`  ${pc.cyan(`echo "your instructions here" > prompt.txt`)}`);
+    console.error(`  ${pc.cyan(`spawn <agent> <cloud> --prompt-file prompt.txt`)}`);
   } else if (code === "EACCES") {
     console.error(pc.red(`Permission denied reading prompt file: ${pc.bold(promptFile)}`));
-    console.error(`\nCheck file permissions: ${pc.cyan(`ls -la ${promptFile}`)}`);
+    console.error(`\nCheck file permissions:`);
+    console.error(`  ${pc.cyan(`ls -la ${promptFile}`)}`);
+    console.error(`\nMake sure the file is readable:`);
+    console.error(`  ${pc.cyan(`chmod 644 ${promptFile}`)}`);
   } else if (code === "EISDIR") {
     console.error(pc.red(`'${promptFile}' is a directory, not a file.`));
-    console.error(`\nProvide a path to a text file containing your prompt.`);
+    console.error(`\nProvide the path to a text file containing your prompt:`);
+    console.error(`  ${pc.cyan(`spawn <agent> <cloud> --prompt-file path/to/prompt.txt`)}`);
+    console.error(`\nCreate a prompt file:`);
+    console.error(`  ${pc.cyan(`echo "your instructions here" > prompt.txt`)}`);
   } else {
     const msg = err && typeof err === "object" && "message" in err ? String(err.message) : String(err);
     console.error(pc.red(`Error reading prompt file '${promptFile}': ${msg}`));
+    console.error(`\nEnsure the file exists and is readable:`);
+    console.error(`  ${pc.cyan(`ls -la ${promptFile}`)}`);
   }
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
When users provide an invalid path to `--prompt-file`, the error messages now include actionable examples instead of generic guidance.

## Changes
- **ENOENT (file not found)**: Shows `echo` command to create a prompt file with example usage
- **EACCES (permission denied)**: Shows `chmod` command to fix file permissions  
- **EISDIR (path is directory)**: Shows correct file path example and how to create a prompt file
- **Generic errors**: Suggests checking file existence with `ls`

## Test Coverage
Updated `prompt-file-errors.test.ts` with expectations for new error message format.

## Impact
This improves UX for first-time users trying the `--prompt-file` flag by:
1. Showing exactly what commands to run
2. Reducing time to resolve errors
3. Providing copy-paste-ready examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)