### PR TITLE
fix: replace non-existent cloud names in CLI help examples

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -2114,9 +2114,9 @@ function getHelpExamplesSection(): string {
   spawn claude sprite --prompt "Fix all linter errors"
                                      ${pc.dim("# Execute Claude with prompt and exit")}
   spawn aider sprite -p "Add tests"  ${pc.dim("# Short form of --prompt")}
-  spawn openclaw vultr -f instructions.txt
+  spawn openclaw digitalocean -f instructions.txt
                                      ${pc.dim("# Read prompt from file (short for --prompt-file)")}
-  spawn interpreter linode --dry-run ${pc.dim("# Preview without provisioning")}
+  spawn interpreter gcp --dry-run    ${pc.dim("# Preview without provisioning")}
   spawn claude                       ${pc.dim("# Show which clouds support Claude")}
   spawn hetzner                      ${pc.dim("# Show which agents run on Hetzner")}
   spawn list                         ${pc.dim("# Browse history and pick one to rerun")}


### PR DESCRIPTION
## Summary
- The `spawn help` EXAMPLES section referenced `vultr` and `linode` as cloud providers, but neither exists in `manifest.json`
- Users running these example commands would get confusing "unknown cloud" errors
- Replaced with `digitalocean` and `gcp` which are valid, implemented clouds

## Changes
- `cli/src/commands.ts`: Updated `getHelpExamplesSection()` to use real cloud names
  - `spawn openclaw vultr` -> `spawn openclaw digitalocean`
  - `spawn interpreter linode` -> `spawn interpreter gcp`

## Test plan
- [x] All 925 commands-related tests pass
- [x] Verified `digitalocean` and `gcp` are both in `manifest.json` with implemented matrix entries
- [x] No test files assert on the specific help example text (test fixtures use vultr/linode as generic test data, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)