### PR TITLE
fix: remove duplicate API key + model selection in spawn_agent()

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1710,15 +1710,7 @@ spawn_agent() {
     server_name=$(get_server_name)
     cloud_provision "${server_name}"
 
-    # 4. Get API key while server provisions (overlaps with cloud-init)
-    get_or_prompt_api_key
-
-    # 5. Model selection while server provisions (if agent needs it)
-    if [[ -n "${AGENT_MODEL_PROMPT:-}" ]]; then
-        MODEL_ID=$(get_model_id_interactive "${AGENT_MODEL_DEFAULT:-openrouter/auto}" "${agent_name}") || exit 1
-    fi
-
-    # 6. Wait for readiness (may already be done after OAuth)
+    # 6. Wait for readiness
     cloud_wait_ready
 
     # 7. Install agent


### PR DESCRIPTION
**Why:** Every `spawn_agent()` call (130+ agent scripts) made duplicate HTTP requests to OpenRouter's API for key validation and model verification, doubling startup latency on slow/metered connections.

## Summary
- Removed duplicate `get_or_prompt_api_key` and model selection calls that ran both before and after `cloud_provision` in `spawn_agent()`
- The duplicate had mismatched step numbering in comments (3,4,5 then 4,5,6), confirming it was accidental
- Pre-provisioning calls (steps 3-4) are the correct placement -- user prompts happen early while the server boots

## Test plan
- [x] `bash -n shared/common.sh` passes
- [ ] `bash test/run.sh` -- all shell tests pass

-- refactor/code-health