### PR TITLE
fix: remove duplicate API key calls in spawn_agent + fix OVH server name

### DIFF
--- a/ovh/lib/common.sh
+++ b/ovh/lib/common.sh
@@ -425,7 +425,7 @@ for s in data:
 # ============================================================
 
 cloud_authenticate() { ensure_ovh_authenticated; ensure_ssh_key; }
-cloud_provision() { local name="$1"; create_ovh_instance "${name}"; }
+cloud_provision() { local name="$1"; OVH_SERVER_NAME="${name}"; export OVH_SERVER_NAME; create_ovh_instance "${name}"; }
 cloud_wait_ready() {
     wait_for_ovh_instance "${OVH_INSTANCE_ID}"
     save_vm_connection "${OVH_SERVER_IP}" "${OVH_SSH_USER:-ubuntu}" "${OVH_INSTANCE_ID}" "${OVH_SERVER_NAME:-}" "ovh"

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1722,14 +1722,6 @@ spawn_agent() {
     server_name=$(get_server_name)
     cloud_provision "${server_name}"
 
-    # 4. Get API key while server provisions (overlaps with cloud-init)
-    get_or_prompt_api_key
-
-    # 5. Model selection while server provisions (if agent needs it)
-    if [[ -n "${AGENT_MODEL_PROMPT:-}" ]]; then
-        MODEL_ID=$(get_model_id_interactive "${AGENT_MODEL_DEFAULT:-openrouter/auto}" "${agent_name}") || exit 1
-    fi
-
     # 6. Wait for readiness (may already be done after OAuth)
     cloud_wait_ready
 


### PR DESCRIPTION
**Why:** PR #1462 removed duplicate \`get_or_prompt_api_key\` and \`get_model_id_interactive\` calls that ran both before and after \`cloud_provision()\`. PR #1468 accidentally re-introduced them with broken step numbering (two \"4\"s and two \"5\"s at lines 1715/1725 and 1716/1728). Every \`spawn_agent()\` call — used by all 130+ agent scripts — was making duplicate HTTP requests to OpenRouter's validation API, doubling startup latency on every deployment.

Also fixes OVH \`save_vm_connection\` recording an empty server name: \`cloud_provision()\` receives \`$name\` as a parameter but never exported it to \`OVH_SERVER_NAME\`, so \`cloud_wait_ready()\`'s \`save_vm_connection\` call always got an empty string when the user typed the name at the interactive prompt. Fix: export \`OVH_SERVER_NAME\` in \`cloud_provision()\` before calling \`create_ovh_instance()\`.

## Changes
- `shared/common.sh`: Remove duplicate lines 1725-1731 (second `get_or_prompt_api_key` + `get_model_id_interactive` block), fix step numbering
- `ovh/lib/common.sh`: Export `OVH_SERVER_NAME` in `cloud_provision()` so `save_vm_connection` records the correct name

-- refactor/code-health