### PR TITLE
fix: improve error handling in remote script loading

### DIFF
--- a/aws-lightsail/lib/common.sh
+++ b/aws-lightsail/lib/common.sh
@@ -14,7 +14,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -16,7 +16,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -13,7 +13,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
     source "$SCRIPT_DIR/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -14,7 +14,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
     source "$SCRIPT_DIR/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -14,7 +14,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -11,7 +11,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
     source "$SCRIPT_DIR/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/local/lib/common.sh
+++ b/local/lib/common.sh
@@ -12,7 +12,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # ============================================================

--- a/oracle/lib/common.sh
+++ b/oracle/lib/common.sh
@@ -14,7 +14,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # ============================================================

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -11,7 +11,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
     source "$SCRIPT_DIR/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -7,7 +7,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _shared_common=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to load shared/common.sh from GitHub" >&2
+        echo "Check your network connection and try again" >&2
+        exit 1
+    }
+    eval "$_shared_common"
+    unset _shared_common
 fi
 
 # Configurable timeout/delay constants

--- a/test/mock-curl-script.sh
+++ b/test/mock-curl-script.sh
@@ -2,6 +2,13 @@
 # Mock curl — returns fixture data based on URL
 # Env vars from parent: MOCK_LOG, MOCK_FIXTURE_DIR, MOCK_CLOUD
 
+# Check for python3 availability (required for JSON validation)
+if ! command -v python3 &>/dev/null; then
+    echo "ERROR: python3 is required for mock tests but not found in PATH" >&2
+    echo "Install python3 and try again" >&2
+    exit 127
+fi
+
 # --- Helper functions ---
 
 _parse_args() {


### PR DESCRIPTION
## Summary
- Fix critical reliability bug: unhandled curl failures when loading `shared/common.sh` in all cloud provider lib files
- Add python3 availability check in mock test infrastructure

## Changes

### 1. Remote Script Loading (10 files)
All cloud provider `lib/common.sh` files now properly handle curl failures:
- **Before**: `eval "$(curl -fsSL ...)"`  — silent failure or arbitrary code execution on network errors
- **After**: Store curl output, check exit code, provide clear error message

**Files updated:**
- `aws-lightsail/lib/common.sh`
- `daytona/lib/common.sh`
- `digitalocean/lib/common.sh`
- `fly/lib/common.sh`
- `gcp/lib/common.sh`
- `hetzner/lib/common.sh`
- `local/lib/common.sh`
- `oracle/lib/common.sh`
- `ovh/lib/common.sh`
- `sprite/lib/common.sh`

### 2. Mock Test Infrastructure
`test/mock-curl-script.sh` now checks for python3 before use:
- Fails fast with clear error message if python3 is missing
- Prevents cryptic JSON parsing failures during tests

## Impact
- **Reliability**: Prevents silent failures when GitHub is unreachable
- **Security**: Avoids eval'ing error HTML on network failures
- **Developer Experience**: Clear error messages guide users to fix network/dependency issues

## Test Plan
- [x] Syntax check all modified shell scripts with `bash -n`
- [x] All modifications follow load-bearing curl|bash compatibility pattern from CLAUDE.md

-- refactor/code-health