### PR TITLE
fix: broken error msg in multi-creds validate, predictable temp path

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -459,24 +459,6 @@ if isinstance(data, list):
     log_info "App '$app_name' destroyed"
 }
 
-# Inject environment variables into both .bashrc and .zshrc (Fly.io specific)
-# Fly uses both bash and zsh, so we append to both rc files
-# Usage: inject_env_vars_fly KEY1=VAL1 KEY2=VAL2 ...
-inject_env_vars_fly() {
-    local env_temp
-    env_temp=$(mktemp)
-    chmod 600 "${env_temp}"
-    track_temp_file "${env_temp}"
-
-    generate_env_config "$@" > "${env_temp}"
-
-    # Append to .bashrc and .zshrc only
-    upload_file "${env_temp}" "/tmp/env_config"
-    run_server "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
-
-    # Note: temp file will be cleaned up by trap handler
-}
-
 # List all Fly.io apps and machines
 list_servers() {
     local org=$(get_fly_org)

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -193,30 +193,6 @@ EOF
     sprite exec -s "${sprite_name}" -file "${bash_temp}:/tmp/bash_config" -- bash -c "cat /tmp/bash_config > ~/.bash_profile && cat /tmp/bash_config > ~/.bashrc && rm /tmp/bash_config"
 }
 
-# Inject environment variables into sprite's shell config
-# Usage: inject_env_vars_sprite SPRITE_NAME KEY1=val1 KEY2=val2 ...
-# Example: inject_env_vars_sprite "$SPRITE_NAME" \
-#            "OPENROUTER_API_KEY=$OPENROUTER_API_KEY" \
-#            "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
-inject_env_vars_sprite() {
-    local sprite_name="${1}"
-    shift
-
-    local env_temp
-    env_temp=$(mktemp)
-    trap 'rm -f "${env_temp}"' EXIT
-    chmod 600 "${env_temp}"
-
-    generate_env_config "$@" > "${env_temp}"
-
-    # Append to .bashrc and .zshrc only
-    sprite exec -s "${sprite_name}" -file "${env_temp}:/tmp/env_config" -- bash -c "cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc && rm /tmp/env_config"
-    trap - EXIT
-
-    # Offer optional GitHub CLI setup
-    offer_github_auth "run_sprite ${sprite_name}"
-}
-
 # Upload file to sprite (for use with setup_claude_code_config callback)
 # Usage: upload_file_sprite SPRITE_NAME LOCAL_PATH REMOTE_PATH
 # Example: upload_file_sprite "$SPRITE_NAME" "/tmp/settings.json" "/root/.claude/settings.json"

--- a/test/run.sh
+++ b/test/run.sh
@@ -242,7 +242,7 @@ _assert_sprite_common_commands() {
     assert_contains "${MOCK_LOG}" "sprite list" "Checks if sprite exists"
     assert_contains "${MOCK_LOG}" "sprite create.*test-sprite-${script_name}" "Creates sprite with correct name"
     assert_contains "${MOCK_LOG}" "sprite exec.*test-sprite-${script_name}" "Runs commands on sprite"
-    assert_contains "${MOCK_LOG}" "sprite exec.*-file.*/tmp/env_config" "Uploads env config to sprite"
+    assert_contains "${MOCK_LOG}" "sprite exec.*-file.*/tmp/spawn_" "Uploads env config to sprite"
     assert_contains "${MOCK_LOG}" "sprite exec.*-tty.*" "Launches interactive session"
 }
 


### PR DESCRIPTION
**Why:** Fixes a broken error message (empty URL shown to users) and a security inconsistency where API credentials are written to a predictable temp path.

## Changes

1. **Bug fix: `_multi_creds_validate` missing `help_url` parameter** (`shared/common.sh`)
   - Function referenced `${help_url}` (line 2784) but it wasn't a parameter — expanded to empty string
   - Users saw "Get new credentials from: " with no URL when OVH credential validation failed
   - Added `help_url` as 3rd parameter and pass it from `ensure_multi_credentials`

2. **Security fix: `_spawn_inject_env_vars` predictable `/tmp/env_config` path** (`shared/common.sh`)
   - The older `inject_env_vars_ssh` and `inject_env_vars_cb` use randomized remote temp paths to prevent symlink attacks (documented with SECURITY comments)
   - But `_spawn_inject_env_vars` (used by 130+ agent scripts) uploaded to static `/tmp/env_config`
   - Fixed to use randomized `/tmp/spawn_env_${rand_suffix}` matching the established pattern

3. **Dead code removal** (`fly/lib/common.sh`, `sprite/lib/common.sh`)
   - Removed `inject_env_vars_fly` and `inject_env_vars_sprite` — all agent scripts now use `spawn_agent` → `_spawn_inject_env_vars`

## Test plan

- [x] `bash -n` syntax check on all modified files
- [x] Updated test assertion in `test/run.sh` to match new randomized path pattern

-- refactor/code-health