### PR TITLE
feat: server lifecycle management (reconnect + delete)

### DIFF
--- a/aws-lightsail/lib/common.sh
+++ b/aws-lightsail/lib/common.sh
@@ -169,6 +169,8 @@ create_server() {
     log_info "Instance creation initiated: ${name}"
 
     _wait_for_lightsail_instance "${name}"
+
+    save_vm_connection "${LIGHTSAIL_SERVER_IP}" "ubuntu" "" "$name" "aws-lightsail"
 }
 
 # Lightsail uses 'ubuntu' user, not 'root'

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.88",
+  "version": "0.3.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -194,6 +194,8 @@ create_server() {
 
     _resolve_sandbox_id "${name}"
     log_info "Sandbox created: ${DAYTONA_SANDBOX_ID}"
+
+    save_vm_connection "daytona-sandbox" "daytona" "${DAYTONA_SANDBOX_ID}" "$name" "daytona"
 }
 
 wait_for_cloud_init() {

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -200,6 +200,8 @@ create_server() {
     log_info "Droplet created: ID=$DO_DROPLET_ID"
 
     _wait_for_droplet_active "$DO_DROPLET_ID"
+
+    save_vm_connection "${DO_SERVER_IP}" "root" "${DO_DROPLET_ID}" "$name" "digitalocean"
 }
 
 # SSH operations — delegates to shared helpers (SSH_USER defaults to root)

--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -284,6 +284,8 @@ create_server() {
     _fly_create_app "$name" || return 1
     _fly_create_machine "$name" "$region" "$vm_memory" || return 1
     _fly_wait_for_machine_start "$name" "$FLY_MACHINE_ID"
+
+    save_vm_connection "fly-ssh" "root" "${FLY_MACHINE_ID}" "$name" "fly"
 }
 
 # Wait for base tools to be installed (Fly.io uses bare Ubuntu image)

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -233,6 +233,8 @@ create_server() {
     export GCP_SERVER_IP="$(_gcp_get_instance_ip "${name}" "${zone}")"
 
     log_info "Instance created: IP=${GCP_SERVER_IP}"
+
+    save_vm_connection "${GCP_SERVER_IP}" "${SSH_USER:-$(whoami)}" "" "$name" "gcp" "{\"zone\":\"${zone}\",\"project\":\"${GCP_PROJECT}\"}"
 }
 
 verify_server_connectivity() { ssh_verify_connectivity "$@"; }

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -406,6 +406,8 @@ create_server() {
     export HETZNER_SERVER_ID HETZNER_SERVER_IP
 
     log_info "Server created: ID=$HETZNER_SERVER_ID, IP=$HETZNER_SERVER_IP"
+
+    save_vm_connection "${HETZNER_SERVER_IP}" "root" "${HETZNER_SERVER_ID}" "$name" "hetzner"
 }
 
 # SSH operations — delegates to shared helpers (SSH_USER defaults to root)

--- a/local/lib/common.sh
+++ b/local/lib/common.sh
@@ -43,6 +43,8 @@ get_server_name() {
 create_server() {
     local name="${1}"
     log_info "Using local machine: ${name}"
+
+    save_vm_connection "localhost" "${USER:-$(whoami)}" "" "$name" "local"
 }
 
 # No cloud-init needed

--- a/oracle/lib/common.sh
+++ b/oracle/lib/common.sh
@@ -423,6 +423,8 @@ create_server() {
 
     export OCI_SERVER_IP="${server_ip}"
     log_info "Instance created: IP=${OCI_SERVER_IP}"
+
+    save_vm_connection "${OCI_SERVER_IP}" "ubuntu" "${OCI_INSTANCE_ID}" "$name" "oracle"
 }
 
 # OCI Ubuntu images use 'ubuntu' user

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -419,7 +419,12 @@ for s in data:
 
 cloud_authenticate() { ensure_ovh_authenticated; ensure_ssh_key; }
 cloud_provision() { local name="$1"; create_ovh_instance "${name}"; }
-cloud_wait_ready() { wait_for_ovh_instance "${OVH_INSTANCE_ID}"; verify_server_connectivity "${OVH_SERVER_IP}"; install_base_deps "${OVH_SERVER_IP}"; }
+cloud_wait_ready() {
+    wait_for_ovh_instance "${OVH_INSTANCE_ID}"
+    save_vm_connection "${OVH_SERVER_IP}" "${OVH_SSH_USER:-ubuntu}" "${OVH_INSTANCE_ID}" "${OVH_SERVER_NAME:-}" "ovh"
+    verify_server_connectivity "${OVH_SERVER_IP}"
+    install_base_deps "${OVH_SERVER_IP}"
+}
 cloud_run() { run_ovh "${OVH_SERVER_IP}" "$1"; }
 cloud_upload() { upload_file_ovh "${OVH_SERVER_IP}" "$1" "$2"; }
 cloud_interactive() { interactive_session "${OVH_SERVER_IP}" "$1"; }

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -3198,13 +3198,16 @@ opencode_install_cmd() {
 
 # Save VM connection info for spawn list reconnect functionality.
 # This allows users to reconnect to previously spawned VMs via `spawn list`.
-# Usage: save_vm_connection IP USER [SERVER_ID] [SERVER_NAME]
-# Example: save_vm_connection "$DO_SERVER_IP" "root" "$DO_DROPLET_ID" "$DROPLET_NAME"
+# Usage: save_vm_connection IP USER [SERVER_ID] [SERVER_NAME] [CLOUD] [METADATA_JSON]
+# Example: save_vm_connection "$DO_SERVER_IP" "root" "$DO_DROPLET_ID" "$DROPLET_NAME" "digitalocean"
+# Example: save_vm_connection "$GCP_IP" "root" "" "$NAME" "gcp" '{"zone":"us-central1-a"}'
 save_vm_connection() {
     local ip="${1}"
     local user="${2}"
     local server_id="${3:-}"
     local server_name="${4:-}"
+    local cloud="${5:-}"
+    local metadata="${6:-}"
 
     local spawn_dir="${HOME}/.spawn"
     mkdir -p "${spawn_dir}"
@@ -3218,6 +3221,12 @@ save_vm_connection() {
     fi
     if [[ -n "${server_name}" ]]; then
         json="${json},\"server_name\":\"${server_name}\""
+    fi
+    if [[ -n "${cloud}" ]]; then
+        json="${json},\"cloud\":\"${cloud}\""
+    fi
+    if [[ -n "${metadata}" ]]; then
+        json="${json},\"metadata\":${metadata}"
     fi
     json="${json}}"
 

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -33,7 +33,7 @@ agent_configure() {
 }
 
 agent_save_connection() {
-    save_vm_connection "sprite-console" "${USER:-root}" "" "${SPRITE_NAME}"
+    save_vm_connection "sprite-console" "${USER:-root}" "" "${SPRITE_NAME}" "sprite"
 }
 
 agent_launch_cmd() {


### PR DESCRIPTION
## Summary

- **Connection tracking**: All 10 clouds now call `save_vm_connection()` in their `create_server()` with cloud name and metadata, enabling reconnect and delete functionality
- **Delete via `spawn list`**: When selecting a server with connection info, a new "Delete this server" option appears alongside Reconnect and Spawn new — with confirmation prompt and spinner feedback
- **Standalone `spawn delete` command**: Interactive picker to select and delete active servers, with `-a`/`-c` filter support (aliases: `rm`, `destroy`)

### How it works

The delete flow reuses each cloud's existing `destroy_server()` shell function by dynamically building a bash script that:
1. Downloads the cloud's `lib/common.sh` (same curl pattern as agent scripts)
2. Calls the cloud's auth function to load saved credentials
3. Calls `destroy_server()` with the server ID/name

Deleted servers are soft-deleted in history (marked with `[deleted]` tag, no reconnect/delete options shown).

### Files changed (15)

| Area | Files | What |
|------|-------|------|
| Shell | `shared/common.sh` | Extended `save_vm_connection()` with `cloud` and `metadata` params |
| Shell | 9× `{cloud}/lib/common.sh` | Added `save_vm_connection` call in `create_server()` |
| Shell | `sprite/claude.sh` | Updated existing call with cloud param |
| CLI | `cli/src/history.ts` | Extended VMConnection interface, added `markRecordDeleted()`, `getActiveServers()` |
| CLI | `cli/src/commands.ts` | Delete UI, `buildDeleteScript()`, `execDeleteServer()`, `cmdDelete()`, help text |
| CLI | `cli/src/index.ts` | DELETE_COMMANDS routing |
| CLI | `cli/package.json` | Version bump 0.2.88 → 0.3.0 |

## Test plan

- [ ] `bash -n` passes on all 11 modified shell scripts (verified in CI pre-commit hook)
- [ ] `bun build` compiles without errors
- [ ] `bun test` passes (0 new failures — 223 pre-existing)
- [ ] Manual: `spawn claude hetzner` → verify `~/.spawn/last-connection.json` has `cloud` field
- [ ] Manual: `spawn list` → select server → "Delete" → confirm → verify server destroyed
- [ ] Manual: `spawn delete` → pick from active servers → confirm
- [ ] Manual: deleted record shows `[deleted]` in `spawn list`
- [ ] Backward compat: old history entries without `cloud` field still work (no delete option, reconnect works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)