### PR TITLE
ux: fix readonly property assignment errors in terminal width tests

### DIFF
--- a/cli/src/__tests__/commands-compact-list.test.ts
+++ b/cli/src/__tests__/commands-compact-list.test.ts
@@ -195,7 +195,13 @@ describe("Compact List View", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.stdout.columns = originalColumns!;
+    if (originalColumns !== undefined) {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: originalColumns,
+        writable: true,
+        configurable: true
+      });
+    }
     restoreMocks(consoleMocks.log, consoleMocks.error);
   });
 
@@ -214,13 +220,25 @@ describe("Compact List View", () => {
       .join("\n");
   }
 
+  function setTerminalWidth(columns: number | undefined): void {
+    Object.defineProperty(process.stdout, 'columns', {
+      value: columns,
+      writable: true,
+      configurable: true
+    });
+  }
+
   // ── View switching based on terminal width ──────────────────────────
 
   describe("grid vs compact view switching", () => {
     it("should use compact view when terminal is narrow and many clouds", async () => {
       await setManifest(wideManifest);
       // Force narrow terminal - compact view triggered
-      process.stdout.columns = 60;
+      Object.defineProperty(process.stdout, 'columns', {
+        value: 60,
+        writable: true,
+        configurable: true
+      });
 
       await cmdMatrix();
       const output = getOutput();
@@ -233,7 +251,11 @@ describe("Compact List View", () => {
     it("should use grid view when terminal is wide enough for small manifest", async () => {
       await setManifest(mockManifest);
       // Force wide terminal
-      process.stdout.columns = 200;
+      Object.defineProperty(process.stdout, 'columns', {
+        value: 200,
+        writable: true,
+        configurable: true
+      });
 
       await cmdMatrix();
       const output = getOutput();
@@ -248,7 +270,11 @@ describe("Compact List View", () => {
     it("should default to 80 columns when process.stdout.columns is undefined", async () => {
       await setManifest(wideManifest);
       // Simulate no tty (columns undefined)
-      (process.stdout as any).columns = undefined;
+      Object.defineProperty(process.stdout, 'columns', {
+        value: undefined,
+        writable: true,
+        configurable: true
+      });
 
       await cmdMatrix();
       const output = getOutput();
@@ -264,7 +290,11 @@ describe("Compact List View", () => {
   describe("compact view header", () => {
     it("should show three column headers: Agent, Clouds, Not yet available", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      Object.defineProperty(process.stdout, 'columns', {
+        value: 60,
+        writable: true,
+        configurable: true
+      });
 
       await cmdMatrix();
       const output = getOutput();
@@ -275,7 +305,7 @@ describe("Compact List View", () => {
 
     it("should include a separator line with dashes", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -289,7 +319,7 @@ describe("Compact List View", () => {
   describe("compact view counts", () => {
     it("should show correct count for fully implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -299,7 +329,7 @@ describe("Compact List View", () => {
 
     it("should show correct count for partially implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -309,7 +339,7 @@ describe("Compact List View", () => {
 
     it("should show 0/N when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -318,7 +348,7 @@ describe("Compact List View", () => {
 
     it("should show N/N for all agents when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -335,7 +365,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds column", () => {
     it("should show 'all clouds supported' when agent is fully implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -345,7 +375,7 @@ describe("Compact List View", () => {
 
     it("should list missing cloud names when agent is partially implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -359,7 +389,7 @@ describe("Compact List View", () => {
 
     it("should not list implemented clouds as missing", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -378,7 +408,7 @@ describe("Compact List View", () => {
 
     it("should list all clouds as missing when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -394,7 +424,7 @@ describe("Compact List View", () => {
 
     it("should show 'all clouds supported' for every agent when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -410,7 +440,7 @@ describe("Compact List View", () => {
   describe("compact view agent names", () => {
     it("should display agent display names (not keys)", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -424,7 +454,7 @@ describe("Compact List View", () => {
   describe("footer in compact view", () => {
     it("should show total implemented count", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -434,7 +464,7 @@ describe("Compact List View", () => {
 
     it("should not show grid legend in compact view", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -445,7 +475,7 @@ describe("Compact List View", () => {
 
     it("should show usage hints", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -472,7 +502,7 @@ describe("Compact List View", () => {
         },
       };
       await setManifest(singleAgent);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -488,7 +518,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds formatting", () => {
     it("should separate missing cloud names with commas", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setTerminalWidth(60);
 
       await cmdMatrix();
       const lines = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" "));

--- a/cli/src/__tests__/commands-list-grid.test.ts
+++ b/cli/src/__tests__/commands-list-grid.test.ts
@@ -217,14 +217,24 @@ describe("cmdMatrix - grid view rendering", () => {
     originalColumns = process.stdout.columns;
 
     // Force wide terminal for grid view
-    process.stdout.columns = 200;
+    Object.defineProperty(process.stdout, 'columns', {
+      value: 200,
+      writable: true,
+      configurable: true
+    });
 
     await setManifest(mockManifest);
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.stdout.columns = originalColumns!;
+    if (originalColumns !== undefined) {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: originalColumns,
+        writable: true,
+        configurable: true
+      });
+    }
     restoreMocks(consoleMocks.log, consoleMocks.error);
   });
 


### PR DESCRIPTION
## Summary

Fixes test failures caused by attempting to assign to the readonly `process.stdout.columns` property in Bun's test environment.

## Changes

- **commands-compact-list.test.ts**: Added `setTerminalWidth()` helper function and updated all test cases to use `Object.defineProperty()` instead of direct property assignment
- **commands-list-grid.test.ts**: Updated `beforeEach()` and `afterEach()` to use `Object.defineProperty()` for setting terminal width
- Fixed cleanup logic in `afterEach()` to properly restore original columns value

## Why

Bun's test runtime makes `process.stdout.columns` readonly, causing all tests that manipulate terminal width to fail with "Attempted to assign to readonly property" errors. Using `Object.defineProperty()` allows us to modify readonly properties safely during tests.

## Test Results

All terminal width tests now pass in Bun runtime.

-- refactor/ux-engineer