### PR TITLE
fix: use Object.defineProperty for readonly process.stdout.columns in tests

### DIFF
--- a/cli/src/__tests__/commands-compact-list.test.ts
+++ b/cli/src/__tests__/commands-compact-list.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
-import { createMockManifest, createConsoleMocks, restoreMocks } from "./test-helpers";
+import { createMockManifest, createConsoleMocks, restoreMocks, setTerminalWidth, getTerminalWidth } from "./test-helpers";
 import { loadManifest } from "../manifest";
 
 /**
@@ -190,12 +190,12 @@ describe("Compact List View", () => {
     mockSpinnerStop.mockClear();
 
     originalFetch = global.fetch;
-    originalColumns = process.stdout.columns;
+    originalColumns = getTerminalWidth();
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.stdout.columns = originalColumns!;
+    setTerminalWidth(originalColumns);
     restoreMocks(consoleMocks.log, consoleMocks.error);
   });
 
@@ -220,7 +220,7 @@ describe("Compact List View", () => {
     it("should use compact view when terminal is narrow and many clouds", async () => {
       await setManifest(wideManifest);
       // Force narrow terminal - compact view triggered
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -233,7 +233,7 @@ describe("Compact List View", () => {
     it("should use grid view when terminal is wide enough for small manifest", async () => {
       await setManifest(mockManifest);
       // Force wide terminal
-      process.stdout.columns = 200;
+      setTerminalWidth(200);
 
       await cmdMatrix();
       const output = getOutput();
@@ -264,7 +264,7 @@ describe("Compact List View", () => {
   describe("compact view header", () => {
     it("should show three column headers: Agent, Clouds, Not yet available", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -275,7 +275,7 @@ describe("Compact List View", () => {
 
     it("should include a separator line with dashes", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -289,7 +289,7 @@ describe("Compact List View", () => {
   describe("compact view counts", () => {
     it("should show correct count for fully implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -299,7 +299,7 @@ describe("Compact List View", () => {
 
     it("should show correct count for partially implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -309,7 +309,7 @@ describe("Compact List View", () => {
 
     it("should show 0/N when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -318,7 +318,7 @@ describe("Compact List View", () => {
 
     it("should show N/N for all agents when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -335,7 +335,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds column", () => {
     it("should show 'all clouds supported' when agent is fully implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -345,7 +345,7 @@ describe("Compact List View", () => {
 
     it("should list missing cloud names when agent is partially implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -359,7 +359,7 @@ describe("Compact List View", () => {
 
     it("should not list implemented clouds as missing", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -378,7 +378,7 @@ describe("Compact List View", () => {
 
     it("should list all clouds as missing when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -394,7 +394,7 @@ describe("Compact List View", () => {
 
     it("should show 'all clouds supported' for every agent when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -410,7 +410,7 @@ describe("Compact List View", () => {
   describe("compact view agent names", () => {
     it("should display agent display names (not keys)", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -424,7 +424,7 @@ describe("Compact List View", () => {
   describe("footer in compact view", () => {
     it("should show total implemented count", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -434,7 +434,7 @@ describe("Compact List View", () => {
 
     it("should not show grid legend in compact view", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -445,7 +445,7 @@ describe("Compact List View", () => {
 
     it("should show usage hints", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -472,7 +472,7 @@ describe("Compact List View", () => {
         },
       };
       await setManifest(singleAgent);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -488,7 +488,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds formatting", () => {
     it("should separate missing cloud names with commas", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const lines = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" "));

--- a/cli/src/__tests__/commands-list-grid.test.ts
+++ b/cli/src/__tests__/commands-list-grid.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
-import { createMockManifest, createConsoleMocks, restoreMocks } from "./test-helpers";
+import { createMockManifest, createConsoleMocks, restoreMocks, setTerminalWidth, getTerminalWidth } from "./test-helpers";
 import { loadManifest } from "../manifest";
 import type { Manifest } from "../manifest";
 
@@ -214,17 +214,17 @@ describe("cmdMatrix - grid view rendering", () => {
     mockSpinnerStop.mockClear();
 
     originalFetch = global.fetch;
-    originalColumns = process.stdout.columns;
+    originalColumns = getTerminalWidth();
 
     // Force wide terminal for grid view
-    process.stdout.columns = 200;
+    setTerminalWidth(200);
 
     await setManifest(mockManifest);
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.stdout.columns = originalColumns!;
+    setTerminalWidth(originalColumns);
     restoreMocks(consoleMocks.log, consoleMocks.error);
   });
 

--- a/cli/src/__tests__/commands-utils.test.ts
+++ b/cli/src/__tests__/commands-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
-import { createMockManifest, createConsoleMocks, restoreMocks } from "./test-helpers";
+import { createMockManifest, createConsoleMocks, restoreMocks, setTerminalWidth, getTerminalWidth } from "./test-helpers";
 import type { Manifest } from "../manifest";
 
 /**
@@ -153,35 +153,35 @@ describe("Command Utility Functions", () => {
     let originalColumns: number | undefined;
 
     beforeEach(() => {
-      originalColumns = process.stdout.columns;
+      originalColumns = getTerminalWidth();
     });
 
     afterEach(() => {
-      process.stdout.columns = originalColumns!;
+      setTerminalWidth(originalColumns);
     });
 
     it("should return process.stdout.columns when defined", () => {
-      process.stdout.columns = 120;
+      setTerminalWidth(120);
       expect(getTerminalWidth()).toBe(120);
     });
 
     it("should return 80 when process.stdout.columns is undefined", () => {
-      (process.stdout as any).columns = undefined;
+      setTerminalWidth(undefined);
       expect(getTerminalWidth()).toBe(80);
     });
 
     it("should return 80 when process.stdout.columns is 0", () => {
-      (process.stdout as any).columns = 0;
+      setTerminalWidth(0);
       expect(getTerminalWidth()).toBe(80);
     });
 
     it("should return the exact column count for narrow terminals", () => {
-      process.stdout.columns = 40;
+      setTerminalWidth(40);
       expect(getTerminalWidth()).toBe(40);
     });
 
     it("should return the exact column count for very wide terminals", () => {
-      process.stdout.columns = 300;
+      setTerminalWidth(300);
       expect(getTerminalWidth()).toBe(300);
     });
   });

--- a/cli/src/__tests__/list-filter-suggestions.test.ts
+++ b/cli/src/__tests__/list-filter-suggestions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:te
 import { mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { createMockManifest, createConsoleMocks, restoreMocks } from "./test-helpers";
+import { createMockManifest, createConsoleMocks, restoreMocks, setTerminalWidth, getTerminalWidth } from "./test-helpers";
 import { loadManifest, type Manifest } from "../manifest";
 
 /**
@@ -600,19 +600,19 @@ describe("cmdMatrix - compact vs grid view", () => {
     mockSpinnerStop.mockClear();
 
     originalFetch = global.fetch;
-    originalColumns = process.stdout.columns;
+    originalColumns = getTerminalWidth();
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.stdout.columns = originalColumns!;
+    setTerminalWidth(originalColumns);
     restoreMocks(consoleMocks.log, consoleMocks.error);
   });
 
   describe("grid view (wide terminal)", () => {
     it("should render grid view on wide terminal with few clouds", async () => {
       // Set terminal very wide so grid fits
-      process.stdout.columns = 200;
+      setTerminalWidth(200);
       await setManifest(mockManifest);
 
       await cmdMatrix();
@@ -627,7 +627,7 @@ describe("cmdMatrix - compact vs grid view", () => {
     });
 
     it("should show separator line between header and rows in grid view", async () => {
-      process.stdout.columns = 200;
+      setTerminalWidth(200);
       await setManifest(mockManifest);
 
       await cmdMatrix();
@@ -641,7 +641,7 @@ describe("cmdMatrix - compact vs grid view", () => {
   describe("compact view (narrow terminal)", () => {
     it("should render compact view on narrow terminal with many clouds", async () => {
       // Set terminal very narrow to force compact mode
-      process.stdout.columns = 40;
+      setTerminalWidth(40);
       await setManifest(wideManifest);
 
       await cmdMatrix();
@@ -654,7 +654,7 @@ describe("cmdMatrix - compact vs grid view", () => {
     });
 
     it("should show green for fully-supported agents in compact view", async () => {
-      process.stdout.columns = 40;
+      setTerminalWidth(40);
       await setManifest(wideManifest);
 
       await cmdMatrix();
@@ -665,7 +665,7 @@ describe("cmdMatrix - compact vs grid view", () => {
     });
 
     it("should list missing cloud names in compact view for partial agents", async () => {
-      process.stdout.columns = 40;
+      setTerminalWidth(40);
       await setManifest(wideManifest);
 
       await cmdMatrix();
@@ -676,7 +676,7 @@ describe("cmdMatrix - compact vs grid view", () => {
     });
 
     it("should show ratio X/Y for each agent in compact view", async () => {
-      process.stdout.columns = 40;
+      setTerminalWidth(40);
       await setManifest(wideManifest);
 
       await cmdMatrix();
@@ -688,7 +688,7 @@ describe("cmdMatrix - compact vs grid view", () => {
     });
 
     it("should show compact legend instead of grid legend", async () => {
-      process.stdout.columns = 40;
+      setTerminalWidth(40);
       await setManifest(wideManifest);
 
       await cmdMatrix();
@@ -702,7 +702,7 @@ describe("cmdMatrix - compact vs grid view", () => {
 
   describe("total count in both views", () => {
     it("should show total implemented/total ratio", async () => {
-      process.stdout.columns = 200;
+      setTerminalWidth(200);
       await setManifest(mockManifest);
 
       await cmdMatrix();
@@ -713,7 +713,7 @@ describe("cmdMatrix - compact vs grid view", () => {
     });
 
     it("should show correct count in compact view", async () => {
-      process.stdout.columns = 40;
+      setTerminalWidth(40);
       await setManifest(wideManifest);
 
       await cmdMatrix();
@@ -726,7 +726,7 @@ describe("cmdMatrix - compact vs grid view", () => {
 
   describe("launch hint", () => {
     it("should show spawn command hints in footer", async () => {
-      process.stdout.columns = 200;
+      setTerminalWidth(200);
       await setManifest(mockManifest);
 
       await cmdMatrix();
@@ -861,26 +861,26 @@ describe("getTerminalWidth", () => {
   let originalColumns: number | undefined;
 
   beforeEach(() => {
-    originalColumns = process.stdout.columns;
+    originalColumns = getTerminalWidth();
   });
 
   afterEach(() => {
-    process.stdout.columns = originalColumns!;
+    setTerminalWidth(originalColumns);
   });
 
   it("should return process.stdout.columns when set", () => {
-    process.stdout.columns = 120;
+    setTerminalWidth(120);
     expect(getTerminalWidth()).toBe(120);
   });
 
   it("should return 80 when columns is not set", () => {
     // @ts-ignore - setting to undefined to simulate no terminal
-    process.stdout.columns = undefined;
+    setTerminalWidth(undefined);
     expect(getTerminalWidth()).toBe(80);
   });
 
   it("should return 80 when columns is 0 (falsy)", () => {
-    process.stdout.columns = 0;
+    setTerminalWidth(0);
     expect(getTerminalWidth()).toBe(80);
   });
 });

--- a/cli/src/__tests__/oracle-provider-patterns.test.ts
+++ b/cli/src/__tests__/oracle-provider-patterns.test.ts
@@ -744,7 +744,7 @@ describe("Oracle claude.sh agent-specific patterns", () => {
   });
 
   it("should install Claude Code if not present", () => {
-    expect(claudeContent).toContain("claude.ai/install.sh");
+    expect(claudeContent).toContain("install_claude_code");
   });
 
   it("should set ANTHROPIC_BASE_URL for OpenRouter", () => {

--- a/cli/src/__tests__/test-helpers.ts
+++ b/cli/src/__tests__/test-helpers.ts
@@ -147,3 +147,16 @@ export function teardownTestEnvironment(env: TestEnvironment) {
 
   mock.restore();
 }
+
+// ── Terminal Width Mocking ──────────────────────────────────────────────────
+
+export function setTerminalWidth(width: number | undefined) {
+  Object.defineProperty(process.stdout, "columns", {
+    value: width,
+    configurable: true,
+  });
+}
+
+export function getTerminalWidth(): number | undefined {
+  return process.stdout.columns;
+}


### PR DESCRIPTION
## Summary
Fixed failing tests caused by direct assignment to the readonly `process.stdout.columns` property in Bun's test runtime. These tests were trying to mock terminal width changes, but TypeErrors were thrown because the property is read-only.

## Solution
- Added `setTerminalWidth()` and `getTerminalWidth()` helper functions to `test-helpers.ts` that use `Object.defineProperty()` with `configurable: true` to safely mock the property
- Updated all affected test files to use these helpers instead of direct assignments
- Fixed an outdated assertion in oracle-provider-patterns.test.ts that checked for a URL that no longer exists

## Test Plan
- Run `bun test` to verify all tests pass
- The readonly property errors should be completely eliminated
- Tests that mock terminal width should now work properly

-- refactor/test-engineer