### PR TITLE
fix: enhance sandbox test to detect agent directory residue

### DIFF
--- a/test/test-sandbox.sh
+++ b/test/test-sandbox.sh
@@ -15,6 +15,29 @@ NC='\033[0m'
 PASSED=0
 FAILED=0
 
+# Capture initial state of agent directories before running tests
+INITIAL_OPENCLAW_EXISTS=false
+INITIAL_SPRITE_EXISTS=false
+INITIAL_CLAUDE_DIR_EXISTS=false
+INITIAL_CLAUDE_JSON_EXISTS=false
+INITIAL_CLAUDE_SETTINGS_EXISTS=false
+INITIAL_CLAUDE_JSON_MTIME=""
+INITIAL_CLAUDE_SETTINGS_MTIME=""
+
+[[ -d "$HOME/.openclaw" ]] && INITIAL_OPENCLAW_EXISTS=true
+[[ -d "$HOME/.sprite" ]] && INITIAL_SPRITE_EXISTS=true
+[[ -d "$HOME/.claude" ]] && INITIAL_CLAUDE_DIR_EXISTS=true
+
+if [[ -f "$HOME/.claude.json" ]]; then
+    INITIAL_CLAUDE_JSON_EXISTS=true
+    INITIAL_CLAUDE_JSON_MTIME=$(stat -c %Y "$HOME/.claude.json" 2>/dev/null || stat -f %m "$HOME/.claude.json" 2>/dev/null)
+fi
+
+if [[ -f "$HOME/.claude/settings.json" ]]; then
+    INITIAL_CLAUDE_SETTINGS_EXISTS=true
+    INITIAL_CLAUDE_SETTINGS_MTIME=$(stat -c %Y "$HOME/.claude/settings.json" 2>/dev/null || stat -f %m "$HOME/.claude/settings.json" 2>/dev/null)
+fi
+
 assert_no_file() {
     local pattern="$1"
     local msg="$2"
@@ -52,6 +75,19 @@ assert_config_not_modified() {
     fi
 }
 
+assert_no_directory() {
+    local dir_path="$1"
+    local msg="$2"
+    if [[ -d "$dir_path" ]]; then
+        printf '%b\n' "  ${RED}✗${NC} ${msg}"
+        printf '%b\n' "    Found: $dir_path"
+        FAILED=$((FAILED + 1))
+    else
+        printf '%b\n' "  ${GREEN}✓${NC} ${msg}"
+        PASSED=$((PASSED + 1))
+    fi
+}
+
 echo "========================================"
 echo " Bash Test Sandboxing Verification"
 echo "========================================"
@@ -81,6 +117,79 @@ echo "${YELLOW}Test 3: test/mock.sh sandboxing${NC}"
 # Just verify it doesn't leave artifacts in /tmp or production dirs
 timeout 10 bash test/mock.sh hetzner claude 2>/dev/null || true
 assert_config_not_modified "Production config not modified by test/mock.sh"
+
+# Test 4: Verify no agent-specific directories created in HOME
+echo ""
+echo "${YELLOW}Test 4: Agent directory residue check${NC}"
+
+# Check if .openclaw was created by tests
+if [[ "$INITIAL_OPENCLAW_EXISTS" == "false" ]]; then
+    assert_no_directory "$HOME/.openclaw" "No ~/.openclaw directory created"
+else
+    printf '%b\n' "  ${YELLOW}⊘${NC} Skipped ~/.openclaw check (existed before tests)"
+fi
+
+# Check if .sprite was created by tests
+if [[ "$INITIAL_SPRITE_EXISTS" == "false" ]]; then
+    assert_no_directory "$HOME/.sprite" "No ~/.sprite directory created"
+else
+    printf '%b\n' "  ${YELLOW}⊘${NC} Skipped ~/.sprite check (existed before tests)"
+fi
+
+# Check if .claude was created by tests
+if [[ "$INITIAL_CLAUDE_DIR_EXISTS" == "false" ]]; then
+    assert_no_directory "$HOME/.claude" "No ~/.claude directory created"
+else
+    printf '%b\n' "  ${YELLOW}⊘${NC} Skipped ~/.claude check (existed before tests)"
+fi
+
+# Test 5: Verify Claude settings not mutated in production config
+echo ""
+echo "${YELLOW}Test 5: Claude settings integrity${NC}"
+
+# Check .claude.json mutation only if it existed before tests
+if [[ "$INITIAL_CLAUDE_JSON_EXISTS" == "true" ]]; then
+    # Compare modification time before and after tests
+    CURRENT_MTIME=$(stat -c %Y "$HOME/.claude.json" 2>/dev/null || stat -f %m "$HOME/.claude.json" 2>/dev/null)
+    if [[ "$CURRENT_MTIME" != "$INITIAL_CLAUDE_JSON_MTIME" ]]; then
+        printf '%b\n' "  ${RED}✗${NC} Production ~/.claude.json was modified by tests"
+        printf '%b\n' "    File: $HOME/.claude.json"
+        FAILED=$((FAILED + 1))
+    else
+        printf '%b\n' "  ${GREEN}✓${NC} Production ~/.claude.json not modified by tests"
+        PASSED=$((PASSED + 1))
+    fi
+elif [[ -f "$HOME/.claude.json" ]]; then
+    # File was created by tests
+    printf '%b\n' "  ${RED}✗${NC} ~/.claude.json should not be created by tests"
+    printf '%b\n' "    Created: $HOME/.claude.json"
+    FAILED=$((FAILED + 1))
+else
+    printf '%b\n' "  ${GREEN}✓${NC} ~/.claude.json not created by tests"
+    PASSED=$((PASSED + 1))
+fi
+
+# Check settings.json mutation only if it existed before tests
+if [[ "$INITIAL_CLAUDE_SETTINGS_EXISTS" == "true" ]]; then
+    # Compare modification time before and after tests
+    CURRENT_MTIME=$(stat -c %Y "$HOME/.claude/settings.json" 2>/dev/null || stat -f %m "$HOME/.claude/settings.json" 2>/dev/null)
+    if [[ "$CURRENT_MTIME" != "$INITIAL_CLAUDE_SETTINGS_MTIME" ]]; then
+        printf '%b\n' "  ${RED}✗${NC} Production ~/.claude/settings.json was modified by tests"
+        printf '%b\n' "    File: $HOME/.claude/settings.json"
+        FAILED=$((FAILED + 1))
+    else
+        printf '%b\n' "  ${GREEN}✓${NC} Production ~/.claude/settings.json not modified by tests"
+        PASSED=$((PASSED + 1))
+    fi
+elif [[ -f "$HOME/.claude/settings.json" ]]; then
+    # File was created by tests
+    printf '%b\n' "  ${RED}✗${NC} ~/.claude/settings.json should not be created by tests"
+    printf '%b\n' "    Created: $HOME/.claude/settings.json"
+    FAILED=$((FAILED + 1))
+else
+    printf '%b\n' "  ${GREEN}✓${NC} ~/.claude/settings.json not created by tests"
+    PASSED=$((PASSED + 1))
+fi
 
 echo ""
 echo "========================================"


### PR DESCRIPTION
Fixes #1409

**Why:** Tests were not checking for agent-specific directory pollution (`.openclaw`, `.sprite`, `.claude`) or mutations to Claude Code configuration files (`~/.claude.json`, `~/.claude/settings.json`). This could allow tests to silently pollute the production environment with agent artifacts.

**Changes:**
- Added checks to verify `~/.openclaw`, `~/.sprite`, and `~/.claude` directories are not created by test runs
- Added verification that `~/.claude.json` and `~/.claude/settings.json` are not modified during tests
- Uses mtime comparison to accurately detect file mutations (handles pre-existing files in development environments)
- Skips checks for directories/files that existed before tests to avoid false positives

**Testing:**
```bash
bash test/test-sandbox.sh
```

All checks pass, ensuring tests remain properly sandboxed.

-- refactor/code-health