### PR TITLE
feat: implement local/opencode script

### DIFF
--- a/local/opencode.sh
+++ b/local/opencode.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eo pipefail
+
+# Source common functions - try local file first, fall back to remote
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
+    source "${SCRIPT_DIR}/lib/common.sh"
+else
+    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/local/lib/common.sh)"
+fi
+
+log_info "OpenCode on local machine"
+echo ""
+
+agent_install() {
+    install_agent "OpenCode" "$(opencode_install_cmd)" cloud_run
+}
+
+agent_env_vars() {
+    generate_env_config \
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+
+agent_launch_cmd() {
+    echo 'source ~/.zshrc 2>/dev/null; opencode'
+}
+
+spawn_agent "OpenCode"

--- a/manifest.json
+++ b/manifest.json
@@ -226,7 +226,7 @@
     "local/openclaw": "implemented",
     "local/zeroclaw": "implemented",
     "local/codex": "implemented",
-    "local/opencode": "missing",
+    "local/opencode": "implemented",
     "local/kilocode": "implemented",
     "hetzner/claude": "implemented",
     "hetzner/openclaw": "implemented",


### PR DESCRIPTION
**Why:** local/opencode was listed as 'missing' in manifest.json — users could not run OpenCode on their local machine via spawn.

## Changes
- Add `local/opencode.sh` following the same pattern as other local scripts (`local/codex.sh`, `local/zeroclaw.sh`, etc.)
  - Sources `local/lib/common.sh` with local/remote fallback
  - Uses `opencode_install_cmd()` from `shared/common.sh` (already exists, used by hetzner/opencode.sh)
  - Injects `OPENROUTER_API_KEY` via `generate_env_config` (OpenCode natively supports OpenRouter)
  - Defines `agent_install()`, `agent_env_vars()`, `agent_launch_cmd()`, calls `spawn_agent "OpenCode"`
- Update `manifest.json` matrix entry `local/opencode` from `"missing"` to `"implemented"`

## Test plan
- [x] `bash -n local/opencode.sh` — syntax check passes
- [ ] Script follows local cloud pattern (same structure as other local/*.sh scripts)
- [ ] `OPENROUTER_API_KEY` is properly injected via `generate_env_config`
- [ ] Run `bash test/run.sh` to confirm no regressions

-- refactor/team-lead