### PR TITLE
feat: add agent stats & metadata to manifest

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/manifest-type-contracts.test.ts
+++ b/cli/src/__tests__/manifest-type-contracts.test.ts
@@ -421,6 +421,102 @@ describe("Interactive prompts structure", () => {
   }
 });
 
+// ── Agent metadata field types ────────────────────────────────────────
+
+describe("Agent metadata field types (when present)", () => {
+  for (const [key, agent] of allAgents) {
+    const a = agent as any;
+
+    if (a.creator !== undefined) {
+      it(`agent "${key}" creator should be a non-empty string`, () => {
+        expect(typeof a.creator).toBe("string");
+        expect(a.creator.length).toBeGreaterThan(0);
+      });
+    }
+
+    if (a.repo !== undefined) {
+      it(`agent "${key}" repo should match owner/repo format`, () => {
+        expect(typeof a.repo).toBe("string");
+        expect(a.repo).toMatch(/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/);
+      });
+    }
+
+    if (a.license !== undefined) {
+      it(`agent "${key}" license should be a non-empty string`, () => {
+        expect(typeof a.license).toBe("string");
+        expect(a.license.length).toBeGreaterThan(0);
+      });
+    }
+
+    if (a.created !== undefined) {
+      it(`agent "${key}" created should be YYYY-MM format`, () => {
+        expect(typeof a.created).toBe("string");
+        expect(a.created).toMatch(/^\d{4}-\d{2}$/);
+      });
+    }
+
+    if (a.added !== undefined) {
+      it(`agent "${key}" added should be YYYY-MM format`, () => {
+        expect(typeof a.added).toBe("string");
+        expect(a.added).toMatch(/^\d{4}-\d{2}$/);
+      });
+    }
+
+    if (a.github_stars !== undefined) {
+      it(`agent "${key}" github_stars should be a non-negative number`, () => {
+        expect(typeof a.github_stars).toBe("number");
+        expect(a.github_stars).toBeGreaterThanOrEqual(0);
+        expect(Number.isInteger(a.github_stars)).toBe(true);
+      });
+    }
+
+    if (a.stars_updated !== undefined) {
+      it(`agent "${key}" stars_updated should be YYYY-MM-DD format`, () => {
+        expect(typeof a.stars_updated).toBe("string");
+        expect(a.stars_updated).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      });
+    }
+
+    if (a.language !== undefined) {
+      it(`agent "${key}" language should be a non-empty string`, () => {
+        expect(typeof a.language).toBe("string");
+        expect(a.language.length).toBeGreaterThan(0);
+      });
+    }
+
+    if (a.runtime !== undefined) {
+      it(`agent "${key}" runtime should be a non-empty string`, () => {
+        expect(typeof a.runtime).toBe("string");
+        expect(a.runtime.length).toBeGreaterThan(0);
+      });
+    }
+
+    if (a.category !== undefined) {
+      it(`agent "${key}" category should be cli, tui, or ide-extension`, () => {
+        expect(typeof a.category).toBe("string");
+        expect(["cli", "tui", "ide-extension"]).toContain(a.category);
+      });
+    }
+
+    if (a.tagline !== undefined) {
+      it(`agent "${key}" tagline should be a non-empty string`, () => {
+        expect(typeof a.tagline).toBe("string");
+        expect(a.tagline.length).toBeGreaterThan(0);
+      });
+    }
+
+    if (a.tags !== undefined) {
+      it(`agent "${key}" tags should be an array of non-empty strings`, () => {
+        expect(Array.isArray(a.tags)).toBe(true);
+        for (const tag of a.tags) {
+          expect(typeof tag).toBe("string");
+          expect(tag.length).toBeGreaterThan(0);
+        }
+      });
+    }
+  }
+});
+
 // ── Config files structure ────────────────────────────────────────────────
 
 describe("Config files structure", () => {

--- a/cli/src/manifest.ts
+++ b/cli/src/manifest.ts
@@ -19,6 +19,18 @@ export interface AgentDef {
   notes?: string;
   icon?: string;
   featured_cloud?: string[];
+  creator?: string;
+  repo?: string;
+  license?: string;
+  created?: string;
+  added?: string;
+  github_stars?: number;
+  stars_updated?: string;
+  language?: string;
+  runtime?: string;
+  category?: string;
+  tagline?: string;
+  tags?: string[];
 }
 
 export interface CloudDef {

--- a/manifest.json
+++ b/manifest.json
@@ -28,9 +28,19 @@
         }
       },
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/claude.png",
-      "featured_cloud": [
-        "sprite"
-      ]
+      "featured_cloud": ["sprite"],
+      "creator": "Anthropic",
+      "repo": "anthropics/claude-code",
+      "license": "Proprietary",
+      "created": "2025-02",
+      "added": "2025-06",
+      "github_stars": 67857,
+      "stars_updated": "2026-02-20",
+      "language": "TypeScript",
+      "runtime": "node",
+      "category": "cli",
+      "tagline": "Agentic coding from the terminal",
+      "tags": ["coding", "terminal", "agentic"]
     },
     "openclaw": {
       "name": "OpenClaw",
@@ -51,9 +61,19 @@
         }
       },
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/openclaw.png",
-      "featured_cloud": [
-        "fly"
-      ]
+      "featured_cloud": ["fly"],
+      "creator": "OpenClaw",
+      "repo": "openclaw/openclaw",
+      "license": "MIT",
+      "created": "2025-11",
+      "added": "2025-11",
+      "github_stars": 212334,
+      "stars_updated": "2026-02-20",
+      "language": "TypeScript",
+      "runtime": "bun",
+      "category": "tui",
+      "tagline": "Personal AI assistant with multi-channel gateway",
+      "tags": ["coding", "tui", "gateway"]
     },
     "zeroclaw": {
       "name": "ZeroClaw",
@@ -67,10 +87,19 @@
       },
       "notes": "Rust-based agent framework built by Harvard/MIT/Sundai.Club communities. Natively supports OpenRouter via OPENROUTER_API_KEY + ZEROCLAW_PROVIDER=openrouter. Requires compilation from source (~5-10 min).",
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/zeroclaw.png",
-      "featured_cloud": [
-        "hetzner",
-        "fly"
-      ]
+      "featured_cloud": ["hetzner", "fly"],
+      "creator": "Sundai.Club",
+      "repo": "zeroclaw-labs/zeroclaw",
+      "license": "NOASSERTION",
+      "created": "2026-02",
+      "added": "2025-12",
+      "github_stars": 15177,
+      "stars_updated": "2026-02-20",
+      "language": "Rust",
+      "runtime": "binary",
+      "category": "cli",
+      "tagline": "Fast, autonomous AI infrastructure \u2014 deploy anywhere",
+      "tags": ["coding", "terminal", "rust", "autonomous"]
     },
     "codex": {
       "name": "Codex CLI",
@@ -85,9 +114,19 @@
       },
       "notes": "Works with OpenRouter via OPENAI_BASE_URL override pointing to openrouter.ai/api/v1",
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/codex.png",
-      "featured_cloud": [
-        "fly"
-      ]
+      "featured_cloud": ["fly"],
+      "creator": "OpenAI",
+      "repo": "openai/codex",
+      "license": "Apache-2.0",
+      "created": "2025-04",
+      "added": "2025-07",
+      "github_stars": 61159,
+      "stars_updated": "2026-02-20",
+      "language": "Rust",
+      "runtime": "binary",
+      "category": "cli",
+      "tagline": "Lightweight coding agent from OpenAI",
+      "tags": ["coding", "terminal", "openai"]
     },
     "opencode": {
       "name": "OpenCode",
@@ -100,9 +139,19 @@
       },
       "notes": "Natively supports OpenRouter via OPENROUTER_API_KEY env var. Go-based TUI using Bubble Tea.",
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/opencode.png",
-      "featured_cloud": [
-        "daytona"
-      ]
+      "featured_cloud": ["daytona"],
+      "creator": "Anomaly",
+      "repo": "anomalyco/opencode",
+      "license": "MIT",
+      "created": "2025-04",
+      "added": "2025-08",
+      "github_stars": 107223,
+      "stars_updated": "2026-02-20",
+      "language": "TypeScript",
+      "runtime": "go",
+      "category": "tui",
+      "tagline": "AI coding agent built for the terminal",
+      "tags": ["coding", "tui", "go"]
     },
     "kilocode": {
       "name": "Kilo Code",
@@ -117,9 +166,19 @@
       },
       "notes": "Natively supports OpenRouter as a provider via KILO_PROVIDER_TYPE=openrouter. CLI installable via npm as @kilocode/cli, invocable as 'kilocode' or 'kilo'.",
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/kilocode.png",
-      "featured_cloud": [
-        "fly"
-      ]
+      "featured_cloud": ["fly"],
+      "creator": "Kilo-Org",
+      "repo": "Kilo-Org/kilocode",
+      "license": "Apache-2.0",
+      "created": "2025-03",
+      "added": "2025-09",
+      "github_stars": 15619,
+      "stars_updated": "2026-02-20",
+      "language": "TypeScript",
+      "runtime": "node",
+      "category": "cli",
+      "tagline": "All-in-one agentic engineering platform",
+      "tags": ["coding", "terminal", "agentic", "engineering"]
     }
   },
   "clouds": {


### PR DESCRIPTION
## Summary
- Enrich each agent entry in `manifest.json` with curated metadata: creator, repo, license, release dates, GitHub stars, language, runtime, category, tagline, and tags
- Extend `AgentDef` interface in `cli/src/manifest.ts` with 12 new optional fields
- Add comprehensive type validation tests for all new metadata fields (format checks for dates, owner/repo patterns, category enum, etc.)
- Bump CLI version 0.5.12 → 0.5.13

## Test plan
- [x] `bun test src/__tests__/manifest-type-contracts.test.ts` — 226 tests pass (0 fail)
- [x] All existing tests unaffected (new fields are optional)
- [ ] Verify manifest.json renders correctly in CLI list/info commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)