### PR TITLE
fix: correct test parameter mismatches causing 8 persistent failures

### DIFF
--- a/cli/src/__tests__/shared-common-credential-mgmt.test.ts
+++ b/cli/src/__tests__/shared-common-credential-mgmt.test.ts
@@ -571,7 +571,7 @@ describe("_multi_creds_load_config", () => {
 describe("_multi_creds_validate", () => {
   it("should return 0 when no test function provided (empty string)", () => {
     const result = runBash(`
-      _multi_creds_validate "" "TestProvider" VAR_A VAR_B
+      _multi_creds_validate "" "TestProvider" "https://example.com" VAR_A VAR_B
     `);
     expect(result.exitCode).toBe(0);
   });
@@ -580,7 +580,7 @@ describe("_multi_creds_validate", () => {
     const result = runBash(`
       test_ok() { return 0; }
       export VAR_A="a"
-      _multi_creds_validate test_ok "TestProvider" VAR_A
+      _multi_creds_validate test_ok "TestProvider" "https://example.com" VAR_A
     `);
     expect(result.exitCode).toBe(0);
   });
@@ -589,7 +589,7 @@ describe("_multi_creds_validate", () => {
     const result = runBash(`
       test_fail() { return 1; }
       export VAR_A="a"
-      _multi_creds_validate test_fail "TestProvider" VAR_A 2>/dev/null
+      _multi_creds_validate test_fail "TestProvider" "https://example.com" VAR_A 2>/dev/null
     `);
     expect(result.exitCode).toBe(1);
   });
@@ -599,7 +599,7 @@ describe("_multi_creds_validate", () => {
       test_fail() { return 1; }
       export VAR_A="a"
       export VAR_B="b"
-      _multi_creds_validate test_fail "TestProvider" VAR_A VAR_B 2>/dev/null
+      _multi_creds_validate test_fail "TestProvider" "https://example.com" VAR_A VAR_B 2>/dev/null
       echo "A=\${VAR_A:-UNSET}"
       echo "B=\${VAR_B:-UNSET}"
     `);
@@ -612,7 +612,7 @@ describe("_multi_creds_validate", () => {
       test_ok() { return 0; }
       export VAR_A="kept"
       export VAR_B="also-kept"
-      _multi_creds_validate test_ok "TestProvider" VAR_A VAR_B 2>/dev/null
+      _multi_creds_validate test_ok "TestProvider" "https://example.com" VAR_A VAR_B 2>/dev/null
       echo "A=$VAR_A"
       echo "B=$VAR_B"
     `);
@@ -624,7 +624,7 @@ describe("_multi_creds_validate", () => {
     const result = runBash(`
       test_fail() { return 1; }
       export VAR_A="a"
-      _multi_creds_validate test_fail "Contabo" VAR_A 2>&1
+      _multi_creds_validate test_fail "Contabo" "https://example.com" VAR_A 2>&1
     `);
     expect(result.stdout).toContain("Contabo");
     expect(result.stdout).toContain("Invalid");

--- a/cli/src/__tests__/shared-common-env-inject.test.ts
+++ b/cli/src/__tests__/shared-common-env-inject.test.ts
@@ -69,7 +69,7 @@ inject_env_vars_ssh "192.168.1.1" mock_upload mock_run "MY_KEY=my_value"
 `);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("UPLOAD: 192.168.1.1");
-      expect(result.stdout).toContain("/tmp/env_config");
+      expect(result.stdout).toContain("/tmp/spawn_env_");
       expect(result.stdout).toContain("RUN: 192.168.1.1");
       expect(result.stdout).toContain(".zshrc");
     } finally {
@@ -155,8 +155,9 @@ inject_env_vars_local mock_upload mock_run "MY_KEY=my_value"
     expect(result.exitCode).toBe(0);
     // inject_env_vars_local does NOT pass server_ip - upload gets (local_path, remote_path)
     expect(result.stdout).toContain("UPLOAD_ARGS:");
-    expect(result.stdout).toContain("/tmp/env_config");
-    expect(result.stdout).toContain("cat /tmp/env_config >> ~/.bashrc && cat /tmp/env_config >> ~/.zshrc");
+    expect(result.stdout).toContain("/tmp/spawn_env_");
+    // The run command should append the temp file to bashrc and zshrc
+    expect(result.stdout).toMatch(/cat '\/tmp\/spawn_env_[^']+' >> ~\/.bashrc && cat '\/tmp\/spawn_env_[^']+' >> ~\/.zshrc/);
   });
 
   it("should generate correct env config content", () => {

--- a/cli/src/__tests__/shared-common-untested-helpers.test.ts
+++ b/cli/src/__tests__/shared-common-untested-helpers.test.ts
@@ -266,7 +266,7 @@ describe("_multi_creds_validate", () => {
   it("should return 0 when test function succeeds", () => {
     const result = runBash(`
       test_pass() { return 0; }
-      _multi_creds_validate test_pass "TestProvider"
+      _multi_creds_validate test_pass "TestProvider" "https://example.com"
     `);
     expect(result.exitCode).toBe(0);
   });
@@ -274,13 +274,13 @@ describe("_multi_creds_validate", () => {
   it("should return 1 when test function fails", () => {
     const result = runBash(`
       test_fail() { return 1; }
-      _multi_creds_validate test_fail "TestProvider" 2>/dev/null
+      _multi_creds_validate test_fail "TestProvider" "https://example.com" 2>/dev/null
     `);
     expect(result.exitCode).toBe(1);
   });
 
   it("should return 0 when test function is empty (no validation)", () => {
-    const result = runBash(`_multi_creds_validate "" "TestProvider"`);
+    const result = runBash(`_multi_creds_validate "" "TestProvider" "https://example.com"`);
     expect(result.exitCode).toBe(0);
   });
 
@@ -289,7 +289,7 @@ describe("_multi_creds_validate", () => {
       export MY_VAR1="secret1"
       export MY_VAR2="secret2"
       test_fail() { return 1; }
-      _multi_creds_validate test_fail "TestProvider" MY_VAR1 MY_VAR2 2>/dev/null
+      _multi_creds_validate test_fail "TestProvider" "https://example.com" MY_VAR1 MY_VAR2 2>/dev/null
       echo "VAR1=\${MY_VAR1:-unset}"
       echo "VAR2=\${MY_VAR2:-unset}"
     `);
@@ -302,7 +302,7 @@ describe("_multi_creds_validate", () => {
       export MY_VAR1="secret1"
       export MY_VAR2="secret2"
       test_pass() { return 0; }
-      _multi_creds_validate test_pass "TestProvider" MY_VAR1 MY_VAR2
+      _multi_creds_validate test_pass "TestProvider" "https://example.com" MY_VAR1 MY_VAR2
       echo "VAR1=\${MY_VAR1:-unset}"
       echo "VAR2=\${MY_VAR2:-unset}"
     `);
@@ -313,7 +313,7 @@ describe("_multi_creds_validate", () => {
   it("should show error message with provider name on failure", () => {
     const result = runBash(`
       test_fail() { return 1; }
-      _multi_creds_validate test_fail "Contabo" MY_VAR 2>&1
+      _multi_creds_validate test_fail "Contabo" "https://example.com" MY_VAR 2>&1
     `);
     expect(result.stdout).toContain("Invalid Contabo credentials");
   });
@@ -321,7 +321,7 @@ describe("_multi_creds_validate", () => {
   it("should show actionable guidance on failure", () => {
     const result = runBash(`
       test_fail() { return 1; }
-      _multi_creds_validate test_fail "UpCloud" MY_VAR 2>&1
+      _multi_creds_validate test_fail "UpCloud" "https://example.com" MY_VAR 2>&1
     `);
     expect(result.stdout).toContain("expired");
     expect(result.stdout).toContain("Re-run");
@@ -330,7 +330,7 @@ describe("_multi_creds_validate", () => {
   it("should show testing message during validation", () => {
     const result = runBash(`
       test_pass() { return 0; }
-      _multi_creds_validate test_pass "Hetzner" 2>&1
+      _multi_creds_validate test_pass "Hetzner" "https://example.com" 2>&1
     `);
     expect(result.stdout).toContain("Testing Hetzner credentials");
   });
@@ -339,7 +339,7 @@ describe("_multi_creds_validate", () => {
     const result = runBash(`
       export SINGLE_VAR="value"
       test_fail() { return 1; }
-      _multi_creds_validate test_fail "Provider" SINGLE_VAR 2>/dev/null
+      _multi_creds_validate test_fail "Provider" "https://example.com" SINGLE_VAR 2>/dev/null
       echo "\${SINGLE_VAR:-unset}"
     `);
     expect(result.stdout).toContain("unset");
@@ -349,7 +349,7 @@ describe("_multi_creds_validate", () => {
     const result = runBash(`
       export V1="a" V2="b" V3="c"
       test_fail() { return 1; }
-      _multi_creds_validate test_fail "Provider" V1 V2 V3 2>/dev/null
+      _multi_creds_validate test_fail "Provider" "https://example.com" V1 V2 V3 2>/dev/null
       echo "\${V1:-x}\${V2:-x}\${V3:-x}"
     `);
     expect(result.stdout).toBe("xxx");


### PR DESCRIPTION
**Why:** 8 tests fail on every CI run because test calls don't match the function signatures they're testing, masking real regressions.

## Summary

- `_multi_creds_validate` tests in 2 files (`shared-common-credential-mgmt.test.ts`, `shared-common-untested-helpers.test.ts`) were missing the required `help_url` 3rd positional parameter. This caused env var names (intended as the 4th+ args) to be consumed as `help_url`, so the "unset all env vars on failure" tests only unset 1 of N variables instead of all N.

- `inject_env_vars_ssh`/`inject_env_vars_local` tests expected the old hardcoded path `/tmp/env_config`, but a prior security fix changed to randomized `/tmp/spawn_env_*` names to prevent symlink race conditions. Updated assertions to match the new naming pattern.

## Test plan
- [x] All 176 tests across the 3 modified files pass (`bun test` on each)
- [x] No shell scripts modified (no `bash -n` needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)