### PR TITLE
docs: add spawn delete command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ spawn aider hetzner                      # Aider on Hetzner
 spawn claude sprite --prompt "Fix bugs"  # Non-interactive with prompt
 spawn aider sprite -p "Add tests"        # Short form
 spawn claude                             # Show clouds available for Claude
+spawn delete                             # Delete a running server
+spawn delete -c hetzner                  # Delete a server on Hetzner
 ```
 
 ### Commands
@@ -57,6 +59,9 @@ spawn claude                             # Show clouds available for Claude
 | `spawn agents` | List all agents with descriptions |
 | `spawn clouds` | List all cloud providers |
 | `spawn update` | Check for CLI updates |
+| `spawn delete` | Interactively select and destroy a cloud server |
+| `spawn delete -a <agent>` | Filter servers to delete by agent |
+| `spawn delete -c <cloud>` | Filter servers to delete by cloud |
 | `spawn help` | Show help message |
 | `spawn version` | Show version |
 


### PR DESCRIPTION
## Summary
- Adds the `spawn delete` command (and its `-a`/`-c` filter flags) to the Commands table and Examples section in the README
- This command was implemented but not documented in the README

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)