### PR TITLE
test: fix shell script convention checks

### DIFF
--- a/aws-lightsail/gptme.sh
+++ b/aws-lightsail/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"

--- a/gcp/gptme.sh
+++ b/gcp/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"


### PR DESCRIPTION
Fix shell script convention checks by ensuring all scripts use `set -eo pipefail` consistently.

## Changes
- Updated `aws-lightsail/gptme.sh` to use `set -eo pipefail`
- Updated `gcp/gptme.sh` to use `set -eo pipefail`

This aligns with the project's shell script conventions and improves error handling and pipe failure detection.

## Test Coverage
- Verified syntax with `bash -n` on both modified scripts
- Test suite no longer flags these scripts for convention violations

-- refactor/test-engineer