### PR TITLE
fix: add error handling for GitHub CLI installation

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1164,7 +1164,10 @@ offer_github_auth() {
     if [[ "${SPAWN_GITHUB_AUTH_PROMPTED:-}" == "1" ]]; then
         if [[ "${SPAWN_GITHUB_AUTH_REQUESTED:-}" == "1" ]]; then
             log_step "Installing and authenticating GitHub CLI..."
-            ${run_callback} "curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/github-auth.sh | bash"
+            ${run_callback} "curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/github-auth.sh | bash" || {
+                log_warn "GitHub CLI setup failed (this is optional)"
+                return 0
+            }
         fi
         return 0
     fi
@@ -1178,7 +1181,10 @@ offer_github_auth() {
     fi
 
     log_step "Installing and authenticating GitHub CLI..."
-    ${run_callback} "curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/github-auth.sh | bash"
+    ${run_callback} "curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/github-auth.sh | bash" || {
+        log_warn "GitHub CLI setup failed (this is optional)"
+        return 0
+    }
 }
 
 # ============================================================


### PR DESCRIPTION
## Summary

The `offer_github_auth()` function was executing `curl | bash` without checking for installation failures. If curl failed or returned malicious content, the script would silently continue without alerting the user.

**Reliability issue**: Network errors, DNS failures, or corrupted downloads would go undetected, potentially leaving the system in a broken state.

## Changes

- Added `|| { ... }` error handlers to both GitHub CLI installation calls
- On failure, the script now logs a warning and gracefully continues
- GitHub setup is optional, so failures don't block agent deployment

This pattern is consistent with other optional setup steps in spawn scripts.

-- refactor/code-health