### PR TITLE
refactor: reduce complexity in shared/common.sh

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1258,41 +1258,34 @@ verify_agent() {
 # The curl installer bundles its own runtime. npm/bun install a Node.js package
 # whose shebang needs 'node', so we ensure a node runtime exists after those.
 # Usage: install_claude_code RUN_CB
-install_claude_code() {
+_finalize_claude_install() {
     local run_cb="$1"
-    local claude_path='export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH'
+    local claude_path="$2"
+    log_step "Setting up Claude Code shell integration..."
+    ${run_cb} "${claude_path} && claude install --force" >/dev/null 2>&1 || true
+    ${run_cb} "for rc in ~/.bashrc ~/.zshrc; do grep -q '.claude/local/bin' \"\$rc\" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH=\"\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"\\n' >> \"\$rc\"; done" >/dev/null 2>&1 || true
+}
 
-    # Clean up ~/.bash_profile if it was created by a previous broken deployment.
-    ${run_cb} "if [ -f ~/.bash_profile ] && grep -q 'spawn:env\|Claude Code PATH\|spawn:path' ~/.bash_profile 2>/dev/null; then rm -f ~/.bash_profile; fi" >/dev/null 2>&1 || true
-
-    _finalize_claude_install() {
-        log_step "Setting up Claude Code shell integration..."
-        ${run_cb} "${claude_path} && claude install --force" >/dev/null 2>&1 || true
-        # Write claude PATH to .bashrc and .zshrc
-        ${run_cb} "for rc in ~/.bashrc ~/.zshrc; do grep -q '.claude/local/bin' \"\$rc\" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH=\"\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"\\n' >> \"\$rc\"; done" >/dev/null 2>&1 || true
-    }
-
-    # Already installed?
-    if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
-        log_info "Claude Code already installed"
-        _finalize_claude_install
-        return 0
-    fi
-
-    # Method 1: official curl installer (standalone binary, no node needed)
+_try_curl_installer() {
+    local run_cb="$1"
+    local claude_path="$2"
     log_step "Installing Claude Code (method 1/2: curl installer)..."
     if ${run_cb} "curl -fsSL https://claude.ai/install.sh | bash" 2>&1; then
         if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
             log_info "Claude Code installed via curl installer"
-            _finalize_claude_install
+            _finalize_claude_install "$run_cb" "$claude_path"
             return 0
         fi
         log_warn "curl installer exited 0 but claude not found on PATH"
     else
         log_warn "curl installer failed (site may be temporarily unavailable)"
     fi
+    return 1
+}
 
-    # Ensure Node.js runtime for bun-installed package (it's a Node.js script)
+_ensure_nodejs() {
+    local run_cb="$1"
+    local claude_path="$2"
     if ! ${run_cb} "${claude_path} && command -v node" >/dev/null 2>&1; then
         log_step "Installing Node.js runtime (required for claude package)..."
         if ${run_cb} "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs" >/dev/null 2>&1; then
@@ -1301,21 +1294,41 @@ install_claude_code() {
             log_warn "Could not install Node.js - bun method may fail"
         fi
     fi
+}
 
-    # Method 2: bun
+_try_bun_installer() {
+    local run_cb="$1"
+    local claude_path="$2"
     log_step "Installing Claude Code (method 2/2: bun)..."
     if ${run_cb} "${claude_path} && bun i -g @anthropic-ai/claude-code 2>&1" 2>&1; then
         if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
             log_info "Claude Code installed via bun"
-            _finalize_claude_install
+            _finalize_claude_install "$run_cb" "$claude_path"
             return 0
         fi
         log_warn "bun install exited 0 but claude binary not found"
     else
         log_warn "bun install failed"
     fi
+    return 1
+}
 
-    # All methods failed
+install_claude_code() {
+    local run_cb="$1"
+    local claude_path='export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH'
+
+    ${run_cb} "if [ -f ~/.bash_profile ] && grep -q 'spawn:env\|Claude Code PATH\|spawn:path' ~/.bash_profile 2>/dev/null; then rm -f ~/.bash_profile; fi" >/dev/null 2>&1 || true
+
+    if ${run_cb} "${claude_path} && command -v claude" >/dev/null 2>&1; then
+        log_info "Claude Code already installed"
+        _finalize_claude_install "$run_cb" "$claude_path"
+        return 0
+    fi
+
+    _try_curl_installer "$run_cb" "$claude_path" && return 0
+    _ensure_nodejs "$run_cb" "$claude_path"
+    _try_bun_installer "$run_cb" "$claude_path" && return 0
+
     log_install_failed "Claude Code" "curl -fsSL https://claude.ai/install.sh | bash"
     exit 1
 }


### PR DESCRIPTION
## Summary
Refactored `install_claude_code()` to reduce complexity by extracting installation methods into focused helper functions.

- Extracted curl installer logic into `_try_curl_installer()`
- Extracted Node.js setup into `_ensure_nodejs()`
- Extracted bun installer logic into `_try_bun_installer()`
- Extracted finalization logic into `_finalize_claude_install()`

**Result:** Main function reduced from 60 lines to 18 lines, improving readability and maintainability.

## Test plan
- [x] bash -n syntax check on modified files
- [x] All helper functions follow existing patterns in common.sh
- [x] Function behavior preserved (same success/failure paths)
- [x] Each helper has single responsibility

-- refactor/complexity-hunter