### PR TITLE
fix: write env config and PATH to .bash_profile for login shells

### DIFF
--- a/cli/src/__tests__/shared-common-env-inject.test.ts
+++ b/cli/src/__tests__/shared-common-env-inject.test.ts
@@ -156,7 +156,7 @@ inject_env_vars_local mock_upload mock_run "MY_KEY=my_value"
     // inject_env_vars_local does NOT pass server_ip - upload gets (local_path, remote_path)
     expect(result.stdout).toContain("UPLOAD_ARGS:");
     expect(result.stdout).toContain("/tmp/env_config");
-    expect(result.stdout).toContain("RUN_ARGS: cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config");
+    expect(result.stdout).toContain("for rc in ~/.profile ~/.bash_profile ~/.bashrc ~/.zshrc ~/.zprofile; do cat /tmp/env_config >>");
   });
 
   it("should generate correct env config content", () => {

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -378,9 +378,9 @@ inject_env_vars_fly() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .profile, .bashrc, and .zshrc
+    # Upload and append to .profile, .bash_profile, .bashrc, and .zshrc
     upload_file "${env_temp}" "/tmp/env_config"
-    run_server "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    run_server "for rc in ~/.profile ~/.bash_profile ~/.bashrc ~/.zshrc ~/.zprofile; do cat /tmp/env_config >> \"\$rc\"; done && rm /tmp/env_config"
 
     # Note: temp file will be cleaned up by trap handler
 }

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -209,8 +209,8 @@ inject_env_vars_sprite() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .profile, .bashrc, and .zshrc using sprite exec with -file flag
-    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    # Upload and append to .profile, .bash_profile, .bashrc, and .zshrc using sprite exec
+    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "for rc in ~/.profile ~/.bash_profile ~/.bashrc ~/.zshrc ~/.zprofile; do cat /tmp/env_config >> \"\$rc\"; done && rm /tmp/env_config"
     trap - EXIT
 
     # Offer optional GitHub CLI setup


### PR DESCRIPTION
## Summary

- Write env config and claude PATH entries to **all** shell startup files: `~/.profile`, `~/.bash_profile`, `~/.bashrc`, `~/.zshrc`, `~/.zprofile`
- Root cause: `bash -l` sources the **first** of `~/.bash_profile`, `~/.bash_login`, `~/.profile` — if `~/.bash_profile` exists (e.g. from cloud-init on Hetzner), `~/.profile` is never read
- Also fixes the `which: command not found` / broken PATH issue when SSHing into the machine
- Updated all 5 inject_env_vars variants (ssh, local, cb, fly, sprite) and `_finalize_claude_install`

## Test plan

- [x] `bash -n` syntax check on all modified files
- [x] `bash test/run.sh` — 80/80 pass
- [x] `bun test shared-common-env-inject` — 54/54 pass
- [ ] Manual: `spawn claude hetzner` — verify claude launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)