### PR TITLE
Simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_request.yml
+++ b/.github/ISSUE_TEMPLATE/agent_request.yml
@@ -1,71 +1,20 @@
 name: Agent Request
-description: Request support for a new AI coding agent
+description: Request a new AI agent
 title: "[Agent]: "
 labels: ["agent-request", "enhancement", "pending-review"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for suggesting a new agent! Put the agent name in the issue title above.
-
   - type: input
     id: agent-url
     attributes:
-      label: Repository / Website URL
-      description: Link to the agent's GitHub repo or homepage
+      label: Link
       placeholder: https://github.com/org/agent
     validations:
-      required: true
-
-  - type: dropdown
-    id: install-method
-    attributes:
-      label: Install Method
-      description: How is the agent installed?
-      options:
-        - npm / npx
-        - pip / pipx
-        - curl | bash
-        - brew
-        - Other (describe below)
-    validations:
-      required: true
-
-  - type: dropdown
-    id: openrouter-support
-    attributes:
-      label: OpenRouter Compatibility
-      description: Does the agent work with OpenRouter?
-      options:
-        - Native support (OPENROUTER_API_KEY)
-        - Via OPENAI_BASE_URL override
-        - Via ANTHROPIC_BASE_URL override
-        - Not sure
-    validations:
-      required: true
+      required: false
 
   - type: textarea
-    id: evidence
+    id: why
     attributes:
-      label: Why This Agent?
-      description: |
-        Any of the following count as evidence of traction:
-        - GitHub stars or active fork activity
-        - Hacker News, Reddit, or Twitter buzz
-        - Venture-funded or backed by a known company
-        - Personal experience / recommendation
-      placeholder: |
-        - 5k GitHub stars, 200+ forks
-        - Backed by YC / raised Series A
-        - HN front page post (link)
-    validations:
-      required: true
-
-  - type: textarea
-    id: additional
-    attributes:
-      label: Additional Context
-      description: Any other details (config requirements, env vars, known limitations)
-      placeholder: Requires Node 20+, uses OPENAI_API_KEY env var
+      label: Why?
+      placeholder: "What makes this agent worth adding?"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,54 +1,13 @@
 name: Bug Report
-description: Report an error or unexpected behavior
+description: Something broken?
 title: "[Bug]: "
 labels: ["bug", "pending-review"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for reporting! Please paste the full error log or run output below.
-
   - type: textarea
-    id: error-log
+    id: what-happened
     attributes:
-      label: Error Log / Run Output
-      description: Paste the complete terminal output showing the error
-      placeholder: |
-        $ spawn claude sprite
-        [error output here...]
+      label: What happened?
+      placeholder: "Paste the error or describe what went wrong"
       render: shell
     validations:
       required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected Behavior
-      description: What did you expect to happen?
-      placeholder: I expected the agent to launch successfully
-    validations:
-      required: false
-
-  - type: textarea
-    id: environment
-    attributes:
-      label: Environment
-      description: |
-        Run these commands and paste the output:
-        - spawn version
-        - uname -a
-      placeholder: |
-        spawn v1.0.0
-        Darwin 23.1.0
-      render: shell
-    validations:
-      required: false
-
-  - type: textarea
-    id: additional
-    attributes:
-      label: Additional Context
-      description: Any other details that might help
-      placeholder: This only happens when using --prompt flag
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/cli_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/cli_feature_request.yml
@@ -1,51 +1,12 @@
 name: CLI Feature Request
-description: Suggest a new feature or improvement for the spawn CLI
+description: Suggest something for the spawn CLI
 title: "[CLI]: "
 labels: ["cli", "enhancement", "pending-review"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for the suggestion! Describe what you'd like the spawn CLI to do.
-
   - type: textarea
     id: description
     attributes:
-      label: Feature Description
-      description: What should the CLI do? Be as specific as you can.
-      placeholder: |
-        spawn should support a `--dry-run` flag that shows what would
-        be provisioned without actually creating anything.
+      label: What would you like?
+      placeholder: "e.g. Add a --dry-run flag to preview what gets created"
     validations:
       required: true
-
-  - type: textarea
-    id: use-case
-    attributes:
-      label: Use Case
-      description: Why do you need this? What problem does it solve?
-      placeholder: |
-        I want to preview costs before spinning up a server.
-    validations:
-      required: true
-
-  - type: textarea
-    id: proposed-ux
-    attributes:
-      label: Proposed UX
-      description: How would you expect to use this feature? Show example commands or workflows.
-      placeholder: |
-        $ spawn claude hetzner --dry-run
-        Would create: Hetzner CX22 in fsn1 (~$0.01/hr)
-        Run without --dry-run to proceed.
-      render: shell
-    validations:
-      required: false
-
-  - type: textarea
-    id: additional
-    attributes:
-      label: Additional Context
-      description: Any other details, mockups, or references to similar tools
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/cloud_request.yml
+++ b/.github/ISSUE_TEMPLATE/cloud_request.yml
@@ -1,70 +1,20 @@
 name: Cloud Provider Request
-description: Request support for a new cloud provider
+description: Request a new cloud provider
 title: "[Cloud]: "
 labels: ["cloud-request", "enhancement", "pending-review"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for suggesting a new cloud provider! Put the provider name in the issue title above.
-
   - type: input
     id: cloud-url
     attributes:
-      label: Website URL
-      description: Link to the provider's homepage
+      label: Link
       placeholder: https://cloud.provider.com
     validations:
-      required: true
-
-  - type: dropdown
-    id: cloud-type
-    attributes:
-      label: Provider Type
-      description: What kind of compute does it offer?
-      options:
-        - VPS / Cloud Servers (SSH access)
-        - Container / Sandbox Platform
-        - GPU Cloud
-        - Serverless / Functions
-        - Other (describe below)
-    validations:
-      required: true
-
-  - type: dropdown
-    id: api-type
-    attributes:
-      label: API / CLI Access
-      description: How do you provision and manage instances?
-      options:
-        - REST API
-        - CLI tool
-        - Both REST API and CLI
-        - SDK only (Python, Node, etc.)
-        - Web console only (no API)
-    validations:
-      required: true
+      required: false
 
   - type: textarea
     id: why
     attributes:
-      label: Why This Provider?
-      description: What makes this provider a good fit for spawn? (pricing, speed, regions, unique features)
-      placeholder: |
-        - Fast provisioning (~30s)
-        - Cheap instances starting at $5/mo
-        - Good API docs
-    validations:
-      required: true
-
-  - type: textarea
-    id: additional
-    attributes:
-      label: Additional Context
-      description: Any other details (API docs link, auth method, regions, billing model, limitations)
-      placeholder: |
-        - API docs: https://docs.provider.com/api
-        - Per-hour billing, API key auth
-        - Available in US and EU regions
+      label: Why?
+      placeholder: "What makes this provider a good fit? (pricing, speed, etc.)"
     validations:
       required: false


### PR DESCRIPTION
## Summary
- Strip verbose fields from all 4 issue templates (bug, CLI feature, agent request, cloud request)
- Keep only the essential field per template — humans say what they want, the refactor team triages and enriches

## Before → After
| Template | Fields before | Fields after |
|---|---|---|
| Bug Report | 4 (1 required) | 1 (required) |
| CLI Feature | 4 (2 required) | 1 (required) |
| Agent Request | 5 (3 required) | 2 (both optional) |
| Cloud Request | 5 (2 required) | 2 (both optional) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)