### PR TITLE
test: add mock test coverage for all 15 Fly.io agent scripts

### DIFF
--- a/test/fixtures/fly/_api_assertions.sh
+++ b/test/fixtures/fly/_api_assertions.sh
@@ -1,0 +1,2 @@
+assert_api_called "POST" "/apps" "creates Fly.io app"
+assert_api_called "POST" "/machines" "creates Fly.io machine"

--- a/test/fixtures/fly/_env.sh
+++ b/test/fixtures/fly/_env.sh
@@ -1,0 +1,7 @@
+export FLY_API_TOKEN="test-token-fly"
+export FLY_APP_NAME="test-app"
+export FLY_REGION="iad"
+export FLY_VM_SIZE="shared-cpu-1x"
+export FLY_VM_MEMORY="1024"
+export FLY_ORG="personal"
+export MODEL_ID="openrouter/auto"

--- a/test/fixtures/fly/_metadata.json
+++ b/test/fixtures/fly/_metadata.json
@@ -1,0 +1,9 @@
+{
+  "cloud": "fly",
+  "recorded_at": "2026-02-17T00:00:00Z",
+  "fixtures": {
+    "apps": {"endpoint": "/apps?org_slug=personal", "type": "synthetic", "recorded_at": "2026-02-17T00:00:00Z"},
+    "create_app": {"endpoint": "POST /apps", "type": "synthetic", "recorded_at": "2026-02-17T00:00:00Z"},
+    "create_server": {"endpoint": "POST /apps/{name}/machines", "type": "synthetic", "recorded_at": "2026-02-17T00:00:00Z"}
+  }
+}

--- a/test/fixtures/fly/apps.json
+++ b/test/fixtures/fly/apps.json
@@ -1,0 +1,13 @@
+{
+  "apps": [
+    {
+      "id": "test-app-id",
+      "name": "test-app",
+      "organization": {
+        "slug": "personal"
+      },
+      "status": "deployed"
+    }
+  ],
+  "total_apps": 1
+}

--- a/test/fixtures/fly/create_server.json
+++ b/test/fixtures/fly/create_server.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "guest": {
+      "cpu_kind": "shared",
+      "cpus": 1,
+      "memory_mb": 1024
+    },
+    "image": "ubuntu:24.04"
+  },
+  "id": "d890e84b0d3089",
+  "instance_id": "01JTEST",
+  "name": "test-app",
+  "private_ip": "fdaa:0:0:0:a7b:0:0:2",
+  "region": "iad",
+  "state": "created"
+}


### PR DESCRIPTION
## Summary
- **75 new test assertions** across all 15 Fly.io agent scripts (aider, claude, openclaw, etc.) — previously zero coverage
- Adds mock `fly`/`flyctl` CLI binary, REST API fixtures for `api.machines.dev`, and live recording support
- Every Fly.io bug fixed recently (stale tokens, FlyV1 auth, name-taken failures, SSH hangs, PATH issues) would have been caught by these tests

## Changes
- **`test/fixtures/fly/`** — env vars, API response fixtures, and assertions for app/machine creation
- **`test/mock-curl-script.sh`** — URL stripping, body validation, synthetic status responses, app creation handler
- **`test/mock.sh`** — mock `fly`/`flyctl` binary, field validation, `base64` mock for file upload
- **`test/record.sh`** — Fly.io REST endpoints now recordable with live create+delete cycle

## Test plan
- [x] `bash test/mock.sh fly` — 75 passed, 0 failed
- [x] `bash test/mock.sh` — no regressions on hetzner/digitalocean (224 passed)
- [x] `bash -n` syntax check on all modified scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)