### PR TITLE
security: fix command injection in cline auth OPENROUTER_API_KEY

### DIFF
--- a/aws/cline.sh
+++ b/aws/cline.sh
@@ -20,7 +20,7 @@ agent_env_vars() {
 }
 agent_configure() {
     log_step "Authenticating Cline with OpenRouter..."
-    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"${OPENROUTER_API_KEY}\""
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"\${OPENROUTER_API_KEY}\""
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/daytona/cline.sh
+++ b/daytona/cline.sh
@@ -23,7 +23,7 @@ agent_env_vars() {
 
 agent_configure() {
     log_step "Authenticating Cline with OpenRouter..."
-    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"${OPENROUTER_API_KEY}\""
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"\${OPENROUTER_API_KEY}\""
 }
 
 agent_launch_cmd() {

--- a/digitalocean/cline.sh
+++ b/digitalocean/cline.sh
@@ -20,7 +20,7 @@ agent_env_vars() {
 }
 agent_configure() {
     log_step "Authenticating Cline with OpenRouter..."
-    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"${OPENROUTER_API_KEY}\""
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"\${OPENROUTER_API_KEY}\""
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/fly/cline.sh
+++ b/fly/cline.sh
@@ -23,7 +23,7 @@ agent_env_vars() {
 
 agent_configure() {
     log_step "Authenticating Cline with OpenRouter..."
-    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"${OPENROUTER_API_KEY}\""
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"\${OPENROUTER_API_KEY}\""
 }
 
 agent_launch_cmd() {

--- a/gcp/cline.sh
+++ b/gcp/cline.sh
@@ -20,7 +20,7 @@ agent_env_vars() {
 }
 agent_configure() {
     log_step "Authenticating Cline with OpenRouter..."
-    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"${OPENROUTER_API_KEY}\""
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"\${OPENROUTER_API_KEY}\""
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/hetzner/cline.sh
+++ b/hetzner/cline.sh
@@ -20,7 +20,7 @@ agent_env_vars() {
 }
 agent_configure() {
     log_step "Authenticating Cline with OpenRouter..."
-    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"${OPENROUTER_API_KEY}\""
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"\${OPENROUTER_API_KEY}\""
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/local/cline.sh
+++ b/local/cline.sh
@@ -23,7 +23,7 @@ agent_env_vars() {
 
 agent_configure() {
     log_step "Authenticating Cline with OpenRouter..."
-    cloud_run "source ~/.zshrc 2>/dev/null; cline auth -p openrouter -k \"${OPENROUTER_API_KEY}\""
+    cloud_run "source ~/.zshrc 2>/dev/null; cline auth -p openrouter -k \"\${OPENROUTER_API_KEY}\""
 }
 
 agent_launch_cmd() {

--- a/ovh/cline.sh
+++ b/ovh/cline.sh
@@ -20,7 +20,7 @@ agent_env_vars() {
 }
 agent_configure() {
     log_step "Authenticating Cline with OpenRouter..."
-    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"${OPENROUTER_API_KEY}\""
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"\${OPENROUTER_API_KEY}\""
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && cline'; }
 

--- a/sprite/cline.sh
+++ b/sprite/cline.sh
@@ -23,7 +23,7 @@ agent_env_vars() {
 
 agent_configure() {
     log_step "Authenticating Cline with OpenRouter..."
-    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"${OPENROUTER_API_KEY}\""
+    cloud_run "source ~/.zshrc && cline auth -p openrouter -k \"\${OPENROUTER_API_KEY}\""
 }
 
 agent_launch_cmd() {


### PR DESCRIPTION
**Why:** All 9 `*/cline.sh` scripts embed `OPENROUTER_API_KEY` directly into the `cloud_run` command string via local shell expansion (`"${OPENROUTER_API_KEY}"`). If the API key contains shell metacharacters (`;`, `$()`, backticks), they get executed as commands on the remote server.

## Fix

Change `"${OPENROUTER_API_KEY}"` to `"\${OPENROUTER_API_KEY}"` (escaped dollar sign) in the `agent_configure()` function of all 9 cline.sh scripts. This makes the shell expand the variable on the **remote** machine (where it's already injected into `~/.zshrc` by `agent_env_vars()`/`generate_env_config`) instead of locally before passing to `cloud_run`.

## Changed files

- `aws/cline.sh`
- `daytona/cline.sh`
- `digitalocean/cline.sh`
- `fly/cline.sh`
- `gcp/cline.sh`
- `hetzner/cline.sh`
- `local/cline.sh`
- `ovh/cline.sh`
- `sprite/cline.sh`

## Test plan

- [x] `bash -n` syntax check passes on all 9 modified files
- [ ] Manual test: deploy cline on any cloud and verify auth still works

Fixes #1469

-- refactor/security-auditor