### PR TITLE
feat: TypeScript CloudProvider interface + Hetzner proof-of-concept

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cloud-provider.test.ts
+++ b/cli/src/__tests__/cloud-provider.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "bun:test";
+import {
+  cloudAPI,
+  CloudAPIError,
+  type CloudProvider,
+  type CloudProviderConfig,
+  type ServerInfo,
+} from "../cloud-provider.js";
+
+describe("CloudProvider interface", () => {
+  it("defines all required methods", () => {
+    // Type-level test: ensure the interface is structurally sound
+    // by creating a mock that satisfies it
+    const mock: CloudProvider = {
+      label: "Test Cloud",
+      id: "test",
+      authenticate: async (_config: CloudProviderConfig) => {},
+      ensureSSHKey: async (_name: string, _publicKey: string) => "key-1",
+      provision: async (name: string, _config: CloudProviderConfig): Promise<ServerInfo> => ({
+        id: "srv-1",
+        name,
+        ip: "1.2.3.4",
+        user: "root",
+        cloud: "test",
+      }),
+      waitReady: async () => {},
+      run: async () => "output",
+      upload: async () => {},
+      interactive: async () => {},
+      destroy: async () => {},
+    };
+
+    expect(mock.label).toBe("Test Cloud");
+    expect(mock.id).toBe("test");
+    expect(typeof mock.authenticate).toBe("function");
+    expect(typeof mock.ensureSSHKey).toBe("function");
+    expect(typeof mock.provision).toBe("function");
+    expect(typeof mock.waitReady).toBe("function");
+    expect(typeof mock.run).toBe("function");
+    expect(typeof mock.upload).toBe("function");
+    expect(typeof mock.interactive).toBe("function");
+    expect(typeof mock.destroy).toBe("function");
+  });
+
+  it("ServerInfo has required fields", () => {
+    const info: ServerInfo = {
+      id: "srv-123",
+      name: "my-server",
+      ip: "10.0.0.1",
+      user: "root",
+      cloud: "hetzner",
+    };
+
+    expect(info.id).toBe("srv-123");
+    expect(info.name).toBe("my-server");
+    expect(info.ip).toBe("10.0.0.1");
+    expect(info.user).toBe("root");
+    expect(info.cloud).toBe("hetzner");
+  });
+
+  it("CloudProviderConfig has required and optional fields", () => {
+    const minimal: CloudProviderConfig = { token: "test-token" };
+    expect(minimal.token).toBe("test-token");
+    expect(minimal.serverType).toBeUndefined();
+    expect(minimal.region).toBeUndefined();
+
+    const full: CloudProviderConfig = {
+      token: "test-token",
+      serverType: "cpx11",
+      region: "fsn1",
+      image: "ubuntu-24.04",
+      sshPublicKey: "ssh-ed25519 AAAA...",
+    };
+    expect(full.serverType).toBe("cpx11");
+    expect(full.region).toBe("fsn1");
+    expect(full.image).toBe("ubuntu-24.04");
+  });
+});
+
+describe("CloudAPIError", () => {
+  it("captures status and body", () => {
+    const err = new CloudAPIError(404, { error: "not found" }, "GET /servers/123 failed with 404");
+    expect(err.status).toBe(404);
+    expect(err.body).toEqual({ error: "not found" });
+    expect(err.message).toBe("GET /servers/123 failed with 404");
+    expect(err.name).toBe("CloudAPIError");
+    expect(err instanceof Error).toBe(true);
+  });
+});
+
+describe("cloudAPI", () => {
+  it("constructs correct URL from base and endpoint", async () => {
+    // Mock fetch globally
+    const originalFetch = globalThis.fetch;
+    let capturedURL = "";
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+      capturedURL = String(url);
+      capturedInit = init;
+      return new Response(JSON.stringify({ servers: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    try {
+      await cloudAPI("https://api.example.com/v1", "test-token", "GET", "/servers");
+      expect(capturedURL).toBe("https://api.example.com/v1/servers");
+      expect(capturedInit?.method).toBe("GET");
+      expect((capturedInit?.headers as Record<string, string>)?.["Authorization"]).toBe("Bearer test-token");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("sends JSON body for POST requests", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedBody = "";
+
+    globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify({ server: { id: 1 } }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    try {
+      await cloudAPI("https://api.example.com", "tok", "POST", "/servers", {
+        name: "test",
+        type: "cpx11",
+      });
+      const parsed = JSON.parse(capturedBody);
+      expect(parsed.name).toBe("test");
+      expect(parsed.type).toBe("cpx11");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("throws CloudAPIError on non-2xx responses", async () => {
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = async () => {
+      return new Response(JSON.stringify({ error: { message: "Unauthorized" } }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    try {
+      await expect(cloudAPI("https://api.example.com", "bad-token", "GET", "/servers")).rejects.toThrow(CloudAPIError);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns parsed JSON data on success", async () => {
+    const originalFetch = globalThis.fetch;
+    const mockData = { servers: [{ id: 1, name: "test" }] };
+
+    globalThis.fetch = async () => {
+      return new Response(JSON.stringify(mockData), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    try {
+      const result = await cloudAPI<typeof mockData>("https://api.example.com", "tok", "GET", "/servers");
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe(200);
+      expect(result.data.servers).toHaveLength(1);
+      expect(result.data.servers[0].name).toBe("test");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not send body for GET requests", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedInit = init;
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    try {
+      await cloudAPI("https://api.example.com", "tok", "GET", "/servers", { ignored: true });
+      expect(capturedInit?.body).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/cli/src/__tests__/providers-hetzner.test.ts
+++ b/cli/src/__tests__/providers-hetzner.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { HetznerProvider } from "../providers/hetzner.js";
+import { CloudAPIError } from "../cloud-provider.js";
+
+describe("HetznerProvider", () => {
+  let provider: HetznerProvider;
+  let originalFetch: typeof globalThis.fetch;
+  let fetchCalls: Array<{ url: string; init: RequestInit }>;
+
+  beforeEach(() => {
+    provider = new HetznerProvider();
+    originalFetch = globalThis.fetch;
+    fetchCalls = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetch(handlers: Record<string, { status: number; body: unknown }>) {
+    globalThis.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = String(url);
+      fetchCalls.push({ url: urlStr, init: init ?? {} });
+
+      for (const [pattern, response] of Object.entries(handlers)) {
+        if (urlStr.includes(pattern)) {
+          return new Response(JSON.stringify(response.body), {
+            status: response.status,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      }
+
+      return new Response(JSON.stringify({ error: "unhandled" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+  }
+
+  describe("metadata", () => {
+    it("has correct label and id", () => {
+      expect(provider.label).toBe("Hetzner Cloud");
+      expect(provider.id).toBe("hetzner");
+    });
+  });
+
+  describe("authenticate", () => {
+    it("validates token against the API", async () => {
+      mockFetch({
+        "/servers": { status: 200, body: { servers: [] } },
+      });
+
+      await provider.authenticate({ token: "valid-token" });
+
+      expect(fetchCalls).toHaveLength(1);
+      expect(fetchCalls[0].url).toContain("api.hetzner.cloud/v1/servers");
+      const headers = fetchCalls[0].init.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer valid-token");
+    });
+
+    it("throws descriptive error on invalid token", async () => {
+      mockFetch({
+        "/servers": { status: 401, body: { error: { message: "unauthorized" } } },
+      });
+
+      await expect(provider.authenticate({ token: "bad-token" })).rejects.toThrow(
+        /Hetzner authentication failed.*Verify your token/,
+      );
+    });
+  });
+
+  describe("ensureSSHKey", () => {
+    it("returns existing key ID if key already registered", async () => {
+      mockFetch({
+        "/ssh_keys": {
+          status: 200,
+          body: {
+            ssh_keys: [
+              { id: 42, name: "spawn-key", fingerprint: "aa:bb", public_key: "ssh-ed25519 AAAA test" },
+            ],
+          },
+        },
+      });
+
+      // Must authenticate first
+      mockFetch({
+        "/servers": { status: 200, body: { servers: [] } },
+        "/ssh_keys": {
+          status: 200,
+          body: {
+            ssh_keys: [
+              { id: 42, name: "spawn-key", fingerprint: "aa:bb", public_key: "ssh-ed25519 AAAA test" },
+            ],
+          },
+        },
+      });
+      await provider.authenticate({ token: "tok" });
+
+      const keyId = await provider.ensureSSHKey("spawn-key", "ssh-ed25519 AAAA test");
+      expect(keyId).toBe("42");
+    });
+
+    it("registers new key if not found", async () => {
+      mockFetch({
+        "/servers": { status: 200, body: { servers: [] } },
+      });
+      await provider.authenticate({ token: "tok" });
+
+      mockFetch({
+        "/ssh_keys": {
+          status: 200,
+          body: { ssh_keys: [] },
+        },
+      });
+
+      // Override fetch to handle both GET and POST
+      globalThis.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = String(url);
+        fetchCalls.push({ url: urlStr, init: init ?? {} });
+
+        if (urlStr.includes("/ssh_keys") && init?.method === "GET") {
+          return new Response(JSON.stringify({ ssh_keys: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        if (urlStr.includes("/ssh_keys") && init?.method === "POST") {
+          return new Response(
+            JSON.stringify({ ssh_key: { id: 99, name: "new-key", fingerprint: "cc:dd", public_key: "ssh-ed25519 BBBB" } }),
+            { status: 201, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        return new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } });
+      };
+
+      const keyId = await provider.ensureSSHKey("new-key", "ssh-ed25519 BBBB");
+      expect(keyId).toBe("99");
+    });
+  });
+
+  describe("provision", () => {
+    it("creates a server and returns ServerInfo", async () => {
+      // Authenticate first
+      mockFetch({
+        "/servers": { status: 200, body: { servers: [] } },
+      });
+      await provider.authenticate({ token: "tok" });
+
+      // Now mock provision calls
+      globalThis.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = String(url);
+        fetchCalls.push({ url: urlStr, init: init ?? {} });
+
+        if (urlStr.includes("/ssh_keys")) {
+          return new Response(
+            JSON.stringify({ ssh_keys: [{ id: 1, name: "key", fingerprint: "aa", public_key: "ssh" }] }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (urlStr.includes("/servers") && init?.method === "POST") {
+          const body = JSON.parse(init?.body as string);
+          expect(body.name).toBe("test-server");
+          expect(body.server_type).toBe("cpx11");
+          expect(body.location).toBe("fsn1");
+          expect(body.image).toBe("ubuntu-24.04");
+          expect(body.ssh_keys).toEqual([1]);
+          expect(body.start_after_create).toBe(true);
+
+          return new Response(
+            JSON.stringify({
+              server: {
+                id: 12345,
+                name: "test-server",
+                status: "initializing",
+                public_net: { ipv4: { ip: "1.2.3.4" } },
+                server_type: { name: "cpx11" },
+              },
+            }),
+            { status: 201, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        return new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } });
+      };
+
+      const info = await provider.provision("test-server", { token: "tok" });
+      expect(info.id).toBe("12345");
+      expect(info.name).toBe("test-server");
+      expect(info.ip).toBe("1.2.3.4");
+      expect(info.user).toBe("root");
+      expect(info.cloud).toBe("hetzner");
+    });
+
+    it("uses custom server type and region from config", async () => {
+      mockFetch({ "/servers": { status: 200, body: { servers: [] } } });
+      await provider.authenticate({ token: "tok" });
+
+      let capturedBody: unknown;
+      globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = String(_url);
+        if (urlStr.includes("/ssh_keys")) {
+          return new Response(JSON.stringify({ ssh_keys: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        if (init?.method === "POST") {
+          capturedBody = JSON.parse(init?.body as string);
+          return new Response(
+            JSON.stringify({
+              server: {
+                id: 1,
+                name: "s",
+                status: "init",
+                public_net: { ipv4: { ip: "5.6.7.8" } },
+                server_type: { name: "cx22" },
+              },
+            }),
+            { status: 201, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } });
+      };
+
+      await provider.provision("s", {
+        token: "tok",
+        serverType: "cx22",
+        region: "nbg1",
+        image: "ubuntu-22.04",
+      });
+
+      expect((capturedBody as Record<string, unknown>).server_type).toBe("cx22");
+      expect((capturedBody as Record<string, unknown>).location).toBe("nbg1");
+      expect((capturedBody as Record<string, unknown>).image).toBe("ubuntu-22.04");
+    });
+  });
+
+  describe("destroy", () => {
+    it("sends DELETE request to the API", async () => {
+      mockFetch({ "/servers": { status: 200, body: { servers: [] } } });
+      await provider.authenticate({ token: "tok" });
+
+      mockFetch({
+        "/servers/12345": { status: 200, body: {} },
+      });
+
+      const server = { id: "12345", name: "test", ip: "1.2.3.4", user: "root", cloud: "hetzner" };
+      await provider.destroy(server);
+
+      const deleteCall = fetchCalls.find(
+        (c) => c.url.includes("/servers/12345") && c.init.method === "DELETE",
+      );
+      expect(deleteCall).toBeDefined();
+    });
+
+    it("throws descriptive error on API failure", async () => {
+      mockFetch({ "/servers": { status: 200, body: { servers: [] } } });
+      await provider.authenticate({ token: "tok" });
+
+      mockFetch({
+        "/servers/99": { status: 404, body: { error: { message: "not found" } } },
+      });
+
+      const server = { id: "99", name: "gone", ip: "0.0.0.0", user: "root", cloud: "hetzner" };
+      await expect(provider.destroy(server)).rejects.toThrow(/Failed to destroy server 99/);
+    });
+  });
+});

--- a/cli/src/cloud-provider.ts
+++ b/cli/src/cloud-provider.ts
@@ -1,0 +1,121 @@
+/**
+ * CloudProvider interface — TypeScript equivalent of the bash cloud adapter pattern.
+ *
+ * Each cloud's lib/common.sh exports these functions:
+ *   cloud_authenticate()  → authenticate with the provider
+ *   cloud_provision(name) → create a server
+ *   cloud_wait_ready()    → wait for SSH/cloud-init
+ *   cloud_run(cmd)        → run a command on the server
+ *   cloud_upload(src,dst) → upload a file to the server
+ *   cloud_interactive(cmd)→ start an interactive SSH session
+ *   cloud_label()         → human-readable label
+ *
+ * This interface maps those 1:1, plus adds structured return types
+ * and typed configuration that bash can't express.
+ */
+
+export interface ServerInfo {
+  id: string;
+  name: string;
+  ip: string;
+  user: string;
+  cloud: string;
+}
+
+export interface CloudProviderConfig {
+  /** API token or credentials */
+  token: string;
+  /** Server/instance type (e.g., "cpx11", "s-1vcpu-1gb") */
+  serverType?: string;
+  /** Region/location (e.g., "fsn1", "nyc1") */
+  region?: string;
+  /** OS image (e.g., "ubuntu-24.04") */
+  image?: string;
+  /** SSH public key content */
+  sshPublicKey?: string;
+}
+
+export interface CloudProvider {
+  /** Human-readable cloud name (e.g., "Hetzner Cloud") */
+  readonly label: string;
+
+  /** Short identifier (e.g., "hetzner", "digitalocean") */
+  readonly id: string;
+
+  /** Authenticate with the cloud provider. Throws on failure. */
+  authenticate(config: CloudProviderConfig): Promise<void>;
+
+  /** Ensure SSH key is registered with the provider. Returns the key ID/name. */
+  ensureSSHKey(name: string, publicKey: string): Promise<string>;
+
+  /** Provision a new server. Returns server info on success. */
+  provision(name: string, config: CloudProviderConfig): Promise<ServerInfo>;
+
+  /** Wait for the server to be ready (SSH reachable, cloud-init done). */
+  waitReady(server: ServerInfo, timeoutSeconds?: number): Promise<void>;
+
+  /** Run a command on the server. Returns stdout. */
+  run(server: ServerInfo, command: string): Promise<string>;
+
+  /** Upload a file to the server. */
+  upload(server: ServerInfo, localPath: string, remotePath: string): Promise<void>;
+
+  /** Start an interactive SSH session (hands control to the terminal). */
+  interactive(server: ServerInfo, command?: string): Promise<void>;
+
+  /** Destroy/delete the server. */
+  destroy(server: ServerInfo): Promise<void>;
+}
+
+/**
+ * CloudAPI — minimal typed wrapper for REST API calls.
+ * Replaces the bash `generic_cloud_api()` function.
+ */
+export interface CloudAPIResponse<T = unknown> {
+  ok: boolean;
+  status: number;
+  data: T;
+}
+
+export class CloudAPIError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: unknown,
+    message: string,
+  ) {
+    super(message);
+    this.name = "CloudAPIError";
+  }
+}
+
+/**
+ * Make an authenticated API request to a cloud provider.
+ * This replaces the bash `generic_cloud_api()` curl wrapper.
+ */
+export async function cloudAPI<T = unknown>(
+  baseURL: string,
+  token: string,
+  method: string,
+  endpoint: string,
+  body?: unknown,
+): Promise<CloudAPIResponse<T>> {
+  const url = `${baseURL}${endpoint}`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+
+  const init: RequestInit = { method, headers };
+  if (body && (method === "POST" || method === "PUT" || method === "PATCH")) {
+    init.body = JSON.stringify(body);
+  }
+
+  const resp = await fetch(url, init);
+  const data = (await resp.json()) as T;
+
+  if (!resp.ok) {
+    throw new CloudAPIError(resp.status, data, `${method} ${endpoint} failed with ${resp.status}`);
+  }
+
+  return { ok: resp.ok, status: resp.status, data };
+}

--- a/cli/src/providers/hetzner.ts
+++ b/cli/src/providers/hetzner.ts
@@ -1,0 +1,164 @@
+/**
+ * Hetzner Cloud provider — TypeScript equivalent of hetzner/lib/common.sh.
+ *
+ * Proof-of-concept: demonstrates how a cloud provider can be implemented
+ * in TypeScript using the CloudProvider interface, replacing ~600 lines
+ * of bash with ~200 lines of typed, testable code.
+ */
+import type {
+  CloudProvider,
+  CloudProviderConfig,
+  ServerInfo,
+} from "../cloud-provider.js";
+import { cloudAPI, CloudAPIError } from "../cloud-provider.js";
+import {
+  sshRun,
+  scpUpload,
+  sshInteractive,
+  waitForSSH,
+  waitForCloudInit,
+} from "../ssh.js";
+
+const API_BASE = "https://api.hetzner.cloud/v1";
+
+interface HetznerSSHKey {
+  id: number;
+  name: string;
+  fingerprint: string;
+  public_key: string;
+}
+
+interface HetznerServer {
+  id: number;
+  name: string;
+  status: string;
+  public_net: {
+    ipv4: { ip: string };
+  };
+  server_type: { name: string };
+}
+
+interface HetznerServerCreateResponse {
+  server: HetznerServer;
+}
+
+interface HetznerSSHKeysResponse {
+  ssh_keys: HetznerSSHKey[];
+}
+
+interface HetznerServersResponse {
+  servers: HetznerServer[];
+}
+
+function api<T>(token: string, method: string, endpoint: string, body?: unknown) {
+  return cloudAPI<T>(API_BASE, token, method, endpoint, body);
+}
+
+export class HetznerProvider implements CloudProvider {
+  readonly label = "Hetzner Cloud";
+  readonly id = "hetzner";
+
+  private token = "";
+
+  async authenticate(config: CloudProviderConfig): Promise<void> {
+    this.token = config.token;
+
+    // Validate the token by making a lightweight API call
+    try {
+      await api<HetznerServersResponse>(this.token, "GET", "/servers?per_page=1");
+    } catch (err) {
+      if (err instanceof CloudAPIError) {
+        throw new Error(
+          `Hetzner authentication failed (HTTP ${err.status}). ` +
+          `Verify your token at: https://console.hetzner.cloud/projects -> API Tokens`,
+        );
+      }
+      throw err;
+    }
+  }
+
+  async ensureSSHKey(name: string, publicKey: string): Promise<string> {
+    // Check if key already exists
+    const { data } = await api<HetznerSSHKeysResponse>(this.token, "GET", "/ssh_keys");
+    const existing = data.ssh_keys.find((k) => k.public_key.trim() === publicKey.trim());
+    if (existing) {
+      return String(existing.id);
+    }
+
+    // Register the key
+    const { data: created } = await api<{ ssh_key: HetznerSSHKey }>(
+      this.token,
+      "POST",
+      "/ssh_keys",
+      { name, public_key: publicKey },
+    );
+    return String(created.ssh_key.id);
+  }
+
+  async provision(name: string, config: CloudProviderConfig): Promise<ServerInfo> {
+    const serverType = config.serverType ?? "cpx11";
+    const location = config.region ?? "fsn1";
+    const image = config.image ?? "ubuntu-24.04";
+
+    // Get all SSH key IDs for the account
+    const { data: keysData } = await api<HetznerSSHKeysResponse>(
+      this.token,
+      "GET",
+      "/ssh_keys",
+    );
+    const sshKeyIds = keysData.ssh_keys.map((k) => k.id);
+
+    const { data } = await api<HetznerServerCreateResponse>(
+      this.token,
+      "POST",
+      "/servers",
+      {
+        name,
+        server_type: serverType,
+        location,
+        image,
+        ssh_keys: sshKeyIds,
+        start_after_create: true,
+      },
+    );
+
+    return {
+      id: String(data.server.id),
+      name: data.server.name,
+      ip: data.server.public_net.ipv4.ip,
+      user: "root",
+      cloud: this.id,
+    };
+  }
+
+  async waitReady(server: ServerInfo, timeoutSeconds = 120): Promise<void> {
+    await waitForSSH(server, timeoutSeconds);
+    await waitForCloudInit(server, 60);
+  }
+
+  async run(server: ServerInfo, command: string): Promise<string> {
+    return sshRun(server, command);
+  }
+
+  async upload(server: ServerInfo, localPath: string, remotePath: string): Promise<void> {
+    return scpUpload(server, localPath, remotePath);
+  }
+
+  async interactive(server: ServerInfo, command?: string): Promise<void> {
+    return sshInteractive(server, command);
+  }
+
+  async destroy(server: ServerInfo): Promise<void> {
+    try {
+      await api(this.token, "DELETE", `/servers/${server.id}`);
+    } catch (err) {
+      if (err instanceof CloudAPIError) {
+        throw new Error(
+          `Failed to destroy server ${server.id}. ` +
+          `Delete it manually at: https://console.hetzner.cloud/`,
+        );
+      }
+      throw err;
+    }
+  }
+}

--- a/cli/src/ssh.ts
+++ b/cli/src/ssh.ts
@@ -1,0 +1,121 @@
+/**
+ * SSH utilities — TypeScript equivalent of shared/common.sh SSH helpers.
+ *
+ * Replaces: generic_ssh_wait, ssh_run_server, ssh_upload_file,
+ *           ssh_interactive_session, ssh_verify_connectivity
+ */
+import { spawn, type SpawnOptions } from "child_process";
+import type { ServerInfo } from "./cloud-provider.js";
+
+const SSH_OPTS = [
+  "-o", "StrictHostKeyChecking=no",
+  "-o", "UserKnownHostsFile=/dev/null",
+  "-o", "LogLevel=ERROR",
+  "-o", "ConnectTimeout=10",
+];
+
+/** Run a command on a remote server via SSH. Returns stdout. */
+export async function sshRun(server: ServerInfo, command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const args = [...SSH_OPTS, `${server.user}@${server.ip}`, command];
+    const child = spawn("ssh", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", (data: Buffer) => { stdout += data.toString(); });
+    child.stderr?.on("data", (data: Buffer) => { stderr += data.toString(); });
+    child.on("close", (code) => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(`SSH command failed (exit ${code}): ${stderr.trim()}`));
+    });
+    child.on("error", reject);
+  });
+}
+
+/** Upload a file to a remote server via SCP. */
+export async function scpUpload(
+  server: ServerInfo,
+  localPath: string,
+  remotePath: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const args = [...SSH_OPTS, localPath, `${server.user}@${server.ip}:${remotePath}`];
+    const child = spawn("scp", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stderr = "";
+    child.stderr?.on("data", (data: Buffer) => { stderr += data.toString(); });
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`SCP upload failed (exit ${code}): ${stderr.trim()}`));
+    });
+    child.on("error", reject);
+  });
+}
+
+/** Start an interactive SSH session (hands control to the terminal). */
+export async function sshInteractive(server: ServerInfo, command?: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const args = [...SSH_OPTS, "-t", `${server.user}@${server.ip}`];
+    if (command) args.push(command);
+    const opts: SpawnOptions = { stdio: "inherit" };
+    const child = spawn("ssh", args, opts);
+    child.on("close", (code) => {
+      if (code === 0 || code === 130) resolve(); // 130 = Ctrl-C
+      else reject(new Error(`SSH session exited with code ${code}`));
+    });
+    child.on("error", reject);
+  });
+}
+
+/** Wait for SSH to become available on a server. Retries with backoff. */
+export async function waitForSSH(
+  server: ServerInfo,
+  timeoutSeconds = 120,
+): Promise<void> {
+  const startTime = Date.now();
+  const deadline = startTime + timeoutSeconds * 1000;
+  let attempt = 0;
+
+  while (Date.now() < deadline) {
+    attempt++;
+    try {
+      await sshRun(server, "echo ok");
+      return;
+    } catch {
+      const elapsed = Math.floor((Date.now() - startTime) / 1000);
+      if (Date.now() + 5000 > deadline) {
+        throw new Error(
+          `SSH not reachable after ${elapsed}s (${attempt} attempts). ` +
+          `Server: ${server.ip}`,
+        );
+      }
+      // Backoff: 2s, 3s, 5s, 5s, 5s...
+      const delay = Math.min(2000 + attempt * 1000, 5000);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+}
+
+/** Wait for cloud-init to complete on a server. */
+export async function waitForCloudInit(
+  server: ServerInfo,
+  timeoutSeconds = 120,
+): Promise<void> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+
+  while (Date.now() < deadline) {
+    try {
+      const status = await sshRun(
+        server,
+        "cloud-init status --format json 2>/dev/null || echo '{\"status\": \"done\"}'",
+      );
+      if (status.includes('"done"') || status.includes('"disabled"')) {
+        return;
+      }
+    } catch {
+      // SSH may not be ready yet
+    }
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+
+  throw new Error(`Cloud-init did not complete within ${timeoutSeconds}s`);
+}


### PR DESCRIPTION
Fixes #1179

## Summary

Proof-of-concept for the bash-to-TypeScript migration proposed in #1179. This PR validates the migration path without touching any existing bash scripts.

### What's added

- **`cli/src/cloud-provider.ts`** — `CloudProvider` interface and `cloudAPI()` utility
  - Typed equivalent of the bash `cloud_*` adapter functions (`cloud_authenticate`, `cloud_provision`, `cloud_run`, etc.)
  - `cloudAPI()` replaces `generic_cloud_api()` curl wrapper with native `fetch`
  - `CloudAPIError` for structured error handling (vs bash string parsing)

- **`cli/src/ssh.ts`** — SSH utilities module
  - `sshRun()`, `scpUpload()`, `sshInteractive()` — typed wrappers for ssh/scp
  - `waitForSSH()`, `waitForCloudInit()` — retry loops with backoff
  - Replaces `generic_ssh_wait`, `ssh_run_server`, `ssh_upload_file`, `ssh_interactive_session`

- **`cli/src/providers/hetzner.ts`** — Hetzner Cloud provider implementation
  - Demonstrates how ~600 lines of bash (`hetzner/lib/common.sh`) maps to ~150 lines of typed TypeScript
  - Full `CloudProvider` implementation: authenticate, SSH key management, provision, destroy

- **18 `bun:test` tests** covering:
  - Interface structural contracts
  - `cloudAPI()` URL construction, body serialization, error handling
  - Hetzner provider authentication, SSH key management, provisioning, destruction

### Key findings from the proof-of-concept

| Aspect | Bash | TypeScript |
|--------|------|------------|
| Hetzner lib | ~600 lines | ~150 lines |
| API calls | curl + string parsing | `fetch` + typed responses |
| Error handling | grep for `"error"` in strings | `CloudAPIError` with status + body |
| Testing | Mock curl binary on PATH | Mock `globalThis.fetch` |
| Type safety | None | Full interface contracts |

### What's NOT changed

- No bash scripts modified or removed
- No changes to `shared/common.sh` or any `lib/common.sh`
- No changes to `test/mock.sh` or `test/run.sh`
- Existing curl|bash distribution model is untouched

### Migration path (from RFC)

1. **Shared utilities -> TS module** (this PR: `cloud-provider.ts`, `ssh.ts`)
2. **CloudProvider interface** (this PR)
3. **One provider as proof-of-concept** (this PR: Hetzner)
4. If validated, migrate remaining providers incrementally
5. Agent scripts last (simplest, just install commands)

-- refactor/complexity-hunter