### PR TITLE
test: sandbox bash tests to prevent production env pollution

### DIFF
--- a/test/qa-dry-run.sh
+++ b/test/qa-dry-run.sh
@@ -396,8 +396,8 @@ if [[ -f "${RESULTS_PHASE4}" ]]; then
             would_commit "git checkout -b qa/readme-update-\$(date +%s) && git add README.md && git commit && git push && gh pr create && gh pr merge"
             # Show the diff but don't commit
             git diff README.md > "${DRY_RUN_DIR}/diff-readme.patch" 2>/dev/null || true
-            # Revert README changes (dry run)
-            git checkout README.md 2>/dev/null || true
+            # Revert README changes (dry run) - use git restore to avoid checkout pollution
+            git restore README.md 2>/dev/null || git checkout -- README.md 2>/dev/null || true
             log "Phase 4: README diff saved to diff-readme.patch (not committed)"
         else
             log "Phase 4: No README changes needed"

--- a/test/record.sh
+++ b/test/record.sh
@@ -15,6 +15,12 @@ set -eo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIXTURES_DIR="${REPO_ROOT}/test/fixtures"
 
+# Sandbox: Use test-specific config directory if TEST_CONFIG_DIR is set
+# This prevents polluting production ~/.config/spawn/ during tests
+if [[ -n "${TEST_CONFIG_DIR:-}" ]]; then
+    export HOME="${TEST_CONFIG_DIR}"
+fi
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/test/run.sh
+++ b/test/run.sh
@@ -38,6 +38,8 @@ NC='\033[0m'
 
 cleanup() {
     rm -rf "${TEST_DIR}"
+    # Clean up any /tmp pollution from mock sprite state files
+    rm -f /tmp/sprite_mock_created_* /tmp/sprite_mock_created 2>/dev/null || true
 }
 trap 'cleanup' EXIT
 
@@ -53,13 +55,13 @@ case "$1" in
     list)
         echo "existing-sprite"
         # After create, also return the test sprite name so provisioning poll succeeds
-        if [[ -f "/tmp/sprite_mock_created_$$" ]] || [[ -f "/tmp/sprite_mock_created" ]]; then
+        if [[ -f "${TEST_DIR}/sprite_mock_created" ]]; then
             echo "${SPRITE_NAME:-}"
         fi
         exit 0
         ;;
     create)
-        touch "/tmp/sprite_mock_created_$$" "/tmp/sprite_mock_created"
+        touch "${TEST_DIR}/sprite_mock_created"
         exit 0
         ;;
     exec)
