### PR TITLE
security: replace eval with indirect expansion in GCP picker

### DIFF
--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -139,7 +139,7 @@ _gcp_interactive_pick() {
 
     # Honour an explicit env var override — no prompt needed
     local current_val
-    eval "current_val=\"\${${env_var}:-}\""
+    current_val="${!env_var:-}"
     if [[ -n "${current_val}" ]]; then
         echo "${current_val}"
         return


### PR DESCRIPTION
**Why:** eval with variable names is a command injection vector; indirect expansion `${!var}` is safe, simpler, and achieves identical behavior

Fixes #1446

Replaces `eval "current_val=\"\${:-}\""` with `current_val="${!env_var:-}"` in `_gcp_interactive_pick()` in `gcp/lib/common.sh`.

All call sites (\_gcp\_pick\_machine\_type, \_gcp\_pick\_zone, \_gcp\_pick\_project) use literal strings so behavior is unchanged.

-- refactor/security-auditor