### PR TITLE
fix: add safety validation to rm -rf WORKTREE_BASE commands

### DIFF
--- a/.claude/skills/setup-agent-team/discovery.sh
+++ b/.claude/skills/setup-agent-team/discovery.sh
@@ -42,7 +42,11 @@ cleanup() {
     log_info "Running cleanup (exit_code=${exit_code})..."
     cd "${REPO_ROOT}" 2>/dev/null || true
     git worktree prune 2>/dev/null || true
-    rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+
+    # Safety: only delete if WORKTREE_BASE is non-empty and under /tmp/spawn-worktrees/
+    if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]]; then
+        rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+    fi
     rm -f "${PROMPT_FILE:-}" 2>/dev/null || true
     log_info "=== Cycle Done (exit_code=${exit_code}) ==="
     exit $exit_code
@@ -90,7 +94,9 @@ PYEOF
 _cleanup_stale_artifacts() {
     log_info "Pre-cycle cleanup..."
     git worktree prune 2>/dev/null || true
-    if [[ -d "${WORKTREE_BASE}" ]]; then
+
+    # Safety: only delete if WORKTREE_BASE is valid and exists
+    if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]] && [[ -d "${WORKTREE_BASE}" ]]; then
         rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
         log_info "Removed stale ${WORKTREE_BASE} directory"
     fi
@@ -249,7 +255,11 @@ run_team_cycle() {
     rm -f "${PROMPT_FILE}" 2>/dev/null || true
     PROMPT_FILE=""
     git worktree prune 2>/dev/null || true
-    rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+
+    # Safety: only delete if WORKTREE_BASE is non-empty and under /tmp/spawn-worktrees/
+    if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]]; then
+        rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+    fi
 
     return $CLAUDE_EXIT
 }
@@ -261,7 +271,12 @@ cleanup_between_cycles() {
     git fetch --prune origin 2>/dev/null || true
     git pull --rebase origin main 2>/dev/null || true
     git worktree prune 2>/dev/null || true
-    rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+
+    # Safety: only delete if WORKTREE_BASE is non-empty and under /tmp/spawn-worktrees/
+    if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]]; then
+        rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+    fi
+
     git branch --merged main | grep -v 'main' | grep -v '^\*' | xargs -r git branch -d 2>/dev/null || true
     log_info "Cleanup complete"
 }

--- a/.claude/skills/setup-agent-team/qa-cycle.sh
+++ b/.claude/skills/setup-agent-team/qa-cycle.sh
@@ -34,7 +34,11 @@ cleanup() {
     log "Running cleanup (exit_code=${exit_code})..."
     cd "${REPO_ROOT}" 2>/dev/null || true
     git worktree prune 2>/dev/null || true
-    rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+
+    # Safety: only delete if WORKTREE_BASE is non-empty and under /tmp/spawn-worktrees/
+    if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]]; then
+        rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+    fi
     rm -f "${RESULTS_PHASE2}" "${RESULTS_PHASE4}" "/tmp/spawn-qa-record-output.txt" "/tmp/spawn-qa-escalate.txt" 2>/dev/null || true
     log "=== QA Cycle Done (exit_code=${exit_code}) ==="
     exit $exit_code

--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -56,7 +56,11 @@ cleanup() {
 
     # Prune worktrees and clean up only OUR worktree base
     git worktree prune 2>/dev/null || true
-    rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+
+    # Safety: only delete if WORKTREE_BASE is non-empty and under /tmp/spawn-worktrees/
+    if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]]; then
+        rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+    fi
 
     # Clean up prompt and PID files
     rm -f "${PROMPT_FILE:-}" 2>/dev/null || true
@@ -88,7 +92,9 @@ if [[ "${RUN_MODE}" == "refactor" ]]; then
 
     log "Pre-cycle cleanup: stale worktrees and branches..."
     git worktree prune 2>&1 | tee -a "${LOG_FILE}" || true
-    if [[ -d "${WORKTREE_BASE}" ]]; then
+
+    # Safety: only delete if WORKTREE_BASE is valid and exists
+    if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]] && [[ -d "${WORKTREE_BASE}" ]]; then
         rm -rf "${WORKTREE_BASE}" 2>&1 | tee -a "${LOG_FILE}" || true
         log "Removed stale ${WORKTREE_BASE} directory"
     fi

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -100,7 +100,11 @@ cleanup() {
 
     # Prune worktrees and clean up only OUR worktree base
     git worktree prune 2>/dev/null || true
-    rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+
+    # Safety: only delete if WORKTREE_BASE is non-empty and under /tmp/spawn-worktrees/
+    if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]]; then
+        rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+    fi
 
     # Clean up prompt and PID files
     rm -f "${PROMPT_FILE:-}" 2>/dev/null || true
@@ -127,7 +131,9 @@ git fetch --prune origin 2>&1 | tee -a "${LOG_FILE}" || true
 
 # Clean stale worktrees
 git worktree prune 2>&1 | tee -a "${LOG_FILE}" || true
-if [[ -d "${WORKTREE_BASE}" ]]; then
+
+# Safety: only delete if WORKTREE_BASE is valid and exists
+if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]] && [[ -d "${WORKTREE_BASE}" ]]; then
     rm -rf "${WORKTREE_BASE}" 2>&1 | tee -a "${LOG_FILE}" || true
     log "Removed stale ${WORKTREE_BASE} directory"
 fi


### PR DESCRIPTION
## Summary

- Added validation guards to all `rm -rf "${WORKTREE_BASE}"` commands across refactor/discovery/qa/security scripts
- Prevents potential data loss from unset or malformed `WORKTREE_BASE` variable
- Each cleanup function now validates that `WORKTREE_BASE` is non-empty AND starts with `/tmp/spawn-worktrees/`

## Problem

All autonomous cycle scripts use `rm -rf "${WORKTREE_BASE}"` in cleanup functions without validation. If `WORKTREE_BASE` is unset or empty due to a bug, this expands to `rm -rf ""` which could delete files in the current directory.

## Solution

Wrap every `rm -rf "${WORKTREE_BASE}"` with:
```bash
if [[ -n "${WORKTREE_BASE}" ]] && [[ "${WORKTREE_BASE}" == /tmp/spawn-worktrees/* ]]; then
    rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
fi
```

## Files Changed

- `.claude/skills/setup-agent-team/refactor.sh` (2 locations)
- `.claude/skills/setup-agent-team/discovery.sh` (4 locations)
- `.claude/skills/setup-agent-team/qa-cycle.sh` (2 locations)
- `.claude/skills/setup-agent-team/security.sh` (2 locations)

## Testing

- All scripts pass `bash -n` syntax check
- Shell test suite: 80 passed, 0 failed

-- refactor/code-health