### PR TITLE
feat: implement local/opencode agent script

### DIFF
--- a/local/opencode.sh
+++ b/local/opencode.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "OpenCode on Local Machine"
+echo ""
+
+# Ensure local machine is ready
+ensure_local_ready
+
+SERVER_NAME=$(get_server_name)
+create_server "${SERVER_NAME}"
+
+# Install OpenCode
+log_step "Installing OpenCode..."
+run_server "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
+
+# Verify installation succeeded
+if ! run_server "command -v opencode &> /dev/null"; then
+    log_install_failed "OpenCode" "curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash"
+    exit 1
+fi
+log_info "OpenCode installation verified successfully"
+
+# Get OpenRouter API key via OAuth
+echo ""
+if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    log_info "Using OpenRouter API key from environment"
+else
+    OPENROUTER_API_KEY=$(get_openrouter_api_key_oauth 5180)
+fi
+
+# Inject environment variables
+log_step "Setting up environment variables..."
+inject_env_vars_local upload_file run_server \
+    "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+
+echo ""
+log_info "Local setup completed successfully!"
+echo ""
+
+# Start OpenCode interactively
+log_step "Starting OpenCode..."
+sleep 1
+clear 2>/dev/null || true
+source ~/.zshrc 2>/dev/null || true
+exec opencode

--- a/manifest.json
+++ b/manifest.json
@@ -537,7 +537,7 @@
     "local/amazonq": "implemented",
     "local/cline": "implemented",
     "local/gptme": "implemented",
-    "local/opencode": "missing",
+    "local/opencode": "implemented",
     "local/plandex": "implemented",
     "local/kilocode": "implemented",
     "local/continue": "implemented"


### PR DESCRIPTION
## Summary

Implements the final missing matrix entry (`local/opencode`) by creating a new OpenCode installation and configuration script for local machine execution.

This completes full coverage of all 19 agents across all 10 cloud providers, with zero missing matrix entries.

## Changes

- Created `/local/opencode.sh` - Local machine installation and launch script for OpenCode
- Updated `manifest.json` - Mark `local/opencode` as `"implemented"`

## Implementation Details

The script follows the standard local agent pattern:
1. Sources the local cloud common library (with remote fallback)
2. Ensures local machine prerequisites (curl, Python)
3. Installs OpenCode via the official installation script
4. Validates installation succeeded
5. Obtains OpenRouter API key (OAuth or environment variable)
6. Injects environment variables for OpenRouter integration
7. Launches OpenCode interactively

The implementation is consistent with other local agent scripts (openclaw, plandex) and properly handles the local-or-remote fallback pattern required for curl|bash compatibility.

🤖 Generated with test-engineer agent

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>