### PR TITLE
test: fix readonly property errors and test expectations

### DIFF
--- a/cli/src/__tests__/commands-compact-list.test.ts
+++ b/cli/src/__tests__/commands-compact-list.test.ts
@@ -195,7 +195,11 @@ describe("Compact List View", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.stdout.columns = originalColumns!;
+    Object.defineProperty(process.stdout, "columns", {
+      value: originalColumns,
+      writable: true,
+      configurable: true,
+    });
     restoreMocks(consoleMocks.log, consoleMocks.error);
   });
 
@@ -214,13 +218,21 @@ describe("Compact List View", () => {
       .join("\n");
   }
 
+  function setTerminalWidth(width: number | undefined) {
+    Object.defineProperty(process.stdout, "columns", {
+      value: width,
+      writable: true,
+      configurable: true,
+    });
+  }
+
   // ── View switching based on terminal width ──────────────────────────
 
   describe("grid vs compact view switching", () => {
     it("should use compact view when terminal is narrow and many clouds", async () => {
       await setManifest(wideManifest);
       // Force narrow terminal - compact view triggered
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -233,7 +245,7 @@ describe("Compact List View", () => {
     it("should use grid view when terminal is wide enough for small manifest", async () => {
       await setManifest(mockManifest);
       // Force wide terminal
-      process.stdout.columns = 200;
+      setTerminalWidth(200);
 
       await cmdMatrix();
       const output = getOutput();
@@ -248,7 +260,7 @@ describe("Compact List View", () => {
     it("should default to 80 columns when process.stdout.columns is undefined", async () => {
       await setManifest(wideManifest);
       // Simulate no tty (columns undefined)
-      (process.stdout as any).columns = undefined;
+      setTerminalWidth(undefined);
 
       await cmdMatrix();
       const output = getOutput();
@@ -264,7 +276,7 @@ describe("Compact List View", () => {
   describe("compact view header", () => {
     it("should show three column headers: Agent, Clouds, Not yet available", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -275,7 +287,7 @@ describe("Compact List View", () => {
 
     it("should include a separator line with dashes", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -289,7 +301,7 @@ describe("Compact List View", () => {
   describe("compact view counts", () => {
     it("should show correct count for fully implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -299,7 +311,7 @@ describe("Compact List View", () => {
 
     it("should show correct count for partially implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -309,7 +321,7 @@ describe("Compact List View", () => {
 
     it("should show 0/N when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -318,7 +330,7 @@ describe("Compact List View", () => {
 
     it("should show N/N for all agents when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -335,7 +347,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds column", () => {
     it("should show 'all clouds supported' when agent is fully implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -345,7 +357,7 @@ describe("Compact List View", () => {
 
     it("should list missing cloud names when agent is partially implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -359,7 +371,7 @@ describe("Compact List View", () => {
 
     it("should not list implemented clouds as missing", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -378,7 +390,7 @@ describe("Compact List View", () => {
 
     it("should list all clouds as missing when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -394,7 +406,7 @@ describe("Compact List View", () => {
 
     it("should show 'all clouds supported' for every agent when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -410,7 +422,7 @@ describe("Compact List View", () => {
   describe("compact view agent names", () => {
     it("should display agent display names (not keys)", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -424,7 +436,7 @@ describe("Compact List View", () => {
   describe("footer in compact view", () => {
     it("should show total implemented count", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -434,7 +446,7 @@ describe("Compact List View", () => {
 
     it("should not show grid legend in compact view", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -445,7 +457,7 @@ describe("Compact List View", () => {
 
     it("should show usage hints", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -472,7 +484,7 @@ describe("Compact List View", () => {
         },
       };
       await setManifest(singleAgent);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -488,7 +500,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds formatting", () => {
     it("should separate missing cloud names with commas", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const lines = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" "));

--- a/cli/src/__tests__/commands-utils.test.ts
+++ b/cli/src/__tests__/commands-utils.test.ts
@@ -157,31 +157,35 @@ describe("Command Utility Functions", () => {
     });
 
     afterEach(() => {
-      process.stdout.columns = originalColumns!;
+      Object.defineProperty(process.stdout, "columns", {
+        value: originalColumns,
+        writable: true,
+        configurable: true,
+      });
     });
 
     it("should return process.stdout.columns when defined", () => {
-      process.stdout.columns = 120;
+      Object.defineProperty(process.stdout, "columns", { value: 120, writable: true, configurable: true });
       expect(getTerminalWidth()).toBe(120);
     });
 
     it("should return 80 when process.stdout.columns is undefined", () => {
-      (process.stdout as any).columns = undefined;
+      Object.defineProperty(process.stdout, "columns", { value: undefined, writable: true, configurable: true });
       expect(getTerminalWidth()).toBe(80);
     });
 
     it("should return 80 when process.stdout.columns is 0", () => {
-      (process.stdout as any).columns = 0;
+      Object.defineProperty(process.stdout, "columns", { value: 0, writable: true, configurable: true });
       expect(getTerminalWidth()).toBe(80);
     });
 
     it("should return the exact column count for narrow terminals", () => {
-      process.stdout.columns = 40;
+      Object.defineProperty(process.stdout, "columns", { value: 40, writable: true, configurable: true });
       expect(getTerminalWidth()).toBe(40);
     });
 
     it("should return the exact column count for very wide terminals", () => {
-      process.stdout.columns = 300;
+      Object.defineProperty(process.stdout, "columns", { value: 300, writable: true, configurable: true });
       expect(getTerminalWidth()).toBe(300);
     });
   });

--- a/cli/src/__tests__/oracle-provider-patterns.test.ts
+++ b/cli/src/__tests__/oracle-provider-patterns.test.ts
@@ -744,7 +744,7 @@ describe("Oracle claude.sh agent-specific patterns", () => {
   });
 
   it("should install Claude Code if not present", () => {
-    expect(claudeContent).toContain("claude.ai/install.sh");
+    expect(claudeContent).toContain("install_claude_code");
   });
 
   it("should set ANTHROPIC_BASE_URL for OpenRouter", () => {


### PR DESCRIPTION
## Summary

Fixed failing tests in the TypeScript test suite (8061 tests now pass with 0 failures).

- Fixed TypeError when attempting to assign to readonly `process.stdout.columns` property by using `Object.defineProperty()` instead
- Updated oracle-provider-patterns test expectation to match current implementation (uses `install_claude_code` helper instead of hardcoded script URL)
- Added helper function to manage readonly columns property in compact list view tests

## Test Results

- All 8061 TypeScript tests pass
- All 80 shell script tests pass
- No failing tests

## Files Changed

- `cli/src/__tests__/commands-compact-list.test.ts` - Fixed readonly property assignments, added helper
- `cli/src/__tests__/commands-utils.test.ts` - Fixed readonly property assignments  
- `cli/src/__tests__/oracle-provider-patterns.test.ts` - Updated test expectation for Claude Code install

🤖 Generated with [Claude Code](https://claude.com/claude-code)