### PR TITLE
fix: deduplicate isInteractiveTTY and remove dead OVH env wrapper

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1682,7 +1682,7 @@ function renderListTable(records: SpawnRecord[], manifest: Manifest | null): voi
   console.log();
 }
 
-function isInteractiveTTY(): boolean {
+export function isInteractiveTTY(): boolean {
   return !!(process.stdin.isTTY && process.stdout.isTTY);
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -20,6 +20,7 @@ import {
   resolveAgentKey,
   resolveCloudKey,
   loadManifestWithSpinner,
+  isInteractiveTTY,
 } from "./commands.js";
 import pc from "picocolors";
 import pkg from "../package.json" with { type: "json" };
@@ -27,10 +28,6 @@ import { checkForUpdates } from "./update-check.js";
 import { loadManifest, agentKeys, cloudKeys, getCacheAge } from "./manifest.js";
 
 const VERSION = pkg.version;
-
-function isInteractiveTTY(): boolean {
-  return process.stdin.isTTY && process.stdout.isTTY;
-}
 
 function handleError(err: unknown): never {
   // Use duck typing instead of instanceof to avoid prototype chain issues

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -390,13 +390,6 @@ install_base_deps() {
     log_info "Base dependencies installed"
 }
 
-# Inject environment variables using SSH
-inject_env_vars_ovh() {
-    local server_ip="$1"
-    shift
-    inject_env_vars_ssh "${server_ip}" "upload_file_ovh ${server_ip}" "run_ovh ${server_ip}" "$@"
-}
-
 # List all OVH instances
 list_instances() {
     local response


### PR DESCRIPTION
**Why:** Prevents behavior drift between two copies of the same TTY-detection function (one had a subtle type bug with missing `!!` coercion), and removes dead code that could mislead contributors.

## Changes

1. **Deduplicate `isInteractiveTTY()`** -- was independently defined in both `cli/src/index.ts` and `cli/src/commands.ts` with a subtle difference:
   - `index.ts`: `return process.stdin.isTTY && process.stdout.isTTY;` (returns `boolean | undefined`)
   - `commands.ts`: `return !!(process.stdin.isTTY && process.stdout.isTTY);` (correctly returns `boolean`)
   - Fix: export from `commands.ts`, import in `index.ts`, remove the local copy

2. **Remove dead `inject_env_vars_ovh`** from `ovh/lib/common.sh` -- defined but never called. All OVH agent scripts use `spawn_agent` which goes through `_spawn_inject_env_vars`. Confirmed zero callers via grep.

3. **Bump CLI version** 0.5.5 -> 0.5.6

## Test plan

- [x] `bash -n ovh/lib/common.sh` passes
- [x] `bun test` index and commands tests pass (0 failures in changed files)
- [x] OVH mock tests confirm env injection still works through spawn_agent path
- [x] No test files reference `inject_env_vars_ovh`

Agent: code-health