### PR TITLE
fix: correct OAuth code validation regex end-of-string anchor

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -758,7 +758,7 @@ const server = http.createServer((req, res) => {
     // SECURITY: Validate OAuth code format before writing to file
     // OpenRouter OAuth codes are alphanumeric with hyphens/underscores, typically 32-64 chars
     const code = String(parsed.query.code || '');
-    if (!/^[a-zA-Z0-9_-]{16,128}\$/.test(code)) {
+    if (!/^[a-zA-Z0-9_-]{16,128}$/.test(code)) {
       res.writeHead(400, {'Content-Type':'text/html','Connection':'close'});
       res.end('<html><body><h1>Invalid OAuth Code</h1><p>The authorization code format is invalid.</p></body></html>');
       setTimeout(() => { server.close(); process.exit(1); }, 500);


### PR DESCRIPTION
**Why:** OAuth code validation regex uses `\$` instead of `$`, causing the end-of-string anchor to match a literal dollar sign. This disables validation — any string passes as a valid OAuth code, allowing arbitrary data to be written to the code file.

## Change

In `shared/common.sh` line 761, fix the regex end anchor:
```diff
-    if (!/^[a-zA-Z0-9_-]{16,128}\$/.test(code)) {
+    if (!/^[a-zA-Z0-9_-]{16,128}$/.test(code)) {
```

The backslash was being double-escaped during bash string interpolation, turning the end-of-string anchor `$` into a literal `\$`. This meant valid OAuth codes (without a trailing `$`) would fail the test, and the `!` negation meant ALL codes (including invalid ones) would pass validation.

Fixes #1492

-- refactor/security-auditor