### PR TITLE
fix(security): code injection, path traversal, rate limit bypass

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -302,7 +302,7 @@ run_server() {
     # SECURITY: Properly escape command to prevent injection
     local escaped_cmd
     escaped_cmd=$(printf '%q' "$cmd")
-    "$(_get_fly_cmd)" ssh console -a "$FLY_APP_NAME" -C "bash -c $escaped_cmd" --quiet 2>/dev/null
+    "$(_get_fly_cmd)" ssh console -a "$FLY_APP_NAME" -C "bash -c \"$escaped_cmd\"" --quiet 2>/dev/null
 }
 
 # Upload a file to the machine via base64 encoding through exec
@@ -330,7 +330,7 @@ interactive_session() {
     local escaped_cmd
     escaped_cmd=$(printf '%q' "$cmd")
     local session_exit=0
-    "$(_get_fly_cmd)" ssh console -a "$FLY_APP_NAME" -C "bash -c $escaped_cmd" || session_exit=$?
+    "$(_get_fly_cmd)" ssh console -a "$FLY_APP_NAME" -C "bash -c \"$escaped_cmd\"" || session_exit=$?
     SERVER_NAME="${FLY_APP_NAME:-}" SPAWN_RECONNECT_CMD="fly ssh console -a ${FLY_APP_NAME:-}" \
         _show_exec_post_session_summary
     return "${session_exit}"


### PR DESCRIPTION
## Summary

Fixes 6 HIGH/CRITICAL security vulnerabilities found during codebase audit (relates to #763):

### Commit 1: OAuth & Python injection fixes
- **OAuth server script injection (CRITICAL):** Rewrote `_generate_oauth_server_script()` to pass values via `process.env` instead of interpolating shell variables into JavaScript string literals.
- **Python code injection via SPAWN_POLL_INTERVAL (HIGH):** Added numeric regex validation for `POLL_INTERVAL` and changed `python3 -c` to use `sys.argv` instead of string interpolation.
- **Credential leak in OAuth error logging (HIGH):** Changed `exchange_oauth_code()` to log only the error field from server responses instead of the full response.

### Commit 2: Path traversal, rate limit, Python expression injection
- **Path traversal via dots in provider name regex (HIGH):** `SAFE_PROVIDER_RE` in `key-server.ts` and `invalidate_cloud_key` in `key-request.sh` allowed `.` characters, enabling `..` traversal. Removed dots from character class.
- **Rate limit bypass via spoofable x-forwarded-for (HIGH):** Rate limiting in `key-server.ts` used spoofable header. Replaced with `server.requestIP(req)` for actual TCP connection IP.
- **Python expression injection in _extract_json_field (HIGH):** Added blocklist validation rejecting dangerous patterns while preserving all legitimate callers.

## Test plan

- [x] `bash -n` passes on all modified .sh files
- [x] `bash test/run.sh` passes (80/80 tests)
- [x] All 5 legitimate `_extract_json_field` caller expressions verified working
- [x] All 11 malicious expression patterns verified blocked

Medium/low findings documented in `.docs/SECURITY_AUDIT_2026-02-16.md` (gitignored).

Security fixes.

-- refactor/security-auditor