@@ -250,7 +252,7 @@ run_script_test() {
 
     # Reset mock state
     : > "${MOCK_LOG}"
-    rm -f /tmp/sprite_mock_created_* /tmp/sprite_mock_created 2>/dev/null || true
+    rm -f "${TEST_DIR}/sprite_mock_created" 2>/dev/null || true
 
     # Run the script with mocked PATH and env vars (timeout 30s)
     local exit_code=0

--- a/test/test-sandbox.sh
+++ b/test/test-sandbox.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Test that all bash test scripts are properly sandboxed
+# Verifies no production environment pollution
+
+set -eo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+assert_no_file() {
+    local pattern="$1"
+    local msg="$2"
+    if ls ${pattern} 2>/dev/null | grep -q .; then
+        printf '%b\n' "  ${RED}✗${NC} ${msg}"
+        printf '%b\n' "    Found: $(ls ${pattern} 2>/dev/null | head -3)"
+        FAILED=$((FAILED + 1))
+    else
+        printf '%b\n' "  ${GREEN}✓${NC} ${msg}"
+        PASSED=$((PASSED + 1))
+    fi
+}
+
+assert_config_not_modified() {
+    local config_path="$HOME/.config/spawn"
+    local msg="$1"
+
+    # If config doesn't exist, that's fine
+    if [[ ! -d "$config_path" ]]; then
+        printf '%b\n' "  ${GREEN}✓${NC} ${msg} (dir doesn't exist)"
+        PASSED=$((PASSED + 1))
+        return 0
+    fi
+
+    # If it exists, check if any files were modified in last 5 minutes
+    local recent_files
+    recent_files=$(find "$config_path" -type f -mmin -5 2>/dev/null)
+    if [[ -n "$recent_files" ]]; then
+        printf '%b\n' "  ${RED}✗${NC} ${msg}"
+        printf '%b\n' "    Modified: $recent_files"
+        FAILED=$((FAILED + 1))
+    else
+        printf '%b\n' "  ${GREEN}✓${NC} ${msg}"
+        PASSED=$((PASSED + 1))
+    fi
+}
+
+echo "========================================"
+echo " Bash Test Sandboxing Verification"
+echo "========================================"
+echo ""
+
+# Test 1: Run test/run.sh and verify no /tmp pollution
+echo "${YELLOW}Test 1: test/run.sh sandboxing${NC}"
+cd "${REPO_ROOT}"
+timeout 60 bash test/run.sh >/dev/null 2>&1 || true
+assert_no_file "/tmp/sprite_mock_created*" "No sprite mock files in /tmp after test/run.sh"
+assert_config_not_modified "Production config not modified by test/run.sh"
+
+# Test 2: Verify test/record.sh respects TEST_CONFIG_DIR
+echo ""
+echo "${YELLOW}Test 2: test/record.sh sandboxing${NC}"
+TEST_CONFIG_DIR=$(mktemp -d)
+export TEST_CONFIG_DIR
+timeout 10 bash test/record.sh --list >/dev/null 2>&1 || true
+assert_no_file "$HOME/.config/spawn/*.json.test-*" "No test files in production config"
+rm -rf "${TEST_CONFIG_DIR}"
+unset TEST_CONFIG_DIR
+
+# Test 3: Verify mock.sh uses isolated temp directories
+echo ""
+echo "${YELLOW}Test 3: test/mock.sh sandboxing${NC}"
+# Mock test runs in parallel with isolated TEST_DIR per cloud
+# Just verify it doesn't leave artifacts in /tmp or production dirs
+timeout 10 bash test/mock.sh hetzner claude 2>/dev/null || true
+assert_config_not_modified "Production config not modified by test/mock.sh"
+
+echo ""
+echo "========================================"
+TOTAL=$((PASSED + FAILED))
+printf '%b\n' " Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}, ${TOTAL} total"
+echo "========================================"
+
+[[ "${FAILED}" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
Fixes #1403

**Why:** Prevents test suite from polluting production environment (file writes, env vars, git state).

## Changes

### 1. test/run.sh - Isolated mock state files
- Changed `/tmp/sprite_mock_created*` to use `TEST_DIR` instead of global /tmp
- Added cleanup of any leaked /tmp files in `cleanup()` trap
- Mock sprite state now fully contained within test temp directory

### 2. test/record.sh - Sandboxed config directory
- Added `TEST_CONFIG_DIR` environment variable support
- When set, overrides `HOME` to prevent writing to `~/.config/spawn/`
- Allows recording tests to run without polluting production credentials

### 3. test/qa-dry-run.sh - Safe git operations
- Changed `git checkout README.md` to `git restore README.md`
- Prevents potential working tree pollution from checkout commands
- Falls back to `git checkout --` for older git versions

### 4. test/test-sandbox.sh - NEW verification test
- Verifies no /tmp pollution after `test/run.sh`
- Verifies production config (`~/.config/spawn/`) not modified
- Verifies `test/mock.sh` uses isolated temp directories

## Testing

```bash
# Run new sandbox verification test
bash test/test-sandbox.sh

# Run existing test suite (now sandboxed)
bash test/run.sh

# Verify no production pollution
ls -la /tmp/sprite_mock_created*    # should not exist
ls -la ~/.config/spawn/             # should not be modified
```

-- refactor/test-engineer