### PR TITLE
fix: validate connection parameters to prevent command injection

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/security-connection-validation.test.ts
+++ b/cli/src/__tests__/security-connection-validation.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for connection parameter validation (security-critical)
+ * These functions prevent command injection via corrupted history files
+ */
+
+import { describe, it, expect } from "bun:test";
+import { validateConnectionIP, validateUsername, validateServerIdentifier } from "../security.js";
+
+describe("validateConnectionIP", () => {
+  describe("valid inputs", () => {
+    it("should accept valid IPv4 addresses", () => {
+      expect(() => validateConnectionIP("192.168.1.1")).not.toThrow();
+      expect(() => validateConnectionIP("10.0.0.1")).not.toThrow();
+      expect(() => validateConnectionIP("8.8.8.8")).not.toThrow();
+      expect(() => validateConnectionIP("255.255.255.255")).not.toThrow();
+    });
+
+    it("should accept valid IPv6 addresses", () => {
+      expect(() => validateConnectionIP("::1")).not.toThrow();
+      expect(() => validateConnectionIP("2001:db8::1")).not.toThrow();
+      expect(() => validateConnectionIP("fe80::1")).not.toThrow();
+      expect(() => validateConnectionIP("2001:0db8:0000:0000:0000:ff00:0042:8329")).not.toThrow();
+    });
+
+    it("should accept special sentinel values", () => {
+      expect(() => validateConnectionIP("sprite-console")).not.toThrow();
+      expect(() => validateConnectionIP("fly-ssh")).not.toThrow();
+      expect(() => validateConnectionIP("daytona-sandbox")).not.toThrow();
+    });
+  });
+
+  describe("invalid inputs", () => {
+    it("should reject empty strings", () => {
+      expect(() => validateConnectionIP("")).toThrow(/required but was empty/);
+      expect(() => validateConnectionIP("   ")).toThrow(/required but was empty/);
+    });
+
+    it("should reject shell metacharacters", () => {
+      expect(() => validateConnectionIP("8.8.8.8; rm -rf /")).toThrow(/Invalid connection IP/);
+      expect(() => validateConnectionIP("$(whoami)")).toThrow(/Invalid connection IP/);
+      expect(() => validateConnectionIP("`id`")).toThrow(/Invalid connection IP/);
+      expect(() => validateConnectionIP("8.8.8.8 | malicious")).toThrow(/Invalid connection IP/);
+    });
+
+    it("should reject invalid IP formats", () => {
+      expect(() => validateConnectionIP("not-an-ip")).toThrow(/Invalid connection IP/);
+      expect(() => validateConnectionIP("256.256.256.256")).toThrow(/Invalid connection IP/);
+      expect(() => validateConnectionIP("localhost")).toThrow(/Invalid connection IP/);
+    });
+
+    it("should reject path-like values", () => {
+      expect(() => validateConnectionIP("/etc/passwd")).toThrow(/Invalid connection IP/);
+      expect(() => validateConnectionIP("../../etc/passwd")).toThrow(/Invalid connection IP/);
+    });
+  });
+});
+
+describe("validateUsername", () => {
+  describe("valid inputs", () => {
+    it("should accept common usernames", () => {
+      expect(() => validateUsername("root")).not.toThrow();
+      expect(() => validateUsername("ubuntu")).not.toThrow();
+      expect(() => validateUsername("admin")).not.toThrow();
+      expect(() => validateUsername("user-123")).not.toThrow();
+      expect(() => validateUsername("_system")).not.toThrow();
+      expect(() => validateUsername("deploy_bot")).not.toThrow();
+    });
+
+    it("should accept usernames with $ suffix (system accounts)", () => {
+      expect(() => validateUsername("postgres$")).not.toThrow();
+      expect(() => validateUsername("mysql$")).not.toThrow();
+    });
+  });
+
+  describe("invalid inputs", () => {
+    it("should reject empty strings", () => {
+      expect(() => validateUsername("")).toThrow(/required but was empty/);
+      expect(() => validateUsername("   ")).toThrow(/required but was empty/);
+    });
+
+    it("should reject usernames that are too long", () => {
+      const longName = "a".repeat(33);
+      expect(() => validateUsername(longName)).toThrow(/too long/);
+    });
+
+    it("should reject shell metacharacters", () => {
+      expect(() => validateUsername("root; whoami")).toThrow(/Invalid username/);
+      expect(() => validateUsername("$(whoami)")).toThrow(/Invalid username/);
+      expect(() => validateUsername("user`id`")).toThrow(/Invalid username/);
+      expect(() => validateUsername("admin|malicious")).toThrow(/Invalid username/);
+    });
+
+    it("should reject uppercase letters", () => {
+      expect(() => validateUsername("Root")).toThrow(/Invalid username/);
+      expect(() => validateUsername("ADMIN")).toThrow(/Invalid username/);
+    });
+
+    it("should reject usernames starting with digits", () => {
+      expect(() => validateUsername("123user")).toThrow(/Invalid username/);
+    });
+
+    it("should reject special characters", () => {
+      expect(() => validateUsername("user@host")).toThrow(/Invalid username/);
+      expect(() => validateUsername("user.name")).toThrow(/Invalid username/);
+      expect(() => validateUsername("user:group")).toThrow(/Invalid username/);
+    });
+  });
+});
+
+describe("validateServerIdentifier", () => {
+  describe("valid inputs", () => {
+    it("should accept common server identifiers", () => {
+      expect(() => validateServerIdentifier("server-123")).not.toThrow();
+      expect(() => validateServerIdentifier("i-0abcd1234efgh5678")).not.toThrow();
+      expect(() => validateServerIdentifier("my-vm.example")).not.toThrow();
+      expect(() => validateServerIdentifier("hetzner_12345")).not.toThrow();
+      expect(() => validateServerIdentifier("test.server.local")).not.toThrow();
+    });
+
+    it("should accept mixed case identifiers", () => {
+      expect(() => validateServerIdentifier("MyServer-123")).not.toThrow();
+      expect(() => validateServerIdentifier("i-ABC123")).not.toThrow();
+    });
+
+    it("should accept identifiers with dots and underscores", () => {
+      expect(() => validateServerIdentifier("server.example.com")).not.toThrow();
+      expect(() => validateServerIdentifier("my_server_123")).not.toThrow();
+      expect(() => validateServerIdentifier("test-vm.local")).not.toThrow();
+    });
+  });
+
+  describe("invalid inputs", () => {
+    it("should reject empty strings", () => {
+      expect(() => validateServerIdentifier("")).toThrow(/required but was empty/);
+      expect(() => validateServerIdentifier("   ")).toThrow(/required but was empty/);
+    });
+
+    it("should reject identifiers that are too long", () => {
+      const longId = "a".repeat(129);
+      expect(() => validateServerIdentifier(longId)).toThrow(/too long/);
+    });
+
+    it("should reject shell metacharacters", () => {
+      expect(() => validateServerIdentifier("server; rm -rf /")).toThrow(/Invalid server identifier/);
+      expect(() => validateServerIdentifier("$(whoami)")).toThrow(/Invalid server identifier/);
+      expect(() => validateServerIdentifier("server`id`")).toThrow(/Invalid server identifier/);
+      expect(() => validateServerIdentifier("vm|malicious")).toThrow(/Invalid server identifier/);
+      expect(() => validateServerIdentifier("test & echo pwned")).toThrow(/Invalid server identifier/);
+    });
+
+    it("should reject path traversal patterns", () => {
+      expect(() => validateServerIdentifier("../../../etc/passwd")).toThrow(/path-like patterns/);
+      expect(() => validateServerIdentifier("server/../malicious")).toThrow(/path-like patterns/);
+      expect(() => validateServerIdentifier("/etc/passwd")).toThrow(/path-like patterns/);
+      expect(() => validateServerIdentifier("\\windows\\system32")).toThrow(/path-like patterns/);
+    });
+
+    it("should reject spaces and special characters", () => {
+      expect(() => validateServerIdentifier("server name")).toThrow(/Invalid server identifier/);
+      expect(() => validateServerIdentifier("server@host")).toThrow(/Invalid server identifier/);
+      expect(() => validateServerIdentifier("server:port")).toThrow(/Invalid server identifier/);
+      expect(() => validateServerIdentifier("server#123")).toThrow(/Invalid server identifier/);
+    });
+  });
+});


