### PR TITLE
fix: use native OpenRouter config for Codex CLI

### DIFF
--- a/aws/codex.sh
+++ b/aws/codex.sh
@@ -15,9 +15,10 @@ echo ""
 agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+agent_configure() {
+    setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && codex'; }
 

--- a/daytona/codex.sh
+++ b/daytona/codex.sh
@@ -18,9 +18,11 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+
+agent_configure() {
+    setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
 
 agent_launch_cmd() {

--- a/digitalocean/codex.sh
+++ b/digitalocean/codex.sh
@@ -15,9 +15,10 @@ echo ""
 agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+agent_configure() {
+    setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && codex'; }
 

--- a/fly/codex.sh
+++ b/fly/codex.sh
@@ -18,9 +18,11 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+
+agent_configure() {
+    setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
 
 agent_launch_cmd() {

--- a/gcp/codex.sh
+++ b/gcp/codex.sh
@@ -15,9 +15,10 @@ echo ""
 agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+agent_configure() {
+    setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && codex'; }
 

--- a/hetzner/codex.sh
+++ b/hetzner/codex.sh
@@ -15,9 +15,10 @@ echo ""
 agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+agent_configure() {
+    setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
 agent_launch_cmd() { echo 'source ~/.zshrc && codex'; }
 

--- a/local/codex.sh
+++ b/local/codex.sh
@@ -18,9 +18,11 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+
+agent_configure() {
+    setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
 
 agent_launch_cmd() {

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -3242,6 +3242,37 @@ wait_for_openclaw_gateway() {
 }
 
 # ============================================================
+# Codex CLI configuration setup
+# ============================================================
+
+# Setup Codex CLI config.toml for OpenRouter
+# Uses the native model_provider config instead of OPENAI_BASE_URL env var,
+# which fixes "Invalid Responses API request" errors with OpenRouter.
+# Usage: setup_codex_config OPENROUTER_KEY UPLOAD_CALLBACK RUN_CALLBACK
+setup_codex_config() {
+    local openrouter_key="${1}"
+    local upload_callback="${2}"
+    local run_callback="${3}"
+
+    log_step "Configuring Codex CLI for OpenRouter..."
+
+    local config_toml
+    config_toml=$(cat <<TOML
+model = "openai/gpt-5-codex"
+model_provider = "openrouter"
+
+[model_providers.openrouter]
+name = "OpenRouter"
+base_url = "https://openrouter.ai/api/v1"
+env_key = "OPENROUTER_API_KEY"
+wire_api = "responses"
+TOML
+)
+
+    upload_config_file "${upload_callback}" "${run_callback}" "${config_toml}" "\$HOME/.codex/config.toml"
+}
+
+# ============================================================
 # Continue configuration setup
 # ============================================================
 

--- a/sprite/codex.sh
+++ b/sprite/codex.sh
@@ -18,9 +18,11 @@ agent_install() {
 
 agent_env_vars() {
     generate_env_config \
-        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_API_KEY=${OPENROUTER_API_KEY}" \
-        "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
+        "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"
+}
+
+agent_configure() {
+    setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
 
 agent_launch_cmd() {


### PR DESCRIPTION
## Summary
- Codex CLI's `OPENAI_BASE_URL` env var approach causes "Invalid Responses API request" / "No matching discriminator" errors because OpenRouter doesn't fully support the Responses API wire format via base URL override
- Added `setup_codex_config()` to `shared/common.sh` that writes `~/.codex/config.toml` with `model_provider = "openrouter"` (native integration)
- Updated all 8 codex scripts (aws, fly, hetzner, digitalocean, gcp, daytona, local, sprite) to use `agent_configure()` instead of `OPENAI_API_KEY`/`OPENAI_BASE_URL` env vars

## Test plan
- [x] Tested Codex CLI on AWS Lightsail — confirmed config.toml approach works
- [x] Tested Codex CLI on Fly.io — confirmed "Invalid Responses API request" error is gone
- [ ] Verify on remaining clouds (hetzner, digitalocean, gcp, daytona, local, sprite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)