### PR TITLE
fix: pcl should checkout main before cleanup

### DIFF
--- a/.claude/skills/pcl/SKILL.md
+++ b/.claude/skills/pcl/SKILL.md
@@ -17,13 +17,24 @@ Delete local and remote git branches that no longer have an open PR, and prune s
 
 ## Procedure
 
-### Step 1: Fetch and prune remote refs
+### Step 1: Checkout main branch
+
+Switch to main and update to latest:
+
+```bash
+git checkout main
+git pull --rebase origin main
+```
+
+**Critical:** This ensures we're not on a branch that's about to be deleted, and that we're working from the latest main.
+
+### Step 2: Fetch and prune remote refs
 
 ```bash
 git fetch --prune origin
 ```
 
-### Step 2: Identify stale remote branches
+### Step 3: Identify stale remote branches
 
 List all remote branches except `main` and `HEAD`:
 
@@ -31,7 +42,7 @@ List all remote branches except `main` and `HEAD`:
 git branch -r --format='%(refname:short) %(committerdate:relative)' | grep -v 'origin/main\|origin/HEAD\|^origin '
 ```
 
-### Step 3: Get branches with open PRs (protected)
+### Step 4: Get branches with open PRs (protected)
 
 ```bash
 gh pr list --repo OpenRouterTeam/spawn --state open --json headRefName --jq '.[].headRefName'
@@ -39,7 +50,7 @@ gh pr list --repo OpenRouterTeam/spawn --state open --json headRefName --jq '.[]
 
 Any branch with an open PR MUST be skipped. Never delete a branch that has an open PR.
 
-### Step 4: Delete stale remote branches
+### Step 5: Delete stale remote branches
 
 For each remote branch that is NOT in the open PR list:
 
@@ -49,7 +60,7 @@ git push origin --delete BRANCH_NAME
 
 If `--dry-run` was passed, print `[dry-run] would delete origin/BRANCH_NAME` instead.
 
-### Step 5: Delete stale local branches
+### Step 6: Delete stale local branches
 
 List local branches (excluding the current branch and `main`):
 
@@ -65,7 +76,7 @@ git branch -d BRANCH_NAME 2>/dev/null || git branch -D BRANCH_NAME
 
 If `--dry-run`, print `[dry-run] would delete local BRANCH_NAME` instead.
 
-### Step 6: Prune worktrees
+### Step 7: Prune worktrees
 
 ```bash
 git worktree prune
@@ -77,7 +88,17 @@ Remove any leftover worktree directories:
 rm -rf /tmp/spawn-worktrees 2>/dev/null || true
 ```
 
-### Step 7: Summary
+### Step 8: Verify final state
+
+Ensure we're on main branch:
+
+```bash
+git branch --show-current
+```
+
+Should output: `main`
+
+### Step 9: Summary
 
 Print a summary:
 - Number of remote branches deleted


### PR DESCRIPTION
## Summary

The `/pcl` skill was deleting branches without first ensuring we're on main, which could cause errors if the current branch is about to be deleted.

## Problem

If you run `/pcl` while on a feature branch that has no open PR (e.g., `fix/security-git-pull` after it's merged), the cleanup process would try to delete the branch you're currently on, causing git errors.

## Solution

**Before:** 
1. Fetch refs
2. Delete branches (could fail if on the branch being deleted)

**After:**
1. **Checkout main and pull latest** ← NEW
2. Fetch refs  
3. Delete branches (safe, we're on main)
4. **Verify we're still on main** ← NEW

## Changes

- Add **Step 1**: Checkout main and pull latest
- Add **Step 8**: Verify final state is on main branch
- Renumber all subsequent steps accordingly

## Benefits

✅ Safe to run from any branch (automatically switches to main)  
✅ Ensures repo ends in predictable state (on main with latest code)  
✅ Prevents git errors when deleting the current branch  
✅ Matches expected behavior: cleanup tool should leave you clean

## Test plan

- [x] Verified step numbering is sequential
- [x] Added critical note about why this is important
- [ ] Test manually by running `/pcl` from a feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)