### PR TITLE
fix: prevent unbound variable error in cleanup_temp_files

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1200,7 +1200,9 @@ track_temp_file() {
 cleanup_temp_files() {
     local exit_code=$?
 
-    for temp_file in "${CLEANUP_TEMP_FILES[@]}"; do
+    # Safe array expansion: only iterate if array has elements
+    # This prevents "unbound variable" errors in strict bash modes
+    for temp_file in "${CLEANUP_TEMP_FILES[@]+"${CLEANUP_TEMP_FILES[@]}"}"; do
         if [[ -f "${temp_file}" ]]; then
             # Securely remove temp files (may contain credentials)
             shred -f -u "${temp_file}" 2>/dev/null || rm -f "${temp_file}"


### PR DESCRIPTION
## Summary
- Fixes array iteration bug in `cleanup_temp_files()` that could fail in strict bash modes
- Prevents cleanup trap failures that could leak credential files

## Issue
The `cleanup_temp_files()` function used unsafe array expansion:
```bash
for temp_file in "${CLEANUP_TEMP_FILES[@]}"; do
```

This throws "unbound variable" error when the array is empty in bash configurations with `set -u` or certain strict modes, breaking the EXIT trap.

## Fix
Use safe array expansion that only iterates if the array has elements:
```bash
for temp_file in "${CLEANUP_TEMP_FILES[@]+"${CLEANUP_TEMP_FILES[@]}"}"; do
```

The `[@]+` expansion prevents errors by only expanding when the array has at least one element.

## Impact
- **Reliability**: Prevents cleanup trap failures across different bash versions/configurations
- **Security**: Ensures temp files containing credentials are always cleaned up
- **Compatibility**: Works consistently on bash 3.2+ (macOS) and bash 4+ (Linux)

## Test plan
- [x] Verified bash syntax with `bash -n shared/common.sh`
- [x] Ran `bash test/run.sh sprite claude` — all 48 tests pass
- [x] Pattern follows CLAUDE.md shell script rules for macOS bash 3.x compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)