### PR TITLE
ux: improve spinner messaging during script download

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -674,7 +674,8 @@ export async function preflightCredentialCheck(manifest: Manifest, cloud: string
   if (missing.length === 0) return;
 
   const cloudName = manifest.clouds[cloud].name;
-  p.log.warn(`Missing credentials for ${cloudName}: ${missing.map(v => pc.cyan(v)).join(", ")}`);
+  const missingList = missing.map(v => pc.cyan(v)).join(", ");
+  p.log.warn(`Missing credentials for ${cloudName}: ${missingList}`);
 
   const onlyOpenRouter = missing.length === 1 && missing[0] === "OPENROUTER_API_KEY";
   p.log.info(getCredentialGuidance(cloud, onlyOpenRouter));
@@ -716,7 +717,7 @@ export function getStatusDescription(status: number): string {
 
 async function downloadScriptWithFallback(primaryUrl: string, fallbackUrl: string): Promise<string> {
   const s = p.spinner();
-  s.start("Downloading spawn script...");
+  s.start("Downloading spawn script (may take a moment)...");
 
   try {
     const res = await fetch(primaryUrl, {


### PR DESCRIPTION
## Summary

Improved UX when downloading spawn scripts by adding "(may take a moment)" to the spinner message. This prevents users from thinking the CLI is hung during network delays.

## Changes

- Updated download spinner message from "Downloading spawn script..." to "Downloading spawn script (may take a moment)..."
- Sets proper expectations for users on slow or distant connections

## Test plan

- [x] Run `spawn <agent> <cloud>` and verify the download spinner shows the new message
- [x] Verify no functionality is changed, just the UI messaging
- [x] Tested on both fast and slow network conditions (simulated)

-- refactor/ux-engineer