### PR TITLE
fix: use pipx to install Aider across all clouds

### DIFF
--- a/aws/aider.sh
+++ b/aws/aider.sh
@@ -17,8 +17,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
 agent_launch_cmd() { printf 'source ~/.zshrc && aider --model openrouter/%s' "${MODEL_ID}"; }

--- a/daytona/aider.sh
+++ b/daytona/aider.sh
@@ -16,8 +16,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 
 agent_env_vars() {

--- a/digitalocean/aider.sh
+++ b/digitalocean/aider.sh
@@ -17,8 +17,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
 agent_launch_cmd() { printf 'source ~/.zshrc && aider --model openrouter/%s' "${MODEL_ID}"; }

--- a/fly/aider.sh
+++ b/fly/aider.sh
@@ -16,8 +16,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 
 agent_env_vars() {

--- a/gcp/aider.sh
+++ b/gcp/aider.sh
@@ -17,8 +17,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
 agent_launch_cmd() { printf 'source ~/.zshrc && aider --model openrouter/%s' "${MODEL_ID}"; }

--- a/hetzner/aider.sh
+++ b/hetzner/aider.sh
@@ -17,8 +17,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
 agent_launch_cmd() { printf 'source ~/.zshrc && aider --model openrouter/%s' "${MODEL_ID}"; }

--- a/local/aider.sh
+++ b/local/aider.sh
@@ -16,8 +16,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 
 agent_env_vars() {

--- a/oracle/aider.sh
+++ b/oracle/aider.sh
@@ -17,8 +17,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
 agent_launch_cmd() { printf 'source ~/.zshrc && aider --model openrouter/%s' "${MODEL_ID}"; }

--- a/ovh/aider.sh
+++ b/ovh/aider.sh
@@ -17,8 +17,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
 agent_launch_cmd() { printf 'source ~/.zshrc && aider --model openrouter/%s' "${MODEL_ID}"; }

--- a/sprite/aider.sh
+++ b/sprite/aider.sh
@@ -16,8 +16,8 @@ AGENT_MODEL_PROMPT=1
 AGENT_MODEL_DEFAULT="openrouter/auto"
 
 agent_install() {
-    install_agent "Aider" "pip install aider-chat 2>/dev/null || pip3 install aider-chat" cloud_run
-    verify_agent "Aider" "command -v aider && aider --version" "pip install aider-chat" cloud_run
+    install_agent "Aider" "python3 -m pip install pipx && pipx install aider-chat" cloud_run
+    verify_agent "Aider" "command -v aider && aider --version" "pipx install aider-chat" cloud_run
 }
 
 agent_env_vars() {


### PR DESCRIPTION
## Summary

- Switch all 10 `aider.sh` scripts from `pip install aider-chat` to `python3 -m pip install pipx && pipx install aider-chat`
- Ubuntu 24.04 blocks system-wide pip installs (PEP 668 externally-managed-environment), causing Aider installation to fail on every cloud
- pipx installs into an isolated virtualenv, working cleanly on all target distros

## Test plan

- [x] `bash -n` passes on all 10 aider.sh scripts (validated by pre-commit hook)
- [ ] E2E: Aider installs and launches on Fly.io
- [ ] E2E: Aider installs and launches on Hetzner/DigitalOcean

🤖 Generated with [Claude Code](https://claude.com/claude-code)