### PR TITLE
feat: shared agent helpers + Claude Code install fallback

### DIFF
--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -26,16 +26,8 @@ RUN="run_server ${HETZNER_SERVER_IP}"
 UPLOAD="upload_file ${HETZNER_SERVER_IP}"
 SESSION="interactive_session ${HETZNER_SERVER_IP}"
 
-# Claude-specific install: try curl first, fall back to bun
-log_step "Verifying Claude Code installation..."
-if ! ${RUN} "export PATH=\$HOME/.claude/local/bin:\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_step "Claude Code not found, installing..."
-    if ! ${RUN} "curl -fsSL https://claude.ai/install.sh | bash"; then
-        log_warn "curl install failed, falling back to bun..."
-        ${RUN} "export PATH=\$HOME/.bun/bin:\$HOME/.local/bin:\$PATH && bun add -g @anthropic-ai/claude-code && claude install"
-    fi
-fi
-verify_agent "Claude Code" "export PATH=\$HOME/.claude/local/bin:\$HOME/.local/bin:\$PATH && command -v claude && claude --version" "curl -fsSL https://claude.ai/install.sh | bash" "$RUN"
+# Install Claude Code (tries curl → npm → bun with clear logging)
+install_claude_code "$RUN"
 
 get_or_prompt_api_key
 inject_env_vars_cb "$RUN" "$UPLOAD" \
@@ -49,4 +41,4 @@ inject_env_vars_cb "$RUN" "$UPLOAD" \
 # Claude-specific config
 setup_claude_code_config "${OPENROUTER_API_KEY}" "$UPLOAD" "$RUN"
 
-launch_session "Hetzner server" "$SESSION" "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"
+launch_session "Hetzner server" "$SESSION" "export PATH=\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.zshrc && claude"


### PR DESCRIPTION
## Summary

- Add 5 composable helper functions to `shared/common.sh` (`install_agent`, `verify_agent`, `get_or_prompt_api_key`, `inject_env_vars_cb`, `launch_session`) using callback pattern
- Add `install_claude_code` helper with 3-method fallback (curl → npm → bun) and per-step error logging
- When npm/bun fallback needs `node`, installs it via fnm (platform-agnostic) with nodesource as Debian/Ubuntu fallback
- Refactor all 15 hetzner agent scripts to use the new helpers (868 → 579 lines, -33%)
- Update test to recognize `get_or_prompt_api_key` as valid API key acquisition pattern

### Before (403 from claude.ai/install.sh)
```
curl: (22) The requested URL returned error: 403
Claude Code installation failed
```
No visibility into which step failed or what alternatives were tried.

### After
```
Installing Claude Code (method 1/3: curl installer)...
⚠ curl installer failed (site may be temporarily unavailable)
Installing Claude Code (method 2/3: npm)...
Installing Node.js (required by Claude Code npm package)...
Node.js installed via fnm
Claude Code installed via npm
```

## Test plan

- [x] `bash -n` passes on all modified `.sh` files
- [x] Mock tests: 150 passed, 0 failed (all clouds)
- [x] Bun tests: no regressions
- [ ] Manual: `spawn claude hetzner` when curl installer returns 403
- [ ] Manual: `spawn aider hetzner` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)