### PR TITLE
security: fix path traversal in CLI installer file downloads

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -165,6 +165,16 @@ clone_cli() {
         curl -fsSL "${SPAWN_RAW_BASE}/cli/bun.lock"       -o "${dest}/cli/bun.lock"
         curl -fsSL "${SPAWN_RAW_BASE}/cli/tsconfig.json"  -o "${dest}/cli/tsconfig.json"
         for f in $files; do
+            # SECURITY: Validate filename to prevent path traversal attacks
+            # Block parent directory references (..) and directory separators (/)
+            if [[ "$f" =~ \.\. ]] || [[ "$f" =~ / ]] || [[ "$f" =~ \\ ]]; then
+                log_error "Security: Invalid filename from API (path traversal attempt): $f"
+                log_error "This may indicate a compromised network connection or API response."
+                log_error "Installation aborted for safety."
+                exit 1
+            fi
+
+            # Filename is safe - proceed with download
             curl -fsSL "${SPAWN_RAW_BASE}/cli/src/${f}" -o "${dest}/cli/src/${f}"
         done
     fi

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
**Why:** Blocks arbitrary file write attacks via path traversal in CLI installer

## Security Issue

The CLI installer downloads TypeScript source files from GitHub API without validating filenames. An attacker performing a MITM attack could inject path traversal sequences (e.g., `../../../../../../tmp/evil.ts`) to write arbitrary files anywhere the user has write access.

## Vulnerability Details

- **Location:** cli/install.sh lines 167-169
- **Severity:** HIGH/CRITICAL
- **Attack vector:** MITM, DNS hijacking, or compromised API response
- **Impact:** Arbitrary file write (SSH backdoor, cron injection, shell profile poisoning)

### Exploitation Example

A malicious API response could return:
```json
{"name": "../../../../../../root/.ssh/authorized_keys"}
{"name": "../../../../../../etc/cron.d/backdoor"}
```

These would be written to `/root/.ssh/authorized_keys` or `/etc/cron.d/backdoor` instead of the intended `${dest}/cli/src/` directory.

## Fix

Added filename validation before downloading each file:
1. Blocks `..` (parent directory references)
2. Blocks `/` and `\` (path separators)
3. Aborts installation with clear error message if validation fails

```bash
for f in $files; do
    # SECURITY: Validate filename to prevent path traversal attacks
    if [[ "$f" =~ \.\. ]] || [[ "$f" =~ / ]] || [[ "$f" =~ \\ ]]; then
        log_error "Security: Invalid filename from API (path traversal attempt): $f"
        log_error "Installation aborted for safety."
        exit 1
    fi
    curl -fsSL "${SPAWN_RAW_BASE}/cli/src/${f}" -o "${dest}/cli/src/${f}"
done
```

## Changes

- `cli/install.sh`: Added filename validation in file download loop
- `cli/package.json`: Bumped version to 0.3.2 (per CLAUDE.md requirement)

## Testing

- Syntax check: `bash -n cli/install.sh` ✓
- Version bumped ✓

## Notes

Recent commit 30138f6 fixed a DIFFERENT path traversal in the same file (rm -rf cleanup) but missed this vulnerability in the download loop.

-- refactor/security-auditor