### PR TITLE
fix: improve code health - safer indirect expansion and type checking

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/manifest.ts
+++ b/cli/src/manifest.ts
@@ -112,9 +112,9 @@ function stripDangerousKeys(obj: any): any {
   return clean;
 }
 
-function isValidManifest(data: any): data is Manifest {
-  return data && typeof data === "object" && !Array.isArray(data) &&
-    data.agents && data.clouds && data.matrix;
+function isValidManifest(data: unknown): data is Manifest {
+  return !!data && typeof data === "object" && !Array.isArray(data) &&
+    "agents" in data && "clouds" in data && "matrix" in data;
 }
 
 async function fetchManifestFromGitHub(): Promise<Manifest | null> {

--- a/test/record.sh
+++ b/test/record.sh
@@ -136,7 +136,7 @@ _save_multi_config_to_file() {
     for spec in "$@"; do
         local config_key="${spec%%:*}"
         local env_var="${spec#*:}"
-        eval "local val=\"\${${env_var}:-}\""
+        local val="${!env_var:-}"
         py_args+=("$val")
         py_keys="${py_keys}'${config_key}': sys.argv[${idx}], "
         idx=$((idx + 1))
@@ -165,7 +165,7 @@ try_load_config() {
     env_var=$(get_auth_env_var "$cloud")
 
     # Already set via env var — nothing to do
-    eval "local current_val=\"\${${env_var}:-}\""
+    local current_val="${!env_var:-}"
     if [[ -n "$current_val" ]]; then
         return 0
     fi
@@ -212,7 +212,7 @@ has_credentials() {
         local line
         while IFS= read -r line; do
             local env_var="${line#*:}"
-            eval "[[ -n \"\${${env_var}:-}\" ]]" || return 1
+            [[ -n "${!env_var:-}" ]] || return 1
         done <<< "$specs"
         return 0
     fi
@@ -220,7 +220,7 @@ has_credentials() {
     # Single-credential clouds
     local env_var
     env_var=$(get_auth_env_var "$cloud")
-    eval "[[ -n \"\${${env_var}:-}\" ]]"
+    [[ -n "${!env_var:-}" ]]
 }
 
 # Save credentials to ~/.config/spawn/{cloud}.json for future use
@@ -243,7 +243,7 @@ save_config() {
         # Standard single-token config
         local env_var
         env_var=$(get_auth_env_var "$cloud")
-        eval "local val=\"\${${env_var}:-}\""
+        local val="${!env_var:-}"
         python3 -c "import json, sys; print(json.dumps({'api_key': sys.argv[1]}, indent=2))" "$val" > "$config_file"
     fi
     printf '%b\n' "  ${GREEN}saved${NC} → ${config_file}"
@@ -273,7 +273,7 @@ prompt_credentials() {
             echo "SECURITY: Invalid env var name rejected: ${var_name}" >&2
             return 1
         fi
-        eval "local current=\"\${${var_name}:-}\""
+        local current="${!var_name:-}"
         if [[ -n "$current" ]]; then
             continue
         fi


### PR DESCRIPTION
## Summary

Addresses code health findings from security audit (issue #763):

- **test/record.sh**: Replace `eval`-based indirect variable expansion with native bash `${!var}` syntax (5 occurrences)
  - More reliable and less fragile than eval pattern
  - Lines 139, 168, 215, 223, 246, 276
  
- **cli/src/manifest.ts**: Change `isValidManifest` parameter from `any` to `unknown` for safer type checking
  - Use `in` operator to check properties after type narrowing
  - Prevents accidental property access on unvalidated data

- Bump CLI version to 0.2.89 (patch release)

## Test Results

- Shell tests: ✅ 80/80 passed
- TypeScript build: ✅ No compilation errors
- Bash syntax check: ✅ Passed

## Related Issue

Partially addresses #763 (MEDIUM findings in test/record.sh and LOW finding in cli/src/manifest.ts)

---
🤖 Generated by spawn refactor/code-health agent