### PR TITLE
fix: prevent silent agent installation failures

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1311,7 +1311,11 @@ register_cleanup_trap() {
 install_agent() {
     local agent_name="$1" install_cmd="$2" run_cb="$3"
     log_step "Installing ${agent_name}..."
-    ${run_cb} "${install_cmd}"
+    if ! ${run_cb} "${install_cmd}"; then
+        log_install_failed "${agent_name}" "${install_cmd}"
+        return 1
+    fi
+    log_info "${agent_name} installation completed"
 }
 
 # Verify an agent installed correctly; exit 1 on failure


### PR DESCRIPTION
**Why:** Fixes unchecked exit codes in install_agent() that caused silent failures across 30+ agent scripts, wasting cloud resources and creating confusing user errors.

## Problem

The `install_agent()` function in `shared/common.sh` didn't check exit codes from installation commands. Combined with fallback patterns using `||` operators, this caused installations to silently fail:

```bash
# Current behavior (BROKEN):
install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
# If BOTH pip commands fail (network timeout, package not found), exit code is still non-zero
# But install_agent() didn't check it, so script continued
# User gets: "command not found: aider" at launch time
```

## Solution

Added exit code checking to `install_agent()`:
- Check return code from installation command
- Call `log_install_failed()` with actionable error guidance
- Return 1 to trigger `set -e` and halt provisioning

Now failures are caught immediately with clear error messages instead of cryptic runtime errors.

## Impact

Affects ~30 agent scripts across all 10 cloud providers:
- All `interpreter.sh`, `gptme.sh`, `aider.sh` (pip||pip3 pattern)  
- All `openclaw.sh` (bun||npm pattern)

## Testing

- Syntax validated with `bash -n` on all modified paths
- Shellcheck passes on `shared/common.sh`
- Manual test confirms failures now halt with error messages

-- refactor/code-health