### PR TITLE
fix: check saved cloud configs in credential validation

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -2,6 +2,8 @@ import "./unicode-detect.js"; // Must be first: configures TERM before clack rea
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { spawn } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
 import {
   loadManifest,
   agentKeys,
@@ -634,7 +636,22 @@ function getAuthHint(manifest: Manifest, cloud: string): string | undefined {
 
 /** Check for missing credentials before running a script and warn the user.
  *  In interactive mode, asks for confirmation. In non-interactive mode, just warns. */
-function collectMissingCredentials(authVars: string[]): string[] {
+/** Check if credentials are saved in ~/.config/spawn/{cloud}.json */
+function hasCloudConfigCredentials(cloud: string): boolean {
+  try {
+    const configPath = path.join(process.env.HOME || "", ".config/spawn", `${cloud}.json`);
+    if (!fs.existsSync(configPath)) return false;
+    const content = fs.readFileSync(configPath, "utf-8");
+    const config = JSON.parse(content);
+    // Check if config has any non-empty credentials
+    return Object.values(config).some(v => typeof v === "string" && v.trim().length > 0);
+  } catch {
+    // If config can't be read, assume no saved credentials
+    return false;
+  }
+}
+
+function collectMissingCredentials(authVars: string[], cloud?: string): string[] {
   const missing: string[] = [];
   if (!process.env.OPENROUTER_API_KEY) {
     missing.push("OPENROUTER_API_KEY");
@@ -644,6 +661,12 @@ function collectMissingCredentials(authVars: string[]): string[] {
       missing.push(v);
     }
   }
+
+  // If there are missing credentials but the cloud has saved config, don't report them as missing
+  if (missing.length > 0 && cloud && hasCloudConfigCredentials(cloud)) {
+    return missing.filter(v => v === "OPENROUTER_API_KEY");
+  }
+
   return missing;
 }
 
@@ -670,7 +693,7 @@ export async function preflightCredentialCheck(manifest: Manifest, cloud: string
   if (cloudAuth.toLowerCase() === "none") return;
 
   const authVars = parseAuthEnvVars(cloudAuth);
-  const missing = collectMissingCredentials(authVars);
+  const missing = collectMissingCredentials(authVars, cloud);
   if (missing.length === 0) return;
 
   const cloudName = manifest.clouds[cloud].name;


### PR DESCRIPTION
## Summary
Fixes #1197 — Hetzner and other clouds with saved configuration files were incorrectly reported as having missing credentials during the preflight check, even though the provisioning scripts would successfully find them.

## What Changed
- Added `hasCloudConfigCredentials()` function to check if a cloud has saved credentials in `~/.config/spawn/{cloud}.json`
- Updated `collectMissingCredentials()` to check both environment variables AND saved config files
- If a cloud has saved credentials, they are no longer reported as missing (unless OPENROUTER_API_KEY is missing)

## Why This Matters
Users with saved cloud credentials (from prior `spawn <cloud>` setup) were seeing false warnings about missing credentials, even though the spawn would work fine. This aligns the CLI's credential detection with the actual behavior of the provisioning scripts.

-- refactor/complexity-hunter