### PR TITLE
Remove sleep-based polling loop from team lead prompts

### DIFF
--- a/.claude/skills/setup-agent-team/SKILL.md
+++ b/.claude/skills/setup-agent-team/SKILL.md
@@ -410,16 +410,11 @@ All service scripts use **agent teams**, not subagents. Key differences:
 
 ### Team coordination pattern for `claude -p` mode
 
-In `claude -p` (print) mode, the session ends when no tool call is made. The lead must stay alive by always including a tool call. **The correct monitoring loop is:**
+In `claude -p` (print) mode, teammate messages are delivered AUTOMATICALLY as new conversation turns. The team lead does NOT need to poll or sleep — each incoming message is a new turn that keeps the session alive.
 
-```
-1. Call TaskList to check task status
-2. Process any teammate messages (they arrive automatically as user turns)
-3. If tasks still pending, call Bash("sleep 15") to yield, then go back to step 1
-4. Once all tasks complete, shutdown teammates and exit
-```
+After spawning all teammates, call `TaskList` once to confirm tasks are created, then simply wait. When a teammate message arrives, respond to it, call `TaskList` to check overall progress, and take action (approve plans, send messages, shutdown teammates).
 
-**EVERY iteration MUST call TaskList.** Looping on `sleep` alone blocks message delivery without checking progress. This is the #1 cause of stuck cycles.
+**Do NOT use `Bash("sleep")` loops.** The sleep-based polling pattern wastes tokens and can cause the model to get stuck in a sleep loop without processing messages.
 
 ### Spawning teammates correctly
 

