### PR TITLE
security: fix remaining medium-severity vulnerabilities from issue #763

### DIFF
--- a/.claude/skills/setup-agent-team/key-server.ts
+++ b/.claude/skills/setup-agent-team/key-server.ts
@@ -327,7 +327,7 @@ const UUID_RE =
 // --- Server ---
 const server = Bun.serve({
   port: PORT,
-  async fetch(req) {
+  async fetch(req, server) {
     const url = new URL(req.url);
     const path = url.pathname;
 
@@ -465,9 +465,8 @@ const server = Bun.serve({
 
       // POST — submit keys (rate-limited)
       if (req.method === "POST") {
-        const ip =
-          req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-          "unknown";
+        // SECURITY: Use actual client IP from server object, not spoofable x-forwarded-for header
+        const ip = server.requestIP(req)?.address ?? "unknown";
         let retry = rateCheck(ip, rateMaps.ip, 10, 15 * 60_000);
         if (retry !== null)
           return new Response("Too many requests", {

--- a/shared/key-request.sh
+++ b/shared/key-request.sh
@@ -191,20 +191,22 @@ print(json.dumps(providers))
 
     log "Key preflight: Requesting keys for: ${MISSING_KEY_PROVIDERS}"
 
-    # Fire-and-forget — don't block the QA cycle, but log failures
+    # Fire-and-forget with timeout watchdog — don't block the QA cycle, but log failures
+    # SECURITY: Wrap in timeout to prevent subprocess leak if curl hangs despite --max-time
     (
-        local http_code
-        http_code=$(curl -s -o /dev/stderr -w '%{http_code}' --max-time 10 \
-            -X POST "${key_server_url}/request-batch" \
-            -H "Authorization: Bearer ${key_server_secret}" \
-            -H "Content-Type: application/json" \
-            -d "{\"providers\": ${providers_json}}" 2>/dev/null) || http_code="000"
-        case "${http_code}" in
-            2*) ;; # success
-            000) log "Key preflight: WARNING — key-server unreachable at ${key_server_url}" ;;
-            401) log "Key preflight: WARNING — 401 Unauthorized (check KEY_SERVER_SECRET)" ;;
-            *)   log "Key preflight: WARNING — key-server returned HTTP ${http_code}" ;;
-        esac
+        timeout 15 bash -c '
+            http_code=$(curl -s -o /dev/stderr -w "%{http_code}" --max-time 10 \
+                -X POST "'"${key_server_url}"'/request-batch" \
+                -H "Authorization: Bearer '"${key_server_secret}"'" \
+                -H "Content-Type: application/json" \
+                -d "{\"providers\": '"${providers_json}"'}" 2>/dev/null) || http_code="000"
+            case "${http_code}" in
+                2*) ;; # success
+                000) echo "Key preflight: WARNING — key-server unreachable at '"${key_server_url}"'" >&2 ;;
+                401) echo "Key preflight: WARNING — 401 Unauthorized (check KEY_SERVER_SECRET)" >&2 ;;
+                *)   echo "Key preflight: WARNING — key-server returned HTTP ${http_code}" >&2 ;;
+            esac
+        ' || log "Key preflight: WARNING — request timed out after 15s"
     ) &
 }
 
@@ -214,7 +216,8 @@ invalidate_cloud_key() {
     local provider="${1}"
 
     # Validate provider name to prevent path traversal
-    if [[ ! "${provider}" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]]; then
+    # SECURITY: Block dots to prevent relative path components like "foo..bar" or ".."
+    if [[ ! "${provider}" =~ ^[a-z0-9][a-z0-9_-]{0,63}$ ]]; then
         log "invalidate_cloud_key: invalid provider name: ${provider}"
         return 1
     fi


### PR DESCRIPTION
## Summary
Addresses three MEDIUM severity findings from the February 12, 2026 security scan (issue #763):

1. **Rate limiting spoofing** (key-server.ts) — MEDIUM severity
2. **Path traversal validation** (key-request.sh) — MEDIUM severity  
3. **Background process timeout** (key-request.sh) — MEDIUM severity

## Changes

### 1. Rate Limiting Spoofable Header Fix
**File:** `.claude/skills/setup-agent-team/key-server.ts`

**Issue:** Rate limiting used `x-forwarded-for` header which can be trivially spoofed by attackers to bypass rate limits.

**Fix:**
- Changed from `req.headers.get("x-forwarded-for")` to `server.requestIP(req)?.address`
- Uses actual client IP from Bun's server object (second parameter to fetch handler)
- Prevents attackers from bypassing rate limits with crafted headers

```diff
- const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+ // SECURITY: Use actual client IP from server object, not spoofable x-forwarded-for header
+ const ip = server.requestIP(req)?.address ?? "unknown";
```

### 2. Path Traversal Validation Fix
**File:** `shared/key-request.sh`

**Issue:** Provider name validation allowed dots (`^[a-z0-9][a-z0-9._-]{0,63}$`), which could permit relative path components like `foo..bar` to escape `~/.config/spawn/` directory.

**Fix:**
- Removed `.` from allowed characters: `^[a-z0-9][a-z0-9_-]{0,63}$`
- Blocks relative path components like `"foo..bar"` or `".."`
- Prevents path traversal attacks in `invalidate_cloud_key()`

```diff
- if [[ ! "${provider}" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]]; then
+ # SECURITY: Block dots to prevent relative path components like "foo..bar" or ".."
+ if [[ ! "${provider}" =~ ^[a-z0-9][a-z0-9_-]{0,63}$ ]]; then
```

### 3. Background Process Timeout Fix
**File:** `shared/key-request.sh`

**Issue:** Fire-and-forget background curl had `--max-time 10` but ran in a subshell that never reported errors. Could leak subprocess if curl hangs.

**Fix:**
- Added `timeout 15` watchdog wrapper around the entire subshell
- Provides defense-in-depth if curl's internal timeout fails
- Logs timeout warning for debugging
- Prevents subprocess leak in edge cases

```diff
+ # SECURITY: Wrap in timeout to prevent subprocess leak if curl hangs despite --max-time
  (
-     local http_code
-     http_code=$(curl -s -o /dev/stderr -w '%{http_code}' --max-time 10 \
-         ...
-     ) &
+     timeout 15 bash -c '
+         http_code=$(curl -s -o /dev/stderr -w "%{http_code}" --max-time 10 \
+             ...
+     ' || log "Key preflight: WARNING — request timed out after 15s"
+ ) &
```

## Testing

- Syntax validation: `bash -n shared/key-request.sh` passes
- All changes include inline security comments documenting the rationale
- Changes are minimal and focused on the specific security issues

## Impact

All three fixes are defense-in-depth improvements with no breaking changes to functionality:
- Rate limiting is now properly enforced using actual client IPs
- Path traversal attacks are blocked in key invalidation
- Background processes have proper timeout guards

## Related

- Issue #763 — Security batch of medium/low findings from scan (Feb 12 2026)
- This PR completes the remaining MEDIUM severity items tracked in that issue

---

🤖 Generated by [refactor/security-auditor](https://github.com/OpenRouterTeam/spawn)