### PR TITLE
test: fix test failures and shell script conventions

### DIFF
--- a/aws-lightsail/gptme.sh
+++ b/aws-lightsail/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"

--- a/cli/src/__tests__/commands-compact-list.test.ts
+++ b/cli/src/__tests__/commands-compact-list.test.ts
@@ -195,9 +195,21 @@ describe("Compact List View", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.stdout.columns = originalColumns!;
+    Object.defineProperty(process.stdout, "columns", {
+      value: originalColumns,
+      writable: true,
+      configurable: true,
+    });
     restoreMocks(consoleMocks.log, consoleMocks.error);
   });
+
+  function setColumns(cols: number | undefined) {
+    Object.defineProperty(process.stdout, "columns", {
+      value: cols,
+      writable: true,
+      configurable: true,
+    });
+  }
 
   function setManifest(manifest: any) {
     global.fetch = mock(async () => ({
@@ -220,7 +232,7 @@ describe("Compact List View", () => {
     it("should use compact view when terminal is narrow and many clouds", async () => {
       await setManifest(wideManifest);
       // Force narrow terminal - compact view triggered
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -233,7 +245,7 @@ describe("Compact List View", () => {
     it("should use grid view when terminal is wide enough for small manifest", async () => {
       await setManifest(mockManifest);
       // Force wide terminal
-      process.stdout.columns = 200;
+      setColumns(200);
 
       await cmdMatrix();
       const output = getOutput();
@@ -248,7 +260,7 @@ describe("Compact List View", () => {
     it("should default to 80 columns when process.stdout.columns is undefined", async () => {
       await setManifest(wideManifest);
       // Simulate no tty (columns undefined)
-      (process.stdout as any).columns = undefined;
+      setColumns(undefined);
 
       await cmdMatrix();
       const output = getOutput();
@@ -264,7 +276,7 @@ describe("Compact List View", () => {
   describe("compact view header", () => {
     it("should show three column headers: Agent, Clouds, Not yet available", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -275,7 +287,7 @@ describe("Compact List View", () => {
 
     it("should include a separator line with dashes", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -289,7 +301,7 @@ describe("Compact List View", () => {
   describe("compact view counts", () => {
     it("should show correct count for fully implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -299,7 +311,7 @@ describe("Compact List View", () => {
 
     it("should show correct count for partially implemented agent", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -309,7 +321,7 @@ describe("Compact List View", () => {
 
     it("should show 0/N when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -318,7 +330,7 @@ describe("Compact List View", () => {
 
     it("should show N/N for all agents when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -335,7 +347,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds column", () => {
     it("should show 'all clouds supported' when agent is fully implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -345,7 +357,7 @@ describe("Compact List View", () => {
 
     it("should list missing cloud names when agent is partially implemented", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -359,7 +371,7 @@ describe("Compact List View", () => {
 
     it("should not list implemented clouds as missing", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -378,7 +390,7 @@ describe("Compact List View", () => {
 
     it("should list all clouds as missing when agent has no implementations", async () => {
       await setManifest(allMissingManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -394,7 +406,7 @@ describe("Compact List View", () => {
 
     it("should show 'all clouds supported' for every agent when everything is implemented", async () => {
       await setManifest(allImplementedManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -410,7 +422,7 @@ describe("Compact List View", () => {
   describe("compact view agent names", () => {
     it("should display agent display names (not keys)", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -424,7 +436,7 @@ describe("Compact List View", () => {
   describe("footer in compact view", () => {
     it("should show total implemented count", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -434,7 +446,7 @@ describe("Compact List View", () => {
 
     it("should not show grid legend in compact view", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -445,7 +457,7 @@ describe("Compact List View", () => {
 
     it("should show usage hints", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -472,7 +484,7 @@ describe("Compact List View", () => {
         },
       };
       await setManifest(singleAgent);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const output = getOutput();
@@ -488,7 +500,7 @@ describe("Compact List View", () => {
   describe("compact view missing clouds formatting", () => {
     it("should separate missing cloud names with commas", async () => {
       await setManifest(wideManifest);
-      process.stdout.columns = 60;
+      setColumns(60);
 
       await cmdMatrix();
       const lines = consoleMocks.log.mock.calls.map((c: any[]) => c.join(" "));

--- a/cli/src/__tests__/oracle-provider-patterns.test.ts
+++ b/cli/src/__tests__/oracle-provider-patterns.test.ts
@@ -744,7 +744,7 @@ describe("Oracle claude.sh agent-specific patterns", () => {
   });
 
   it("should install Claude Code if not present", () => {
-    expect(claudeContent).toContain("claude.ai/install.sh");
+    expect(claudeContent).toContain("install_claude_code");
   });
 
   it("should set ANTHROPIC_BASE_URL for OpenRouter", () => {

--- a/gcp/gptme.sh
+++ b/gcp/gptme.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 # Source common functions - try local file first, fall back to remote
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"


### PR DESCRIPTION
## Summary
- Fixed oracle-provider-patterns test to check for updated install_claude_code function instead of outdated URL
- Updated aws-lightsail/gptme.sh and gcp/gptme.sh to use proper 'set -eo pipefail' error handling
- Fixed process.stdout.columns mocking in compact-list test using Object.defineProperty
- Ensured proper cleanup of terminal width mocks in test afterEach hooks

## Test Results
- All 8061 tests passing
- No test failures or regressions
- Shell script syntax verified with bash -n

## Verification
- `npx bun test` runs all 8061 tests successfully
- Modified shell scripts pass shellcheck syntax validation

Agent: test-engineer
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>