### PR TITLE
fix: use shared install_claude_code across all clouds with fnm PATH fix

### DIFF
--- a/aws-lightsail/claude.sh
+++ b/aws-lightsail/claude.sh
@@ -29,13 +29,9 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${LIGHTSAIL_SERVER_IP}"
 wait_for_cloud_init "${LIGHTSAIL_SERVER_IP}" 60
 
-# 5. Verify Claude Code is installed (fallback to manual install)
-log_step "Verifying Claude Code installation..."
-if ! run_server "${LIGHTSAIL_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_step "Claude Code not found, installing manually..."
-    run_server "${LIGHTSAIL_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
-fi
-log_info "Claude Code is installed"
+# 5. Install Claude Code (tries curl → npm → bun with clear logging)
+RUN="run_server ${LIGHTSAIL_SERVER_IP}"
+install_claude_code "$RUN"
 
 # 6. Get OpenRouter API key
 echo ""

--- a/daytona/claude.sh
+++ b/daytona/claude.sh
@@ -25,13 +25,8 @@ create_server "${SERVER_NAME}"
 # 3. Wait for base tools
 wait_for_cloud_init
 
-# 4. Verify Claude Code is installed (fallback to manual install)
-log_step "Verifying Claude Code installation..."
-if ! run_server "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_step "Claude Code not found, installing manually..."
-    run_server "curl -fsSL https://claude.ai/install.sh | bash"
-fi
-log_info "Claude Code is installed"
+# 4. Install Claude Code (tries curl → npm → bun with clear logging)
+install_claude_code "run_server"
 
 # 5. Get OpenRouter API key
 echo ""

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -30,19 +30,9 @@ create_server "${DROPLET_NAME}"
 verify_server_connectivity "${DO_SERVER_IP}"
 wait_for_cloud_init "${DO_SERVER_IP}" 60
 
-# 5. Verify Claude Code is installed (fallback to manual install)
-log_step "Verifying Claude Code installation..."
-if ! run_server "${DO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_step "Claude Code not found, installing manually..."
-    run_server "${DO_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
-fi
-
-# Verify installation succeeded
-if ! run_server "${DO_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${DO_SERVER_IP}"
-    exit 1
-fi
-log_info "Claude Code installation verified successfully"
+# 5. Install Claude Code (tries curl → npm → bun with clear logging)
+RUN="run_server ${DO_SERVER_IP}"
+install_claude_code "$RUN"
 
 # 6. Get OpenRouter API key
 echo ""

--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -23,16 +23,8 @@ create_server "$SERVER_NAME"
 # 3. Install base tools
 wait_for_cloud_init
 
-# 4. Install Claude Code
-log_step "Installing Claude Code..."
-run_server "curl -fsSL https://claude.ai/install.sh | bash"
-
-# Verify installation
-if ! run_server "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
-    exit 1
-fi
-log_info "Claude Code installed"
+# 4. Install Claude Code (tries curl → npm → bun with clear logging)
+install_claude_code "run_server"
 
 # 5. Get OpenRouter API key
 echo ""

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -32,13 +32,9 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${GCP_SERVER_IP}"
 wait_for_cloud_init "${GCP_SERVER_IP}" 60
 
-# 5. Verify Claude Code is installed (fallback to manual install)
-log_step "Verifying Claude Code installation..."
-if ! run_server "${GCP_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_step "Claude Code not found, installing manually..."
-    run_server "${GCP_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
-fi
-log_info "Claude Code is installed"
+# 5. Install Claude Code (tries curl → npm → bun with clear logging)
+RUN="run_server ${GCP_SERVER_IP}"
+install_claude_code "$RUN"
 
 # 6. Get OpenRouter API key
 echo ""

--- a/oracle/claude.sh
+++ b/oracle/claude.sh
@@ -32,13 +32,9 @@ create_server "${SERVER_NAME}"
 verify_server_connectivity "${OCI_SERVER_IP}"
 wait_for_cloud_init "${OCI_SERVER_IP}" 60
 
