### PR TITLE
fix: resolve 18 test/run.sh failures and expand sprite agent coverage

### DIFF
--- a/test/fixtures/_shared_agent_assertions.sh
+++ b/test/fixtures/_shared_agent_assertions.sh
@@ -32,30 +32,18 @@ assert_agent_install() {
         openclaw)
             # npm install -g openclaw OR bun install -g openclaw (varies by cloud)
             _assert_install_pattern "install.*openclaw" "installs openclaw via npm/bun" ;;
-        nanoclaw)
-            # git clone https://github.com/gavrielc/nanoclaw.git && npm install
-            _assert_install_pattern "git.*clone.*nanoclaw" "installs nanoclaw via git clone" ;;
         codex)
             # npm install -g @openai/codex
             _assert_install_pattern "npm.*install.*codex" "installs codex via npm" ;;
-        cline)
-            # npm install -g cline
-            _assert_install_pattern "npm.*install.*cline" "installs cline via npm" ;;
-        gptme)
-            # uv tool install gptme
-            _assert_install_pattern "uv.*tool.*install.*gptme" "installs gptme via uv" ;;
         opencode)
             # curl to download opencode tarball (via opencode_install_cmd)
             _assert_install_pattern "opencode" "installs opencode" ;;
-        plandex)
-            # curl -sL https://plandex.ai/install.sh | bash
-            _assert_install_pattern "plandex.ai/install" "installs plandex via curl installer" ;;
         kilocode)
             # npm install -g @kilocode/cli
             _assert_install_pattern "npm.*install.*kilocode" "installs kilocode via npm" ;;
-        continue)
-            # npm install -g @continuedev/cli
-            _assert_install_pattern "npm.*install.*continuedev" "installs continue via npm" ;;
+        zeroclaw)
+            # curl installer from zeroclaw-labs/zeroclaw repo
+            _assert_install_pattern "zeroclaw" "installs zeroclaw" ;;
         *)
             # Unknown agent — skip assertion (no failure)
             return 0 ;;

--- a/test/run.sh
+++ b/test/run.sh
@@ -260,10 +260,6 @@ _assert_agent_specific() {
             assert_contains "${MOCK_LOG}" "sprite exec.*bun.*openclaw" "Installs openclaw via bun"
             assert_contains "${MOCK_LOG}" "sprite exec.*openclaw gateway" "Starts openclaw gateway"
             ;;
-        nanoclaw)
-            assert_contains "${MOCK_LOG}" "sprite exec.*git.*nanoclaw" "Clones nanoclaw repo"
-            assert_contains "${MOCK_LOG}" "sprite exec.*nanoclaw/\.env" "Uploads nanoclaw .env"
-            ;;
     esac
 }
 
@@ -296,6 +292,8 @@ run_script_test() {
     TEST_DIR="${TEST_DIR}" \
     SPRITE_NAME="test-sprite-${script_name}" \
     OPENROUTER_API_KEY="sk-or-v1-0000000000000000000000000000000000000000000000000000000000000000" \
+    SPAWN_SKIP_API_VALIDATION=1 \
+    SPAWN_SKIP_GITHUB_AUTH=1 \
     PATH="${TEST_DIR}:${PATH}" \
     HOME="${TEST_DIR}/fakehome" \
         timeout 30 bash "${script_path}" > "${output_file}" 2>&1 || exit_code=$?
@@ -607,7 +605,7 @@ test_source_detection() {
     echo ""
     printf '%b\n' "${YELLOW}━━━ Testing source detection ━━━${NC}"
 
-    for script in claude openclaw nanoclaw; do
+    for script in claude openclaw codex opencode kilocode zeroclaw; do
         local script_path="${REPO_ROOT}/sprite/${script}.sh"
         [[ -f "${script_path}" ]] || continue
 
@@ -712,7 +710,7 @@ test_shared_common
 test_source_detection
 
 # Run per-script tests
-for script in claude openclaw nanoclaw; do
+for script in claude openclaw codex opencode kilocode zeroclaw; do
     if [[ -n "${FILTER}" && "${FILTER}" != "${script}" && "${FILTER}" != "--remote" ]]; then
         continue
     fi


### PR DESCRIPTION
**Why:** test/run.sh has 18 persistent failures (27% of tests) that mask real regressions and block CI. Additionally, 4 out of 6 sprite agent scripts have zero test coverage because the iteration list is stale.

## Summary
- Add `SPAWN_SKIP_API_VALIDATION=1` and `SPAWN_SKIP_GITHUB_AUTH=1` to the sprite test environment so `verify_openrouter_key()` doesn't make real HTTP calls with the fake test key (which gets HTTP 401, clears the key, and cascades into OAuth failure)
- Update agent iteration lists from stale `claude openclaw nanoclaw` to current `claude openclaw codex opencode kilocode zeroclaw`
- Remove dead `nanoclaw` case from `_assert_agent_specific` in test/run.sh
- Remove 5 dead agent cases (nanoclaw, cline, gptme, plandex, continue) from `_shared_agent_assertions.sh`, add zeroclaw

## Test plan
- [x] `bash test/run.sh` passes: **108 passed, 0 failed** (was: 48 passed, 18 failed)
- [x] `bash -n test/run.sh` syntax check passes
- [x] `bash -n test/fixtures/_shared_agent_assertions.sh` syntax check passes
- [x] All 6 sprite agents now tested: claude, openclaw, codex, opencode, kilocode, zeroclaw

Agent: code-health