### PR TITLE
fix: handle 409/429 in trigger workflows

### DIFF
--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -23,6 +23,15 @@ jobs:
           SPRITE_URL: ${{ secrets.DISCOVERY_SPRITE_URL }}
           TRIGGER_SECRET: ${{ secrets.DISCOVERY_TRIGGER_SECRET }}
         run: |
-          curl -sS --fail-with-body -X POST \
+          HTTP_CODE=$(curl -sS -o /tmp/trigger-response.txt -w '%{http_code}' -X POST \
             "${SPRITE_URL}/trigger?reason=${{ github.event_name }}&issue=${{ github.event.issue.number || '' }}" \
-            -H "Authorization: Bearer ${TRIGGER_SECRET}"
+            -H "Authorization: Bearer ${TRIGGER_SECRET}" || echo "000")
+          BODY=$(cat /tmp/trigger-response.txt 2>/dev/null || true)
+          rm -f /tmp/trigger-response.txt
+          echo "HTTP ${HTTP_CODE}: ${BODY}"
+          case "$HTTP_CODE" in
+            2*) echo "Trigger accepted" ;;
+            409) echo "Already in progress — skipping (not an error)" ;;
+            429) echo "Capacity full — skipping (not an error)" ;;
+            *)  echo "::error::Trigger failed with HTTP ${HTTP_CODE}"; exit 1 ;;
+          esac

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -13,6 +13,15 @@ jobs:
           SPRITE_URL: ${{ secrets.QA_SPRITE_URL }}
           TRIGGER_SECRET: ${{ secrets.QA_TRIGGER_SECRET }}
         run: |
-          curl -sS --fail-with-body -X POST \
+          HTTP_CODE=$(curl -sS -o /tmp/trigger-response.txt -w '%{http_code}' -X POST \
             "${SPRITE_URL}/trigger?reason=${{ github.event_name }}" \
-            -H "Authorization: Bearer ${TRIGGER_SECRET}"
+            -H "Authorization: Bearer ${TRIGGER_SECRET}" || echo "000")
+          BODY=$(cat /tmp/trigger-response.txt 2>/dev/null || true)
+          rm -f /tmp/trigger-response.txt
+          echo "HTTP ${HTTP_CODE}: ${BODY}"
+          case "$HTTP_CODE" in
+            2*) echo "Trigger accepted" ;;
+            409) echo "Already in progress — skipping (not an error)" ;;
+            429) echo "Capacity full — skipping (not an error)" ;;
+            *)  echo "::error::Trigger failed with HTTP ${HTTP_CODE}"; exit 1 ;;
+          esac

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -25,6 +25,15 @@ jobs:
           SPRITE_URL: ${{ secrets.REFACTOR_SPRITE_URL }}
           TRIGGER_SECRET: ${{ secrets.REFACTOR_TRIGGER_SECRET }}
         run: |
-          curl -sS --fail-with-body -X POST \
+          HTTP_CODE=$(curl -sS -o /tmp/trigger-response.txt -w '%{http_code}' -X POST \
             "${SPRITE_URL}/trigger?reason=${{ github.event_name }}&issue=${{ github.event.issue.number || '' }}" \
-            -H "Authorization: Bearer ${TRIGGER_SECRET}"
+            -H "Authorization: Bearer ${TRIGGER_SECRET}" || echo "000")
+          BODY=$(cat /tmp/trigger-response.txt 2>/dev/null || true)
+          rm -f /tmp/trigger-response.txt
+          echo "HTTP ${HTTP_CODE}: ${BODY}"
+          case "$HTTP_CODE" in
+            2*) echo "Trigger accepted" ;;
+            409) echo "Already in progress — skipping (not an error)" ;;
+            429) echo "Capacity full — skipping (not an error)" ;;
+            *)  echo "::error::Trigger failed with HTTP ${HTTP_CODE}"; exit 1 ;;
+          esac


### PR DESCRIPTION
## Summary

- Refactor, discovery, and QA trigger workflows treat HTTP 409/429 from the trigger server as fatal errors, causing every scheduled run to show as "failed" when a previous run is still in progress.
- Replace `curl --fail-with-body` with explicit HTTP status code handling: 2xx passes, 409 (already in progress) and 429 (capacity full) skip gracefully, anything else fails with a `::error` annotation.
- Fixes the wall of red failures on the Actions tab from scheduled triggers.

## Test plan

- [ ] Merge and wait for next scheduled refactor trigger — should show green (or skip) instead of red
- [ ] Manually trigger `workflow_dispatch` on refactor.yml while a run is in progress — should succeed with "Already in progress" message
- [ ] Verify actual failures (e.g. bad secret, server down) still fail the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)