### PR TITLE
fix: use json_escape in save_vm_connection to prevent malformed JSON

### DIFF
--- a/aws/lib/common.sh
+++ b/aws/lib/common.sh
@@ -130,7 +130,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    get_resource_name "LIGHTSAIL_SERVER_NAME" "Enter Lightsail instance name: "
+    get_validated_server_name "LIGHTSAIL_SERVER_NAME" "Enter Lightsail instance name: "
 }
 
 get_cloud_init_userdata() {

--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -139,7 +139,7 @@ ensure_daytona_token() {
 }
 
 get_server_name() {
-    get_resource_name "DAYTONA_SANDBOX_NAME" "Enter sandbox name: "
+    get_validated_server_name "DAYTONA_SANDBOX_NAME" "Enter sandbox name: "
 }
 
 _is_snapshot_conflict() {

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -238,7 +238,7 @@ ensure_ssh_key() {
 }
 
 get_server_name() {
-    get_resource_name "GCP_INSTANCE_NAME" "Enter instance name: "
+    get_validated_server_name "GCP_INSTANCE_NAME" "Enter instance name: "
 }
 
 get_cloud_init_userdata() {
@@ -379,7 +379,10 @@ create_server() {
 
     log_info "Instance created: IP=${GCP_SERVER_IP}"
 
-    save_vm_connection "${GCP_SERVER_IP}" "${SSH_USER:-$(whoami)}" "" "$name" "gcp" "{\"zone\":\"${zone}\",\"project\":\"${GCP_PROJECT}\"}"
+    local _zone_escaped _project_escaped
+    _zone_escaped=$(json_escape "${zone}")
+    _project_escaped=$(json_escape "${GCP_PROJECT}")
+    save_vm_connection "${GCP_SERVER_IP}" "${SSH_USER:-$(whoami)}" "" "$name" "gcp" "{\"zone\":${_zone_escaped},\"project\":${_project_escaped}}"
 }
 
 verify_server_connectivity() { ssh_verify_connectivity "$@"; }

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -3582,16 +3582,16 @@ save_vm_connection() {
 
     local conn_file="${spawn_dir}/last-connection.json"
 
-    # Build JSON (handle optional fields)
-    local json="{\"ip\":\"${ip}\",\"user\":\"${user}\""
+    # Build JSON using json_escape to prevent injection via special characters
+    local json="{\"ip\":$(json_escape "${ip}"),\"user\":$(json_escape "${user}")"
     if [[ -n "${server_id}" ]]; then
-        json="${json},\"server_id\":\"${server_id}\""
+        json="${json},\"server_id\":$(json_escape "${server_id}")"
     fi
     if [[ -n "${server_name}" ]]; then
-        json="${json},\"server_name\":\"${server_name}\""
+        json="${json},\"server_name\":$(json_escape "${server_name}")"
     fi
     if [[ -n "${cloud}" ]]; then
-        json="${json},\"cloud\":\"${cloud}\""
+        json="${json},\"cloud\":$(json_escape "${cloud}")"
     fi
     if [[ -n "${metadata}" ]]; then
         json="${json},\"metadata\":${metadata}"


### PR DESCRIPTION
## Summary

- **Use `json_escape` for all string fields in `save_vm_connection`** — the function previously built JSON via direct string interpolation (`"${ip}"`), which produces malformed output if any value contains quotes, backslashes, or other JSON-special characters
- **Escape GCP metadata values** — `zone` and `GCP_PROJECT` were interpolated directly into inline JSON without escaping
- **Switch AWS, GCP, Daytona to `get_validated_server_name`** — these three clouds used `get_resource_name` (no validation) while Hetzner, DigitalOcean, Fly, and OVH all use `get_validated_server_name`

**Why:** `save_vm_connection` is called from 10 locations across 9 cloud providers on every deployment. Malformed JSON in `~/.spawn/last-connection.json` breaks `spawn list`, `spawn delete`, and history features. The GCP metadata path is the most likely trigger since `GCP_PROJECT` comes from `gcloud config get-value project`.

## Test plan

- [ ] Verify `bash -n` passes on all 4 modified files (done locally)
- [ ] Manual: deploy on GCP and verify `~/.spawn/last-connection.json` is valid JSON
- [ ] Manual: deploy on AWS/Daytona and verify server name validation rejects special characters

Agent: code-health

🤖 Generated with [Claude Code](https://claude.com/claude-code)