### PR TITLE
refactor: extract install_claude_code helpers to reduce complexity

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1258,62 +1258,95 @@ verify_agent() {
 # The curl installer bundles its own runtime. npm/bun install a Node.js package
 # whose shebang needs 'node', so we ensure a node runtime exists after those.
 # Usage: install_claude_code RUN_CB
-install_claude_code() {
+_finalize_claude_install() {
     local run_cb="$1"
     local claude_path='export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH'
 
-    # Clean up ~/.bash_profile if it was created by a previous broken deployment.
-    ${run_cb} "if [ -f ~/.bash_profile ] && grep -q 'spawn:env\|Claude Code PATH\|spawn:path' ~/.bash_profile 2>/dev/null; then rm -f ~/.bash_profile; fi" >/dev/null 2>&1 || true
+    log_step "Setting up Claude Code shell integration..."
+    ${run_cb} "${claude_path} && claude install --force" >/dev/null 2>&1 || true
+    # Write claude PATH to .bashrc and .zshrc
+    ${run_cb} "for rc in ~/.bashrc ~/.zshrc; do grep -q '.claude/local/bin' \"\$rc\" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH=\"\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"\\n' >> \"\$rc\"; done" >/dev/null 2>&1 || true
+}
 
-    _finalize_claude_install() {
-        log_step "Setting up Claude Code shell integration..."
-        ${run_cb} "${claude_path} && claude install --force" >/dev/null 2>&1 || true
-        # Write claude PATH to .bashrc and .zshrc
-        ${run_cb} "for rc in ~/.bashrc ~/.zshrc; do grep -q '.claude/local/bin' \"\$rc\" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH=\"\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"\\n' >> \"\$rc\"; done" >/dev/null 2>&1 || true
-    }
+_is_claude_installed() {
+    local run_cb="$1"
+    local claude_path='export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH'
+    ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1
+}
 
-    # Already installed?
-    if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
-        log_info "Claude Code already installed"
-        _finalize_claude_install
-        return 0
-    fi
-
-    # Method 1: official curl installer (standalone binary, no node needed)
+_try_curl_installer() {
+    local run_cb="$1"
     log_step "Installing Claude Code (method 1/2: curl installer)..."
     if ${run_cb} "curl -fsSL https://claude.ai/install.sh | bash" 2>&1; then
-        if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
+        if _is_claude_installed "${run_cb}"; then
             log_info "Claude Code installed via curl installer"
-            _finalize_claude_install
+            _finalize_claude_install "${run_cb}"
             return 0
         fi
         log_warn "curl installer exited 0 but claude not found on PATH"
     else
         log_warn "curl installer failed (site may be temporarily unavailable)"
     fi
+    return 1
+}
 
-    # Ensure Node.js runtime for bun-installed package (it's a Node.js script)
-    if ! ${run_cb} "${claude_path} && command -v node" >/dev/null 2>&1; then
-        log_step "Installing Node.js runtime (required for claude package)..."
-        if ${run_cb} "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs" >/dev/null 2>&1; then
-            log_info "Node.js installed via nodesource"
-        else
-            log_warn "Could not install Node.js - bun method may fail"
-        fi
+_ensure_nodejs() {
+    local run_cb="$1"
+    local claude_path='export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH'
+
+    if ${run_cb} "${claude_path} && command -v node" >/dev/null 2>&1; then
+        return 0
     fi
 
-    # Method 2: bun
+    log_step "Installing Node.js runtime (required for claude package)..."
+    if ${run_cb} "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs" >/dev/null 2>&1; then
+        log_info "Node.js installed via nodesource"
+        return 0
+    else
+        log_warn "Could not install Node.js - bun method may fail"
+        return 1
+    fi
+}
+
+_try_bun_installer() {
+    local run_cb="$1"
+    local claude_path='export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH'
+
     log_step "Installing Claude Code (method 2/2: bun)..."
     if ${run_cb} "${claude_path} && bun i -g @anthropic-ai/claude-code 2>&1" 2>&1; then
-        if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
+        if _is_claude_installed "${run_cb}"; then
             log_info "Claude Code installed via bun"
-            _finalize_claude_install
+            _finalize_claude_install "${run_cb}"
             return 0
         fi
         log_warn "bun install exited 0 but claude binary not found"
     else
         log_warn "bun install failed"
     fi
+    return 1
+}
+
+install_claude_code() {
+    local run_cb="$1"
+
+    # Clean up ~/.bash_profile if it was created by a previous broken deployment.
+    ${run_cb} "if [ -f ~/.bash_profile ] && grep -q 'spawn:env\|Claude Code PATH\|spawn:path' ~/.bash_profile 2>/dev/null; then rm -f ~/.bash_profile; fi" >/dev/null 2>&1 || true
+
+    # Already installed?
+    if _is_claude_installed "${run_cb}"; then
+        log_info "Claude Code already installed"
+        _finalize_claude_install "${run_cb}"
+        return 0
+    fi
+
+    # Try curl installer first
+    _try_curl_installer "${run_cb}" && return 0
+
+    # Ensure Node.js before bun install
+    _ensure_nodejs "${run_cb}"
+
+    # Try bun installer
+    _try_bun_installer "${run_cb}" && return 0
 
     # All methods failed
     log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"


### PR DESCRIPTION
## Summary

Refactored the 60-line `install_claude_code()` function by extracting helper functions to reduce complexity and improve maintainability:

- **_finalize_claude_install**: Setup shell integration and PATH configuration
- **_is_claude_installed**: Verify if Claude Code is on PATH
- **_try_curl_installer**: Attempt official curl-based installation
- **_ensure_nodejs**: Check/install Node.js runtime dependency
- **_try_bun_installer**: Attempt bun package manager installation

## Benefits

- Main function reduced from 60 lines to 25 lines
- Each helper has a single, clear responsibility
- Installation logic is more modular and testable
- Error handling is easier to follow
- Reduces cognitive load when reading the code

## Test Plan

- [x] Syntax check passed (bash -n)
- [x] All 80 existing tests pass
- [x] Shell scripts maintain backward compatibility

-- refactor/complexity-hunter