### PR TITLE
fix: use ~/.spawnrc for env vars instead of inlining into .bashrc

### DIFF
--- a/aws-lightsail/claude.sh
+++ b/aws-lightsail/claude.sh
@@ -25,6 +25,6 @@ agent_env_vars() {
         "CLAUDE_CODE_ENABLE_TELEMETRY=0"
 }
 agent_configure() { setup_claude_code_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run; }
-agent_launch_cmd() { echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
 
 spawn_agent "Claude Code"

--- a/daytona/claude.sh
+++ b/daytona/claude.sh
@@ -33,7 +33,7 @@ agent_configure() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+    echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
 }
 
 spawn_agent "Claude Code"

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -25,6 +25,6 @@ agent_env_vars() {
         "CLAUDE_CODE_ENABLE_TELEMETRY=0"
 }
 agent_configure() { setup_claude_code_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run; }
-agent_launch_cmd() { echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
 
 spawn_agent "Claude Code"

--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -33,7 +33,7 @@ agent_configure() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+    echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
 }
 
 spawn_agent "Claude Code"

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -25,6 +25,6 @@ agent_env_vars() {
         "CLAUDE_CODE_ENABLE_TELEMETRY=0"
 }
 agent_configure() { setup_claude_code_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run; }
-agent_launch_cmd() { echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
 
 spawn_agent "Claude Code"

--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -25,6 +25,6 @@ agent_env_vars() {
         "CLAUDE_CODE_ENABLE_TELEMETRY=0"
 }
 agent_configure() { setup_claude_code_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run; }
-agent_launch_cmd() { echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
 
 spawn_agent "Claude Code"

--- a/local/claude.sh
+++ b/local/claude.sh
@@ -33,9 +33,9 @@ agent_configure() {
 agent_launch_cmd() {
     if [[ -n "${SPAWN_PROMPT:-}" ]]; then
         local escaped; escaped=$(printf '%q' "${SPAWN_PROMPT}")
-        printf 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude -p %s' "${escaped}"
+        printf 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude -p %s' "${escaped}"
     else
-        echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+        echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
     fi
 }
 

--- a/oracle/claude.sh
+++ b/oracle/claude.sh
@@ -25,6 +25,6 @@ agent_env_vars() {
         "CLAUDE_CODE_ENABLE_TELEMETRY=0"
 }
 agent_configure() { setup_claude_code_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run; }
-agent_launch_cmd() { echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
 
 spawn_agent "Claude Code"

--- a/ovh/claude.sh
+++ b/ovh/claude.sh
@@ -25,6 +25,6 @@ agent_env_vars() {
         "CLAUDE_CODE_ENABLE_TELEMETRY=0"
 }
 agent_configure() { setup_claude_code_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run; }
-agent_launch_cmd() { echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'; }
 
 spawn_agent "Claude Code"

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1409,7 +1409,15 @@ _spawn_inject_env_vars() {
     agent_env_vars > "${env_temp}"
 
     cloud_upload "${env_temp}" "/tmp/env_config"
-    cloud_run "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
+
+    # Write env vars to ~/.spawnrc instead of inlining into .bashrc/.zshrc.
+    # Ubuntu's default .bashrc has an interactive-shell guard that exits early —
+    # anything appended after the guard is never loaded when SSH runs a command string.
+    cloud_run "cp /tmp/env_config ~/.spawnrc && chmod 600 ~/.spawnrc && rm /tmp/env_config"
+
+    # Hook .spawnrc into .bashrc and .zshrc so interactive shells pick up the vars too
+    cloud_run "grep -q 'source ~/.spawnrc' ~/.bashrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.bashrc"
+    cloud_run "grep -q 'source ~/.spawnrc' ~/.zshrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.zshrc"
 
     offer_github_auth cloud_run
 }

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -39,9 +39,9 @@ agent_save_connection() {
 agent_launch_cmd() {
     if [[ -n "${SPAWN_PROMPT:-}" ]]; then
         local escaped; escaped=$(printf '%q' "${SPAWN_PROMPT}")
-        printf 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude -p %s' "${escaped}"
+        printf 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude -p %s' "${escaped}"
     else
-        echo 'source ~/.bashrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
+        echo 'source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude'
     fi
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: Ubuntu's default `~/.bashrc` has an interactive-shell guard (`case $- in *i*) ;; *) return;; esac`) that exits early in non-interactive shells. When SSH runs `ssh -t user@host -- "source ~/.bashrc; claude"`, env vars appended at the bottom of `.bashrc` are never loaded — Claude Code starts without OpenRouter credentials and gets rejected.
- **Fix**: Write env vars to `~/.spawnrc` (a standalone file with no guard). `.bashrc`/`.zshrc` get a one-liner to source it for interactive shells. Launch commands source `~/.spawnrc` directly.
- Affects all 10 clouds, not just Hetzner

## Test plan

- [ ] Deploy Claude Code on Hetzner — verify `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` are set when claude starts
- [ ] SSH into the server manually — verify env vars are loaded in interactive shell via `.bashrc` sourcing `.spawnrc`
- [ ] Run `cat ~/.spawnrc` on remote — verify env vars are written correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)