-# 5. Verify Claude Code is installed (fallback to manual install)
-log_step "Verifying Claude Code installation..."
-if ! run_server "${OCI_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_step "Claude Code not found, installing manually..."
-    run_server "${OCI_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
-fi
-log_info "Claude Code is installed"
+# 5. Install Claude Code (tries curl → npm → bun with clear logging)
+RUN="run_server ${OCI_SERVER_IP}"
+install_claude_code "$RUN"
 
 # 6. Get OpenRouter API key
 echo ""

--- a/ovh/claude.sh
+++ b/ovh/claude.sh
@@ -32,19 +32,9 @@ verify_server_connectivity "${OVH_SERVER_IP}"
 # 6. Install base dependencies and Claude Code
 install_base_deps "${OVH_SERVER_IP}"
 
-# 7. Verify Claude Code is installed (fallback to manual install)
-log_step "Verifying Claude Code installation..."
-if ! run_ovh "${OVH_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude" >/dev/null 2>&1; then
-    log_step "Claude Code not found, installing manually..."
-    run_ovh "${OVH_SERVER_IP}" "curl -fsSL https://claude.ai/install.sh | bash"
-fi
-
-# Verify installation succeeded
-if ! run_ovh "${OVH_SERVER_IP}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash" "${OVH_SERVER_IP}"
-    exit 1
-fi
-log_info "Claude Code installation verified successfully"
+# 7. Install Claude Code (tries curl → npm → bun with clear logging)
+RUN="run_ovh ${OVH_SERVER_IP}"
+install_claude_code "$RUN"
 
 # 8. Get OpenRouter API key
 echo ""

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -25,16 +25,9 @@ log_step "Setting up sprite environment..."
 # Configure shell environment
 setup_shell_environment "${SPRITE_NAME}"
 
-# Install Claude Code
-log_step "Installing Claude Code..."
-run_sprite "${SPRITE_NAME}" "curl -fsSL https://claude.ai/install.sh | bash"
-
-# Verify installation succeeded
-if ! run_sprite "${SPRITE_NAME}" "export PATH=\$HOME/.local/bin:\$PATH && command -v claude &> /dev/null && claude --version &> /dev/null"; then
-    log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
-    exit 1
-fi
-log_info "Claude Code installation verified successfully"
+# Install Claude Code (tries curl → npm → bun with clear logging)
+RUN="run_sprite ${SPRITE_NAME}"
+install_claude_code "$RUN"
 
 # Get OpenRouter API key
 echo ""

--- a/test/run.sh
+++ b/test/run.sh
@@ -213,7 +213,7 @@ _assert_agent_specific() {
     local script_name="$1"
     case "${script_name}" in
         claude)
-            assert_contains "${MOCK_LOG}" "sprite exec.*claude.*install" "Installs Claude Code"
+            assert_contains "${MOCK_LOG}" "sprite exec.*command -v claude" "Checks Claude Code installation"
             assert_contains "${MOCK_LOG}" "sprite exec.*-file.*/tmp/.*spawn_config" "Uploads Claude config file"
             assert_contains "${MOCK_LOG}" "sprite exec.*mv.*settings.json" "Moves settings.json to final path"
             assert_contains "${MOCK_LOG}" "sprite exec.*mv.*\.claude\.json" "Moves .claude.json to final path"


### PR DESCRIPTION
## Summary

- Migrate all 8 SSH-based cloud `claude.sh` scripts from inline curl-only install to the shared `install_claude_code` function (3-method fallback: curl → npm → bun)
- Fix fnm-installed Node.js being invisible across SSH sessions by adding `$HOME/.local/share/fnm` to PATH and bootstrapping `fnm env` in every remote command
- Move `_ensure_node_runtime` call **before** npm/bun install attempts (was incorrectly called after, when the `claude` binary already needed `node` to run)

## Test plan

- [x] `bash -n` syntax check on all 10 modified files
- [x] `bash test/run.sh` — 80/80 tests pass
- [ ] Manual test: `spawn claude hetzner` with curl installer temporarily failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)