### PR TITLE
fix: add error handling for remote script downloads in all cloud providers

### DIFF
--- a/aws-lightsail/lib/common.sh
+++ b/aws-lightsail/lib/common.sh
@@ -14,7 +14,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _SHARED_COMMON=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
+        echo "Check your internet connection or try again later." >&2
+        exit 1
+    }
+    eval "$_SHARED_COMMON"
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -16,7 +16,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _SHARED_COMMON=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
+        echo "Check your internet connection or try again later." >&2
+        exit 1
+    }
+    eval "$_SHARED_COMMON"
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -13,7 +13,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
     source "$SCRIPT_DIR/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _SHARED_COMMON=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
+        echo "Check your internet connection or try again later." >&2
+        exit 1
+    }
+    eval "$_SHARED_COMMON"
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -14,7 +14,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
     source "$SCRIPT_DIR/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _SHARED_COMMON=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
+        echo "Check your internet connection or try again later." >&2
+        exit 1
+    }
+    eval "$_SHARED_COMMON"
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -14,7 +14,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _SHARED_COMMON=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
+        echo "Check your internet connection or try again later." >&2
+        exit 1
+    }
+    eval "$_SHARED_COMMON"
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -11,7 +11,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
     source "$SCRIPT_DIR/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _SHARED_COMMON=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
+        echo "Check your internet connection or try again later." >&2
+        exit 1
+    }
+    eval "$_SHARED_COMMON"
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/oracle/lib/common.sh
+++ b/oracle/lib/common.sh
@@ -14,7 +14,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _SHARED_COMMON=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
+        echo "Check your internet connection or try again later." >&2
+        exit 1
+    }
+    eval "$_SHARED_COMMON"
 fi
 
 # ============================================================

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -11,7 +11,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../shared/common.sh" ]]; then
     source "$SCRIPT_DIR/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _SHARED_COMMON=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
+        echo "Check your internet connection or try again later." >&2
+        exit 1
+    }
+    eval "$_SHARED_COMMON"
 fi
 
 # Note: Provider-agnostic functions (logging, OAuth, browser, nc_listen) are now in shared/common.sh

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -7,7 +7,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 if [[ -n "${SCRIPT_DIR}" && -f "${SCRIPT_DIR}/../../shared/common.sh" ]]; then
     source "${SCRIPT_DIR}/../../shared/common.sh"
 else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh)"
+    _SHARED_COMMON=$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/common.sh) || {
+        echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
+        echo "Check your internet connection or try again later." >&2
+        exit 1
+    }
+    eval "$_SHARED_COMMON"
 fi
 
 # Configurable timeout/delay constants


### PR DESCRIPTION
## Summary

Add proper error handling to `eval $(curl)` patterns in all cloud provider `lib/common.sh` files. Previously, if curl failed (network issue, GitHub down, etc.), the eval would run with an empty string and continue silently, leading to undefined behavior and cryptic errors later.

## Changes

- Capture curl output in `_SHARED_COMMON` variable before eval
- Check curl exit code and fail fast with actionable error message
- Applies to 9 cloud providers: aws-lightsail, daytona, digitalocean, fly, gcp, hetzner, oracle, ovh, sprite

## Impact

**Before this fix:**
```bash
# If GitHub is down or network fails:
eval "$(curl -fsSL https://...)"  # curl fails silently, eval runs empty string
# Script continues with undefined functions, fails with cryptic errors like:
# "line 42: log_error: command not found"
```

**After this fix:**
```bash
# curl failure is caught immediately:
_SHARED_COMMON=$(curl -fsSL https://...) || {
    echo "ERROR: Failed to download shared/common.sh from GitHub" >&2
    echo "Check your internet connection or try again later." >&2
    exit 1
}
eval "$_SHARED_COMMON"
```

## Benefits

- **Prevents silent failures** when GitHub is unreachable
- **Clear error messages** directing users to check connectivity
- **Easier debugging** of network issues
- **Maintains backward compatibility** (local sourcing still works first)

## Testing

- All files pass `bash -n` syntax check
- Pattern matches existing successful implementations in the codebase
- Follows shell script best practices for error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- refactor/code-health