### PR TITLE
chore: improve code health with safety and maintainability fixes

### DIFF
--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -61,6 +61,6 @@ echo ""
 
 # 8. Start Claude Code interactively
 log_step "Starting Claude Code..."
-sleep 1
+sleep "${SLEEP_BRIEF}"
 clear
 interactive_session "export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.bashrc && claude"

--- a/fly/openclaw.sh
+++ b/fly/openclaw.sh
@@ -71,5 +71,5 @@ echo ""
 # 8. Start openclaw gateway in background and launch TUI
 log_step "Starting openclaw..."
 run_server "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-sleep 2
+sleep "${SLEEP_SHORT}"
 interactive_session "source ~/.zshrc && openclaw tui"

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -141,9 +141,10 @@ get_cloud_init_userdata() {
 apt-get update -y
 apt-get install -y curl unzip git zsh
 # Install Bun
-su - $(logname 2>/dev/null || echo "$(whoami)") -c 'curl -fsSL https://bun.sh/install | bash' || true
+CURRENT_USER="$(logname 2>/dev/null || whoami)"
+su - "${CURRENT_USER}" -c 'curl -fsSL https://bun.sh/install | bash' || true
 # Install Claude Code
-su - $(logname 2>/dev/null || echo "$(whoami)") -c 'curl -fsSL https://claude.ai/install.sh | bash' || true
+su - "${CURRENT_USER}" -c 'curl -fsSL https://claude.ai/install.sh | bash' || true
 # Configure PATH for all users
 echo 'export PATH="${HOME}/.claude/local/bin:${HOME}/.bun/bin:${PATH}"' >> /etc/profile.d/spawn.sh
 chmod +x /etc/profile.d/spawn.sh


### PR DESCRIPTION
## Summary
- Fix unquoted nested command substitution in GCP cloud-init (prevents word splitting with spaces in usernames)
- Replace hardcoded sleep magic numbers with named constants (SLEEP_BRIEF, SLEEP_SHORT, SLEEP_MEDIUM, SLEEP_POLLING)
- Add error handling for critical command substitutions in OAuth flows and API calls

## Test plan
- [x] Run `bash -n` on all modified files (passed)
- [x] Verify backward compatibility (no breaking changes)
- [x] Check that timing constants are properly defined in shared/common.sh

🤖 Generated with refactor/code-health agent