### PR TITLE
ux: wait for OpenClaw gateway to be ready before launching TUI

### DIFF
--- a/aws/openclaw.sh
+++ b/aws/openclaw.sh
@@ -26,7 +26,7 @@ agent_env_vars() {
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
     cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
 

--- a/daytona/openclaw.sh
+++ b/daytona/openclaw.sh
@@ -32,7 +32,7 @@ agent_configure() {
 
 agent_pre_launch() {
     cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 
 agent_launch_cmd() {

--- a/digitalocean/openclaw.sh
+++ b/digitalocean/openclaw.sh
@@ -26,7 +26,7 @@ agent_env_vars() {
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
     cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
 

--- a/fly/openclaw.sh
+++ b/fly/openclaw.sh
@@ -32,7 +32,7 @@ agent_configure() {
 
 agent_pre_launch() {
     cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 
 agent_launch_cmd() {

--- a/gcp/openclaw.sh
+++ b/gcp/openclaw.sh
@@ -26,7 +26,7 @@ agent_env_vars() {
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
     cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
 

--- a/hetzner/openclaw.sh
+++ b/hetzner/openclaw.sh
@@ -26,7 +26,7 @@ agent_env_vars() {
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
     cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
 

--- a/local/openclaw.sh
+++ b/local/openclaw.sh
@@ -32,7 +32,7 @@ agent_configure() {
 
 agent_pre_launch() {
     cloud_run "source ~/.zshrc 2>/dev/null; nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 
 agent_launch_cmd() {

--- a/oracle/openclaw.sh
+++ b/oracle/openclaw.sh
@@ -26,7 +26,7 @@ agent_env_vars() {
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
     cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
 

--- a/ovh/openclaw.sh
+++ b/ovh/openclaw.sh
@@ -26,7 +26,7 @@ agent_env_vars() {
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
     cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
 

--- a/sprite/openclaw.sh
+++ b/sprite/openclaw.sh
@@ -32,7 +32,7 @@ agent_configure() {
 
 agent_pre_launch() {
     cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
-    sleep 2
+    wait_for_openclaw_gateway cloud_run
 }
 
 agent_launch_cmd() {


### PR DESCRIPTION
## Summary
- Fixes #1354 - eliminates ~30s "gateway not connected" delay when launching OpenClaw
- Adds `wait_for_openclaw_gateway()` helper that polls port 18789 until ready (max 30s)
- Updates all 10 openclaw.sh scripts to use the new health check instead of `sleep 2`

**Why:** Users reported seeing "gateway not connected" errors for ~30 seconds after `spawn openclaw sprite` launched. The gateway takes time to initialize, but the TUI started immediately. This confused users into thinking the installation failed. Now the TUI only launches when the gateway is confirmed ready, enabling immediate interaction.

## Test plan
- [x] Syntax validation passed for all modified shell scripts
- [ ] Manual test on Sprite (reported issue platform)
- [ ] Verify gateway starts within expected time and TUI is immediately usable

-- refactor/ux-engineer