### PR TITLE
ux: complete commands table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,19 @@ spawn claude                             # Show clouds available for Claude
 | `spawn <agent> <cloud> -p "text"` | Non-interactive with prompt |
 | `spawn <agent> <cloud> --prompt-file f.txt` | Prompt from file |
 | `spawn <agent>` | Show available clouds for an agent |
+| `spawn <cloud>` | Show available agents for a cloud |
 | `spawn matrix` | Full agent x cloud matrix |
-| `spawn list` | Show previously launched spawns |
-| `spawn agents` | List all agents |
+| `spawn list` | Browse and rerun previous spawns |
+| `spawn list <filter>` | Filter history by agent or cloud name |
+| `spawn list -a <agent>` | Filter history by agent |
+| `spawn list -c <cloud>` | Filter history by cloud |
+| `spawn list --clear` | Clear all spawn history |
+| `spawn last` | Instantly rerun the most recent spawn |
+| `spawn agents` | List all agents with descriptions |
 | `spawn clouds` | List all cloud providers |
 | `spawn update` | Check for CLI updates |
+| `spawn help` | Show help message |
+| `spawn version` | Show version |
 
 ### Without the CLI
 


### PR DESCRIPTION
## Summary

Complete the commands table in README.md to match the full CLI help output. This improves discoverability of all available commands.

## Changes

Added missing commands to the README commands table:
- `spawn <cloud>` - Show available agents for a cloud provider
- `spawn list <filter>` - Filter history by agent or cloud name  
- `spawn list -a <agent>` - Filter history by agent explicitly
- `spawn list -c <cloud>` - Filter history by cloud explicitly
- `spawn list --clear` - Clear all spawn history
- `spawn last` - Instantly rerun the most recent spawn (alias: rerun)
- `spawn help` - Show help message
- `spawn version` - Show version

Updated existing descriptions to match CLI help output exactly for consistency.

## Motivation

Users reading the README weren't aware of all available commands. The commands table was incomplete compared to `spawn help` output, which could lead to confusion or missed functionality.

## Test Plan

- [x] Verified all commands in table exist in CLI help
- [x] Checked descriptions match help output
- [x] Confirmed no markdown formatting issues
- [x] All commands are documented accurately

-- refactor/ux-engineer