### PR TITLE
fix: ask GitHub CLI setup before provisioning

### DIFF
--- a/aws-lightsail/claude.sh
+++ b/aws-lightsail/claude.sh
@@ -21,7 +21,10 @@ ensure_aws_cli
 # 2. Generate + register SSH key
 ensure_ssh_key
 
-# 3. Get instance name and create server
+# 3. Gather user preferences before provisioning
+prompt_github_auth
+
+# 4. Get instance name and create server
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 

--- a/daytona/claude.sh
+++ b/daytona/claude.sh
@@ -18,7 +18,10 @@ echo ""
 ensure_daytona_cli
 ensure_daytona_token
 
-# 2. Get sandbox name and create sandbox
+# 2. Gather user preferences before provisioning
+prompt_github_auth
+
+# 3. Get sandbox name and create sandbox
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -22,7 +22,10 @@ ensure_do_token
 # 2. Generate + register SSH key
 ensure_ssh_key
 
-# 3. Get droplet name and create droplet
+# 3. Gather user preferences before provisioning
+prompt_github_auth
+
+# 4. Get droplet name and create droplet
 DROPLET_NAME=$(get_server_name)
 create_server "${DROPLET_NAME}"
 

--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -16,7 +16,10 @@ echo ""
 ensure_fly_cli
 ensure_fly_token
 
-# 2. Get app name and create machine
+# 2. Gather user preferences before provisioning
+prompt_github_auth
+
+# 3. Get app name and create machine
 SERVER_NAME=$(get_server_name)
 create_server "$SERVER_NAME"
 

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -24,7 +24,10 @@ ensure_gcloud
 # 2. Generate + register SSH key
 ensure_ssh_key
 
-# 3. Get server name and create server
+# 3. Gather user preferences before provisioning
+prompt_github_auth
+
+# 4. Get server name and create server
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 

--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -16,6 +16,7 @@ echo ""
 # Provision server
 ensure_hcloud_token
 ensure_ssh_key
+prompt_github_auth
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 verify_server_connectivity "${HETZNER_SERVER_IP}"

--- a/oracle/claude.sh
+++ b/oracle/claude.sh
@@ -24,7 +24,10 @@ ensure_oci_cli
 # 2. Generate SSH key
 ensure_ssh_key
 
-# 3. Get server name and create server
+# 3. Gather user preferences before provisioning
+prompt_github_auth
+
+# 4. Get server name and create server
 SERVER_NAME=$(get_server_name)
 create_server "${SERVER_NAME}"
 

--- a/ovh/claude.sh
+++ b/ovh/claude.sh
@@ -19,7 +19,10 @@ ensure_ovh_authenticated
 # 2. Generate + register SSH key
 ensure_ssh_key
 
-# 3. Get server name and create instance
+# 3. Gather user preferences before provisioning
+prompt_github_auth
+
+# 4. Get server name and create instance
 SERVER_NAME=$(get_server_name)
 create_ovh_instance "${SERVER_NAME}"
 

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -16,6 +16,9 @@ echo ""
 ensure_sprite_installed
 ensure_sprite_authenticated
 
+# Gather user preferences before provisioning
+prompt_github_auth
+
 SPRITE_NAME=$(get_sprite_name)
 ensure_sprite_exists "${SPRITE_NAME}"
 verify_sprite_connectivity "${SPRITE_NAME}"


### PR DESCRIPTION
## Summary

- Split `offer_github_auth` into a prompt phase (`prompt_github_auth`) and an execution phase
- `prompt_github_auth` is called before `create_server` in all 9 cloud `claude.sh` scripts, so users answer the "Set up GitHub CLI?" question before waiting for provisioning
- `offer_github_auth` (called later from `inject_env_vars_*`) uses the stored answer without re-prompting
- Backwards compatible: if `prompt_github_auth` was never called (non-claude agent scripts), falls back to the original interactive prompt

## Test plan

- [x] `bash -n` syntax check on all modified files
- [x] `bash test/run.sh` — 80/80 tests pass
- [ ] Manual test: verify GitHub prompt appears before server creation starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)