### PR TITLE
security: escape single quotes in OAuth server script generation

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -629,6 +629,16 @@ _validate_oauth_server_args() {
 _generate_oauth_server_script() {
     local expected_state="${1}" success_html="${2}" error_html="${3}"
     local code_file="${4}" port_file="${5}" starting_port="${6}"
+
+    # SECURITY: Escape single quotes in all parameters to prevent injection
+    # When parameters are embedded in the Node.js script string, unescaped quotes
+    # could break out of the string context and execute arbitrary code
+    expected_state="${expected_state//\'/\\\'}"
+    success_html="${success_html//\'/\\\'}"
+    error_html="${error_html//\'/\\\'}"
+    code_file="${code_file//\'/\\\'}"
+    port_file="${port_file//\'/\\\'}"
+
     printf '%s' "
 const http = require('http');
 const fs = require('fs');


### PR DESCRIPTION
## Summary

Fixes a potential code injection vulnerability in `_generate_oauth_server_script()` by escaping single quotes in all parameters before embedding them in the generated Node.js script.

## Vulnerability Details

**Severity**: HIGH  
**CWE**: CWE-94 (Improper Control of Generation of Code)  
**Attack Vector**: Malicious parameters containing single quotes  

The function generates a Node.js script by embedding bash variables directly into JavaScript string literals using single quotes. Without proper escaping, a crafted parameter like `"foo'; malicious(); '"` could break out of the string context and execute arbitrary code.

### Affected Parameters
- `expected_state` (OAuth CSRF token)
- `success_html` / `error_html` (HTML content)
- `code_file` / `port_file` (file paths)

### Example Attack
```bash
expected_state="x'; require('child_process').exec('rm -rf /'); '"
```

This would generate:
```javascript
const expectedState = 'x'; require('child_process').exec('rm -rf /'); '';
```

## Fix

All parameters are now sanitized with bash parameter expansion `${var//\'/\\\'}` which escapes single quotes to `\'` before embedding in the script.

## Risk Assessment

**Current Risk**: LOW (current callers use safe values: randomUUID, tempfile paths, HTML constants)  
**Defense-in-Depth**: HIGH value (prevents future regressions if callers change)

## Testing

- ✅ All shell script tests pass (80/80)
- ✅ Syntax validation passes
- ✅ No functional regressions

-- refactor/security-auditor