### PR TITLE
fix: stop creating ~/.bash_profile — was destroying system PATH

### DIFF
--- a/cli/src/__tests__/shared-common-env-inject.test.ts
+++ b/cli/src/__tests__/shared-common-env-inject.test.ts
@@ -156,7 +156,7 @@ inject_env_vars_local mock_upload mock_run "MY_KEY=my_value"
     // inject_env_vars_local does NOT pass server_ip - upload gets (local_path, remote_path)
     expect(result.stdout).toContain("UPLOAD_ARGS:");
     expect(result.stdout).toContain("/tmp/env_config");
-    expect(result.stdout).toContain("for rc in ~/.profile ~/.bash_profile ~/.bashrc ~/.zshrc ~/.zprofile; do cat /tmp/env_config >>");
+    expect(result.stdout).toContain("cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc");
   });
 
   it("should generate correct env config content", () => {

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -378,9 +378,10 @@ inject_env_vars_fly() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .profile, .bash_profile, .bashrc, and .zshrc
+    # Upload and append to .profile, .bashrc, .zshrc ONLY.
+    # CRITICAL: Do NOT write to ~/.bash_profile or ~/.zprofile — see shared/common.sh.
     upload_file "${env_temp}" "/tmp/env_config"
-    run_server "for rc in ~/.profile ~/.bash_profile ~/.bashrc ~/.zshrc ~/.zprofile; do cat /tmp/env_config >> \"\$rc\"; done && rm /tmp/env_config"
+    run_server "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
 
     # Note: temp file will be cleaned up by trap handler
 }

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -178,8 +178,8 @@ setup_shell_environment() {
 export PATH="${HOME}/.bun/bin:/.sprite/languages/bun/bin:${PATH}"
 EOF
 
-    # Upload and append to shell configs
-    sprite exec -s "${sprite_name}" -file "${path_temp}:/tmp/path_config" -- bash -c "cat /tmp/path_config >> ~/.zprofile && cat /tmp/path_config >> ~/.zshrc && rm /tmp/path_config"
+    # Upload and append to .profile and .zshrc ONLY (not .zprofile)
+    sprite exec -s "${sprite_name}" -file "${path_temp}:/tmp/path_config" -- bash -c "cat /tmp/path_config >> ~/.profile && cat /tmp/path_config >> ~/.zshrc && rm /tmp/path_config"
 
     # Switch bash to zsh
     local bash_temp
@@ -209,8 +209,9 @@ inject_env_vars_sprite() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .profile, .bash_profile, .bashrc, and .zshrc using sprite exec
-    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "for rc in ~/.profile ~/.bash_profile ~/.bashrc ~/.zshrc ~/.zprofile; do cat /tmp/env_config >> \"\$rc\"; done && rm /tmp/env_config"
+    # Upload and append to .profile, .bashrc, .zshrc ONLY using sprite exec.
+    # CRITICAL: Do NOT write to ~/.bash_profile or ~/.zprofile — see shared/common.sh.
+    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
     trap - EXIT
 
     # Offer optional GitHub CLI setup


### PR DESCRIPTION
## Summary

**Critical fix**: env var injection and Claude Code install were creating `~/.bash_profile` on Ubuntu servers, which completely destroyed the system PATH (even `ls` stopped working).

### Root Cause

On Ubuntu/Debian, `~/.bash_profile` does **not** exist by default. `bash -l` sources the **first** of:
1. `~/.bash_profile`
2. `~/.bash_login`  
3. `~/.profile`

Ubuntu's `~/.profile` sets up the standard PATH (`/usr/bin:/bin`) and sources `~/.bashrc`. When our code created `~/.bash_profile` (via `>>` redirection or `touch`), bash sourced it instead of `~/.profile`, losing all standard PATH setup.

### Fix

Only write to `~/.profile`, `~/.bashrc`, `~/.zshrc` — these always exist on Linux and don't interfere with the login shell initialization chain. Removed all references to `~/.bash_profile` and `~/.zprofile` from:
- `inject_env_vars_ssh`
- `inject_env_vars_local`  
- `inject_env_vars_cb`
- `_finalize_claude_install`
- `inject_env_vars_fly`
- `inject_env_vars_sprite`

## Test plan

- [x] `bash -n` on all modified .sh files
- [x] `bash test/run.sh` — 80/80 pass
- [x] `bun test shared-common-env-inject` — 54/54 pass
- [ ] Manual: `spawn claude hetzner` — verify `ls`, `which`, `claude` all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)