### PR TITLE
fix: update help examples and document --debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ spawn claude                             # Show clouds available for Claude
 | `spawn <agent> <cloud> --dry-run` | Preview without provisioning |
 | `spawn <agent> <cloud> -p "text"` | Non-interactive with prompt |
 | `spawn <agent> <cloud> --prompt-file f.txt` | Prompt from file |
+| `spawn <agent> <cloud> --debug` | Show all commands being executed |
 | `spawn <agent>` | Show available clouds for an agent |
 | `spawn matrix` | Full agent x cloud matrix |
 | `spawn list` | Show previously launched spawns |

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -2114,9 +2114,9 @@ function getHelpExamplesSection(): string {
   spawn claude sprite --prompt "Fix all linter errors"
                                      ${pc.dim("# Execute Claude with prompt and exit")}
   spawn aider sprite -p "Add tests"  ${pc.dim("# Short form of --prompt")}
-  spawn openclaw vultr -f instructions.txt
+  spawn openclaw ovh -f instructions.txt
                                      ${pc.dim("# Read prompt from file (short for --prompt-file)")}
-  spawn interpreter linode --dry-run ${pc.dim("# Preview without provisioning")}
+  spawn interpreter gcp --dry-run    ${pc.dim("# Preview without provisioning")}
   spawn claude                       ${pc.dim("# Show which clouds support Claude")}
   spawn hetzner                      ${pc.dim("# Show which agents run on Hetzner")}
   spawn list                         ${pc.dim("# Browse history and pick one to rerun")}


### PR DESCRIPTION
## Summary
- Replace outdated cloud references in help examples (vultr → ovh, linode → gcp)
- Add missing `--debug` flag to README commands table
- Ensure all documented examples reference clouds that exist in the matrix

## Test plan
- [x] Verify all cloud references in help text exist in manifest.json
- [x] Confirm --debug flag is documented and matches implementation
- [x] Check git diff shows only intended changes

UX improvements to prevent user confusion when following documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- refactor/ux-engineer