### PR TITLE
fix: install Node.js runtime before bun method (npm package needs node)

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1292,6 +1292,16 @@ install_claude_code() {
         log_warn "curl installer failed (site may be temporarily unavailable)"
     fi
 
+    # Ensure Node.js runtime for bun-installed package (it's a Node.js script)
+    if ! ${run_cb} "${claude_path} && command -v node" >/dev/null 2>&1; then
+        log_step "Installing Node.js runtime (required for claude package)..."
+        if ${run_cb} "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs" >/dev/null 2>&1; then
+            log_info "Node.js installed via nodesource"
+        else
+            log_warn "Could not install Node.js - bun method may fail"
+        fi
+    fi
+
     # Method 2: bun
     log_step "Installing Claude Code (method 2/2: bun)..."
     if ${run_cb} "${claude_path} && bun i -g @anthropic-ai/claude-code 2>&1" 2>&1; then


### PR DESCRIPTION
## Summary

Fixes the "node: No such file or directory" error when Claude Code is installed via bun.

## Root Cause

- `bun i -g @anthropic-ai/claude-code` installs the npm package to `~/.bun/bin/claude`
- The npm package is a Node.js script with `#!/usr/bin/env node` shebang
- When you run `claude`, it tries to execute with `node` - but node wasn't installed

## Fix

Before attempting the bun install method, check if node exists. If not, install it via nodesource (Debian/Ubuntu LTS).

## Flow Now

1. **Method 1**: curl installer (standalone binary, no node needed)
2. **Install node if missing** (required for method 2)
3. **Method 2**: bun i -g (npm package, needs node runtime)

Tested on Hetzner with fresh Ubuntu server.