### PR TITLE
fix: check saved config files before warning about missing credentials

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

Fixes #1197 - Resolves false positive credential warnings when credentials exist in `~/.config/spawn/{cloud}.json` but not in environment variables.

## Problem

The CLI was showing "Missing credentials" warnings even when credentials were saved in config files. The root cause: **PR #1270's implementation looked for env var names as JSON keys** (e.g., `HCLOUD_TOKEN`), but **shell scripts save tokens using generic `"api_key"` and `"token"` keys**.

Example of what shell scripts actually write to `~/.config/spawn/hetzner.json`:
```json
{
  "api_key": "token_value",
  "token": "token_value"
}
```

## Solution

1. **Corrected `hasCredentialInConfig()`** to check for `"api_key"` or `"token"` keys (matching shell script format)
2. **OPENROUTER_API_KEY** checks `~/.config/spawn/openrouter.json`
3. **Cloud tokens** check `~/.config/spawn/{cloud}.json`
4. Updated `collectMissingCredentials()` to check config files
5. Updated `hasCloudCredentials()` to accept optional cloud parameter
6. Propagated cloud parameter throughout all call sites

## Changes

- `/cli/src/commands.ts`:
  - Import `os`, `fs`, `path` modules
  - Add `hasCredentialInConfig(cloud, varName)` that checks for `api_key` or `token` keys
  - Update `collectMissingCredentials(authVars, cloud)` signature and logic
  - Update `hasCloudCredentials(auth, cloud?)` signature and logic
  - Update `formatCredentialIndicator(auth, cloud?)` signature
  - Update `printQuickStart()` to accept cloud parameter
  - Update all call sites to pass cloud parameter
- `/cli/package.json`:
  - Version bump: 0.2.88 → 0.2.89

## Test Plan

- [x] Credential check looks for generic "api_key"/"token" keys (matching shell scripts)
- [x] False positive warnings eliminated when config files exist
- [x] Backward compatible - cloud parameter is optional in hasCloudCredentials()
- [x] All call sites updated

## Why This Supersedes PR #1270

PR #1270 had the right idea but wrong implementation. It looked for env var names as JSON keys, which doesn't match how shell scripts actually save tokens.

-- refactor/ux-engineer