### PR TITLE
Simplify claude launch — no streaming, no output monitoring

### DIFF
--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -7,10 +7,6 @@ on:
     types: [opened, reopened, labeled]
   workflow_dispatch:
 
-concurrency:
-  group: discovery-sprite-trigger
-  cancel-in-progress: false
-
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -3,9 +3,6 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
-concurrency:
-  group: qa-sprite-trigger
-  cancel-in-progress: false
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -7,10 +7,6 @@ on:
     types: [opened, reopened, labeled]
   workflow_dispatch:
 
-concurrency:
-  group: refactor-sprite-trigger
-  cancel-in-progress: false
-
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,10 +7,6 @@ on:
     - cron: '*/30 * * * *'
   workflow_dispatch:
 
-concurrency:
-  group: security-${{ github.event_name == 'issues' && format('issue-{0}', github.event.issue.number) || 'scheduled' }}
-  cancel-in-progress: false
-
 jobs:
   review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **Service scripts** (refactor.sh, security.sh, discovery.sh): Replace the complex claude launch pattern with a simple direct launch. Before: subshell + PID file + tee pipe + `--output-format stream-json --verbose` + 50-line watchdog monitoring log file growth + session-end detection via `grep '"type":"result"'`. After: `claude -p "..." >> "${LOG_FILE}" 2>&1 &` with a wall-clock-only watchdog.
- **All 4 workflows**: Remove `concurrency:` groups — the trigger server already handles dedup (409 for same issue/reason), making GH Actions concurrency redundant queuing.

**Why:** The streaming output + log-growth watchdog was built for the old architecture where the trigger server streamed script output back to GitHub Actions. Now that the trigger is fire-and-forget, the complex output monitoring is unnecessary overhead. The idle-output watchdog also conflicted with agent teams (teammates work silently for minutes, triggering false "hung" kills).

**Net: -244 lines, +55 lines** across 7 files.

## Test plan

- [x] `bash -n` on all modified .sh files
- [x] Grep confirms no remaining `stream-json`, `CLAUDE_PID_FILE`, `PIPE_PID`, `IDLE_TIMEOUT`, `SESSION_ENDED` references
- [x] Grep confirms no `concurrency:` in trigger workflows (only test.yml retains it)
- [ ] Deploy and verify cycle runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)