### PR TITLE
fix: sync cloud READMEs with current agent list

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -18,10 +18,10 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/openclaw.sh)
 ```
 
-#### NanoClaw
+#### ZeroClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/zeroclaw.sh)
 ```
 
 #### Codex CLI
@@ -30,28 +30,16 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/nanoclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/codex.sh)
 ```
 
-#### Cline
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/cline.sh)
-```
-
-#### gptme
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/gptme.sh)
-```
-
 #### OpenCode
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/opencode.sh)
 ```
 
-#### Plandex
+#### Kilo Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/kilocode.sh)
 ```
 
 ## Non-Interactive Mode

--- a/daytona/README.md
+++ b/daytona/README.md
@@ -18,10 +18,10 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/openclaw.sh)
 ```
 
-#### NanoClaw
+#### ZeroClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/zeroclaw.sh)
 ```
 
 #### Codex CLI
@@ -30,28 +30,16 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/nanoclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/codex.sh)
 ```
 
-#### Cline
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/cline.sh)
-```
-
-#### gptme
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/gptme.sh)
-```
-
 #### OpenCode
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/opencode.sh)
 ```
 
-#### Plandex
+#### Kilo Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/kilocode.sh)
 ```
 
 ## Non-Interactive Mode

--- a/digitalocean/README.md
+++ b/digitalocean/README.md
@@ -16,10 +16,10 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/openclaw.sh)
 ```
 
-#### NanoClaw
+#### ZeroClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/zeroclaw.sh)
 ```
 
 #### Codex CLI
@@ -28,28 +28,16 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/nanoclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/codex.sh)
 ```
 
-#### Cline
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/cline.sh)
-```
-
-#### gptme
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/gptme.sh)
-```
-
 #### OpenCode
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/opencode.sh)
 ```
 
-#### Plandex
+#### Kilo Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/kilocode.sh)
 ```
 
 ## Non-Interactive Mode

--- a/fly/README.md
+++ b/fly/README.md
@@ -16,10 +16,10 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/openclaw.sh)
 ```
 
-#### NanoClaw
+#### ZeroClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/zeroclaw.sh)
 ```
 
 #### Codex CLI
@@ -28,28 +28,16 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/nanoclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/codex.sh)
 ```
 
-#### Cline
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/cline.sh)
-```
-
-#### gptme
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/gptme.sh)
-```
-
 #### OpenCode
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/opencode.sh)
 ```
 
-#### Plandex
+#### Kilo Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/fly/kilocode.sh)
 ```
 
 ## Non-Interactive Mode

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -18,10 +18,10 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/openclaw.sh)
 ```
 
-#### NanoClaw
+#### ZeroClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/zeroclaw.sh)
 ```
 
 #### Codex CLI
@@ -30,28 +30,16 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/nanoclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/codex.sh)
 ```
 
-#### Cline
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/cline.sh)
-```
-
-#### gptme
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/gptme.sh)
-```
-
 #### OpenCode
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/opencode.sh)
 ```
 
-#### Plandex
+#### Kilo Code
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/plandex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/kilocode.sh)
 ```
 
 ## Non-Interactive Mode

--- a/hetzner/README.md
+++ b/hetzner/README.md
@@ -16,10 +16,10 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/openclaw.sh)
 ```
 
-#### NanoClaw
+#### ZeroClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/zeroclaw.sh)
 ```
 
 #### Codex CLI
@@ -28,40 +28,16 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/nanoclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/codex.sh)
 ```
 
-#### Cline
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/cline.sh)
-```
-
-#### gptme
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/gptme.sh)
-```
-
 #### OpenCode
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/opencode.sh)
 ```
 
-#### Plandex
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/plandex.sh)
-```
-
 #### Kilo Code
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/kilocode.sh)
-```
-
-#### Continue
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/continue.sh)
 ```
 
 ## Non-Interactive Mode

--- a/local/README.md
+++ b/local/README.md
@@ -11,14 +11,9 @@ If you have the [spawn CLI](https://github.com/OpenRouterTeam/spawn) installed:
 ```bash
 spawn claude local
 spawn openclaw local
-spawn nanoclaw local
+spawn zeroclaw local
 spawn codex local
-spawn cline local
-spawn gptme local
-spawn opencode local
-spawn plandex local
 spawn kilocode local
-spawn continue local
 ```
 
 Or run directly without the CLI:
@@ -26,14 +21,9 @@ Or run directly without the CLI:
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/openclaw.sh)
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/zeroclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/codex.sh)
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/cline.sh)
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/gptme.sh)
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/opencode.sh)
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/plandex.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/kilocode.sh)
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/continue.sh)
 ```
 
 ## Non-Interactive Mode

--- a/sprite/README.md
+++ b/sprite/README.md
@@ -16,10 +16,10 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/openclaw.sh)
 ```
 
-#### NanoClaw
+#### ZeroClaw
 
 ```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/nanoclaw.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/zeroclaw.sh)
 ```
 
 #### Codex CLI
@@ -28,40 +28,16 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/nanoclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/codex.sh)
 ```
 
-#### Cline
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/cline.sh)
-```
-
-#### gptme
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/gptme.sh)
-```
-
 #### OpenCode
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/opencode.sh)
 ```
 
-#### Plandex
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/plandex.sh)
-```
-
 #### Kilo Code
 
 ```bash
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/kilocode.sh)
-```
-
-#### Continue
-
-```bash
-bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/continue.sh)
 ```
 
 ## Non-Interactive Mode


### PR DESCRIPTION
## Why

All 8 cloud READMEs still listed 5 agents removed in PRs #1475 and #1477 (NanoClaw, Cline, gptme, Plandex, Continue) and were missing ZeroClaw (added in #1476). Users following these docs got 404 errors when running the documented curl commands.

## Changes

- Removed references to NanoClaw, Cline, gptme, Plandex, Continue from all cloud READMEs
- Added ZeroClaw to all cloud READMEs
- Added Kilo Code to READMEs that were missing it (fly, aws, daytona, digitalocean, gcp)
- Agent lists now match `manifest.json` exactly

## Files changed

- `hetzner/README.md`
- `fly/README.md`
- `aws/README.md`
- `daytona/README.md`
- `digitalocean/README.md`
- `gcp/README.md`
- `sprite/README.md`
- `local/README.md`

-- refactor/ux-engineer