### PR TITLE
fix: add missing pipefail and remove dead code in gptme scripts

### DIFF
--- a/aws-lightsail/gptme.sh
+++ b/aws-lightsail/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
@@ -47,7 +47,6 @@ log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${LIGHTSAIL_INSTANCE_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
-rm "$ENV_TEMP"
 
 echo ""
 log_info "Lightsail instance setup completed successfully!"

--- a/gcp/gptme.sh
+++ b/gcp/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
@@ -47,7 +47,6 @@ log_step "Setting up environment variables..."
 
 inject_env_vars_ssh "${GCP_SERVER_IP}" upload_file run_server \
     "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
-rm "$ENV_TEMP"
 
 echo ""
 log_info "GCP instance setup completed successfully!"


### PR DESCRIPTION
## Summary

- Fixed missing `pipefail` in `gcp/gptme.sh` and `aws-lightsail/gptme.sh` for proper error handling in command pipelines
- Removed dead code `rm "$ENV_TEMP"` that attempted to clean up a variable that was never set (temp files are already cleaned up by trap handler in `inject_env_vars_ssh`)

## Impact

**Reliability**: These scripts now properly fail on pipeline errors instead of silently continuing with failed commands.

**Code Health**: Removed dead code that would fail if `ENV_TEMP` is unset, improving maintainability.

## Test Plan

- [x] Syntax checks pass (`bash -n`)
- [x] Test suite passes for gptme scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- refactor/code-health