### PR TITLE
feat: add spawn pick command and interactive GCP project/zone/machine-type pickers

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -2601,6 +2601,86 @@ function getHelpFooterSection(): string {
   OpenRouter:  https://openrouter.ai`;
 }
 
+// ── Pick ────────────────────────────────────────────────────────────────────
+
+/**
+ * `spawn pick` — interactive option picker invokable from bash scripts.
+ *
+ * Reads options from stdin (when piped) as tab-separated lines:
+ *   "value\tLabel\tHint"
+ *
+ * Supported flags:
+ *   --prompt <text>    Question shown above the option list
+ *   --default <value>  Value pre-selected in the picker
+ *
+ * Writes the selected value to stdout (one line, no extra whitespace).
+ * Exit code 0 = selection made; exit code 1 = cancelled / no TTY.
+ *
+ * Example from bash:
+ *   zone=$(printf 'us-central1-a\tIowa\nus-east1-b\tVirginia\n' \
+ *            | spawn pick --prompt "Select GCP zone" --default "us-central1-a")
+ */
+export async function cmdPick(pickArgs: string[]): Promise<void> {
+  // ── parse flags ──────────────────────────────────────────────────────────
+  let message = "Select an option";
+  let defaultValue: string | undefined;
+
+  const remaining: string[] = [];
+  for (let i = 0; i < pickArgs.length; i++) {
+    const a = pickArgs[i];
+    if ((a === "--prompt" || a === "-p") && pickArgs[i + 1]) {
+      message = pickArgs[++i];
+    } else if (a === "--default" && pickArgs[i + 1]) {
+      defaultValue = pickArgs[++i];
+    } else if (!a.startsWith("-")) {
+      remaining.push(a);
+    }
+    // unknown flags silently ignored — keeps pick composable
+  }
+
+  // ── read options from stdin (if piped) ────────────────────────────────────
+  const { parsePickerInput, pickToTTY } = await import("./picker.js");
+
+  let inputText = "";
+  if (!process.stdin.isTTY) {
+    // Stdin is piped — read options from it synchronously
+    const { readFileSync } = await import("fs");
+    try {
+      inputText = readFileSync(0, "utf8"); // fd 0 = stdin
+    } catch {
+      // ignore read errors (e.g. already closed)
+    }
+  }
+
+  const options = parsePickerInput(inputText);
+
+  if (options.length === 0) {
+    process.stderr.write(
+      pc.red("spawn pick: no options provided.\n") +
+      pc.dim(
+        "  Supply options via stdin as tab-separated lines:\n" +
+        '  printf "value1\\tLabel1\\nvalue2\\tLabel2" | spawn pick --prompt "..."\n'
+      )
+    );
+    process.exit(1);
+  }
+
+  // ── run picker ────────────────────────────────────────────────────────────
+  const config = { message, options, defaultValue };
+
+  // pickToTTY already falls back to pickFallback internally when /dev/tty is
+  // unavailable or stty fails.  It returns null only when the user cancels.
+  const result = pickToTTY(config);
+
+  if (result === null) {
+    // User pressed Ctrl-C / Escape — or an unrecoverable TTY error
+    process.exit(1);
+  }
+
+  // Write ONLY the selected value to stdout (so bash `$()` captures it cleanly)
+  process.stdout.write(result + "\n");
+}
+
 export function cmdHelp(): void {
   const sections = [
     "",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -15,6 +15,7 @@ import {
   cmdCloudInfo,
   cmdUpdate,
   cmdHelp,
+  cmdPick,
   findClosestKeyByNameOrKey,
   resolveAgentKey,
   resolveCloudKey,
@@ -517,7 +518,17 @@ async function dispatchCommand(cmd: string, filteredArgs: string[], prompt: stri
 }
 
 async function main(): Promise<void> {
-  const args = expandEqualsFlags(process.argv.slice(2));
+  const rawArgs = process.argv.slice(2);
+
+  // ── `spawn pick` — bypass all flag parsing; used by bash scripts ──────────
+  // Must be handled before expandEqualsFlags / resolvePrompt so that pick's
+  // own --prompt flag is not mistakenly consumed by the top-level prompt logic.
+  if (rawArgs[0] === "pick") {
+    await cmdPick(expandEqualsFlags(rawArgs.slice(1)));
+    return;
+  }
+
+  const args = expandEqualsFlags(rawArgs);
 
   await checkForUpdates();
 

--- a/cli/src/picker.ts
+++ b/cli/src/picker.ts
@@ -1,0 +1,264 @@
+/**
+ * picker.ts — Modular interactive option picker.
+ *
+ * Two modes:
+ *   pickToTTY(config)  — renders arrow-key UI to /dev/tty, writes result to
+ *                        stdout.  Works even when stdout is captured by bash
+ *                        `result=$(spawn pick ...)` and stdin is piped.
+ *   pickFallback(config) — numbered list on stderr for non-TTY environments.
+ *
+ * Input format (stdin lines or --options strings):
+ *   "value\tLabel\tHint"  (tab-separated; hint is optional)
+ *   "value\tLabel"
+ *   "value"               (label defaults to value)
+ *
+ * Usage from bash:
+ *   zone=$(printf 'us-central1-a\tIowa\nus-east1-b\tVirginia' \
+ *            | spawn pick --prompt "Select zone" --default "us-central1-a")
+ */
+
+import * as fs from "fs";
+import { spawnSync } from "child_process";
+
+export interface PickOption {
+  value: string;
+  label: string;
+  hint?: string;
+}
+
+export interface PickConfig {
+  message: string;
+  options: PickOption[];
+  defaultValue?: string;
+}
+
+/**
+ * Parse piped input into picker options.
+ * Each line: "value\tLabel\tHint" — tab-separated; hint is optional.
+ */
+export function parsePickerInput(text: string): PickOption[] {
+  return text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .map((l) => {
+      const parts = l.split("\t");
+      const value = (parts[0] ?? "").trim();
+      const label = (parts[1] ?? value).trim();
+      const hint = parts[2]?.trim();
+      return { value, label, ...(hint ? { hint } : {}) };
+    })
+    .filter((o) => o.value.length > 0);
+}
+
+// ── ANSI helpers ─────────────────────────────────────────────────────────────
+
+const A = {
+  reset:     "\x1b[0m",
+  bold:      "\x1b[1m",
+  dim:       "\x1b[2m",
+  green:     "\x1b[32m",
+  cyan:      "\x1b[36m",
+  hideC:     "\x1b[?25l",
+  showC:     "\x1b[?25h",
+  clearBelow:"\x1b[J",
+  up: (n: number) => `\x1b[${n}A`,
+  col1:      "\x1b[1G",
+};
+
+// ── TTY picker ────────────────────────────────────────────────────────────────
+
+/**
+ * Render an arrow-key picker directly on /dev/tty so it works even when
+ * stdout is captured.  Returns the selected value, or null on cancel.
+ *
+ * This function is synchronous internally (blocking readSync loop on the tty
+ * fd) but returns void so callers can `await` it uniformly.
+ */
+export function pickToTTY(config: PickConfig): string | null {
+  if (config.options.length === 0) return config.defaultValue ?? null;
+
+  // ── open /dev/tty ──────────────────────────────────────────────────────────
+  let ttyFd: number;
+  try {
+    ttyFd = fs.openSync("/dev/tty", "r+");
+  } catch {
+    return pickFallback(config);
+  }
+
+  // ── save terminal settings ────────────────────────────────────────────────
+  const savedRes = spawnSync("stty", ["-g"], {
+    stdio: [ttyFd, "pipe", "pipe"],
+  });
+  if (savedRes.status !== 0 || !savedRes.stdout) {
+    fs.closeSync(ttyFd);
+    return pickFallback(config);
+  }
+  const savedSettings = savedRes.stdout.toString().trim();
+
+  // ── enable raw / no-echo mode ─────────────────────────────────────────────
+  const rawRes = spawnSync("stty", ["raw", "-echo"], {
+    stdio: [ttyFd, "pipe", "pipe"],
+  });
+  if (rawRes.status !== 0) {
+    fs.closeSync(ttyFd);
+    return pickFallback(config);
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+  const w = (s: string) => { try { fs.writeSync(ttyFd, s); } catch {} };
+
+  const restore = () => {
+    try { spawnSync("stty", [savedSettings], { stdio: [ttyFd, "pipe", "pipe"] }); } catch {}
+    w(A.showC);
+    try { fs.closeSync(ttyFd); } catch {}
+  };
+
+  // ── initial state ─────────────────────────────────────────────────────────
+  let selected = 0;
+  if (config.defaultValue) {
+    const idx = config.options.findIndex((o) => o.value === config.defaultValue);
+    if (idx >= 0) selected = idx;
+  }
+
+  // header line + one line per option + footer line
+  const pickerHeight = config.options.length + 2;
+
+  const render = (first: boolean) => {
+    if (!first) {
+      w(A.up(pickerHeight) + A.col1 + A.clearBelow);
+    }
+    w(`${A.bold}${A.cyan}? ${config.message}${A.reset}\r\n`);
+    for (let i = 0; i < config.options.length; i++) {
+      const opt = config.options[i];
+      if (i === selected) {
+        w(`${A.green}${A.bold}> ${opt.label}${A.reset}`);
+        if (opt.hint) w(`  ${A.dim}${opt.hint}${A.reset}`);
+      } else {
+        w(`  ${A.dim}${opt.label}${A.reset}`);
+      }
+      w("\r\n");
+    }
+    w(`${A.dim}  \u2191/\u2193 move  \u23ce select  Ctrl-C cancel${A.reset}\r\n`);
+  };
+
+  // ── render & key loop ─────────────────────────────────────────────────────
+  w(A.hideC);
+  render(true);
+
+  const buf = Buffer.alloc(8);
+  let result: string | null = null;
+
+  try {
+    // Synchronous blocking read loop — each iteration waits for one keypress.
+    // Arrow keys (\x1b[A / \x1b[B) arrive as a single read() because the
+    // terminal driver delivers escape sequences atomically.
+    outer: while (true) {
+      let n: number;
+      try {
+        n = fs.readSync(ttyFd, buf, 0, 8);
+      } catch {
+        break;
+      }
+      if (n === 0) continue;
+
+      const key = buf.slice(0, n).toString("binary");
+
+      switch (key) {
+        // ── cancel ─────────────────────────────────────────────────────────
+        case "\x03": // Ctrl-C
+        case "\x1b": // standalone Escape
+          break outer;
+
+        // ── confirm ────────────────────────────────────────────────────────
+        case "\r":
+        case "\n": {
+          result = config.options[selected].value;
+          // Replace picker with a one-line confirmation
+          w(A.up(pickerHeight) + A.col1 + A.clearBelow);
+          const opt = config.options[selected];
+          w(
+            `${A.green}${A.bold}> ${config.message}:${A.reset} ` +
+            `${A.cyan}${opt.label}${A.reset}\r\n`
+          );
+          break outer;
+        }
+
+        // ── navigation ─────────────────────────────────────────────────────
+        case "\x1b[A": // Up (CSI)
+        case "\x1bOA": // Up (SS3, some terminals)
+        case "k":      // vim-style
+          selected = (selected - 1 + config.options.length) % config.options.length;
+          render(false);
+          break;
+
+        case "\x1b[B": // Down (CSI)
+        case "\x1bOB": // Down (SS3)
+        case "j":      // vim-style
+          selected = (selected + 1) % config.options.length;
+          render(false);
+          break;
+
+        default:
+          break;
+      }
+    }
+  } finally {
+    restore();
+  }
+
+  return result;
+}
+
+// ── fallback picker ───────────────────────────────────────────────────────────
+
+/**
+ * Simple numbered-list fallback when no /dev/tty is available.
+ * Renders to stderr, reads from /dev/tty or stdin.
+ */
+export function pickFallback(config: PickConfig): string | null {
+  const { message, options, defaultValue } = config;
+  if (options.length === 0) return defaultValue ?? null;
+
+  const defaultIdx = Math.max(
+    options.findIndex((o) => o.value === defaultValue) + 1,
+    1
+  );
+
+  process.stderr.write(`\n${message}\n`);
+  options.forEach((opt, i) => {
+    const marker = opt.value === defaultValue ? "*" : " ";
+    let line = `  ${marker} ${i + 1}) ${opt.label}`;
+    if (opt.hint) line += `  — ${opt.hint}`;
+    process.stderr.write(line + "\n");
+  });
+  process.stderr.write(`\nSelect [${defaultIdx}]: `);
+
+  // Attempt to read from /dev/tty (stdin may be piped with options)
+  let inputFd = 0;
+  let openedTTY = false;
+  try {
+    const fd = fs.openSync("/dev/tty", "r");
+    inputFd = fd;
+    openedTTY = true;
+  } catch {
+    // fall through: read from stdin (fd 0)
+  }
+
+  let line = "";
+  try {
+    const lb = Buffer.alloc(256);
+    const n = fs.readSync(inputFd, lb, 0, 255);
+    line = lb.slice(0, n).toString().replace(/[\r\n]/g, "").trim();
+  } catch {
+    // ignore
+  } finally {
+    if (openedTTY) try { fs.closeSync(inputFd); } catch {}
+  }
+
+  const choice = parseInt(line, 10);
+  if (choice >= 1 && choice <= options.length) {
+    return options[choice - 1].value;
+  }
+  return defaultValue ?? options[0]?.value ?? null;
+}

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -82,31 +82,131 @@ _gcp_check_auth() {
     fi
 }
 
-# Resolve and export GCP_PROJECT from env var or gcloud config
+# ============================================================
+# Interactive pickers for GCP project, zone, and machine type
+# ============================================================
+
+# Curated list of popular GCP machine types (value\tLabel\tHint)
+_gcp_machine_type_options() {
+    printf '%s\n' \
+        "e2-micro	e2-micro	Shared CPU · 2 vCPU · 1 GB RAM   (~\$7/mo)" \
+        "e2-small	e2-small	Shared CPU · 2 vCPU · 2 GB RAM   (~\$14/mo)" \
+        "e2-medium	e2-medium	Shared CPU · 2 vCPU · 4 GB RAM   (~\$28/mo)  ← default" \
+        "e2-standard-2	e2-standard-2	2 vCPU · 8 GB RAM                (~\$49/mo)" \
+        "e2-standard-4	e2-standard-4	4 vCPU · 16 GB RAM               (~\$98/mo)" \
+        "n2-standard-2	n2-standard-2	2 vCPU · 8 GB RAM, higher perf   (~\$72/mo)" \
+        "n2-standard-4	n2-standard-4	4 vCPU · 16 GB RAM, higher perf  (~\$144/mo)" \
+        "c4-standard-2	c4-standard-2	2 vCPU · 8 GB RAM, latest gen    (~\$82/mo)"
+}
+
+# Curated list of popular GCP zones (value\tLabel\tHint)
+_gcp_zone_options() {
+    printf '%s\n' \
+        "us-central1-a	us-central1-a	Iowa, US        ← default" \
+        "us-east1-b	us-east1-b	South Carolina, US" \
+        "us-east4-a	us-east4-a	N. Virginia, US" \
+        "us-west1-a	us-west1-a	Oregon, US" \
+        "us-west2-a	us-west2-a	Los Angeles, US" \
+        "northamerica-northeast1-a	northamerica-northeast1-a	Montreal, Canada" \
+        "europe-west1-b	europe-west1-b	Belgium" \
+        "europe-west4-a	europe-west4-a	Netherlands" \
+        "europe-west6-a	europe-west6-a	Zurich, Switzerland" \
+        "asia-east1-a	asia-east1-a	Taiwan" \
+        "asia-southeast1-a	asia-southeast1-a	Singapore" \
+        "australia-southeast1-a	australia-southeast1-a	Sydney, Australia"
+}
+
+# Fetch active GCP projects accessible to the authenticated user (value\tLabel\tHint)
+_gcp_project_options() {
+    gcloud projects list \
+        --filter="lifecycleState=ACTIVE" \
+        --format="value(projectId,name)" \
+        2>/dev/null | \
+    awk -F'\t' '{ print $1 "\t" $1 "\t" $2 }'
+}
+
+# Generic GCP interactive picker.
+# Respects the named env var (skip picker if already set).
+# Tries `spawn pick` for a nice arrow-key UI, falls back to a numbered list.
+#
+# Usage: _gcp_interactive_pick DISPLAY_NAME ENV_VAR_NAME DEFAULT OPTIONS_FN
+# Outputs the selected value on stdout.
+_gcp_interactive_pick() {
+    local display="${1}"     # e.g. "GCP machine type"
+    local env_var="${2}"     # e.g. "GCP_MACHINE_TYPE"
+    local default_val="${3}" # e.g. "e2-medium"
+    local options_fn="${4}"  # function name that prints "value\tLabel\tHint" lines
+
+    # Honour an explicit env var override — no prompt needed
+    local current_val
+    eval "current_val=\"\${${env_var}:-}\""
+    if [[ -n "${current_val}" ]]; then
+        echo "${current_val}"
+        return
+    fi
+
+    # Fetch available options
+    local options_text
+    options_text=$("${options_fn}")
+    if [[ -z "${options_text}" ]]; then
+        log_warn "Could not list ${display} options — using default: ${default_val}"
+        echo "${default_val}"
+        return
+    fi
+
+    # Try `spawn pick` for a nicer arrow-key UI (available when user ran `spawn`)
+    if command -v spawn >/dev/null 2>&1; then
+        local picked
+        picked=$(printf '%s\n' "${options_text}" | \
+            spawn pick --prompt "Select ${display}" --default "${default_val}" 2>/dev/tty) && {
+            echo "${picked}"
+            return
+        }
+    fi
+
+    # Fallback: shared/common.sh numbered-list selector
+    # Convert "value\tLabel\tHint" → "value|Label" for _display_and_select
+    local items
+    items=$(printf '%s\n' "${options_text}" | awk -F'\t' '{ print $1 "|" $2 }')
+    _display_and_select "${display}" "${default_val}" "${default_val}" <<< "${items}"
+}
+
+_gcp_pick_machine_type() {
+    _gcp_interactive_pick "GCP machine type" "GCP_MACHINE_TYPE" "e2-medium" "_gcp_machine_type_options"
+}
+
+_gcp_pick_zone() {
+    _gcp_interactive_pick "GCP zone" "GCP_ZONE" "us-central1-a" "_gcp_zone_options"
+}
+
+_gcp_pick_project() {
+    _gcp_interactive_pick "GCP project" "GCP_PROJECT" "" "_gcp_project_options"
+}
+
+# Resolve and export GCP_PROJECT — prompt interactively if not already set
 _gcp_resolve_project() {
+    # Check env var and gcloud config
     local project="${GCP_PROJECT:-$(gcloud config get-value project 2>/dev/null)}"
-    if [[ -z "${project}" || "${project}" == "(unset)" ]]; then
-        log_error "No GCP project configured"
+    if [[ "${project}" == "(unset)" ]]; then project=""; fi
+
+    # If not set, offer an interactive project picker
+    if [[ -z "${project}" ]]; then
+        log_info "No GCP project configured — fetching your projects..."
+        project=$(_gcp_pick_project)
+    fi
+
+    if [[ -z "${project}" ]]; then
+        log_error "No GCP project selected"
         log_error ""
-        log_error "Possible causes:"
-        log_error "  - No project is set in gcloud config or GCP_PROJECT env var"
-        log_error "  - You haven't created a GCP project yet"
+        log_error "Set one before retrying:"
+        log_error "  export ${CYAN}GCP_PROJECT=your-project-id${NC}"
+        log_error "  or: gcloud config set project YOUR_PROJECT_ID"
         log_error ""
-        log_error "How to fix:"
-        log_error "  1. List your existing projects:"
-        log_error "     ${CYAN}gcloud projects list${NC}"
+        log_error "Don't have a project? Create one:"
+        log_error "  ${CYAN}https://console.cloud.google.com/projectcreate${NC}"
         log_error ""
-        log_error "  2. Set a project via environment variable:"
-        log_error "     ${CYAN}export GCP_PROJECT=your-project-id${NC}"
-        log_error ""
-        log_error "  3. Or set via gcloud config:"
-        log_error "     ${CYAN}gcloud config set project YOUR_PROJECT_ID${NC}"
-        log_error ""
-        log_error "  4. Don't have a project? Create one:"
-        log_error "     ${CYAN}https://console.cloud.google.com/projectcreate${NC}"
-        log_error ""
-        log_error "  5. Enable Compute Engine API for your project:"
-        log_error "     ${CYAN}https://console.cloud.google.com/apis/library/compute.googleapis.com${NC}"
+        log_error "Then enable Compute Engine API:"
+        log_error "  ${CYAN}https://console.cloud.google.com/apis/library/compute.googleapis.com${NC}"
         return 1
     fi
     export GCP_PROJECT="${project}"
@@ -230,14 +330,22 @@ _gcp_get_instance_ip() {
 
 create_server() {
     local name="${1}"
-    local machine_type="${GCP_MACHINE_TYPE:-e2-medium}"
-    local zone="${GCP_ZONE:-us-central1-a}"
     local image_family="ubuntu-2404-lts-amd64"
     local image_project="ubuntu-os-cloud"
 
-    # Validate env var inputs to prevent command injection
-    validate_resource_name "${machine_type}" || { log_error "Invalid GCP_MACHINE_TYPE"; return 1; }
-    validate_region_name "${zone}" || { log_error "Invalid GCP_ZONE"; return 1; }
+    # Interactive pickers — each respects the env var override and skips the
+    # prompt when GCP_MACHINE_TYPE / GCP_ZONE are already set.
+    local machine_type zone
+    machine_type=$(_gcp_pick_machine_type)
+    zone=$(_gcp_pick_zone)
+
+    # Validate to prevent command injection (covers both interactive and env-var paths)
+    validate_resource_name "${machine_type}" || { log_error "Invalid GCP_MACHINE_TYPE: ${machine_type}"; return 1; }
+    validate_region_name "${zone}" || { log_error "Invalid GCP_ZONE: ${zone}"; return 1; }
+
+    # Export so downstream functions (cloud_wait_ready, destroy_server, etc.) see them
+    export GCP_MACHINE_TYPE="${machine_type}"
+    export GCP_ZONE="${zone}"
 
     log_step "Creating GCP instance '${name}' (type: ${machine_type}, zone: ${zone})..."
 


### PR DESCRIPTION
## Summary

- **New `spawn pick` subcommand** — modular interactive option picker usable from bash scripts via `result=$(spawn pick --prompt "..." --default "...")`. Reads tab-separated `value\tLabel\tHint` lines from stdin, renders an arrow-key UI to `/dev/tty` (so it works even when stdout is captured), and writes the selected value to stdout.
- **New `cli/src/picker.ts`** — standalone picker module with `pickToTTY()` (arrow-key UI on `/dev/tty`), `pickFallback()` (numbered list fallback), and `parsePickerInput()`.
- **GCP interactive pickers** — all GCP agent scripts now prompt interactively for project, zone, and machine type before provisioning. Each respects env var overrides (`GCP_PROJECT`, `GCP_ZONE`, `GCP_MACHINE_TYPE`) and skips the prompt when already set.

## Changes

### `cli/src/picker.ts` (new)
- `pickToTTY(config)` — renders arrow-key picker to `/dev/tty`; works with stdout captured by `$()`
- `pickFallback(config)` — numbered list on stderr for headless/non-TTY environments
- `parsePickerInput(text)` — parses `value\tLabel\tHint` tab-separated lines

### `spawn pick` (new subcommand)
```bash
zone=$(printf 'us-central1-a\tIowa\nus-east1-b\tVirginia\n' \
         | spawn pick --prompt "Select GCP zone" --default "us-central1-a")
```
Bypasses top-level flag parsing so `--prompt` doesn't conflict with `spawn <agent> <cloud> --prompt`.

### `gcp/lib/common.sh`
- `_gcp_resolve_project()` — now shows a live project picker (`gcloud projects list`) instead of hard-erroring when no project is configured
- `create_server()` — calls zone + machine type pickers before provisioning
- 8 curated machine types: `e2-micro` ($7/mo) → `c4-standard-2` ($82/mo)
- 12 curated zones across US / EU / APAC / AU
- All pickers try `spawn pick` first; fall back to `_display_and_select` (fzf or numbered list)

## Test plan
- [ ] `spawn pick` with piped stdin and captured stdout: `result=$(printf 'a\tA\nb\tB\n' | spawn pick --prompt "test")` → `$result` is `a` or `b`
- [ ] Arrow-key navigation selects correct item
- [ ] Ctrl-C exits with code 1
- [ ] `GCP_ZONE=us-east1-b spawn claude gcp` skips zone picker, uses override
- [ ] Running `spawn claude gcp` with no `GCP_PROJECT` set shows project list picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)