### PR TITLE
fix: resolve unknown --default flag in CLI picker

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/index-dispatch-routing.test.ts
+++ b/cli/src/__tests__/index-dispatch-routing.test.ts
@@ -200,7 +200,12 @@ const KNOWN_FLAGS = new Set([
   "--version", "-v", "-V",
   "--prompt", "-p", "--prompt-file", "-f",
   "--dry-run", "-n",
+  "--debug",
+  "--headless",
+  "--output",
+  "--default",
   "-a", "-c", "--agent", "--cloud",
+  "--clear",
 ]);
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -974,8 +979,13 @@ describe("KNOWN_FLAGS completeness", () => {
     "--prompt", "-p",
     "--prompt-file", "-f",
     "--dry-run", "-n",
+    "--debug",
+    "--headless",
+    "--output",
+    "--default",
     "-a", "-c",
     "--agent", "--cloud",
+    "--clear",
   ];
 
   for (const flag of expectedFlags) {
@@ -991,8 +1001,8 @@ describe("KNOWN_FLAGS completeness", () => {
     expect(KNOWN_FLAGS.has("--force")).toBe(false);
   });
 
-  it("should have exactly 15 known flags", () => {
-    expect(KNOWN_FLAGS.size).toBe(15);
+  it("should have exactly 20 known flags", () => {
+    expect(KNOWN_FLAGS.size).toBe(20);
   });
 });
 

--- a/cli/src/__tests__/unknown-flags.test.ts
+++ b/cli/src/__tests__/unknown-flags.test.ts
@@ -12,6 +12,12 @@ const KNOWN_FLAGS = new Set([
   "--version", "-v", "-V",
   "--prompt", "-p", "--prompt-file", "-f",
   "--dry-run", "-n",
+  "--debug",
+  "--headless",
+  "--output",
+  "--default",
+  "-a", "-c", "--agent", "--cloud",
+  "--clear",
 ]);
 
 /** Replicated from index.ts for testability - returns the first unknown flag or null */
@@ -41,8 +47,8 @@ describe("Unknown Flag Detection", () => {
       expect(findUnknownFlag(["list", "-x"])).toBe("-x");
     });
 
-    it("should detect --output as unknown", () => {
-      expect(findUnknownFlag(["agents", "--output", "json"])).toBe("--output");
+    it("should detect --force as unknown", () => {
+      expect(findUnknownFlag(["agents", "--force"])).toBe("--force");
     });
 
     it("should detect --verbose as unknown", () => {
@@ -101,6 +107,22 @@ describe("Unknown Flag Detection", () => {
 
     it("should allow -n (short form of --dry-run)", () => {
       expect(findUnknownFlag(["claude", "sprite", "-n"])).toBeNull();
+    });
+
+    it("should allow --default (used by spawn pick)", () => {
+      expect(findUnknownFlag(["--default", "us-central1-a"])).toBeNull();
+    });
+
+    it("should allow --output", () => {
+      expect(findUnknownFlag(["claude", "sprite", "--output", "json"])).toBeNull();
+    });
+
+    it("should allow --headless", () => {
+      expect(findUnknownFlag(["claude", "sprite", "--headless"])).toBeNull();
+    });
+
+    it("should allow --debug", () => {
+      expect(findUnknownFlag(["claude", "sprite", "--debug"])).toBeNull();
     });
   });
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -72,6 +72,7 @@ const KNOWN_FLAGS = new Set([
   "--debug",
   "--headless",
   "--output",
+  "--default",
   "-a", "-c", "--agent", "--cloud",
   "--clear",
 ]);
@@ -105,6 +106,9 @@ function checkUnknownFlags(args: string[]): void {
       console.error(`    ${pc.cyan("--output json")}       Output structured JSON to stdout`);
       console.error(`    ${pc.cyan("--help, -h")}          Show help information`);
       console.error(`    ${pc.cyan("--version, -v")}       Show version`);
+      console.error();
+      console.error(`  For ${pc.cyan("spawn pick")}:`);
+      console.error(`    ${pc.cyan("--default")}           Pre-selected value in the picker`);
       console.error();
       console.error(`  For ${pc.cyan("spawn list")}:`);
       console.error(`    ${pc.cyan("-a, --agent")}         Filter history by agent`);
@@ -524,7 +528,11 @@ async function main(): Promise<void> {
   // Must be handled before expandEqualsFlags / resolvePrompt so that pick's
   // own --prompt flag is not mistakenly consumed by the top-level prompt logic.
   if (rawArgs[0] === "pick") {
-    await cmdPick(expandEqualsFlags(rawArgs.slice(1)));
+    try {
+      await cmdPick(expandEqualsFlags(rawArgs.slice(1)));
+    } catch (err) {
+      handleError(err);
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary

- Add `--default` to `KNOWN_FLAGS` in `cli/src/index.ts` so the flag is recognized even when the `spawn pick` early-return path is bypassed (e.g. due to Bun kqueue/TTY errors on certain platforms)
- Wrap `cmdPick` in a try/catch so TTY-related errors produce a clean error message instead of an unhandled rejection
- Sync test copies of `KNOWN_FLAGS` in `unknown-flags.test.ts` and `index-dispatch-routing.test.ts` that had drifted from the source of truth (were missing `--debug`, `--headless`, `--output`, `--clear`, `-a`, `-c`, `--agent`, `--cloud`)
- Fix incorrect test that expected `--output` to be flagged as unknown (it has been a known flag since headless mode was added)
- Bump CLI version to 0.5.4

Fixes #1447

## Test plan

- [x] `bun test src/__tests__/unknown-flags.test.ts` — all 24 tests pass
- [x] `bun test src/__tests__/index-dispatch-routing.test.ts` — all 162 tests pass
- [x] `bun test src/__tests__/index-parsing.test.ts src/__tests__/index-edge-cases.test.ts src/__tests__/index-main-routing.test.ts` — all 101 tests pass

-- refactor/code-health