### PR TITLE
ux: match OAuth callback page to OpenRouter design theme

### DIFF
--- a/cli/src/__tests__/shared-common-oauth-security.test.ts
+++ b/cli/src/__tests__/shared-common-oauth-security.test.ts
@@ -168,13 +168,13 @@ describe("_generate_oauth_html", () => {
     expect(result.stdout).toContain("font-family");
   });
 
-  it("success HTML should have green color for heading", () => {
+  it("success HTML should contain checkmark icon", () => {
     const result = runBash(`
       _generate_oauth_html
       echo "$OAUTH_SUCCESS_HTML"
     `);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("#00d4aa");
+    expect(result.stdout).toContain("&#10003;");
   });
 
   it("error HTML should have red color for heading", () => {
@@ -183,7 +183,7 @@ describe("_generate_oauth_html", () => {
       echo "$OAUTH_ERROR_HTML"
     `);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("#d9534f");
+    expect(result.stdout).toContain("#dc2626");
   });
 
   it("should include 'close this tab' message in success HTML", () => {

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -596,9 +596,9 @@ validate_oauth_port() {
 # Generate OAuth callback HTML pages (success and error)
 # Sets OAUTH_SUCCESS_HTML and OAUTH_ERROR_HTML variables
 _generate_oauth_html() {
-    local css='body{font-family:system-ui,-apple-system,sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#1a1a2e}.card{text-align:center;color:#fff}h1{margin:0 0 8px;font-size:1.6rem}p{margin:0 0 6px;color:#ffffffcc;font-size:1rem}'
-    OAUTH_SUCCESS_HTML="<html><head><style>${css}h1{color:#00d4aa}</style></head><body><div class=\"card\"><h1>Authentication Successful!</h1><p>You can close this tab</p></div><script>setTimeout(function(){try{window.close()}catch(e){}},3000)</script></body></html>"
-    OAUTH_ERROR_HTML="<html><head><style>${css}h1{color:#d9534f}</style></head><body><div class=\"card\"><h1>Authentication Failed</h1><p>Invalid or missing state parameter (CSRF protection)</p><p>Please try again</p></div></body></html>"
+    local css='*{margin:0;padding:0;box-sizing:border-box}body{font-family:system-ui,-apple-system,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;background:#fff;color:#090a0b}@media(prefers-color-scheme:dark){body{background:#090a0b;color:#fafafa}}.card{text-align:center;max-width:400px;padding:2rem}.icon{font-size:2.5rem;margin-bottom:1rem}h1{font-size:1.25rem;font-weight:600;margin-bottom:.5rem}p{font-size:.875rem;color:#6b7280}@media(prefers-color-scheme:dark){p{color:#9ca3af}}'
+    OAUTH_SUCCESS_HTML="<html><head><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><style>${css}</style></head><body><div class=\"card\"><div class=\"icon\">&#10003;</div><h1>Authentication Successful</h1><p>You can close this tab and return to your terminal.</p></div><script>setTimeout(function(){try{window.close()}catch(e){}},3000)</script></body></html>"
+    OAUTH_ERROR_HTML="<html><head><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><style>${css}h1{color:#dc2626}@media(prefers-color-scheme:dark){h1{color:#ef4444}}</style></head><body><div class=\"card\"><div class=\"icon\">&#10007;</div><h1>Authentication Failed</h1><p>Invalid or missing state parameter (CSRF protection). Please try again.</p></div></body></html>"
 }
 
 # Validate OAuth server prerequisites (port, state token, runtime)


### PR DESCRIPTION
## Summary

- Restyle OAuth success/error callback pages to match openrouter.ai's minimal aesthetic
- Add `prefers-color-scheme` media queries for automatic light/dark mode detection
- Light mode: white background, dark text; Dark mode: near-black (#090a0b), light text
- Replace colored headings with simple checkmark/cross Unicode icons for status indication
- Add viewport meta tag for mobile responsiveness
- Muted secondary text (`#6b7280` light / `#9ca3af` dark) instead of white-on-dark-only

**Before:** Always dark purple background (`#1a1a2e`), green/red colored headings
**After:** Adapts to user's OS theme, clean and minimal like openrouter.ai

## Test plan

- [x] `bash -n shared/common.sh` syntax check
- [x] `bun test` — 154/154 OAuth tests pass
- [x] `bash test/run.sh` — 80/80 shell tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)