### PR TITLE
ux: standardize destroy_server() wrapper for OVH and Sprite

### DIFF
--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -343,6 +343,11 @@ destroy_ovh_instance() {
     log_info "Instance $instance_id destroyed"
 }
 
+# Standardized destroy_server wrapper (for compatibility with cross-cloud scripts)
+destroy_server() {
+    destroy_ovh_instance "$@"
+}
+
 # OVH uses configurable SSH user (ubuntu for newer images, root for older)
 SSH_USER="${OVH_SSH_USER:-ubuntu}"
 

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -239,4 +239,21 @@ upload_file_sprite() {
     sprite exec -s "${sprite_name}" -file "${local_path}:${temp_remote}" -- bash -c "mkdir -p \$(dirname '${remote_path}') && mv '${temp_remote}' '${remote_path}'"
 }
 
+# Destroy a sprite (standardized wrapper for cross-cloud compatibility)
+destroy_server() {
+    local sprite_name="$1"
+
+    log_step "Destroying sprite '${sprite_name}'..."
+    if ! sprite destroy "${sprite_name}" 2>&1; then
+        log_error "Failed to destroy sprite '${sprite_name}'"
+        log_error ""
+        log_error "The sprite may still be running and incurring charges."
+        log_error "Delete it manually: sprite destroy ${sprite_name}"
+        log_error "Or check status: sprite list"
+        return 1
+    fi
+
+    log_info "Sprite '${sprite_name}' destroyed"
+}
+
 # Note: Provider-agnostic functions (nc_listen, open_browser, OAuth helpers, validate_model_id) are now in shared/common.sh


### PR DESCRIPTION
Improvements: Standardized destroy_server() function across all clouds to fix PR #1217 blocker.

**Problem**: PR #1217 hardcodes destroy_server() calls, but OVH and Sprite used different function names:
- 8 clouds have destroy_server() ✅
- OVH used destroy_ovh_instance() ❌
- Sprite had no destroy function ❌

**Impact**: VM deletion would silently fail for OVH and Sprite users.

**Solution**: Added destroy_server() wrapper functions to both clouds:
- `/home/spawn/spawn/ovh/lib/common.sh` - wraps destroy_ovh_instance()
- `/home/spawn/spawn/sprite/lib/common.sh` - wraps "sprite destroy <name>" CLI

All 10 clouds now have uniform destroy_server() interface for cross-cloud scripts.

Fixes #1178

-- refactor/ux-engineer