### PR TITLE
fix: undefined help_url and unsafe JSON in shared/common.sh

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2552,7 +2552,8 @@ _multi_creds_prompt() {
 _multi_creds_validate() {
     local test_func="${1}"
     local provider_name="${2}"
-    shift 2
+    local help_url="${3}"
+    shift 3
 
     if [[ -z "${test_func}" ]]; then
         return 0
@@ -2623,7 +2624,7 @@ ensure_multi_credentials() {
     _multi_creds_prompt "${provider_name}" "${help_url}" "${n}" "${env_vars[@]}" "${labels[@]}" || return 1
 
     # 4. Validate credentials
-    _multi_creds_validate "${test_func}" "${provider_name}" "${env_vars[@]}" || return 1
+    _multi_creds_validate "${test_func}" "${provider_name}" "${help_url}" "${env_vars[@]}" || return 1
 
     # 5. Save to config file
     local save_args=()
@@ -3150,13 +3151,13 @@ save_vm_connection() {
 
     local conn_file="${spawn_dir}/last-connection.json"
 
-    # Build JSON (handle optional fields)
-    local json="{\"ip\":\"${ip}\",\"user\":\"${user}\""
+    # Build JSON with proper escaping (handle optional fields)
+    local json="{\"ip\":$(json_escape "${ip}"),\"user\":$(json_escape "${user}")"
     if [[ -n "${server_id}" ]]; then
-        json="${json},\"server_id\":\"${server_id}\""
+        json="${json},\"server_id\":$(json_escape "${server_id}")"
     fi
     if [[ -n "${server_name}" ]]; then
-        json="${json},\"server_name\":\"${server_name}\""
+        json="${json},\"server_name\":$(json_escape "${server_name}")"
     fi
     json="${json}}"
 


### PR DESCRIPTION
## Summary
- **`_multi_creds_validate` undefined `help_url`**: The function referenced `${help_url}` (line 2567) but never received it as a parameter. This caused OVH users who fail credential validation to see a broken error message with an empty URL instead of `https://api.ovh.com/createToken/`. Fixed by passing `help_url` from `ensure_multi_credentials` as a third argument.
- **`save_vm_connection` missing `json_escape`**: The function used raw string interpolation (`"${ip}"`, `"${server_name}"`, etc.) to build JSON, which could produce invalid JSON if any values contained special characters like `"` or `\`. Fixed by using the existing `json_escape` function (which was already available and used elsewhere, e.g., in `_save_json_config`).

## Test plan
- [x] `bash -n shared/common.sh` passes (syntax check)
- [x] `bash test/run.sh` passes (80/80 unit tests)
- [x] `bash test/mock.sh digitalocean` passes (75/75 mock tests)
- [x] Hetzner mock test failures are pre-existing (verified same failures on main branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)