### PR TITLE
fix: ensure bun is in PATH for subprocess execSync calls in tests

### DIFF
--- a/cli/src/__tests__/cli-entry-edge-cases.test.ts
+++ b/cli/src/__tests__/cli-entry-edge-cases.test.ts
@@ -33,7 +33,7 @@ function runCli(
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/cmdrun-resolution.test.ts
+++ b/cli/src/__tests__/cmdrun-resolution.test.ts
@@ -30,7 +30,7 @@ function runCli(
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/index-main-routing.test.ts
+++ b/cli/src/__tests__/index-main-routing.test.ts
@@ -36,6 +36,8 @@ function runCli(
         // Prevent local manifest.json from being used
         NODE_ENV: "test",
         BUN_ENV: "test",
+        // Ensure bun is available in PATH for subprocess
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
       },
       encoding: "utf-8",
       timeout: 15000,

--- a/cli/src/__tests__/no-cloud-error-paths.test.ts
+++ b/cli/src/__tests__/no-cloud-error-paths.test.ts
@@ -34,7 +34,7 @@ function runCli(
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/prompt-file-errors.test.ts
+++ b/cli/src/__tests__/prompt-file-errors.test.ts
@@ -39,7 +39,7 @@ function runCli(
     const stdout = execSync(cmd, {
       cwd: PROJECT_ROOT,
       env: {
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/show-info-or-error.test.ts
+++ b/cli/src/__tests__/show-info-or-error.test.ts
@@ -37,7 +37,7 @@ function runCli(
       cwd: PROJECT_ROOT,
       env: {
         // Start with clean env to avoid bun test's NODE_ENV=test leaking
-        PATH: process.env.PATH,
+        PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
         HOME: process.env.HOME,
         SHELL: process.env.SHELL,
         TERM: process.env.TERM || "xterm",

--- a/cli/src/__tests__/unicode-detect.test.ts
+++ b/cli/src/__tests__/unicode-detect.test.ts
@@ -22,7 +22,7 @@ function detectTerm(env: Record<string, string>): string {
   `;
   const result = execSync(`bun -e '${script}'`, {
     cwd: CLI_DIR,
-    env: { ...env, PATH: process.env.PATH, HOME: process.env.HOME },
+    env: { ...env, PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`, HOME: process.env.HOME },
     encoding: "utf-8",
     timeout: 5000,
   });
@@ -104,7 +104,7 @@ describe("unicode-detect", () => {
       `;
       const result = execSync(`bun -e '${script}'`, {
         cwd: CLI_DIR,
-        env: { TERM: "xterm-256color", PATH: process.env.PATH, HOME: process.env.HOME },
+        env: { TERM: "xterm-256color", PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`, HOME: process.env.HOME },
         encoding: "utf-8",
         timeout: 5000,
       });
@@ -118,7 +118,7 @@ describe("unicode-detect", () => {
       `;
       const result = execSync(`bun -e '${script}'`, {
         cwd: CLI_DIR,
-        env: { TERM: "xterm-256color", LANG: "fr_FR.UTF-8", PATH: process.env.PATH, HOME: process.env.HOME },
+        env: { TERM: "xterm-256color", LANG: "fr_FR.UTF-8", PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`, HOME: process.env.HOME },
         encoding: "utf-8",
         timeout: 5000,
       });
@@ -132,7 +132,7 @@ describe("unicode-detect", () => {
       `;
       const result = execSync(`bun -e '${script}'`, {
         cwd: CLI_DIR,
-        env: { TERM: "xterm-256color", LANG: "C", PATH: process.env.PATH, HOME: process.env.HOME },
+        env: { TERM: "xterm-256color", LANG: "C", PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`, HOME: process.env.HOME },
         encoding: "utf-8",
         timeout: 5000,
       });
@@ -151,7 +151,7 @@ describe("unicode-detect", () => {
         env: {
           TERM: "xterm-256color",
           SPAWN_DEBUG: "1",
-          PATH: process.env.PATH,
+          PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`,
           HOME: process.env.HOME,
         },
         encoding: "utf-8",
@@ -170,7 +170,7 @@ describe("unicode-detect", () => {
       // Capture both stdout and stderr
       const result = execSync(`bun -e '${script}' 2>&1`, {
         cwd: CLI_DIR,
-        env: { TERM: "xterm-256color", PATH: process.env.PATH, HOME: process.env.HOME },
+        env: { TERM: "xterm-256color", PATH: `${process.env.HOME}/.bun/bin:${process.env.PATH}`, HOME: process.env.HOME },
         encoding: "utf-8",
         timeout: 5000,
       });


### PR DESCRIPTION
## Summary

Multiple test files spawn `bun` subprocesses via `execSync` but don't include `~/.bun/bin` in PATH, causing "bun: not found" errors when bun is not in the system PATH.

This fix adds PATH with `~/.bun/bin` prepended in all execSync env configurations across 7 test files:
- index-main-routing.test.ts
- prompt-file-errors.test.ts  
- no-cloud-error-paths.test.ts
- cli-entry-edge-cases.test.ts
- show-info-or-error.test.ts
- cmdrun-resolution.test.ts
- unicode-detect.test.ts

## Test plan

- [x] Run `bun test` to verify all affected tests now pass (28 tests in index-main-routing, 16 in unicode-detect, etc.)
- [x] Verify no new test failures are introduced
- [x] Confirm bash syntax is valid

🤖 Generated with Claude Code