### PR TITLE
security: fix JSON injection vulnerability in save_vm_connection

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -3118,13 +3118,20 @@ save_vm_connection() {
 
     local conn_file="${spawn_dir}/last-connection.json"
 
-    # Build JSON (handle optional fields)
-    local json="{\"ip\":\"${ip}\",\"user\":\"${user}\""
+    # SECURITY: Use json_escape to prevent JSON injection
+    # Build JSON with properly escaped values
+    local json_ip json_user json_server_id json_server_name
+    json_ip=$(json_escape "${ip}")
+    json_user=$(json_escape "${user}")
+
+    local json="{\"ip\":${json_ip},\"user\":${json_user}"
     if [[ -n "${server_id}" ]]; then
-        json="${json},\"server_id\":\"${server_id}\""
+        json_server_id=$(json_escape "${server_id}")
+        json="${json},\"server_id\":${json_server_id}"
     fi
     if [[ -n "${server_name}" ]]; then
-        json="${json},\"server_name\":\"${server_name}\""
+        json_server_name=$(json_escape "${server_name}")
+        json="${json},\"server_name\":${json_server_name}"
     fi
     json="${json}}"
 


### PR DESCRIPTION
## Security Fix: JSON Injection in save_vm_connection

**Severity**: HIGH  
**Component**: `shared/common.sh:3110-3132`

### Vulnerability

The `save_vm_connection()` function directly interpolates user-controlled strings into JSON without escaping:

```bash
local json="{\"ip\":\"${ip}\",\"user\":\"${user}\""
```

This allows **JSON injection attacks** where malicious cloud providers or compromised APIs can inject arbitrary JSON by returning crafted server names/IPs with special characters.

### Attack Example

A malicious cloud provider API returns this server name:
```
test\",\"malicious_field\":\"injected\",\"admin\":\"true
```

**Without fix**, the generated JSON becomes:
```json
{"ip":"1.2.3.4","user":"root","server_name":"test","malicious_field":"injected","admin":"true"}
```

The attacker has successfully:
- Injected a new field `malicious_field`
- Injected a fake `admin` field
- Broken out of the intended string value

### Fix

Use the existing `json_escape()` function (line 1459) which:
1. Uses Python's `json.dumps()` for proper JSON encoding
2. Falls back to manual escaping of quotes and backslashes
3. Wraps the result in quotes

**After fix**:
```bash
json_ip=$(json_escape "${ip}")
json_user=$(json_escape "${user}")
local json="{\"ip\":${json_ip},\"user\":${json_user}"
```

The malicious server name is now properly escaped as:
```json
{"ip":"1.2.3.4","user":"root","server_name":"test\",\"malicious_field\":\"injected\",\"admin\":\"true"}
```

The injection attempt is neutralized — it's now just a literal string value.

### Impact

- **Attack surface**: All cloud provider scripts that call `save_vm_connection()`
- **Attack vector**: Malicious or compromised cloud provider APIs
- **Consequences**: 
  - Corrupt `~/.spawn/last-connection.json`
  - Inject fake connection data
  - Cause JSON parsing errors in CLI
  - Potential privilege escalation if `admin` or similar fields are trusted

### Testing

Syntax validation:
```bash
bash -n shared/common.sh
```

No existing tests need updates — this is a security hardening fix that preserves all existing behavior for legitimate inputs.

---

-- refactor/security-auditor