### PR TITLE
fix: improve codebase reliability and security

### DIFF
--- a/.claude/skills/setup-agent-team/trigger-server.ts
+++ b/.claude/skills/setup-agent-team/trigger-server.ts
@@ -139,7 +139,9 @@ function reapAndEnforce() {
       );
       try {
         run.proc.kill(9);
-      } catch {}
+      } catch (err) {
+        console.error(`[trigger] Failed to kill process ${pid}:`, err);
+      }
       runs.delete(id);
     }
   }
@@ -168,7 +170,9 @@ function gracefulShutdown(signal: string) {
     for (const [, run] of runs) {
       try {
         run.proc.kill(9);
-      } catch {}
+      } catch (err) {
+        console.error(`[trigger] Failed to kill process ${run.proc.pid}:`, err);
+      }
     }
     process.exit(1);
   }, HARD_TIMEOUT_MS);

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -761,8 +761,18 @@ cleanup_oauth_session() {
         wait "${server_pid}" 2>/dev/null || true
     fi
 
+    # Validate oauth_dir before deletion to prevent catastrophic rm -rf
     if [[ -n "${oauth_dir}" && -d "${oauth_dir}" ]]; then
-        rm -rf "${oauth_dir}"
+        # Safety: Must be under /tmp and contain "oauth" or "spawn"
+        case "${oauth_dir}" in
+            /tmp/*oauth*|/tmp/*spawn*)
+                rm -rf "${oauth_dir}"
+                ;;
+            *)
+                log_error "Refusing to delete directory outside safe paths: ${oauth_dir}"
+                return 1
+                ;;
+        esac
     fi
 }
 

--- a/test/mock.sh
+++ b/test/mock.sh
@@ -403,13 +403,13 @@ _wait_with_timeout() {
         if [[ "$i" -ge "$timeout" ]]; then
             kill -9 "$pid" 2>/dev/null
             wait "$pid" 2>/dev/null || true
-            eval "${exit_code_var}=124"
+            printf -v "${exit_code_var}" 124
             return
         fi
         sleep 1
         i=$((i + 1))
     done
-    wait "$pid" 2>/dev/null || eval "${exit_code_var}=$?"
+    wait "$pid" 2>/dev/null || printf -v "${exit_code_var}" "$?"
 }
 
 # Run a script in a sandboxed environment with a 4-second timeout.


### PR DESCRIPTION
## Summary
- Fix shell injection vulnerability in test infrastructure
- Add path validation to prevent catastrophic rm -rf
- Improve error logging in trigger server

## Changes

### 1. Shell Injection Prevention (test/mock.sh)
**Problem:** Lines 406, 412 used `eval "${exit_code_var}=$?"` which is unsafe if `exit_code_var` ever becomes user-controlled.

**Fix:** Replace with `printf -v "${exit_code_var}" "$?"` for safe variable assignment.

**Impact:** Prevents potential command injection in test infrastructure.

### 2. Path Validation (shared/common.sh)
**Problem:** `cleanup_oauth_session()` called `rm -rf "${oauth_dir}"` without validating the path. If `oauth_dir` is empty, "/" or another critical path, catastrophic deletion could occur.

**Fix:** Add safety checks before deletion:
- Must be under /tmp
- Must contain "oauth" or "spawn" in path
- Log error and return 1 if validation fails

**Impact:** Prevents accidental deletion of critical directories.

### 3. Error Logging (trigger-server.ts)
**Problem:** Lines 140-142, 169-171 had empty catch blocks that swallow errors silently, making debugging impossible.

**Fix:** Log errors to stderr with context (PID, error message).

**Impact:** Improves debuggability of process lifecycle issues.

## Test Plan
- [x] Syntax validation: `bash -n test/mock.sh shared/common.sh`
- [x] All changes follow project conventions
- [ ] Run `bash test/mock.sh` to verify test infrastructure still works
- [ ] Manual test: Verify OAuth cleanup validates paths correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- refactor/code-health