### PR TITLE
refactor: extract claude code installation helpers

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1253,6 +1253,71 @@ verify_agent() {
     log_info "${agent_name} installation verified successfully"
 }
 
+# Helper: Check if Claude Code is already installed
+_claude_is_installed() {
+    local run_cb="$1"
+    local claude_path="$2"
+    ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1
+}
+
+# Helper: Finalize Claude Code installation (shell integration + PATH setup)
+_finalize_claude_install() {
+    local run_cb="$1"
+    local claude_path="$2"
+    log_step "Setting up Claude Code shell integration..."
+    ${run_cb} "${claude_path} && claude install --force" >/dev/null 2>&1 || true
+    # Write claude PATH to .bashrc and .zshrc
+    ${run_cb} "for rc in ~/.bashrc ~/.zshrc; do grep -q '.claude/local/bin' \"\$rc\" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH=\"\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"\\n' >> \"\$rc\"; done" >/dev/null 2>&1 || true
+}
+
+# Helper: Try installing Claude Code via curl installer (method 1)
+_try_curl_install() {
+    local run_cb="$1"
+    local claude_path="$2"
+    log_step "Installing Claude Code (method 1/2: curl installer)..."
+    if ${run_cb} "curl -fsSL https://claude.ai/install.sh | bash" 2>&1; then
+        if _claude_is_installed "$run_cb" "$claude_path"; then
+            log_info "Claude Code installed via curl installer"
+            return 0
+        fi
+        log_warn "curl installer exited 0 but claude not found on PATH"
+    else
+        log_warn "curl installer failed (site may be temporarily unavailable)"
+    fi
+    return 1
+}
+
+# Helper: Ensure Node.js runtime is installed (needed for bun package manager)
+_ensure_node_runtime() {
+    local run_cb="$1"
+    local claude_path="$2"
+    if ! ${run_cb} "${claude_path} && command -v node" >/dev/null 2>&1; then
+        log_step "Installing Node.js runtime (required for claude package)..."
+        if ${run_cb} "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs" >/dev/null 2>&1; then
+            log_info "Node.js installed via nodesource"
+        else
+            log_warn "Could not install Node.js - bun method may fail"
+        fi
+    fi
+}
+
+# Helper: Try installing Claude Code via bun (method 2)
+_try_bun_install() {
+    local run_cb="$1"
+    local claude_path="$2"
+    log_step "Installing Claude Code (method 2/2: bun)..."
+    if ${run_cb} "${claude_path} && bun i -g @anthropic-ai/claude-code 2>&1" 2>&1; then
+        if _claude_is_installed "$run_cb" "$claude_path"; then
+            log_info "Claude Code installed via bun"
+            return 0
+        fi
+        log_warn "bun install exited 0 but claude binary not found"
+    else
+        log_warn "bun install failed"
+    fi
+    return 1
+}
+
 # Install Claude Code with multi-method fallback and detailed error reporting.
 # Tries: 1) curl installer (standalone binary)  2) bun  3) npm
 # The curl installer bundles its own runtime. npm/bun install a Node.js package
@@ -1265,54 +1330,26 @@ install_claude_code() {
     # Clean up ~/.bash_profile if it was created by a previous broken deployment.
     ${run_cb} "if [ -f ~/.bash_profile ] && grep -q 'spawn:env\|Claude Code PATH\|spawn:path' ~/.bash_profile 2>/dev/null; then rm -f ~/.bash_profile; fi" >/dev/null 2>&1 || true
 
-    _finalize_claude_install() {
-        log_step "Setting up Claude Code shell integration..."
-        ${run_cb} "${claude_path} && claude install --force" >/dev/null 2>&1 || true
-        # Write claude PATH to .bashrc and .zshrc
-        ${run_cb} "for rc in ~/.bashrc ~/.zshrc; do grep -q '.claude/local/bin' \"\$rc\" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH=\"\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"\\n' >> \"\$rc\"; done" >/dev/null 2>&1 || true
-    }
-
     # Already installed?
-    if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
+    if _claude_is_installed "$run_cb" "$claude_path"; then
         log_info "Claude Code already installed"
-        _finalize_claude_install
+        _finalize_claude_install "$run_cb" "$claude_path"
         return 0
     fi
 
     # Method 1: official curl installer (standalone binary, no node needed)
-    log_step "Installing Claude Code (method 1/2: curl installer)..."
-    if ${run_cb} "curl -fsSL https://claude.ai/install.sh | bash" 2>&1; then
-        if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
-            log_info "Claude Code installed via curl installer"
-            _finalize_claude_install
-            return 0
-        fi
-        log_warn "curl installer exited 0 but claude not found on PATH"
-    else
-        log_warn "curl installer failed (site may be temporarily unavailable)"
+    if _try_curl_install "$run_cb" "$claude_path"; then
+        _finalize_claude_install "$run_cb" "$claude_path"
+        return 0
     fi
 
     # Ensure Node.js runtime for bun-installed package (it's a Node.js script)
-    if ! ${run_cb} "${claude_path} && command -v node" >/dev/null 2>&1; then
-        log_step "Installing Node.js runtime (required for claude package)..."
-        if ${run_cb} "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs" >/dev/null 2>&1; then
-            log_info "Node.js installed via nodesource"
-        else
-            log_warn "Could not install Node.js - bun method may fail"
-        fi
-    fi
+    _ensure_node_runtime "$run_cb" "$claude_path"
 
     # Method 2: bun
-    log_step "Installing Claude Code (method 2/2: bun)..."
-    if ${run_cb} "${claude_path} && bun i -g @anthropic-ai/claude-code 2>&1" 2>&1; then
-        if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
-            log_info "Claude Code installed via bun"
-            _finalize_claude_install
-            return 0
-        fi
-        log_warn "bun install exited 0 but claude binary not found"
-    else
-        log_warn "bun install failed"
+    if _try_bun_install "$run_cb" "$claude_path"; then
+        _finalize_claude_install "$run_cb" "$claude_path"
+        return 0
     fi
 
     # All methods failed


### PR DESCRIPTION
## Summary

Refactored `install_claude_code()` function in `shared/common.sh` to reduce complexity by extracting installation methods into focused helper functions.

**Complexity improvements:**
- Main function reduced from 61 lines to 32 lines
- Extracted 5 focused helper functions with single responsibilities
- Clearer control flow: setup → method 1 → method 2 → failure handling

## Changes

**New helper functions:**
- `_claude_is_installed()` - Check if Claude Code is on PATH
- `_finalize_claude_install()` - Shell integration + PATH setup (shared between methods)
- `_try_curl_install()` - Official curl installer (method 1)
- `_ensure_node_runtime()` - Install Node.js if needed for bun
- `_try_bun_install()` - Bun package manager (method 2)

**Benefits:**
- Main function flow is now immediately clear: 3-step installation process
- Each helper has a single responsibility, easier to debug
- No behavior changes, purely structural refactoring
- Bash syntax verified with `bash -n`

-- refactor/complexity-hunter