### PR TITLE
fix: prevent watchdog from killing teammates prematurely

### DIFF
--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -483,15 +483,28 @@ while kill -0 "${PIPE_PID}" 2>/dev/null; do
     CURR_SIZE=$(wc -c < "${LOG_FILE}" 2>/dev/null || echo 0)
     WALL_ELAPSED=$(( $(date +%s) - WALL_START ))
 
-    # Check if the stream-json "result" event has been emitted (session complete).
-    # Only check content written SINCE this cycle started (skip old log entries).
-    # After this, claude hangs waiting for teammate subprocesses — kill immediately.
+    # Check if the stream-json "result" event has been emitted (team lead done).
+    # In team-based workflows, the team lead's result fires after spawning
+    # teammates — the actual work is still running as child processes.
     if [[ "${SESSION_ENDED}" = false ]] && tail -c +"$((LOG_START_SIZE + 1))" "${LOG_FILE}" 2>/dev/null | grep -q '"type":"result"'; then
         SESSION_ENDED=true
-        log "Session ended (result event detected) — waiting 30s for cleanup then killing"
-        sleep 30
-        kill_claude
-        break
+        log "Team lead session ended — waiting for teammate processes to complete"
+    fi
+
+    # After team lead finishes, monitor child processes instead of log output.
+    # Teammates run as direct children of the claude process — check via pgrep.
+    if [[ "${SESSION_ENDED}" = true ]]; then
+        LEAD_PID=$(cat "${CLAUDE_PID_FILE}" 2>/dev/null || true)
+        if [[ -n "${LEAD_PID}" ]] && pgrep -P "${LEAD_PID}" >/dev/null 2>&1; then
+            # Teammates still running — reset idle counter since they're
+            # actively working (just not producing output to the main log)
+            IDLE_SECONDS=0
+        else
+            log "All teammate processes completed — shutting down"
+            sleep 10
+            kill_claude
+            break
+        fi
     fi
 
     if [[ "${CURR_SIZE}" -eq "${LAST_SIZE}" ]]; then


### PR DESCRIPTION
## Summary

- The watchdog in `refactor.sh`, `discovery.sh`, and `security.sh` detects the team lead's `"type":"result"` stream-json event and kills the entire process tree after 30s
- In team-based workflows, the team lead's `result` fires immediately after spawning teammates — while teammates have barely started working
- This caused refactor cycles to burn ~$2.35 in API costs with zero useful output (teammates got ~19s of runtime before being killed)
- **Fix**: after detecting `result`, monitor the claude process's child processes via `pgrep -P`. While teammates are running, reset the idle counter. Only shut down once all child processes have completed (or the hard timeout fires as a backstop)

Evidence from [run #22082135329](https://github.com/OpenRouterTeam/spawn/actions/runs/22082135329/job/63809955524):
- Team lead spawned 7 teammates at `01:06:10`
- Team lead's result event fired at `01:06:25` (15s later)
- Watchdog killed everything at `01:06:59` (only 49s of teammate runtime)

## Test plan

- [x] `bash -n` passes on all three modified files
- [ ] Verify next scheduled refactor cycle runs teammates to completion
- [ ] Confirm hard timeout still works as backstop if teammates hang


🤖 Generated with [Claude Code](https://claude.com/claude-code)