### PR TITLE
feat: collect all auth prompts before server provisioning

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1562,25 +1562,25 @@ spawn_agent() {
     # 2. Pre-provision hooks (e.g., prompt for GitHub auth)
     if _fn_exists agent_pre_provision; then agent_pre_provision; fi
 
-    # 3. Provision server
+    # 3. Get API key (before provisioning so user isn't waiting on server)
+    get_or_prompt_api_key
+
+    # 4. Model selection (if agent needs it)
+    if [[ -n "${AGENT_MODEL_PROMPT:-}" ]]; then
+        MODEL_ID=$(get_model_id_interactive "${AGENT_MODEL_DEFAULT:-openrouter/auto}" "${agent_name}") || exit 1
+    fi
+
+    # 5. Provision server
     local server_name
     server_name=$(get_server_name)
     cloud_provision "${server_name}"
 
-    # 4. Wait for readiness
+    # 6. Wait for readiness
     cloud_wait_ready
 
-    # 5. Install agent
+    # 7. Install agent
     if _fn_exists agent_install; then
         agent_install || exit 1
-    fi
-
-    # 6. Get API key
-    get_or_prompt_api_key
-
-    # 7. Model selection (if agent needs it)
-    if [[ -n "${AGENT_MODEL_PROMPT:-}" ]]; then
-        MODEL_ID=$(get_model_id_interactive "${AGENT_MODEL_DEFAULT:-openrouter/auto}" "${agent_name}") || exit 1
     fi
 
     # 8. Inject environment variables


### PR DESCRIPTION
## Summary
- Move OpenRouter OAuth and model selection prompts to run **before** server provisioning in `spawn_agent()`
- Previously: user waited for server to spin up, then was prompted for API key and model — dead time
- Now: all interactive prompts (GitHub auth, OpenRouter OAuth, model selection) happen upfront, then server provisions without further user interaction

## New flow order in `spawn_agent()`
1. Cloud authenticate
2. Pre-provision hooks (GitHub auth prompt)
3. **OpenRouter API key** (moved up from step 6)
4. **Model selection** (moved up from step 7)
5. Provision server (no more waiting on user)
6. Wait for readiness
7. Install agent
8. Inject env vars
9. Configure, save, launch

## Test plan
- [x] `bash -n` syntax check
- [x] `bash test/run.sh` — all 80 tests pass
- [ ] Manual: verify OAuth flow completes before server starts provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)