### PR TITLE
fix: harden agent reliability across all clouds

### DIFF
--- a/aws/amazonq.sh
+++ b/aws/amazonq.sh
@@ -14,11 +14,10 @@ log_info "Amazon Q on AWS Lightsail"
 echo ""
 
 agent_install() { install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" cloud_run; }
+# Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && q chat'; }
 

--- a/aws/cline.sh
+++ b/aws/cline.sh
@@ -16,9 +16,11 @@ echo ""
 agent_install() { install_agent "Cline" "npm install -g cline" cloud_run; }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+agent_configure() {
+    log_step "Authenticating Cline with OpenRouter..."
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k ${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/aws/gemini.sh
+++ b/aws/gemini.sh
@@ -14,11 +14,11 @@ log_info "Gemini CLI on AWS Lightsail"
 echo ""
 
 agent_install() { install_agent "Gemini CLI" "npm install -g @google/gemini-cli" cloud_run; }
+# Gemini CLI uses Google's native API format (/v1beta/models/:streamGenerateContent),
+# not the OpenAI-compatible format — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
-        "GOOGLE_GEMINI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && gemini'; }
 

--- a/aws/interpreter.sh
+++ b/aws/interpreter.sh
@@ -21,9 +21,7 @@ agent_install() {
 }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { printf 'export PATH="$HOME/.local/bin:$PATH"; source ~/.zshrc && interpreter --model %s --api_key %s' "${MODEL_ID}" "${OPENROUTER_API_KEY}"; }
 

--- a/aws/nanoclaw.sh
+++ b/aws/nanoclaw.sh
@@ -14,6 +14,8 @@ log_info "NanoClaw on AWS Lightsail"
 echo ""
 
 agent_install() {
+    log_step "Installing Docker (required by NanoClaw on Linux)..."
+    cloud_run "command -v docker >/dev/null || (curl -fsSL https://get.docker.com | sudo sh && sudo usermod -aG docker \$(whoami))"
     log_step "Installing tsx..."
     cloud_run "source ~/.bashrc && bun install -g tsx"
     log_step "Cloning and building nanoclaw..."
@@ -27,13 +29,9 @@ agent_env_vars() {
         "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 }
 agent_configure() {
-    log_step "Configuring nanoclaw..."
-    local dotenv_temp
-    dotenv_temp=$(mktemp)
-    trap 'rm -f "${dotenv_temp}"' EXIT
-    chmod 600 "${dotenv_temp}"
-    printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${dotenv_temp}"
-    cloud_upload "${dotenv_temp}" "/root/nanoclaw/.env"
+    local dotenv_content
+    dotenv_content=$(printf 'ANTHROPIC_API_KEY=%s\nANTHROPIC_BASE_URL=https://openrouter.ai/api\n' "${OPENROUTER_API_KEY}")
+    upload_config_file cloud_upload cloud_run "${dotenv_content}" "\$HOME/nanoclaw/.env"
 }
 agent_launch_cmd() { echo 'cd ~/nanoclaw && source ~/.zshrc && npm run dev'; }
 

--- a/aws/openclaw.sh
+++ b/aws/openclaw.sh
@@ -25,7 +25,7 @@ agent_env_vars() {
 }
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
-    cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 </dev/null & disown"
+    start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }

--- a/daytona/amazonq.sh
+++ b/daytona/amazonq.sh
@@ -16,11 +16,10 @@ agent_install() {
     install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" cloud_run
 }
 
+# Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/daytona/cline.sh
+++ b/daytona/cline.sh
@@ -18,9 +18,12 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+
+agent_configure() {
+    log_step "Authenticating Cline with OpenRouter..."
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k ${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/daytona/gemini.sh
+++ b/daytona/gemini.sh
@@ -16,11 +16,11 @@ agent_install() {
     install_agent "Gemini CLI" "npm install -g @google/gemini-cli" cloud_run
 }
 
+# Gemini CLI uses Google's native API format (/v1beta/models/:streamGenerateContent),
+# not the OpenAI-compatible format — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
-        "GOOGLE_GEMINI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/daytona/interpreter.sh
+++ b/daytona/interpreter.sh
@@ -22,9 +22,7 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/daytona/nanoclaw.sh
+++ b/daytona/nanoclaw.sh
@@ -13,6 +13,8 @@ log_info "NanoClaw on Daytona"
 echo ""
 
 agent_install() {
+    log_step "Installing Docker (required by NanoClaw on Linux)..."
+    cloud_run "command -v docker >/dev/null || (curl -fsSL https://get.docker.com | sudo sh && sudo usermod -aG docker \$(whoami))"
     log_step "Installing tsx..."
     cloud_run "source ~/.bashrc && bun install -g tsx"
     log_step "Cloning and building nanoclaw..."
@@ -28,13 +30,9 @@ agent_env_vars() {
 }
 
 agent_configure() {
-    log_step "Configuring nanoclaw..."
-    local dotenv_temp
-    dotenv_temp=$(mktemp)
-    chmod 600 "${dotenv_temp}"
-    track_temp_file "${dotenv_temp}"
-    printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${dotenv_temp}"
-    cloud_upload "${dotenv_temp}" "/root/nanoclaw/.env"
+    local dotenv_content
+    dotenv_content=$(printf 'ANTHROPIC_API_KEY=%s\nANTHROPIC_BASE_URL=https://openrouter.ai/api\n' "${OPENROUTER_API_KEY}")
+    upload_config_file cloud_upload cloud_run "${dotenv_content}" "\$HOME/nanoclaw/.env"
 }
 
 agent_launch_cmd() {

--- a/daytona/openclaw.sh
+++ b/daytona/openclaw.sh
@@ -31,7 +31,7 @@ agent_configure() {
 }
 
 agent_pre_launch() {
-    cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 </dev/null & disown"
+    start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
 

--- a/digitalocean/amazonq.sh
+++ b/digitalocean/amazonq.sh
@@ -14,11 +14,10 @@ log_info "Amazon Q on DigitalOcean"
 echo ""
 
 agent_install() { install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" cloud_run; }
+# Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && q chat'; }
 

--- a/digitalocean/cline.sh
+++ b/digitalocean/cline.sh
@@ -16,9 +16,11 @@ echo ""
 agent_install() { install_agent "Cline" "npm install -g cline" cloud_run; }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+agent_configure() {
+    log_step "Authenticating Cline with OpenRouter..."
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k ${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/digitalocean/gemini.sh
+++ b/digitalocean/gemini.sh
@@ -14,11 +14,11 @@ log_info "Gemini CLI on DigitalOcean"
 echo ""
 
 agent_install() { install_agent "Gemini CLI" "npm install -g @google/gemini-cli" cloud_run; }
+# Gemini CLI uses Google's native API format (/v1beta/models/:streamGenerateContent),
+# not the OpenAI-compatible format — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
-        "GOOGLE_GEMINI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && gemini'; }
 

--- a/digitalocean/interpreter.sh
+++ b/digitalocean/interpreter.sh
@@ -21,9 +21,7 @@ agent_install() {
 }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { printf 'export PATH="$HOME/.local/bin:$PATH"; source ~/.zshrc && interpreter --model %s --api_key %s' "${MODEL_ID}" "${OPENROUTER_API_KEY}"; }
 

--- a/digitalocean/nanoclaw.sh
+++ b/digitalocean/nanoclaw.sh
@@ -14,6 +14,8 @@ log_info "NanoClaw on DigitalOcean"
 echo ""
 
 agent_install() {
+    log_step "Installing Docker (required by NanoClaw on Linux)..."
+    cloud_run "command -v docker >/dev/null || (curl -fsSL https://get.docker.com | sh)"
     log_step "Installing tsx..."
     cloud_run "source ~/.bashrc && bun install -g tsx"
     log_step "Cloning and building nanoclaw..."
@@ -27,13 +29,9 @@ agent_env_vars() {
         "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 }
 agent_configure() {
-    log_step "Configuring nanoclaw..."
-    local dotenv_temp
-    dotenv_temp=$(mktemp)
-    trap 'rm -f "${dotenv_temp}"' EXIT
-    chmod 600 "${dotenv_temp}"
-    printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${dotenv_temp}"
-    cloud_upload "${dotenv_temp}" "/root/nanoclaw/.env"
+    local dotenv_content
+    dotenv_content=$(printf 'ANTHROPIC_API_KEY=%s\nANTHROPIC_BASE_URL=https://openrouter.ai/api\n' "${OPENROUTER_API_KEY}")
+    upload_config_file cloud_upload cloud_run "${dotenv_content}" "\$HOME/nanoclaw/.env"
 }
 agent_launch_cmd() { echo 'cd ~/nanoclaw && source ~/.zshrc && npm run dev'; }
 

--- a/digitalocean/openclaw.sh
+++ b/digitalocean/openclaw.sh
@@ -25,7 +25,7 @@ agent_env_vars() {
 }
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
-    cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 </dev/null & disown"
+    start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }

--- a/fly/amazonq.sh
+++ b/fly/amazonq.sh
@@ -16,11 +16,10 @@ agent_install() {
     install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" cloud_run
 }
 
+# Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/fly/cline.sh
+++ b/fly/cline.sh
@@ -18,9 +18,12 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+
+agent_configure() {
+    log_step "Authenticating Cline with OpenRouter..."
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k ${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/fly/gemini.sh
+++ b/fly/gemini.sh
@@ -16,11 +16,11 @@ agent_install() {
     install_agent "Gemini CLI" "npm install -g @google/gemini-cli" cloud_run
 }
 
+# Gemini CLI uses Google's native API format (/v1beta/models/:streamGenerateContent),
+# not the OpenAI-compatible format — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
-        "GOOGLE_GEMINI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/fly/interpreter.sh
+++ b/fly/interpreter.sh
@@ -22,9 +22,7 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/fly/nanoclaw.sh
+++ b/fly/nanoclaw.sh
@@ -13,6 +13,8 @@ log_info "NanoClaw on Fly.io"
 echo ""
 
 agent_install() {
+    log_step "Installing Docker (required by NanoClaw on Linux)..."
+    cloud_run "command -v docker >/dev/null || (curl -fsSL https://get.docker.com | sh)"
     log_step "Installing tsx..."
     cloud_run "source ~/.bashrc && bun install -g tsx"
     log_step "Cloning and building nanoclaw..."
@@ -28,13 +30,9 @@ agent_env_vars() {
 }
 
 agent_configure() {
-    log_step "Configuring nanoclaw..."
-    local dotenv_temp
-    dotenv_temp=$(mktemp)
-    chmod 600 "${dotenv_temp}"
-    track_temp_file "${dotenv_temp}"
-    printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${dotenv_temp}"
-    cloud_upload "${dotenv_temp}" "/root/nanoclaw/.env"
+    local dotenv_content
+    dotenv_content=$(printf 'ANTHROPIC_API_KEY=%s\nANTHROPIC_BASE_URL=https://openrouter.ai/api\n' "${OPENROUTER_API_KEY}")
+    upload_config_file cloud_upload cloud_run "${dotenv_content}" "\$HOME/nanoclaw/.env"
 }
 
 agent_launch_cmd() {

--- a/fly/openclaw.sh
+++ b/fly/openclaw.sh
@@ -36,7 +36,7 @@ agent_configure() {
 }
 
 agent_pre_launch() {
-    cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 </dev/null & disown"
+    start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
 

--- a/gcp/amazonq.sh
+++ b/gcp/amazonq.sh
@@ -14,11 +14,10 @@ log_info "Amazon Q on GCP Compute Engine"
 echo ""
 
 agent_install() { install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" cloud_run; }
+# Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && q chat'; }
 

--- a/gcp/cline.sh
+++ b/gcp/cline.sh
@@ -16,9 +16,11 @@ echo ""
 agent_install() { install_agent "Cline" "npm install -g cline" cloud_run; }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+agent_configure() {
+    log_step "Authenticating Cline with OpenRouter..."
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k ${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/gcp/gemini.sh
+++ b/gcp/gemini.sh
@@ -14,11 +14,11 @@ log_info "Gemini CLI on GCP Compute Engine"
 echo ""
 
 agent_install() { install_agent "Gemini CLI" "npm install -g @google/gemini-cli" cloud_run; }
+# Gemini CLI uses Google's native API format (/v1beta/models/:streamGenerateContent),
+# not the OpenAI-compatible format — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
-        "GOOGLE_GEMINI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && gemini'; }
 

--- a/gcp/interpreter.sh
+++ b/gcp/interpreter.sh
@@ -21,9 +21,7 @@ agent_install() {
 }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { printf 'export PATH="$HOME/.local/bin:$PATH"; source ~/.zshrc && interpreter --model %s --api_key %s' "${MODEL_ID}" "${OPENROUTER_API_KEY}"; }
 

--- a/gcp/nanoclaw.sh
+++ b/gcp/nanoclaw.sh
@@ -14,6 +14,8 @@ log_info "NanoClaw on GCP Compute Engine"
 echo ""
 
 agent_install() {
+    log_step "Installing Docker (required by NanoClaw on Linux)..."
+    cloud_run "command -v docker >/dev/null || (curl -fsSL https://get.docker.com | sudo sh && sudo usermod -aG docker \$(whoami))"
     log_step "Installing tsx..."
     cloud_run "source ~/.bashrc && bun install -g tsx"
     log_step "Cloning and building nanoclaw..."
@@ -27,13 +29,9 @@ agent_env_vars() {
         "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 }
 agent_configure() {
-    log_step "Configuring nanoclaw..."
-    local dotenv_temp
-    dotenv_temp=$(mktemp)
-    trap 'rm -f "${dotenv_temp}"' EXIT
-    chmod 600 "${dotenv_temp}"
-    printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${dotenv_temp}"
-    cloud_upload "${dotenv_temp}" "/root/nanoclaw/.env"
+    local dotenv_content
+    dotenv_content=$(printf 'ANTHROPIC_API_KEY=%s\nANTHROPIC_BASE_URL=https://openrouter.ai/api\n' "${OPENROUTER_API_KEY}")
+    upload_config_file cloud_upload cloud_run "${dotenv_content}" "\$HOME/nanoclaw/.env"
 }
 agent_launch_cmd() { echo 'cd ~/nanoclaw && source ~/.zshrc && npm run dev'; }
 

--- a/gcp/openclaw.sh
+++ b/gcp/openclaw.sh
@@ -25,7 +25,7 @@ agent_env_vars() {
 }
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
-    cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 </dev/null & disown"
+    start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }

--- a/hetzner/amazonq.sh
+++ b/hetzner/amazonq.sh
@@ -14,11 +14,11 @@ log_info "Amazon Q on Hetzner Cloud"
 echo ""
 
 agent_install() { install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" cloud_run; }
+# Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter.
+# OPENROUTER_API_KEY is set for consistency but Q CLI ignores it.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && q chat'; }
 

--- a/hetzner/cline.sh
+++ b/hetzner/cline.sh
@@ -16,9 +16,11 @@ echo ""
 agent_install() { install_agent "Cline" "npm install -g cline" cloud_run; }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+agent_configure() {
+    log_step "Authenticating Cline with OpenRouter..."
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k ${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/hetzner/gemini.sh
+++ b/hetzner/gemini.sh
@@ -14,11 +14,11 @@ log_info "Gemini CLI on Hetzner Cloud"
 echo ""
 
 agent_install() { install_agent "Gemini CLI" "npm install -g @google/gemini-cli" cloud_run; }
+# Gemini CLI uses Google's native API format (/v1beta/models/:streamGenerateContent),
+# not the OpenAI-compatible format — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
-        "GOOGLE_GEMINI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && gemini'; }
 

--- a/hetzner/interpreter.sh
+++ b/hetzner/interpreter.sh
@@ -21,9 +21,7 @@ agent_install() {
 }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { printf 'export PATH="$HOME/.local/bin:$PATH"; source ~/.zshrc && interpreter --model %s --api_key %s' "${MODEL_ID}" "${OPENROUTER_API_KEY}"; }
 

--- a/hetzner/nanoclaw.sh
+++ b/hetzner/nanoclaw.sh
@@ -14,6 +14,8 @@ log_info "NanoClaw on Hetzner Cloud"
 echo ""
 
 agent_install() {
+    log_step "Installing Docker (required by NanoClaw on Linux)..."
+    cloud_run "command -v docker >/dev/null || (curl -fsSL https://get.docker.com | sh)"
     log_step "Installing tsx..."
     cloud_run "source ~/.bashrc && bun install -g tsx"
     log_step "Cloning and building nanoclaw..."
@@ -27,13 +29,9 @@ agent_env_vars() {
         "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 }
 agent_configure() {
-    log_step "Configuring nanoclaw..."
-    local dotenv_temp
-    dotenv_temp=$(mktemp)
-    trap 'rm -f "${dotenv_temp}"' EXIT
-    chmod 600 "${dotenv_temp}"
-    printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${dotenv_temp}"
-    cloud_upload "${dotenv_temp}" "/root/nanoclaw/.env"
+    local dotenv_content
+    dotenv_content=$(printf 'ANTHROPIC_API_KEY=%s\nANTHROPIC_BASE_URL=https://openrouter.ai/api\n' "${OPENROUTER_API_KEY}")
+    upload_config_file cloud_upload cloud_run "${dotenv_content}" "\$HOME/nanoclaw/.env"
 }
 agent_launch_cmd() { echo 'cd ~/nanoclaw && source ~/.zshrc && npm run dev'; }
 

--- a/hetzner/openclaw.sh
+++ b/hetzner/openclaw.sh
@@ -25,7 +25,7 @@ agent_env_vars() {
 }
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
-    cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 </dev/null & disown"
+    start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }

--- a/local/amazonq.sh
+++ b/local/amazonq.sh
@@ -16,11 +16,10 @@ agent_install() {
     install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" cloud_run
 }
 
+# Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/local/cline.sh
+++ b/local/cline.sh
@@ -18,9 +18,12 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+
+agent_configure() {
+    log_step "Authenticating Cline with OpenRouter..."
+    cloud_run "source ~/.zshrc 2>/dev/null; cline auth -p openrouter -k ${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/local/gemini.sh
+++ b/local/gemini.sh
@@ -16,11 +16,11 @@ agent_install() {
     install_agent "Gemini CLI" "npm install -g @google/gemini-cli" cloud_run
 }
 
+# Gemini CLI uses Google's native API format (/v1beta/models/:streamGenerateContent),
+# not the OpenAI-compatible format — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
-        "GOOGLE_GEMINI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/local/interpreter.sh
+++ b/local/interpreter.sh
@@ -22,9 +22,7 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/local/nanoclaw.sh
+++ b/local/nanoclaw.sh
@@ -28,13 +28,9 @@ agent_env_vars() {
 }
 
 agent_configure() {
-    log_step "Configuring nanoclaw..."
-    local dotenv_temp
-    dotenv_temp=$(mktemp)
-    chmod 600 "${dotenv_temp}"
-    track_temp_file "${dotenv_temp}"
-    printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${dotenv_temp}"
-    cloud_upload "${dotenv_temp}" "${HOME}/nanoclaw/.env"
+    local dotenv_content
+    dotenv_content=$(printf 'ANTHROPIC_API_KEY=%s\nANTHROPIC_BASE_URL=https://openrouter.ai/api\n' "${OPENROUTER_API_KEY}")
+    upload_config_file cloud_upload cloud_run "${dotenv_content}" "\$HOME/nanoclaw/.env"
 }
 
 agent_launch_cmd() {

--- a/local/openclaw.sh
+++ b/local/openclaw.sh
@@ -31,7 +31,7 @@ agent_configure() {
 }
 
 agent_pre_launch() {
-    cloud_run "source ~/.zshrc 2>/dev/null; nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &"
+    start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -124,11 +124,9 @@
       "install": "pip install open-interpreter",
       "launch": "interpreter",
       "env": {
-        "OPENAI_API_KEY": "${OPENROUTER_API_KEY}",
-        "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
-      "notes": "Works with OpenRouter via OPENAI_BASE_URL override",
+      "notes": "Native OpenRouter support via --model openrouter/MODEL and --api_key flags",
       "featured_cloud": "gcp"
     },
     "gemini": {
@@ -138,25 +136,19 @@
       "install": "npm install -g @google/gemini-cli",
       "launch": "gemini",
       "env": {
-        "GEMINI_API_KEY": "${OPENROUTER_API_KEY}",
-        "GOOGLE_GEMINI_BASE_URL": "https://openrouter.ai/api/v1",
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
-      "notes": "Works with OpenRouter via GOOGLE_GEMINI_BASE_URL override",
+      "notes": "Gemini CLI uses Google's native API format — cannot route through OpenRouter",
       "featured_cloud": "gcp"
     },
     "amazonq": {
       "name": "Amazon Q CLI",
-      "description": "AWS's AI coding assistant CLI",
+      "description": "AWS's AI coding assistant CLI (uses AWS auth, no OpenRouter support)",
       "url": "https://aws.amazon.com/q/developer/",
       "install": "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash",
       "launch": "q chat",
-      "env": {
-        "OPENAI_API_KEY": "${OPENROUTER_API_KEY}",
-        "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
-        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
-      },
-      "notes": "Works with OpenRouter via OPENAI_BASE_URL override",
+      "env": {},
+      "notes": "Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter. Deprecated in favor of Kiro CLI.",
       "featured_cloud": "fly"
     },
     "cline": {
@@ -166,11 +158,9 @@
       "install": "npm install -g cline",
       "launch": "cline",
       "env": {
-        "OPENAI_API_KEY": "${OPENROUTER_API_KEY}",
-        "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },
-      "notes": "Works with OpenRouter via OPENAI_BASE_URL override",
+      "notes": "Uses cline auth -p openrouter for native OpenRouter integration",
       "featured_cloud": "fly"
     },
     "gptme": {

--- a/ovh/amazonq.sh
+++ b/ovh/amazonq.sh
@@ -14,11 +14,10 @@ log_info "Amazon Q on OVHcloud"
 echo ""
 
 agent_install() { install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" cloud_run; }
+# Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && q chat'; }
 

--- a/ovh/cline.sh
+++ b/ovh/cline.sh
@@ -16,9 +16,11 @@ echo ""
 agent_install() { install_agent "Cline" "npm install -g cline" cloud_run; }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+agent_configure() {
+    log_step "Authenticating Cline with OpenRouter..."
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k ${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/ovh/gemini.sh
+++ b/ovh/gemini.sh
@@ -14,11 +14,11 @@ log_info "Gemini CLI on OVHcloud"
 echo ""
 
 agent_install() { install_agent "Gemini CLI" "npm install -g @google/gemini-cli" cloud_run; }
+# Gemini CLI uses Google's native API format (/v1beta/models/:streamGenerateContent),
+# not the OpenAI-compatible format — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
-        "GOOGLE_GEMINI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && gemini'; }
 

--- a/ovh/interpreter.sh
+++ b/ovh/interpreter.sh
@@ -21,9 +21,7 @@ agent_install() {
 }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 agent_launch_cmd() { printf 'export PATH="$HOME/.local/bin:$PATH"; source ~/.zshrc && interpreter --model %s --api_key %s' "${MODEL_ID}" "${OPENROUTER_API_KEY}"; }
 

--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -383,9 +383,12 @@ install_base_deps() {
     # Install Claude Code
     run_ovh "$ip" "curl -fsSL https://claude.ai/install.sh | bash"
 
+    # Configure npm global prefix so non-root user can npm install -g without sudo
+    run_ovh "$ip" "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global"
+
     # Configure PATH
-    run_ovh "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.bashrc"
-    run_ovh "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.zshrc"
+    run_ovh "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.npm-global/bin:\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.bashrc"
+    run_ovh "$ip" "printf '%s\n' 'export PATH=\"\${HOME}/.npm-global/bin:\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.zshrc"
 
     log_info "Base dependencies installed"
 }

--- a/ovh/nanoclaw.sh
+++ b/ovh/nanoclaw.sh
@@ -14,6 +14,8 @@ log_info "NanoClaw on OVHcloud"
 echo ""
 
 agent_install() {
+    log_step "Installing Docker (required by NanoClaw on Linux)..."
+    cloud_run "command -v docker >/dev/null || (curl -fsSL https://get.docker.com | sudo sh && sudo usermod -aG docker \$(whoami))"
     log_step "Installing tsx..."
     cloud_run "source ~/.bashrc && bun install -g tsx"
     log_step "Cloning and building nanoclaw..."
@@ -27,13 +29,9 @@ agent_env_vars() {
         "ANTHROPIC_BASE_URL=https://openrouter.ai/api"
 }
 agent_configure() {
-    log_step "Configuring nanoclaw..."
-    local dotenv_temp
-    dotenv_temp=$(mktemp)
-    trap 'rm -f "${dotenv_temp}"' EXIT
-    chmod 600 "${dotenv_temp}"
-    printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${dotenv_temp}"
-    cloud_upload "${dotenv_temp}" "/root/nanoclaw/.env"
+    local dotenv_content
+    dotenv_content=$(printf 'ANTHROPIC_API_KEY=%s\nANTHROPIC_BASE_URL=https://openrouter.ai/api\n' "${OPENROUTER_API_KEY}")
+    upload_config_file cloud_upload cloud_run "${dotenv_content}" "\$HOME/nanoclaw/.env"
 }
 agent_launch_cmd() { echo 'cd ~/nanoclaw && source ~/.zshrc && npm run dev'; }
 

--- a/ovh/openclaw.sh
+++ b/ovh/openclaw.sh
@@ -25,7 +25,7 @@ agent_env_vars() {
 }
 agent_configure() { setup_openclaw_config "${OPENROUTER_API_KEY}" "${MODEL_ID}" cloud_upload cloud_run; }
 agent_pre_launch() {
-    cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 </dev/null & disown"
+    start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }

--- a/sprite/amazonq.sh
+++ b/sprite/amazonq.sh
@@ -16,11 +16,10 @@ agent_install() {
     install_agent "Amazon Q CLI" "curl -fsSL https://desktop-release.q.us-east-1.amazonaws.com/latest/amazon-q-cli-install.sh | bash" cloud_run
 }
 
+# Amazon Q uses AWS Builder ID auth — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/sprite/cline.sh
+++ b/sprite/cline.sh
@@ -18,9 +18,12 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+
+agent_configure() {
+    log_step "Authenticating Cline with OpenRouter..."
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k ${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/sprite/gemini.sh
+++ b/sprite/gemini.sh
@@ -16,11 +16,11 @@ agent_install() {
     install_agent "Gemini CLI" "npm install -g @google/gemini-cli" cloud_run
 }
 
+# Gemini CLI uses Google's native API format (/v1beta/models/:streamGenerateContent),
+# not the OpenAI-compatible format — cannot route through OpenRouter.
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "GEMINI_API_KEY=${OPENROUTER_API_KEY}" \
-        "GOOGLE_GEMINI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/sprite/interpreter.sh
+++ b/sprite/interpreter.sh
@@ -22,9 +22,7 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
 
 agent_launch_cmd() {

--- a/sprite/nanoclaw.sh
+++ b/sprite/nanoclaw.sh
@@ -13,6 +13,8 @@ log_info "NanoClaw on Sprite"
 echo ""
 
 agent_install() {
+    log_step "Installing Docker (required by NanoClaw on Linux)..."
+    cloud_run "command -v docker >/dev/null || (curl -fsSL https://get.docker.com | sh)"
     log_step "Installing tsx..."
     cloud_run "source ~/.bashrc && bun install -g tsx"
     log_step "Cloning and building nanoclaw..."
@@ -28,13 +30,9 @@ agent_env_vars() {
 }
 
 agent_configure() {
-    log_step "Configuring nanoclaw..."
-    local dotenv_temp
-    dotenv_temp=$(mktemp)
-    chmod 600 "${dotenv_temp}"
-    track_temp_file "${dotenv_temp}"
-    printf 'ANTHROPIC_API_KEY=%s\n' "${OPENROUTER_API_KEY}" > "${dotenv_temp}"
-    cloud_upload "${dotenv_temp}" "/root/nanoclaw/.env"
+    local dotenv_content
+    dotenv_content=$(printf 'ANTHROPIC_API_KEY=%s\nANTHROPIC_BASE_URL=https://openrouter.ai/api\n' "${OPENROUTER_API_KEY}")
+    upload_config_file cloud_upload cloud_run "${dotenv_content}" "\$HOME/nanoclaw/.env"
 }
 
 agent_launch_cmd() {

--- a/sprite/openclaw.sh
+++ b/sprite/openclaw.sh
@@ -31,7 +31,7 @@ agent_configure() {
 }
 
 agent_pre_launch() {
-    cloud_run "source ~/.zshrc && nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 </dev/null & disown"
+    start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
 


### PR DESCRIPTION
## Summary

- **OpenClaw gateway hang**: Use `setsid` to fully detach the daemon from SSH sessions — fixes the hang at "Configuring openclaw..." on all 9 clouds
- **NanoClaw**: Install Docker on Linux (required runtime), replace hardcoded `/root/` path with `$HOME` for non-root clouds
- **npm EACCES**: Configure `~/.npm-global` prefix for non-root clouds (AWS, GCP, OVH) so `npm install -g` works without root
- **Gemini CLI**: Remove broken OpenRouter routing — uses Google's native API format, cannot route through OpenRouter
- **Auto-install CLIs**: AWS CLI and gcloud SDK auto-install when missing (macOS + Linux)
- **Error handling**: Guard optional `spawn_agent` hooks, handle github-auth errors gracefully
- **Agent env vars**: Fix env vars for Amazon Q, Cline, Open Interpreter across all clouds

## Test plan

- [ ] Deploy openclaw on any cloud — gateway starts without hanging
- [ ] Deploy nanoclaw on AWS — Docker installs, `.env` written to correct path
- [ ] Deploy any npm-based agent on AWS/GCP/OVH — `npm install -g` succeeds
- [ ] Run `bash test/run.sh` — mock tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)