### PR TITLE
fix: revert .profile writes, simplify Claude Code install and launch

### DIFF
--- a/aws-lightsail/claude.sh
+++ b/aws-lightsail/claude.sh
@@ -69,4 +69,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${LIGHTSAIL_SERVER_IP}" "bash -lc claude"
+interactive_session "${LIGHTSAIL_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude'

--- a/cli/src/__tests__/shared-common-env-inject.test.ts
+++ b/cli/src/__tests__/shared-common-env-inject.test.ts
@@ -156,7 +156,7 @@ inject_env_vars_local mock_upload mock_run "MY_KEY=my_value"
     // inject_env_vars_local does NOT pass server_ip - upload gets (local_path, remote_path)
     expect(result.stdout).toContain("UPLOAD_ARGS:");
     expect(result.stdout).toContain("/tmp/env_config");
-    expect(result.stdout).toContain("cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc");
+    expect(result.stdout).toContain("cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc");
   });
 
   it("should generate correct env config content", () => {

--- a/daytona/claude.sh
+++ b/daytona/claude.sh
@@ -64,4 +64,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "bash -lc claude"
+interactive_session 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude'

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -72,4 +72,4 @@ save_vm_connection "${DO_SERVER_IP}" "root" "${DO_DROPLET_ID}" "${DROPLET_NAME}"
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${DO_SERVER_IP}" "bash -lc claude"
+interactive_session "${DO_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude'

--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -63,4 +63,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "bash -lc claude"
+interactive_session 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude'

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -378,10 +378,9 @@ inject_env_vars_fly() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .profile, .bashrc, .zshrc ONLY.
-    # CRITICAL: Do NOT write to ~/.bash_profile or ~/.zprofile — see shared/common.sh.
+    # Append to .bashrc and .zshrc only
     upload_file "${env_temp}" "/tmp/env_config"
-    run_server "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    run_server "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
 
     # Note: temp file will be cleaned up by trap handler
 }

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -72,4 +72,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${GCP_SERVER_IP}" "bash -lc claude"
+interactive_session "${GCP_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude'

--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -42,4 +42,4 @@ inject_env_vars_cb "$RUN" "$UPLOAD" \
 # Claude-specific config
 setup_claude_code_config "${OPENROUTER_API_KEY}" "$UPLOAD" "$RUN"
 
-launch_session "Hetzner server" "$SESSION" "bash -lc claude"
+launch_session "Hetzner server" "$SESSION" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude'

--- a/local/claude.sh
+++ b/local/claude.sh
@@ -61,14 +61,16 @@ echo ""
 # 6. Start Claude Code
 if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     log_step "Executing Claude Code with prompt..."
-    export PATH="${HOME}/.local/bin:${PATH}"
+    export PATH="${HOME}/.claude/local/bin:${HOME}/.local/bin:${HOME}/.bun/bin:${PATH}"
+    source ~/.bashrc 2>/dev/null || true
     source ~/.zshrc 2>/dev/null || true
     claude -p "${SPAWN_PROMPT}"
 else
     log_step "Starting Claude Code..."
     sleep 1
     clear 2>/dev/null || true
-    export PATH="${HOME}/.local/bin:${PATH}"
+    export PATH="${HOME}/.claude/local/bin:${HOME}/.local/bin:${HOME}/.bun/bin:${PATH}"
+    source ~/.bashrc 2>/dev/null || true
     source ~/.zshrc 2>/dev/null || true
     exec claude
 fi

--- a/oracle/claude.sh
+++ b/oracle/claude.sh
@@ -72,4 +72,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${OCI_SERVER_IP}" "bash -lc claude"
+interactive_session "${OCI_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude'

--- a/ovh/claude.sh
+++ b/ovh/claude.sh
@@ -70,4 +70,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${OVH_SERVER_IP}" "bash -lc claude"
+interactive_session "${OVH_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude'

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1090,10 +1090,9 @@ inject_env_vars_ssh() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Append to .profile, .bashrc, .zshrc only — NEVER create ~/.bash_profile
-    # (creating it makes bash -l skip ~/.profile, destroying the standard PATH)
+    # Append to .bashrc and .zshrc only — do NOT write to .profile or .bash_profile
     "${upload_func}" "${server_ip}" "${env_temp}" "/tmp/env_config"
-    "${run_func}" "${server_ip}" "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    "${run_func}" "${server_ip}" "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
 
     # Note: temp file will be cleaned up by trap handler
 
@@ -1119,9 +1118,9 @@ inject_env_vars_local() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Append to .profile, .bashrc, .zshrc only — never .bash_profile
+    # Append to .bashrc and .zshrc only
     "${upload_func}" "${env_temp}" "/tmp/env_config"
-    "${run_func}" "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    "${run_func}" "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
 
     # Note: temp file will be cleaned up by trap handler
 
@@ -1264,15 +1263,15 @@ install_claude_code() {
     # Include fnm paths so node is found even in non-interactive SSH sessions
     local claude_path='export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$HOME/.local/share/fnm:$PATH; if command -v fnm >/dev/null 2>&1; then eval "$(fnm env)"; fi'
 
-    # Finalize: set up shell integration and persist PATH to .profile/.bashrc/.zshrc.
-    # NEVER write to ~/.bash_profile — creating it breaks Ubuntu's login shell chain.
+    # Finalize: set up shell integration and persist PATH to .bashrc/.zshrc.
+    # Do NOT write to ~/.profile or ~/.bash_profile — it breaks shell init on Ubuntu.
     _finalize_claude_install() {
         log_step "Setting up Claude Code shell integration..."
         ${run_cb} "${claude_path} && claude install --force" >/dev/null 2>&1 || true
-        # Write claude PATH to .profile (login shells), .bashrc, .zshrc
-        ${run_cb} "for rc in ~/.profile ~/.bashrc ~/.zshrc; do grep -q '.claude/local/bin' \"\$rc\" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH=\"\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"\\n' >> \"\$rc\"; done" >/dev/null 2>&1 || true
+        # Write claude PATH to .bashrc and .zshrc
+        ${run_cb} "for rc in ~/.bashrc ~/.zshrc; do grep -q '.claude/local/bin' \"\$rc\" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH=\"\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"\\n' >> \"\$rc\"; done" >/dev/null 2>&1 || true
         # Ensure fnm bootstrap is in shell configs so new shells can find node
-        ${run_cb} "if command -v fnm >/dev/null 2>&1 || test -d \$HOME/.local/share/fnm; then for rc in ~/.profile ~/.bashrc ~/.zshrc; do grep -q 'fnm env' \"\$rc\" 2>/dev/null || printf '\\n# fnm (node version manager)\\nexport PATH=\"\$HOME/.local/share/fnm:\$PATH\"\\nif command -v fnm >/dev/null 2>&1; then eval \"\\\$(fnm env)\"; fi\\n' >> \"\$rc\"; done; fi" >/dev/null 2>&1 || true
+        ${run_cb} "if command -v fnm >/dev/null 2>&1 || test -d \$HOME/.local/share/fnm; then for rc in ~/.bashrc ~/.zshrc; do grep -q 'fnm env' \"\$rc\" 2>/dev/null || printf '\\n# fnm (node version manager)\\nexport PATH=\"\$HOME/.local/share/fnm:\$PATH\"\\nif command -v fnm >/dev/null 2>&1; then eval \"\\\$(fnm env)\"; fi\\n' >> \"\$rc\"; done; fi" >/dev/null 2>&1 || true
     }
 
     # Already installed?
@@ -1376,7 +1375,7 @@ inject_env_vars_cb() {
     generate_env_config "$@" > "${env_temp}"
 
     ${upload_cb} "${env_temp}" "/tmp/env_config"
-    ${run_cb} "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    ${run_cb} "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
 
     # Offer optional GitHub CLI setup
     offer_github_auth "${run_cb}"

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -70,11 +70,11 @@ if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
 
     # Execute without -tty flag
-    sprite exec -s "${SPRITE_NAME}" -- bash -lc "claude -p ${escaped_prompt}"
+    sprite exec -s "${SPRITE_NAME}" -- bash -c "export PATH=\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude -p ${escaped_prompt}"
 else
     # Interactive mode: start Claude Code normally
     log_step "Starting Claude Code..."
     sleep 1
     clear 2>/dev/null || true
-    sprite exec -s "${SPRITE_NAME}" -tty -- bash -lc claude
+    sprite exec -s "${SPRITE_NAME}" -tty -- bash -c 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH && source ~/.bashrc 2>/dev/null; source ~/.zshrc 2>/dev/null; claude'
 fi

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -178,8 +178,8 @@ setup_shell_environment() {
 export PATH="${HOME}/.bun/bin:/.sprite/languages/bun/bin:${PATH}"
 EOF
 
-    # Upload and append to .profile and .zshrc ONLY (not .zprofile)
-    sprite exec -s "${sprite_name}" -file "${path_temp}:/tmp/path_config" -- bash -c "cat /tmp/path_config >> ~/.profile && cat /tmp/path_config >> ~/.zshrc && rm /tmp/path_config"
+    # Upload and append to .bashrc and .zshrc only
+    sprite exec -s "${sprite_name}" -file "${path_temp}:/tmp/path_config" -- bash -c "cat /tmp/path_config >> ~/.bashrc && cat /tmp/path_config >> ~/.zshrc && rm /tmp/path_config"
 
     # Switch bash to zsh
     local bash_temp
@@ -209,9 +209,8 @@ inject_env_vars_sprite() {
 
     generate_env_config "$@" > "${env_temp}"
 
-    # Upload and append to .profile, .bashrc, .zshrc ONLY using sprite exec.
-    # CRITICAL: Do NOT write to ~/.bash_profile or ~/.zprofile — see shared/common.sh.
-    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.profile && cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+    # Append to .bashrc and .zshrc only
+    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
     trap - EXIT
 
     # Offer optional GitHub CLI setup


### PR DESCRIPTION
## Summary
- **Stop writing to ~/.profile entirely** — env vars and PATH entries now only go to `.bashrc` and `.zshrc`. Writing to `.profile` caused issues because login shells source it inconsistently, and creating `.bash_profile` makes `bash -l` skip `.profile` entirely on Ubuntu.
- **Replace `bash -lc claude` with explicit PATH export** in all cloud provider launch commands. The new pattern (`export PATH=...; source ~/.bashrc; source ~/.zshrc; claude`) ensures claude is found regardless of shell initialization quirks.
- **Update test assertions** to match the new 2-file (.bashrc/.zshrc) pattern.

## Files changed (14)
- `shared/common.sh` — `inject_env_vars_ssh`, `inject_env_vars_local`, `inject_env_vars_cb`, `_finalize_claude_install`
- `fly/lib/common.sh` — `inject_env_vars_fly`
- `sprite/lib/common.sh` — `inject_env_vars_sprite`, `setup_shell_environment`
- All `*/claude.sh` (9 files) — launch commands
- `cli/src/__tests__/shared-common-env-inject.test.ts` — test assertions

## Test plan
- [x] `bash -n` syntax check on all 13 modified .sh files
- [x] `bash test/run.sh` — 80 passed, 0 failed
- [x] `bun test shared-common-env-inject.test.ts` — 54 passed, 0 failed
- [ ] Manual test on Hetzner to verify end-to-end Claude Code launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)