### PR TITLE
fix: source .bashrc in launch commands so env vars are available

### DIFF
--- a/aws-lightsail/claude.sh
+++ b/aws-lightsail/claude.sh
@@ -69,4 +69,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${LIGHTSAIL_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+interactive_session "${LIGHTSAIL_SERVER_IP}" 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'

--- a/daytona/claude.sh
+++ b/daytona/claude.sh
@@ -64,4 +64,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+interactive_session 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -72,4 +72,4 @@ save_vm_connection "${DO_SERVER_IP}" "root" "${DO_DROPLET_ID}" "${DROPLET_NAME}"
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${DO_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+interactive_session "${DO_SERVER_IP}" 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'

--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -63,4 +63,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+interactive_session 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -72,4 +72,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${GCP_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+interactive_session "${GCP_SERVER_IP}" 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'

--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -42,4 +42,4 @@ inject_env_vars_cb "$RUN" "$UPLOAD" \
 # Claude-specific config
 setup_claude_code_config "${OPENROUTER_API_KEY}" "$UPLOAD" "$RUN"
 
-launch_session "Hetzner server" "$SESSION" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+launch_session "Hetzner server" "$SESSION" 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'

--- a/oracle/claude.sh
+++ b/oracle/claude.sh
@@ -72,4 +72,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${OCI_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+interactive_session "${OCI_SERVER_IP}" 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'

--- a/ovh/claude.sh
+++ b/ovh/claude.sh
@@ -70,4 +70,4 @@ echo ""
 log_step "Starting Claude Code..."
 sleep 1
 clear
-interactive_session "${OVH_SERVER_IP}" 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+interactive_session "${OVH_SERVER_IP}" 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -70,11 +70,11 @@ if [[ -n "${SPAWN_PROMPT:-}" ]]; then
     escaped_prompt=$(printf '%q' "${SPAWN_PROMPT}")
 
     # Execute without -tty flag
-    sprite exec -s "${SPRITE_NAME}" -- bash -c "export PATH=\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH; claude -p ${escaped_prompt}"
+    sprite exec -s "${SPRITE_NAME}" -- bash -c "source ~/.bashrc 2>/dev/null; export PATH=\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH; claude -p ${escaped_prompt}"
 else
     # Interactive mode: start Claude Code normally
     log_step "Starting Claude Code..."
     sleep 1
     clear 2>/dev/null || true
-    sprite exec -s "${SPRITE_NAME}" -tty -- bash -c 'export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+    sprite exec -s "${SPRITE_NAME}" -tty -- bash -c 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
 fi


### PR DESCRIPTION
## Summary

- Add `source ~/.bashrc 2>/dev/null;` before the PATH export in all 9 cloud `claude.sh` launch commands
- Env vars (`OPENROUTER_API_KEY`, `ANTHROPIC_BASE_URL`, etc.) are written to `~/.bashrc` by `inject_env_vars_*` functions, but launch commands only exported PATH inline — Claude started without API keys
- Previously removed because `fnm`'s `eval "$(fnm env)"` was corrupting PATH — fnm has been fully removed from the codebase, so it's safe to source `.bashrc` again
- `local/claude.sh` already uses this pattern successfully

## Files changed

`gcp/claude.sh`, `digitalocean/claude.sh`, `aws-lightsail/claude.sh`, `oracle/claude.sh`, `ovh/claude.sh`, `fly/claude.sh`, `daytona/claude.sh`, `sprite/claude.sh`, `hetzner/claude.sh`

## Test plan

- [ ] `bash -n` syntax check passes on all 9 files
- [ ] `grep -r fnm *.sh` returns no results
- [ ] Deploy on Hetzner, verify `echo $OPENROUTER_API_KEY` is set inside Claude session

🤖 Generated with [Claude Code](https://claude.com/claude-code)