### PR TITLE
refactor: shared agent setup helpers, deduplicate hetzner scripts

### DIFF
--- a/cli/src/__tests__/agent-env-injection-contract.test.ts
+++ b/cli/src/__tests__/agent-env-injection-contract.test.ts
@@ -203,10 +203,12 @@ describe("Agent Environment Variable Injection Contract", () => {
         // 2. OAuth flow: get_openrouter_api_key_oauth
         // 3. Manual prompt: get_openrouter_api_key_manual
         // 4. try_oauth_flow
+        // 5. Shared helper: get_or_prompt_api_key (wraps env check + OAuth)
         const hasEnvCheck = code.includes("OPENROUTER_API_KEY:-") || code.includes("OPENROUTER_API_KEY:=");
         const hasOAuth = code.includes("get_openrouter_api_key_oauth") || code.includes("try_oauth_flow");
         const hasManual = code.includes("get_openrouter_api_key_manual");
-        const hasAnyAcquisition = hasEnvCheck || hasOAuth || hasManual;
+        const hasSharedHelper = code.includes("get_or_prompt_api_key");
+        const hasAnyAcquisition = hasEnvCheck || hasOAuth || hasManual || hasSharedHelper;
 
         if (!hasAnyAcquisition) {
           failures.push(key + ".sh");

--- a/hetzner/aider.sh
+++ b/hetzner/aider.sh
@@ -13,53 +13,24 @@ fi
 log_info "Aider on Hetzner Cloud"
 echo ""
 
-# 1. Resolve Hetzner API token
+# Provision server
 ensure_hcloud_token
-
-# 2. Generate + register SSH key
 ensure_ssh_key
-
-# 3. Get server name and create server
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
-
-# 4. Wait for SSH and cloud-init
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-# 5. Install Aider
-log_step "Installing Aider..."
-run_server "${HETZNER_SERVER_IP}" "pip install aider-chat 2>/dev/null || pip3 install aider-chat"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-# Verify installation succeeded
-if ! run_server "${HETZNER_SERVER_IP}" "command -v aider &> /dev/null && aider --version &> /dev/null"; then
-    log_install_failed "Aider" "pip install aider-chat" "${HETZNER_SERVER_IP}"
-    exit 1
-fi
-log_info "Aider installation verified successfully"
-
-# 6. Get OpenRouter API key
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-# Get model preference
+# Install, configure, launch
+install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" "$RUN"
+verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" "$RUN"
+get_or_prompt_api_key
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Aider") || exit 1
-
-log_step "Setting up environment variables..."
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
-echo ""
-
-# 9. Start Aider interactively
-log_step "Starting Aider..."
-sleep 1
-clear
-interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && aider --model openrouter/${MODEL_ID}"

--- a/hetzner/amazonq.sh
+++ b/hetzner/amazonq.sh
@@ -4,7 +4,6 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 # shellcheck source=hetzner/lib/common.sh
-
 if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
     source "${SCRIPT_DIR}/lib/common.sh"
 else
@@ -14,37 +13,24 @@ fi
 log_info "Amazon Q on Hetzner Cloud"
 echo ""
 
+# Provision server
 ensure_hcloud_token
 ensure_ssh_key
-
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_step "Installing Amazon Q CLI..."
-run_server "${HETZNER_SERVER_IP}" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash"
-log_info "Amazon Q CLI installed"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-log_step "Setting up environment variables..."
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+# Install, configure, launch
+install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" "$RUN"
+get_or_prompt_api_key
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
-echo ""
-
-log_step "Starting Amazon Q..."
-sleep 1
-clear
-interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && q chat"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && q chat"

--- a/hetzner/codex.sh
+++ b/hetzner/codex.sh
@@ -12,37 +12,24 @@ fi
 log_info "Codex CLI on Hetzner Cloud"
 echo ""
 
+# Provision server
 ensure_hcloud_token
 ensure_ssh_key
-
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_step "Installing Codex CLI..."
-run_server "${HETZNER_SERVER_IP}" "npm install -g @openai/codex"
-log_info "Codex CLI installed"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-log_step "Setting up environment variables..."
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+# Install, configure, launch
+install_agent "Codex CLI" "npm install -g @openai/codex" "$RUN"
+get_or_prompt_api_key
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
-echo ""
-
-log_step "Starting Codex..."
-sleep 1
-clear
-interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && codex"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && codex"

--- a/hetzner/continue.sh
+++ b/hetzner/continue.sh
@@ -4,7 +4,6 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 # shellcheck source=hetzner/lib/common.sh
-
 if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
     source "${SCRIPT_DIR}/lib/common.sh"
 else
@@ -14,40 +13,23 @@ fi
 log_info "Continue on Hetzner Cloud"
 echo ""
 
+# Provision server
 ensure_hcloud_token
 ensure_ssh_key
-
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_step "Installing Continue CLI..."
-run_server "${HETZNER_SERVER_IP}" "npm install -g @continuedev/cli"
-log_info "Continue installed"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-log_step "Setting up environment variables..."
-
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+# Install, configure, launch
+install_agent "Continue CLI" "npm install -g @continuedev/cli" "$RUN"
+get_or_prompt_api_key
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
-
-setup_continue_config "${OPENROUTER_API_KEY}" \
-    "upload_file ${HETZNER_SERVER_IP}" \
-    "run_server ${HETZNER_SERVER_IP}"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
-echo ""
-
-log_step "Starting Continue CLI in TUI mode..."
-sleep 1
-clear
-interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && cn"
+setup_continue_config "${OPENROUTER_API_KEY}" "$UPLOAD" "$RUN"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && cn"

--- a/hetzner/gemini.sh
+++ b/hetzner/gemini.sh
@@ -4,7 +4,6 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 # shellcheck source=hetzner/lib/common.sh
-
 if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
     source "${SCRIPT_DIR}/lib/common.sh"
 else
@@ -14,39 +13,25 @@ fi
 log_info "Gemini CLI on Hetzner Cloud"
 echo ""
 
+# Provision server
 ensure_hcloud_token
 ensure_ssh_key
-
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_step "Installing Gemini CLI..."
-run_server "${HETZNER_SERVER_IP}" "npm install -g @google/gemini-cli"
-log_info "Gemini CLI installed"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-log_step "Setting up environment variables..."
-
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+# Install, configure, launch
+install_agent "Gemini CLI" "npm install -g @google/gemini-cli" "$RUN"
+get_or_prompt_api_key
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
-echo ""
-
-log_step "Starting Gemini..."
-sleep 1
-clear
-interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && gemini"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && gemini"

--- a/hetzner/gptme.sh
+++ b/hetzner/gptme.sh
@@ -12,53 +12,24 @@ fi
 log_info "gptme on Hetzner Cloud"
 echo ""
 
-# 1. Resolve Hetzner API token
+# Provision server
 ensure_hcloud_token
-
-# 2. Generate + register SSH key
 ensure_ssh_key
-
-# 3. Get server name and create server
 SERVER_NAME=$(get_server_name)
 create_server "$SERVER_NAME"
-
-# 4. Wait for SSH and cloud-init
 verify_server_connectivity "$HETZNER_SERVER_IP"
 wait_for_cloud_init "$HETZNER_SERVER_IP"
 
-# 5. Install gptme
-log_step "Installing gptme..."
-run_server "$HETZNER_SERVER_IP" "pip install gptme 2>/dev/null || pip3 install gptme"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-# Verify installation succeeded
-if ! run_server "$HETZNER_SERVER_IP" "command -v gptme &> /dev/null && gptme --version &> /dev/null"; then
-    log_install_failed "gptme" "pip install gptme" "${HETZNER_SERVER_IP}"
-    exit 1
-fi
-log_info "gptme installation verified successfully"
-
-# 6. Get OpenRouter API key
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-# Get model preference
+# Install, configure, launch
+install_agent "gptme" "pip install gptme 2>/dev/null || pip3 install gptme" "$RUN"
+verify_agent "gptme" "command -v gptme && gptme --version" "pip install gptme" "$RUN"
+get_or_prompt_api_key
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "gptme") || exit 1
-
-log_step "Setting up environment variables..."
-inject_env_vars_ssh "$HETZNER_SERVER_IP" upload_file run_server \
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=$OPENROUTER_API_KEY"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: $SERVER_NAME (ID: $HETZNER_SERVER_ID, IP: $HETZNER_SERVER_IP)"
-echo ""
-
-# 9. Start gptme interactively
-log_step "Starting gptme..."
-sleep 1
-clear
-interactive_session "$HETZNER_SERVER_IP" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && gptme -m openrouter/${MODEL_ID}"

--- a/hetzner/interpreter.sh
+++ b/hetzner/interpreter.sh
@@ -12,37 +12,24 @@ fi
 log_info "Open Interpreter on Hetzner Cloud"
 echo ""
 
+# Provision server
 ensure_hcloud_token
 ensure_ssh_key
-
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_step "Installing Open Interpreter..."
-run_server "${HETZNER_SERVER_IP}" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter"
-log_info "Open Interpreter installed"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-log_step "Setting up environment variables..."
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+# Install, configure, launch
+install_agent "Open Interpreter" "pip install open-interpreter 2>/dev/null || pip3 install open-interpreter" "$RUN"
+get_or_prompt_api_key
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
     "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
-echo ""
-
-log_step "Starting Open Interpreter..."
-sleep 1
-clear
-interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && interpreter"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && interpreter"

--- a/hetzner/kilocode.sh
+++ b/hetzner/kilocode.sh
@@ -4,7 +4,6 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 # shellcheck source=hetzner/lib/common.sh
-
 if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
     source "${SCRIPT_DIR}/lib/common.sh"
 else
@@ -14,38 +13,24 @@ fi
 log_info "Kilo Code on Hetzner Cloud"
 echo ""
 
+# Provision server
 ensure_hcloud_token
 ensure_ssh_key
-
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_step "Installing Kilo Code..."
-run_server "${HETZNER_SERVER_IP}" "npm install -g @kilocode/cli"
-log_info "Kilo Code installed"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-log_step "Setting up environment variables..."
-
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+# Install, configure, launch
+install_agent "Kilo Code" "npm install -g @kilocode/cli" "$RUN"
+get_or_prompt_api_key
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "KILO_PROVIDER_TYPE=openrouter" \
     "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
-echo ""
-
-log_step "Starting Kilo Code..."
-sleep 1
-clear
-interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && kilocode"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && kilocode"

--- a/hetzner/nanoclaw.sh
+++ b/hetzner/nanoclaw.sh
@@ -13,58 +13,43 @@ fi
 log_info "NanoClaw on Hetzner Cloud"
 echo ""
 
-# 1. Resolve Hetzner API token
+# Provision server
 ensure_hcloud_token
-
-# 2. Generate + register SSH key
 ensure_ssh_key
-
-# 3. Get server name and create server
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
-
-# 4. Wait for SSH and cloud-init
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-# 5. Install Node.js deps and clone nanoclaw
-log_step "Installing tsx..."
-run_server "${HETZNER_SERVER_IP}" "source ~/.bashrc && bun install -g tsx"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
 
+# NanoClaw multi-step install
+log_step "Installing tsx..."
+${RUN} "source ~/.bashrc && bun install -g tsx"
 log_step "Cloning and building nanoclaw..."
-run_server "${HETZNER_SERVER_IP}" "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
+${RUN} "git clone https://github.com/gavrielc/nanoclaw.git ~/nanoclaw && cd ~/nanoclaw && npm install && npm run build"
 log_info "NanoClaw installed"
 
-# 6. Get OpenRouter API key
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-log_step "Setting up environment variables..."
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+get_or_prompt_api_key
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 
-# 8. Create nanoclaw .env file
+# NanoClaw-specific .env file
 log_step "Configuring nanoclaw..."
-
 DOTENV_TEMP=$(mktemp)
 trap 'rm -f "${DOTENV_TEMP}"' EXIT
 chmod 600 "${DOTENV_TEMP}"
 printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${DOTENV_TEMP}"
-
-upload_file "${HETZNER_SERVER_IP}" "${DOTENV_TEMP}" "/root/nanoclaw/.env"
+${UPLOAD} "${DOTENV_TEMP}" "/root/nanoclaw/.env"
 
 echo ""
 log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-# 9. Start nanoclaw
 log_step "Starting nanoclaw..."
 log_info "You will need to scan a WhatsApp QR code to authenticate."
 echo ""

--- a/hetzner/openclaw.sh
+++ b/hetzner/openclaw.sh
@@ -13,54 +13,34 @@ fi
 log_info "OpenClaw on Hetzner Cloud"
 echo ""
 
-# 1. Resolve Hetzner API token
+# Provision server
 ensure_hcloud_token
-
-# 2. Generate + register SSH key
 ensure_ssh_key
-
-# 3. Get server name and create server
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
-
-# 4. Wait for SSH and cloud-init
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-# 5. Install openclaw via bun
-log_step "Installing openclaw..."
-run_server "${HETZNER_SERVER_IP}" "source ~/.bashrc && bun install -g openclaw"
-log_info "OpenClaw installed"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
 
-# 6. Get OpenRouter API key
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-# Get model preference
+# Install, configure
+install_agent "openclaw" "source ~/.bashrc && bun install -g openclaw" "$RUN"
+get_or_prompt_api_key
 MODEL_ID=$(get_model_id_interactive "openrouter/auto" "Openclaw") || exit 1
-
-log_step "Setting up environment variables..."
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_API_KEY=${OPENROUTER_API_KEY}" \
     "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
-
-# 9. Configure openclaw
-setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" \
-    "upload_file ${HETZNER_SERVER_IP}" \
-    "run_server ${HETZNER_SERVER_IP}"
+setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" "$UPLOAD" "$RUN"
 
 echo ""
 log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
 echo ""
 
-# 10. Start openclaw gateway in background and launch TUI
+# Start openclaw gateway in background, then launch TUI
 log_step "Starting openclaw..."
-run_server "${HETZNER_SERVER_IP}" "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+${RUN} "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
 sleep 2
 interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && openclaw tui"

--- a/hetzner/opencode.sh
+++ b/hetzner/opencode.sh
@@ -12,35 +12,22 @@ fi
 log_info "OpenCode on Hetzner Cloud"
 echo ""
 
+# Provision server
 ensure_hcloud_token
 ensure_ssh_key
-
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-log_step "Installing OpenCode..."
-run_server "${HETZNER_SERVER_IP}" "$(opencode_install_cmd)"
-log_info "OpenCode installed"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-log_step "Setting up environment variables..."
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+# Install, configure, launch
+install_agent "OpenCode" "$(opencode_install_cmd)" "$RUN"
+get_or_prompt_api_key
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
-echo ""
-
-log_step "Starting OpenCode..."
-sleep 1
-clear
-interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && opencode"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && opencode"

--- a/hetzner/plandex.sh
+++ b/hetzner/plandex.sh
@@ -13,50 +13,23 @@ fi
 log_info "Plandex on Hetzner Cloud"
 echo ""
 
-# 1. Resolve Hetzner API token
+# Provision server
 ensure_hcloud_token
-
-# 2. Generate + register SSH key
 ensure_ssh_key
-
-# 3. Get server name and create server
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
-
-# 4. Wait for SSH and cloud-init
 verify_server_connectivity "${HETZNER_SERVER_IP}"
 wait_for_cloud_init "${HETZNER_SERVER_IP}" 60
 
-# 5. Install Plandex
-log_step "Installing Plandex..."
-run_server "${HETZNER_SERVER_IP}" "curl -sL https://plandex.ai/install.sh | bash"
+# Set up callbacks
+RUN="run_server ${HETZNER_SERVER_IP}"
+UPLOAD="upload_file ${HETZNER_SERVER_IP}"
+SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-# Verify installation succeeded
-if ! run_server "${HETZNER_SERVER_IP}" "command -v plandex &> /dev/null && plandex version &> /dev/null"; then
-    log_install_failed "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "${HETZNER_SERVER_IP}"
-    exit 1
-fi
-log_info "Plandex installation verified successfully"
-
-# 6. Get OpenRouter API key
-echo ""
-if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
-    log_info "Using OpenRouter API key from environment"
-else
-    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
-fi
-
-log_step "Setting up environment variables..."
-inject_env_vars_ssh "${HETZNER_SERVER_IP}" upload_file run_server \
+# Install, configure, launch
+install_agent "Plandex" "curl -sL https://plandex.ai/install.sh | bash" "$RUN"
+verify_agent "Plandex" "command -v plandex && plandex version" "curl -sL https://plandex.ai/install.sh | bash" "$RUN"
+get_or_prompt_api_key
+inject_env_vars_cb "$RUN" "$UPLOAD" \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
-
-echo ""
-log_info "Hetzner server setup completed successfully!"
-log_info "Server: ${SERVER_NAME} (ID: ${HETZNER_SERVER_ID}, IP: ${HETZNER_SERVER_IP})"
-echo ""
-
-# 7. Start Plandex interactively
-log_step "Starting Plandex..."
-sleep 1
-clear
-interactive_session "${HETZNER_SERVER_IP}" "source ~/.zshrc && plandex"
+launch_session "Hetzner server" "$SESSION" "source ~/.zshrc && plandex"


### PR DESCRIPTION
## Summary

- Add 5 composable helper functions to `shared/common.sh`: `install_agent`, `verify_agent`, `get_or_prompt_api_key`, `inject_env_vars_cb`, `launch_session`
- Refactor all 15 hetzner agent scripts to use the new helpers, reducing total line count from 868 → 579 (-33%, 289 lines removed)
- Update `agent-env-injection-contract.test.ts` to recognize `get_or_prompt_api_key` as a valid API key acquisition pattern

The helpers use the same callback pattern already established by `offer_github_auth` and `setup_claude_code_config`. Phase 1 of a multi-phase rollout — remaining clouds (digitalocean, gcp, oracle, etc.) to follow.

## Test plan

- [x] `bash -n` passes on all 16 modified `.sh` files
- [x] Full bun test suite: 8053 pass, 8 fail (identical to baseline — all 8 failures pre-existing)
- [x] `bash test/run.sh` passes (exit 127 from missing `timeout` on macOS is pre-existing)
- [ ] Manual: `spawn aider hetzner` full flow
- [ ] Manual: `spawn claude hetzner` (claude-specific extras)

🤖 Generated with [Claude Code](https://claude.com/claude-code)