### PR TITLE
ux: move spawn name prompt after agent/cloud selection

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -480,13 +480,14 @@ export async function cmdInteractive(): Promise<void> {
   p.intro(pc.inverse(` spawn v${VERSION} `));
 
   const manifest = await loadManifestWithSpinner();
-  const spawnName = await promptSpawnName();
   const agentChoice = await selectAgent(manifest);
 
   const { clouds, hintOverrides } = getAndValidateCloudChoices(manifest, agentChoice);
   const cloudChoice = await selectCloud(manifest, clouds, hintOverrides);
 
   await preflightCredentialCheck(manifest, cloudChoice);
+
+  const spawnName = await promptSpawnName();
 
   const agentName = manifest.agents[agentChoice].name;
   const cloudName = manifest.clouds[cloudChoice].name;
@@ -502,7 +503,6 @@ export async function cmdAgentInteractive(agent: string, prompt?: string, dryRun
   p.intro(pc.inverse(` spawn v${VERSION} `));
 
   const manifest = await loadManifestWithSpinner();
-  const spawnName = await promptSpawnName();
   const resolvedAgent = resolveAgentKey(manifest, agent);
 
   if (!resolvedAgent) {
@@ -519,6 +519,8 @@ export async function cmdAgentInteractive(agent: string, prompt?: string, dryRun
   const cloudChoice = await selectCloud(manifest, clouds, hintOverrides);
 
   await preflightCredentialCheck(manifest, cloudChoice);
+
+  const spawnName = await promptSpawnName();
 
   const agentName = manifest.agents[resolvedAgent].name;
   const cloudName = manifest.clouds[cloudChoice].name;


### PR DESCRIPTION
**Why:** Every interactive user sees the "Enter a name for this spawn" prompt as their first interaction, before they've chosen an agent or cloud -- they don't know what they're naming yet. Moving it after selection reduces cognitive friction.

## Summary
- Move `promptSpawnName()` call in `cmdInteractive()` and `cmdAgentInteractive()` to after agent/cloud selection and credential preflight check
- Users now see: select agent -> select cloud -> credential check -> name prompt (optional) -> launch
- Bump CLI version 0.5.5 -> 0.5.6

## Test plan
- [x] `bun test src/__tests__/cmd-interactive.test.ts` -- all 18 tests pass
- [x] Full `bun test` -- no new test failures introduced (pre-existing failures unchanged)
- [x] Change is pure reordering of existing function calls, no new logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)