### PR TITLE
Simplify trigger server to fire-and-forget + fix monitoring loop prompts

### DIFF
--- a/.claude/skills/setup-agent-team/discovery-team-prompt.txt
+++ b/.claude/skills/setup-agent-team/discovery-team-prompt.txt
@@ -210,9 +210,24 @@ gh pr edit NUMBER --add-label "needs-team-review"
 git worktree remove WORKTREE_BASE_PLACEHOLDER/BRANCH
 ```
 
+## Monitor Loop (CRITICAL)
+
+**CRITICAL**: After spawning all teammates, you MUST enter an infinite monitoring loop.
+
+1. Call `TaskList` to check task status
+2. Process any completed tasks or teammate messages
+3. Call `Bash("sleep 15")` to wait before next check
+4. **REPEAT** steps 1-3 until all teammates report done or time budget reached
+
+**The session ENDS when you produce a response with NO tool calls.** EVERY iteration MUST include at minimum: `TaskList` + `Bash("sleep 15")`.
+
+Keep looping until:
+- All tasks are completed OR
+- Time budget is reached (35 min warn, 40 min shutdown)
+
 ## Team Coordination
 
-You use **spawn teams**. Messages arrive AUTOMATICALLY. After spawning, loop: `TaskList` → process messages → `Bash("sleep 5")` → repeat. EVERY iteration MUST call TaskList.
+You use **spawn teams**. Messages arrive AUTOMATICALLY.
 
 ## Lifecycle Management
 

--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -408,24 +408,24 @@ git worktree remove WORKTREE_BASE_PLACEHOLDER/BRANCH
 
 Setup: `mkdir -p WORKTREE_BASE_PLACEHOLDER`. Cleanup: `git worktree prune` at cycle end.
 
+## Monitor Loop (CRITICAL)
+
+**CRITICAL**: After spawning all teammates, you MUST enter an infinite monitoring loop.
+
+1. Call \`TaskList\` to check task status
+2. Process any completed tasks or teammate messages
+3. Call \`Bash("sleep 15")\` to wait before next check
+4. **REPEAT** steps 1-3 until all teammates report done or time budget reached
+
+**The session ENDS when you produce a response with NO tool calls.** EVERY iteration MUST include at minimum: \`TaskList\` + \`Bash("sleep 15")\`.
+
+Keep looping until:
+- All tasks are completed OR
+- Time budget is reached (10 min warn, 12 min shutdown, 15 min force)
+
 ## Team Coordination
 
-You use **spawn teams**. Messages from teammates arrive AUTOMATICALLY between turns — you do NOT need to check for them.
-
-**CRITICAL: Your session ENDS if you produce a response with NO tool call. You MUST call a tool every turn to stay alive.**
-
-After spawning all teammates, enter a monitoring loop:
-1. Call `TaskList` to check progress
-2. Process any plan approval requests (approve/reject immediately)
-3. Process any teammate messages (respond if needed)
-4. Call `Bash("sleep 3")` to yield before next check
-5. Repeat until all work is done
-
-**IMPORTANT rules for the monitoring loop:**
-- NEVER use `sleep` longer than 5 seconds — short sleeps keep you responsive to teammate messages
-- NEVER produce a text-only response — always include a tool call (even just `TaskList` or `Bash("sleep 3")`)
-- If you have nothing else to do, call `TaskList` — that counts as a tool call and keeps you alive
-- Teammates typically respond within 30-60 seconds — if no messages after 2 minutes, check `TaskList` for stuck tasks
+You use **spawn teams**. Messages arrive AUTOMATICALLY between turns.
 
 ## Lifecycle Management
 
@@ -462,8 +462,8 @@ fi
 
 log "Hard timeout: ${HARD_TIMEOUT}s"
 
-# NOTE: VM keep-alive is handled by the trigger server streaming output back
-# to the GitHub Actions runner via a long-lived HTTP response.
+# NOTE: The trigger server is fire-and-forget — GitHub Actions just makes
+# the POST and exits. VM keep-alive is handled by systemd.
 
 # Activity watchdog: kill claude if no output for IDLE_TIMEOUT seconds.
 # This catches hung API calls (pre-flight check hangs, network issues) much

--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 5
     # Only trigger on issues with safe-to-work AND (cloud-request or agent-request) labels, or schedule/manual
     if: >-
       github.event_name != 'issues' ||
@@ -22,30 +22,11 @@ jobs:
        (contains(github.event.issue.labels.*.name, 'cloud-request') ||
         contains(github.event.issue.labels.*.name, 'agent-request')))
     steps:
-      - name: Trigger and stream discovery cycle
+      - name: Trigger discovery cycle
         env:
           SPRITE_URL: ${{ secrets.DISCOVERY_SPRITE_URL }}
           TRIGGER_SECRET: ${{ secrets.DISCOVERY_TRIGGER_SECRET }}
         run: |
-          set +e
-          # --fail-with-body: exit 22 on HTTP errors but still print the body
-          # -N: no output buffering (stream chunks in real-time)
-          # --max-time: hard cap matching the Sprite's cycle timeout + grace
-          curl -sSN --http1.1 --fail-with-body --max-time 5400 -X POST \
+          curl -sS --fail-with-body -X POST \
             "${SPRITE_URL}/trigger?reason=${{ github.event_name }}&issue=${{ github.event.issue.number || '' }}" \
             -H "Authorization: Bearer ${TRIGGER_SECRET}"
-          CURL_EXIT=$?
-          set -e
-
-          if [ "$CURL_EXIT" -eq 0 ]; then
-            echo ""
-            echo "=== Cycle completed ==="
-          elif [ "$CURL_EXIT" -eq 22 ]; then
-            # HTTP error — body was already printed above (429 = already running, etc.)
-            echo ""
-            echo "=== Trigger returned HTTP error (see output above) ==="
-          else
-            echo ""
-            echo "=== curl failed (exit=$CURL_EXIT) ==="
-            exit 1
-          fi

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -9,13 +9,13 @@ concurrency:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 5
     steps:
-      - name: Trigger QA cycle on Sprite
+      - name: Trigger QA cycle
         env:
           SPRITE_URL: ${{ secrets.QA_SPRITE_URL }}
           TRIGGER_SECRET: ${{ secrets.QA_TRIGGER_SECRET }}
         run: |
-          curl -sSN --fail-with-body --max-time 5400 -X POST \
+          curl -sS --fail-with-body -X POST \
             "${SPRITE_URL}/trigger?reason=${{ github.event_name }}" \
             -H "Authorization: Bearer ${TRIGGER_SECRET}"

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 5
     # Only trigger on issues with safe-to-work AND (bug, cli, enhancement, or maintenance) labels, or schedule/manual
     if: >-
       github.event_name != 'issues' ||
@@ -24,30 +24,11 @@ jobs:
         contains(github.event.issue.labels.*.name, 'enhancement') ||
         contains(github.event.issue.labels.*.name, 'maintenance')))
     steps:
-      - name: Trigger and stream refactor cycle
+      - name: Trigger refactor cycle
         env:
           SPRITE_URL: ${{ secrets.REFACTOR_SPRITE_URL }}
           TRIGGER_SECRET: ${{ secrets.REFACTOR_TRIGGER_SECRET }}
         run: |
-          set +e
-          # --fail-with-body: exit 22 on HTTP errors but still print the body
-          # -N: no output buffering (stream chunks in real-time)
-          # --max-time: hard cap matching the Sprite's cycle timeout + grace
-          curl -sSN --http1.1 --fail-with-body --max-time 5400 -X POST \
+          curl -sS --fail-with-body -X POST \
             "${SPRITE_URL}/trigger?reason=${{ github.event_name }}&issue=${{ github.event.issue.number || '' }}" \
             -H "Authorization: Bearer ${TRIGGER_SECRET}"
-          CURL_EXIT=$?
-          set -e
-
-          if [ "$CURL_EXIT" -eq 0 ]; then
-            echo ""
-            echo "=== Cycle completed ==="
-          elif [ "$CURL_EXIT" -eq 22 ]; then
-            # HTTP error — body was already printed above (429 = already running, 409 = dedup, etc.)
-            echo ""
-            echo "=== Trigger returned HTTP error (see output above) ==="
-          else
-            echo ""
-            echo "=== curl failed (exit=$CURL_EXIT) ==="
-            exit 1
-          fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 5
     # Only trigger on issues with safe-to-work AND (team-building or security) labels, or schedule/manual
     if: >-
       github.event_name != 'issues' ||
@@ -32,25 +32,6 @@ jobs:
             exit 0
           fi
 
-          set +e
-          # --fail-with-body: exit 22 on HTTP errors but still print the body
-          # -N: no output buffering (stream chunks in real-time)
-          # --max-time: hard cap matching the Sprite's cycle timeout + grace
-          curl -sSN --http1.1 --fail-with-body --max-time 2700 -X POST \
+          curl -sS --fail-with-body -X POST \
             "${SPRITE_URL}/trigger?reason=${{ github.event_name }}&issue=${{ github.event.issue.number || '' }}" \
             -H "Authorization: Bearer ${TRIGGER_SECRET}"
-          CURL_EXIT=$?
-          set -e
-
-          if [ "$CURL_EXIT" -eq 0 ]; then
-            echo ""
-            echo "=== Security review completed ==="
-          elif [ "$CURL_EXIT" -eq 22 ]; then
-            # HTTP error — body was already printed above (429 = already running, 409 = dedup, etc.)
-            echo ""
-            echo "=== Trigger returned HTTP error (see output above) ==="
-          else
-            echo ""
-            echo "=== curl failed (exit=$CURL_EXIT) ==="
-            exit 1
-          fi


### PR DESCRIPTION
## Summary

- **Trigger server**: Remove ~150 lines of streaming architecture (`createEnqueuer`, `drainStreamOutput`, `startStreamingRun`, heartbeat, `ReadableStream`, `server.timeout`). Replace with fire-and-forget: spawn script, return `200 {"ok":true,"runId":N}` immediately. Script output goes to console (journalctl).
- **All 4 workflows** (refactor, security, discovery, qa): Simple `curl -sS --fail-with-body` POST, `timeout-minutes` 90→5, remove `--http1.1`/`-N`/`--max-time 5400`/exit-code handling.
- **Monitoring loop fix**: The refactor and discovery team lead prompts buried the monitoring loop in a single compressed line that the model ignored (doing `Bash("sleep 10")` without calling `TaskList`). Replace with a dedicated `## Monitor Loop (CRITICAL)` section with numbered steps, matching the security.sh pattern that actually works.
- **SKILL.md**: Updated architecture docs to reflect fire-and-forget, removed streaming-specific sections.

## Test plan

- [x] `bash -n` on all modified .sh files
- [x] `bun build trigger-server.ts --no-bundle` compiles cleanly
- [x] Grep confirms no remaining streaming references in modified files
- [ ] Deploy to VM and verify `/health` + `/trigger` endpoints work
- [ ] Verify next scheduled workflow triggers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)