### PR TITLE
fix: stop creating ~/.bash_profile — was destroying system PATH

### DIFF
--- a/cli/src/__tests__/shared-common-env-inject.test.ts
+++ b/cli/src/__tests__/shared-common-env-inject.test.ts
@@ -156,7 +156,7 @@ inject_env_vars_local mock_upload mock_run "MY_KEY=my_value"
     // inject_env_vars_local does NOT pass server_ip - upload gets (local_path, remote_path)
     expect(result.stdout).toContain("UPLOAD_ARGS:");
     expect(result.stdout).toContain("/tmp/env_config");
-    expect(result.stdout).toContain("for rc in ~/.profile ~/.bash_profile ~/.bashrc ~/.zshrc ~/.zprofile; do cat /tmp/env_config >>");
+    expect(result.stdout).toContain("cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc");
   });
 
   it("should generate correct env config content", () => {

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -378,9 +378,10 @@ inject_env_vars_fly() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .profile, .bash_profile, .bashrc, and .zshrc
+    # Upload and append to .profile, .bashrc, .zshrc ONLY.
+    # CRITICAL: Do NOT write to ~/.bash_profile or ~/.zprofile — see shared/common.sh.
     upload_file "${env_temp}" "/tmp/env_config"
-    run_server "for rc in ~/.profile ~/.bash_profile ~/.bashrc ~/.zshrc ~/.zprofile; do cat /tmp/env_config >> \"\$rc\"; done && rm /tmp/env_config"
+    run_server "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
 
     # Note: temp file will be cleaned up by trap handler
 }

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -178,8 +178,8 @@ setup_shell_environment() {
 export PATH="${HOME}/.bun/bin:/.sprite/languages/bun/bin:${PATH}"
 EOF
 
-    # Upload and append to shell configs
-    sprite exec -s "${sprite_name}" -file "${path_temp}:/tmp/path_config" -- bash -c "cat /tmp/path_config >> ~/.zprofile && cat /tmp/path_config >> ~/.zshrc && rm /tmp/path_config"
+    # Upload and append to .profile and .zshrc ONLY (not .zprofile)
+    sprite exec -s "${sprite_name}" -file "${path_temp}:/tmp/path_config" -- bash -c "cat /tmp/path_config >> ~/.profile && cat /tmp/path_config >> ~/.zshrc && rm /tmp/path_config"
 
     # Switch bash to zsh
     local bash_temp
@@ -209,8 +209,9 @@ inject_env_vars_sprite() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .profile, .bash_profile, .bashrc, and .zshrc using sprite exec
-    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "for rc in ~/.profile ~/.bash_profile ~/.bashrc ~/.zshrc ~/.zprofile; do cat /tmp/env_config >> \"\$rc\"; done && rm /tmp/env_config"
+    # Upload and append to .profile, .bashrc, .zshrc ONLY using sprite exec.
+    # CRITICAL: Do NOT write to ~/.bash_profile or ~/.zprofile — see shared/common.sh.
+    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
     trap - EXIT
 
     # Offer optional GitHub CLI setup


### PR DESCRIPTION
## Summary

- **Root cause**: `inject_env_vars_*` functions and `_finalize_claude_install` wrote to `~/.bash_profile` and `~/.zprofile`. On Ubuntu/Debian, these files don't exist. Creating `~/.bash_profile` causes `bash -l` to source it INSTEAD of `~/.profile`, skipping the standard PATH setup (`/usr/bin`, `/bin`, etc.).
- **Fix**: All env injection functions now write ONLY to `~/.profile`, `~/.bashrc`, `~/.zshrc` — the standard files that work on all Linux distros.
- **Scope**: `shared/common.sh` (4 functions), `fly/lib/common.sh`, `sprite/lib/common.sh`, and the env injection test.

## Files changed

| File | Change |
|------|--------|
| `shared/common.sh` | `inject_env_vars_ssh`, `inject_env_vars_local`, `inject_env_vars_cb`, `_finalize_claude_install` — removed `.bash_profile`/`.zprofile` from all write targets |
| `fly/lib/common.sh` | `inject_env_vars_fly` — same fix |
| `sprite/lib/common.sh` | `inject_env_vars_sprite` + `setup_shell_environment` — same fix (note: `setup_shell_environment` intentionally writes `.bash_profile` to redirect bash->zsh, which is a different use case) |
| `cli/src/__tests__/shared-common-env-inject.test.ts` | Updated assertion to match new command format |

## Test plan

- [x] `bash -n` passes on all modified .sh files
- [x] `bun test cli/src/__tests__/shared-common-env-inject.test.ts` — 54/54 pass
- [x] `bash test/run.sh` — 80/80 pass
- [ ] Manual test: deploy Claude Code on Hetzner, verify `ls`, `cat` etc. work after deployment

Generated with [Claude Code](https://claude.com/claude-code)