### PR DESCRIPTION
**Why:** Prevents HIGH severity command injection vulnerability where malicious values in ~/.spawn/history.json could execute arbitrary commands when connecting to or deleting servers.

## Summary

- Fixes #1381 (HIGH): Command injection via SSH connection parameters
- Fixes #1380 (MEDIUM): Command injection via server deletion script
- Adds comprehensive input validation for all connection parameters
- Prevents attacks if history file is corrupted or tampered with

## Security Impact

**Attack Vector (Before Fix):**
1. User's `~/.spawn/history.json` gets corrupted or manually edited
2. Malicious values inserted: `{"ip": "8.8.8.8; rm -rf /tmp/pwned", ...}`
3. User runs `spawn list` and selects the record
4. Shell command constructed with unvalidated input → code execution

**After Fix:**
- All connection parameters validated before use (IP, username, server_id)
- Strict allowlist patterns reject shell metacharacters
- IPv4 octets validated to be 0-255
- Unix usernames validated against standard pattern
- Server IDs validated to prevent path traversal and injection

## Changes

**New validation functions in `cli/src/security.ts`:**
- `validateConnectionIP()` - validates IPv4/IPv6 or sentinel values ("sprite-console", "fly-ssh", "daytona-sandbox")
- `validateUsername()` - validates Unix username pattern (lowercase, starts with letter/underscore)
- `validateServerIdentifier()` - validates server names/IDs (alphanumeric, hyphens, dots, underscores only)

**Updated functions:**
- `cmdConnect()` - validates all connection params before constructing SSH/sprite commands
- `buildDeleteScript()` - validates server IDs before shell interpolation
- `mergeLastConnection()` - validates data from bash scripts before saving to history

**Test coverage:**
- Added `security-connection-validation.test.ts` with 23 test cases
- Covers valid inputs (IPv4, IPv6, sentinels, usernames, server IDs)
- Covers invalid inputs (shell metacharacters, path traversal, injection attempts)

## Version Bump

- Bumped CLI version from 0.3.2 → 0.3.3 (security patch)
- Users will auto-update on next `spawn` run

## Testing

```bash
cd cli
bun test security-connection-validation.test.ts  # All 23 tests pass
bun run build                                     # Builds successfully
```

Verified no regressions in existing test suite (same failures as main branch).

---

-- refactor/security-auditor