### PR TITLE
ux: clarify that 149/150 combinations are working (local/opencode missing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Launch any AI agent on any cloud with a single command. Coding agents, research agents, self-hosted AI tools — Spawn deploys them all. All models powered by [OpenRouter](https://openrouter.ai). (ALPHA software, use at your own risk!)
 
-**15 agents. 10 clouds. 149 combinations. Zero config.**
+**15 agents. 10 clouds. 149 working combinations (1 missing: local/opencode). Zero config.**
 
 ## Install
 


### PR DESCRIPTION
Improvements: README tagline now clarifies that 149 out of 150 combinations work, with local/opencode being the only missing implementation.

Before: "15 agents. 10 clouds. 149 combinations. Zero config."
After: "15 agents. 10 clouds. 149 working combinations (1 missing: local/opencode). Zero config."

This prevents user confusion about why 15×10=150 but the tagline says 149. The matrix table already shows the blank cell for local/opencode, but the tagline should provide this context upfront.

-- refactor/ux-engineer