### PR TITLE
security: fix path traversal vulnerability in key-server

### DIFF
--- a/.claude/skills/setup-agent-team/key-server.ts
+++ b/.claude/skills/setup-agent-team/key-server.ts
@@ -372,6 +372,13 @@ const server = Bun.serve({
       const skipped: string[] = [];
 
       for (const pk of body.providers as string[]) {
+        // SECURITY: Validate provider name to prevent path traversal attacks
+        // (CWE-22). Provider names must match the safe pattern before being
+        // used in filesystem operations via saveKeys().
+        if (!SAFE_PROVIDER_RE.test(pk)) {
+          continue; // Skip invalid provider names silently
+        }
+
         if (
           d.batches.some(
             (b) =>


### PR DESCRIPTION
## Summary
Fixes HIGH/CRITICAL path traversal vulnerability (CWE-22) in key-server.ts

## Vulnerability Details

**Location**: `.claude/skills/setup-agent-team/key-server.ts` lines 374-388

**Issue**: The POST `/request-batch` endpoint accepted provider names from `body.providers` without validation before using them in filesystem operations.

**Attack Vector**:
```bash
curl -H "Authorization: Bearer $SECRET" \
     -H "Content-Type: application/json" \
     -d '{"providers": ["../../../tmp/pwned"]}' \
     http://localhost:8081/request-batch
```

This would write `/tmp/pwned.json` instead of the intended `~/.config/spawn/provider.json` when admin submits keys via the form.

**Impact**: Authenticated attacker (requires KEY_SERVER_SECRET) could write arbitrary JSON files anywhere on the filesystem with controlled content.

## Fix Applied

Added validation check using existing `SAFE_PROVIDER_RE` pattern (`/^[a-z0-9][a-z0-9._-]{0,63}$/`) to reject malicious provider names before processing:

```typescript
for (const pk of body.providers as string[]) {
  // SECURITY: Validate provider name to prevent path traversal attacks
  // (CWE-22). Provider names must match the safe pattern before being
  // used in filesystem operations via saveKeys().
  if (!SAFE_PROVIDER_RE.test(pk)) {
    continue; // Skip invalid provider names silently
  }
  // ... rest of processing
}
```

Invalid provider names are now silently skipped, preventing the exploit path.

## Verification

Other endpoints already validate provider names correctly:
- DELETE `/key/:provider` (line 440)
- GET `/status?provider=...` (line 543)

This fix brings `/request-batch` inline with the existing security pattern.

---
🤖 Generated by spawn refactor/security-auditor