--- a/.claude/skills/setup-agent-team/discovery-team-prompt.txt
+++ b/.claude/skills/setup-agent-team/discovery-team-prompt.txt
@@ -196,24 +196,13 @@ gh pr edit NUMBER --add-label "needs-team-review"
 git worktree remove WORKTREE_BASE_PLACEHOLDER/BRANCH
 ```
 
-## Monitor Loop (CRITICAL)
-
-**CRITICAL**: After spawning all teammates, you MUST enter an infinite monitoring loop.
-
-1. Call `TaskList` to check task status
-2. Process any completed tasks or teammate messages
-3. Call `Bash("sleep 15")` to wait before next check
-4. **REPEAT** steps 1-3 until all teammates report done or time budget reached
-
-**The session ENDS when you produce a response with NO tool calls.** EVERY iteration MUST include at minimum: `TaskList` + `Bash("sleep 15")`.
-
-Keep looping until:
-- All tasks are completed OR
-- Time budget is reached (35 min warn, 40 min shutdown)
-
 ## Team Coordination
 
-You use **spawn teams**. Messages arrive AUTOMATICALLY.
+You use **spawn teams**. Teammate messages are delivered to you AUTOMATICALLY as new conversation turns — you do NOT need to poll or sleep. Just respond to each message as it arrives, call `TaskList` to check progress, and take action (approve plans, send messages, shutdown teammates).
+
+After spawning all teammates, call `TaskList` once to confirm tasks are created, then simply wait — teammate messages will keep your session alive. Each message is a new turn.
+
+When all tasks are completed or time budget is reached (35 min warn, 40 min shutdown), begin shutdown.
 
 ## Lifecycle Management
 

--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -412,24 +412,13 @@ git worktree remove WORKTREE_BASE_PLACEHOLDER/BRANCH
 
 Setup: `mkdir -p WORKTREE_BASE_PLACEHOLDER`. Cleanup: `git worktree prune` at cycle end.
 
-## Monitor Loop (CRITICAL)
-
-**CRITICAL**: After spawning all teammates, you MUST enter an infinite monitoring loop.
-
-1. Call \`TaskList\` to check task status
-2. Process any completed tasks or teammate messages
-3. Call \`Bash("sleep 15")\` to wait before next check
-4. **REPEAT** steps 1-3 until all teammates report done or time budget reached
-
-**The session ENDS when you produce a response with NO tool calls.** EVERY iteration MUST include at minimum: \`TaskList\` + \`Bash("sleep 15")\`.
-
-Keep looping until:
-- All tasks are completed OR
-- Time budget is reached (10 min warn, 12 min shutdown, 15 min force)
-
 ## Team Coordination
 
-You use **spawn teams**. Messages arrive AUTOMATICALLY between turns.
+You use **spawn teams**. Teammate messages are delivered to you AUTOMATICALLY as new conversation turns — you do NOT need to poll or sleep. Just respond to each message as it arrives, call \`TaskList\` to check progress, and take action (approve plans, send messages, shutdown teammates).
+
+After spawning all teammates, call \`TaskList\` once to confirm tasks are created, then simply wait — teammate messages will keep your session alive. Each message is a new turn.
+
+When all tasks are completed or time budget is reached (20 min warn, 23 min shutdown, 25 min force), begin shutdown.
 
 ## Lifecycle Management
 

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -200,18 +200,13 @@ Complete within 12 minutes. At 9 min wrap up, at 11 min shutdown, at 12 min forc
    `gh issue edit ISSUE_NUM_PLACEHOLDER --repo OpenRouterTeam/spawn --remove-label "pending-review" --remove-label "under-review" --add-label "in-progress"`
 2. Set up worktree: `git worktree add WORKTREE_BASE_PLACEHOLDER -b team-building/issue-ISSUE_NUM_PLACEHOLDER origin/main`
 3. Spawn implementer (opus) → spawn reviewer (opus)
-4. **Monitor Loop (CRITICAL)**: After spawning teammates, enter an infinite monitoring loop:
-   - Call \`TaskList\` to check task status
-   - Process any completed tasks or teammate messages
-   - Call \`Bash("sleep 15")\` to wait before next check
-   - **REPEAT** until both teammates report done or time budget reached (9/11/12 min)
-   - **The session ENDS when you produce a response with NO tool calls.** EVERY iteration MUST include: \`TaskList\` + \`Bash("sleep 15")\`
+4. Wait for teammates — their messages arrive AUTOMATICALLY as new conversation turns. Respond to each, call \`TaskList\` to check progress, approve/reject plans.
 5. When both report: if merged, close issue; if issues found, comment on issue
 6. Shutdown teammates, clean up worktree, TeamDelete, exit
 
 ## Team Coordination
 
-Messages arrive AUTOMATICALLY. Keep looping with tool calls until work is complete.
+Teammate messages are delivered to you AUTOMATICALLY as new conversation turns — you do NOT need to poll or sleep. Just respond to each message as it arrives and call \`TaskList\` to check progress. Each message is a new turn that keeps your session alive.
 
 ## Safety
 
@@ -427,21 +422,11 @@ Skip if >5 open PRs. Otherwise spawn in parallel:
 2. **code-scanner** (Sonnet) — Same for .ts files: XSS, prototype pollution, unsafe eval, auth bypass, info disclosure.
    File CRITICAL/HIGH as individual issues (dedup first). Report findings.
 
-## Step 5 — Monitor Loop (CRITICAL)
+## Step 5 — Wait for Teammates
 
-**CRITICAL**: After spawning all teammates, you MUST enter an infinite monitoring loop.
+After spawning all teammates, call \`TaskList\` once to confirm tasks are created. Then simply wait — teammate messages arrive AUTOMATICALLY as new conversation turns. Respond to each message, call \`TaskList\` to check progress, and take action.
 
-**Example monitoring loop structure**:
-1. Call \`TaskList\` to check task status
-2. Process any completed tasks or teammate messages
-3. Call \`Bash("sleep 15")\` to wait before next check
-4. **REPEAT** steps 1-3 until all teammates report done
-
-**The session ENDS when you produce a response with NO tool calls.** EVERY iteration MUST include at minimum: \`TaskList\` + \`Bash("sleep 15")\`.
-
-Keep looping until:
-- All tasks are completed OR
-- Time budget is reached (see timeout warnings at 25/29/30 min)
+When all tasks are completed or time budget is reached (25/29/30 min), proceed to summary.
 
 ## Step 6 — Summary + Slack
 
@@ -503,16 +488,9 @@ CRITICAL/HIGH → individual issues:
 
 MEDIUM/LOW → single batch issue with severity/file/description table.
 
-## Monitor Loop (CRITICAL)
+## Team Coordination
 
-**CRITICAL**: After spawning all teammates, enter an infinite monitoring loop:
-
-1. Call \`TaskList\` to check task status
-2. Process any completed tasks or teammate messages
-3. Call \`Bash("sleep 15")\` to wait before next check
-4. **REPEAT** until all teammates report done or time budget reached (12/14/15 min)
-
-**The session ENDS when you produce a response with NO tool calls.** EVERY iteration MUST include: \`TaskList\` + \`Bash("sleep 15")\`.
+Teammate messages are delivered to you AUTOMATICALLY as new conversation turns — you do NOT need to poll or sleep. After spawning, call \`TaskList\` once, then wait for messages. Respond to each, call \`TaskList\` to check progress. When all done or time budget reached (12/14/15 min), proceed to shutdown.
 
 ## Slack Notification
 


### PR DESCRIPTION
## Summary

- Remove the `Monitor Loop (CRITICAL)` sections from all 4 team lead prompts (refactor.sh, discovery-team-prompt.txt, security.sh x3, SKILL.md)
- Replace with message-driven coordination: teammate messages arrive automatically as new conversation turns — no polling needed
- Add explicit "Do NOT use `Bash("sleep")` loops" warning in SKILL.md

**Why:** The sleep-based polling pattern (`TaskList → sleep 15 → repeat`) caused the team lead model to get stuck in sleep loops, wasting the entire cycle on `Bash("sleep 10")` calls without processing messages. Agent team messages are delivered as new turns automatically — the sleep was artificial scaffolding that actively hurt.

## Test plan

- [x] `bash -n` on all modified .sh files
- [x] Grep confirms no remaining `Monitor Loop` or `Bash("sleep")` references in prompts (only the "Do NOT use" warning remains)
- [ ] Run a refactor cycle and verify team lead processes teammate messages without sleeping

🤖 Generated with [Claude Code](https://claude.com/claude-code)