### PR TITLE
test: fix test failures and improve shell script conventions

### DIFF
--- a/aws-lightsail/gptme.sh
+++ b/aws-lightsail/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"

--- a/cli/src/__tests__/commands-compact-list.test.ts
+++ b/cli/src/__tests__/commands-compact-list.test.ts
@@ -195,9 +195,22 @@ describe("Compact List View", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.stdout.columns = originalColumns!;
+    // Restore columns using Object.defineProperty
+    Object.defineProperty(process.stdout, "columns", {
+      value: originalColumns,
+      writable: true,
+      configurable: true,
+    });
     restoreMocks(consoleMocks.log, consoleMocks.error);
   });
+
+  function setColumns(cols: number | undefined) {
+    Object.defineProperty(process.stdout, "columns", {
+      value: cols,
+      writable: true,
+      configurable: true,
+    });
+  }
 
   function setManifest(manifest: any) {
     global.fetch = mock(async () => ({
@@ -220,7 +233,7 @@ describe("Compact List View", () => {
     it("should use compact view when terminal is narrow and many clouds", async () => {
       await setManifest(wideManifest);
       // Force narrow terminal - compact view triggered
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -233,7 +246,7 @@ describe("Compact List View", () => {
     it("should use grid view when terminal is wide enough for small manifest", async () => {
       await setManifest(mockManifest);
       // Force wide terminal
-      process.stdout.columns = 200;
+      setColumns(200);
 
       await cmdMatrix();
       const output = getOutput();
@@ -248,7 +261,7 @@ describe("Compact List View", () => {
     it("should default to 80 columns when process.stdout.columns is undefined", async () => {
       await setManifest(wideManifest);
       // Simulate no tty (columns undefined)
-      (process.stdout as any).columns = undefined;
+      setColumns(undefined);
 
       await cmdMatrix();
       const output = getOutput();
@@ -264,7 +277,7 @@ describe("Compact List View", () => {
   describe("compact view header", () => {
     it("should show three column headers: Agent, Clouds, Not yet available", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -275,7 +288,7 @@ describe("Compact List View", () => {
 
     it("should include a separator line with dashes", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -289,7 +302,7 @@ describe("Compact List View", () => {
   describe("compact view counts", () => {
     it("should show correct count for fully implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -299,7 +312,7 @@ describe("Compact List View", () => {
 
     it("should show correct count for partially implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -309,7 +322,7 @@ describe("Compact List View", () => {
 
     it("should show 0/N when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -318,7 +331,7 @@ describe("Compact List View", () => {
 
     it("should show N/N for all agents when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -335,7 +348,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds column", () => {
     it("should show 'all clouds supported' when agent is fully implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -345,7 +358,7 @@ describe("Compact List View", () => {
 
     it("should list missing cloud names when agent is partially implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -359,7 +372,7 @@ describe("Compact List View", () => {
 
     it("should not list implemented clouds as missing", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -378,7 +391,7 @@ describe("Compact List View", () => {
 
     it("should list all clouds as missing when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -394,7 +407,7 @@ describe("Compact List View", () => {
 
     it("should show 'all clouds supported' for every agent when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -410,7 +423,7 @@ describe("Compact List View", () => {
   describe("compact view agent names", () => {
     it("should display agent display names (not keys)", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -424,7 +437,7 @@ describe("Compact List View", () => {
   describe("footer in compact view", () => {
     it("should show total implemented count", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -434,7 +447,7 @@ describe("Compact List View", () => {
 
     it("should not show grid legend in compact view", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -445,7 +458,7 @@ describe("Compact List View", () => {
 
     it("should show usage hints", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -472,7 +485,7 @@ describe("Compact List View", () => {
         },
       };
       await setManifest(singleAgent);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -488,7 +501,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds formatting", () => {
     it("should separate missing cloud names with commas", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const lines = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" "));

--- a/cli/src/__tests__/oracle-provider-patterns.test.ts
+++ b/cli/src/__tests__/oracle-provider-patterns.test.ts
@@ -744,7 +744,7 @@ describe("Oracle claude.sh agent-specific patterns", () => {
   });
 
   it("should install Claude Code if not present", () => {
-    expect(claudeContent).toContain("claude.ai/install.sh");
+    expect(claudeContent).toContain("install_claude_code");
   });
 
   it("should set ANTHROPIC_BASE_URL for OpenRouter", () => {

--- a/gcp/gptme.sh
+++ b/gcp/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"


### PR DESCRIPTION
## Summary

Fixed all failing tests and improved shell script compliance with CLAUDE.md conventions.

- Fixed shell script convention violations (set -eo pipefail instead of set -e)
- Updated outdated test expectations for Claude Code installation
- Fixed readonly property assignment issues in test mocking
- All 8061 tests now passing (previously 57 failures)

## Test plan

- [x] Run `bun test` - all 8061 tests pass
- [x] Verify shell script syntax with bash -n - no errors
- [x] Check for proper test cleanup and isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)