### PR TITLE
docs: fix misleading Sprite authentication example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Skip prompts by providing environment variables:
 export OPENROUTER_API_KEY=sk-or-v1-xxxxx
 
 # Cloud-specific credentials (varies by provider)
-export SPRITE_API_KEY=...        # For Sprite
+# Note: Sprite uses `sprite login` for authentication
 export HCLOUD_TOKEN=...           # For Hetzner
 export DO_API_TOKEN=...           # For DigitalOcean
 
 # Run non-interactively
-spawn claude sprite
+spawn claude hetzner
 ```
 
 You can also use inline environment variables:


### PR DESCRIPTION
## Summary
- Fixed incorrect `SPRITE_API_KEY` example in README
- Added clarification that Sprite uses `sprite login` for authentication
- Changed example command to use Hetzner (which actually uses an API token)

## Details

The README's "Non-Interactive Mode" section incorrectly showed `SPRITE_API_KEY` as an environment variable for Sprite. However, Sprite actually uses `sprite login` for authentication (interactive browser-based OAuth), not an API key.

### Changes Made:
1. Removed the misleading `export SPRITE_API_KEY=...` line
2. Added a clarifying comment: `# Note: Sprite uses 'sprite login' for authentication`
3. Changed the example from `spawn claude sprite` to `spawn claude hetzner` since Hetzner genuinely uses an API token (`HCLOUD_TOKEN`)

### Why This Matters:
- Prevents user confusion when trying to authenticate with Sprite
- Makes documentation accurate with actual authentication methods
- Provides a better example with a cloud that actually uses env var auth

## Test plan
- [x] Verified Sprite uses `sprite login` in `/tmp/spawn-worktrees/refactor/ux-improvements-1771274893/sprite/lib/common.sh`
- [x] Confirmed manifest.json shows `"auth": "sprite login"` for Sprite
- [x] Verified Hetzner uses `HCLOUD_TOKEN` environment variable
- [x] README examples now accurately reflect authentication methods

🤖 Generated with Claude Code

-- refactor/ux-engineer