### PR TITLE
fix: gh CLI setup on remote VMs — pass local token through

### DIFF
--- a/cli/src/__tests__/shared-github-auth.test.ts
+++ b/cli/src/__tests__/shared-github-auth.test.ts
@@ -500,7 +500,7 @@ describe("ensure_gh_auth", () => {
       ensure_gh_auth 2>&1
     `);
     expect(result.exitCode).not.toBe(0);
-    expect(result.stdout + result.stderr).toContain("Failed to authenticate");
+    expect(result.stdout + result.stderr).toContain("authentication failed");
   });
 
   it("should fail when post-login auth status check fails", () => {

--- a/shared/github-auth.sh
+++ b/shared/github-auth.sh
@@ -222,10 +222,12 @@ ensure_gh_auth() {
             return 1
         }
     else
-        # Interactive: browser-based OAuth flow
-        log_step "Initiating GitHub CLI authentication..."
-        gh auth login || {
-            log_error "Failed to authenticate with GitHub CLI"
+        # Device code flow — works on headless/remote servers
+        # Shows a URL + code; user opens URL in local browser and enters the code
+        log_step "Authenticating via device code flow..."
+        log_info "A URL and code will appear below. Open the URL in your browser and enter the code."
+        gh auth login --web -p https -h github.com || {
+            log_error "GitHub authentication failed"
             log_error "Run manually: gh auth login"
             return 1
         }
@@ -254,7 +256,8 @@ ensure_github_auth() {
 # ============================================================
 
 # If executed directly (not sourced), run ensure_github_auth
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# When piped via curl|bash, BASH_SOURCE[0] is empty and $0 is "bash"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" ]]; then
     set -eo pipefail
     ensure_github_auth
 fi


### PR DESCRIPTION
## Summary
- `prompt_github_auth()` now captures the user's local GitHub token (from `GITHUB_TOKEN` env var or `gh auth token`) before server provisioning
- `offer_github_auth()` passes captured token as `GITHUB_TOKEN='xxx'` env var prefix to the remote `curl | bash` command, so `ensure_gh_auth()` uses the non-interactive `--with-token` path
- `github-auth.sh`: device code fallback now uses `gh auth login --web -p https -h github.com` instead of bare `gh auth login` (which tried to open a browser on headless VMs)

## What was broken
GitHub CLI auth on remote VMs never worked because:
1. No token was passed to the remote — `ensure_gh_auth()` always fell through to device code flow
2. Device code flow used bare `gh auth login` which tries to open a browser — impossible on headless VMs

## Test plan
- [x] `bash -n` syntax check on both files
- [x] `bash test/run.sh` — all 80 tests pass
- [ ] Manual: run any agent script, say "y" to GitHub auth, verify gh is installed and authenticated on remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)