### PR TITLE
security: fix command injection in fly/lib/common.sh bash -c invocations

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -372,12 +372,12 @@ run_server() {
         elif command -v gtimeout &>/dev/null; then timeout_bin="gtimeout"
         fi
         if [[ -n "${timeout_bin}" ]]; then
-            "${timeout_bin}" "${timeout_secs}" "$fly_cmd" ssh console -a "$FLY_APP_NAME" -C "bash -c $escaped_cmd" --quiet 2>/dev/null
+            "${timeout_bin}" "${timeout_secs}" "$fly_cmd" ssh console -a "$FLY_APP_NAME" -C "bash -c \"$escaped_cmd\"" --quiet 2>/dev/null
             return $?
         fi
     fi
 
-    "$fly_cmd" ssh console -a "$FLY_APP_NAME" -C "bash -c $escaped_cmd" --quiet 2>/dev/null
+    "$fly_cmd" ssh console -a "$FLY_APP_NAME" -C "bash -c \"$escaped_cmd\"" --quiet 2>/dev/null
 }
 
 # Upload a file to the machine via base64 encoding through exec
@@ -405,7 +405,7 @@ interactive_session() {
     local escaped_cmd
     escaped_cmd=$(printf '%q' "$cmd")
     local session_exit=0
-    "$(_get_fly_cmd)" ssh console -a "$FLY_APP_NAME" -C "bash -c $escaped_cmd" || session_exit=$?
+    "$(_get_fly_cmd)" ssh console -a "$FLY_APP_NAME" -C "bash -c \"$escaped_cmd\"" || session_exit=$?
     SERVER_NAME="${FLY_APP_NAME:-}" SPAWN_RECONNECT_CMD="fly ssh console -a ${FLY_APP_NAME:-}" \
         _show_exec_post_session_summary
     return "${session_exit}"


### PR DESCRIPTION
## Summary
- Quotes `$escaped_cmd` in `bash -c` arguments in `run_server()` and `interactive_session()` to prevent word splitting
- Despite `printf '%q'` escaping, unquoted variable expansion allows shell word splitting before the value reaches `bash -c`
- Affects lines 375, 380, and 408 in `fly/lib/common.sh`

Fixes #1422

## Test plan
- [ ] Verify `bash -n fly/lib/common.sh` passes (syntax check)
- [ ] Run `test/run.sh fly` to confirm no regressions
- [ ] Manual test: deploy an agent on Fly.io and verify commands with spaces/special chars execute correctly