### PR TITLE
fix: add pipefail to gptme scripts for consistent error handling

### DIFF
--- a/aws-lightsail/gptme.sh
+++ b/aws-lightsail/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"

--- a/gcp/gptme.sh
+++ b/gcp/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"


### PR DESCRIPTION
## Problem

AWS Lightsail and GCP gptme scripts were using `set -e` instead of `set -eo pipefail`, creating an inconsistency with the rest of the codebase. This means piped commands could fail silently without triggering script termination.

## Fix

Changed both scripts to use `set -eo pipefail` to match the codebase standard defined in CLAUDE.md.

## Impact

- Improved reliability: piped commands now properly propagate failures
- Consistency: all agent scripts now use the same error handling flags
- No functional changes to script behavior in success paths

---
*refactor/code-health*