### PR TITLE
fix: check saved config files before warning about missing credentials

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/credential-config-file.test.ts
+++ b/cli/src/__tests__/credential-config-file.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { credentialHints } from "../commands";
+
+/**
+ * Tests for config file detection in credential checking.
+ *
+ * Verifies that the CLI checks for saved config files (~/.config/spawn/{cloud}.json)
+ * before reporting credentials as missing.
+ *
+ * Fixes issue #1197: Hetzner missing credentials did not check for saved config
+ * Agent: ux-engineer
+ */
+
+describe("credentialHints with config files", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  let mockExistsSync: ReturnType<typeof mock>;
+
+  function setEnv(key: string, value: string): void {
+    savedEnv[key] = process.env[key];
+    process.env[key] = value;
+  }
+
+  function unsetEnv(key: string): void {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  beforeEach(() => {
+    // Mock fs.existsSync to control config file detection
+    const fs = require("fs");
+    mockExistsSync = mock((path: string) => {
+      // Return true for hetzner config, false for others
+      return path.includes("hetzner.json");
+    });
+    fs.existsSync = mockExistsSync;
+  });
+
+  afterEach(() => {
+    // Restore env vars
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    // Clear saved env for next test
+    for (const key of Object.keys(savedEnv)) {
+      delete savedEnv[key];
+    }
+
+    // Restore fs.existsSync
+    if (mockExistsSync) {
+      mockExistsSync.mockRestore();
+    }
+  });
+
+  describe("when config file exists but env var is not set", () => {
+    it("should not report cloud-specific token as missing", () => {
+      unsetEnv("HCLOUD_TOKEN");
+      unsetEnv("OPENROUTER_API_KEY");
+
+      const hints = credentialHints("hetzner", "HCLOUD_TOKEN");
+      const joined = hints.join("\n");
+
+      // Should only complain about OPENROUTER_API_KEY, not HCLOUD_TOKEN
+      expect(joined).toContain("OPENROUTER_API_KEY");
+      expect(joined).not.toContain("HCLOUD_TOKEN -- not set");
+      expect(joined).toContain("saved config");
+    });
+
+    it("should indicate credentials are set when only OpenRouter is missing but config exists", () => {
+      unsetEnv("HCLOUD_TOKEN");
+      setEnv("OPENROUTER_API_KEY", "sk-or-v1-test");
+
+      const hints = credentialHints("hetzner", "HCLOUD_TOKEN");
+      const joined = hints.join("\n");
+
+      expect(joined).toContain("Credentials appear to be set");
+      expect(joined).toContain("saved config");
+    });
+  });
+
+  describe("when config file does not exist", () => {
+    it("should report both tokens as missing", () => {
+      unsetEnv("DO_API_TOKEN");
+      unsetEnv("OPENROUTER_API_KEY");
+
+      const hints = credentialHints("digitalocean", "DO_API_TOKEN");
+      const joined = hints.join("\n");
+
+      expect(joined).toContain("Missing credentials");
+      expect(joined).toContain("DO_API_TOKEN");
+      expect(joined).toContain("OPENROUTER_API_KEY");
+      expect(joined).toContain("not set");
+    });
+  });
+
+  describe("when both env var and config file are available", () => {
+    it("should indicate all credentials are set", () => {
+      setEnv("HCLOUD_TOKEN", "test-token");
+      setEnv("OPENROUTER_API_KEY", "sk-or-v1-test");
+
+      const hints = credentialHints("hetzner", "HCLOUD_TOKEN");
+      const joined = hints.join("\n");
+
+      expect(joined).toContain("Credentials appear to be set");
+      expect(joined).toContain("saved config");
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1197

## Problem

When a user has a saved cloud provider token in `~/.config/spawn/{cloud}.json`, the CLI still shows "Missing credentials" warning even though the bash scripts will successfully load from the config file.

From the issue:
```
▲ Missing credentials for Hetzner Cloud: OPENROUTER_API_KEY, HCLOUD_TOKEN
...
Claude Code on Hetzner Cloud
Using Hetzner Cloud API token from /Users/lab/.config/spawn/hetzner.json
```

The user has `hetzner.json` saved, but the CLI's preflight check only looks at environment variables.

## Solution

Updated the credential checking logic to also check for saved config files:

1. **Added `hasCloudConfigFile()`** - checks if `~/.config/spawn/{cloud}.json` exists
2. **Updated `collectMissingCredentials()`** - skips cloud-specific vars when config file exists
3. **Updated `credentialHints()`** - shows "saved config" status in diagnostic output
4. **Added test coverage** - new test file for config file detection

## Changes

- `cli/src/commands.ts`: Added config file checking logic
- `cli/src/__tests__/credential-config-file.test.ts`: Test coverage for config file detection
- `cli/package.json`: Version bump to 0.2.89

## Behavior

**Before:** Shows HCLOUD_TOKEN as missing even when config file exists
**After:** Only shows OPENROUTER_API_KEY as missing (if not set), mentions "saved config"

The warning now accurately reflects what credentials the user needs to provide.

## Testing

Run the new test suite:
```bash
cd cli && bun test credential-config-file
```

Manual test:
1. Ensure `~/.config/spawn/hetzner.json` exists with valid token
2. Unset `HCLOUD_TOKEN` env var
3. Run `spawn claude hetzner`
4. Should not warn about HCLOUD_TOKEN being missing

-- refactor/ux-engineer