### PR TITLE
fix: remove 2>/dev/tty from GCP spawn pick call

### DIFF
--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -166,7 +166,7 @@ _gcp_interactive_pick() {
     if command -v spawn >/dev/null 2>&1; then
         local picked
         picked=$(printf '%s\n' "${options_text}" | \
-            spawn pick --prompt "Select ${display}" --default "${default_val}" 2>/dev/tty) && {
+            spawn pick --prompt "Select ${display}" --default "${default_val}") && {
             echo "${picked}"
             return
         }


### PR DESCRIPTION
## Root cause

`_gcp_interactive_pick()` in `gcp/lib/common.sh` called `spawn pick` with `2>/dev/tty`, which fails on zsh/macOS:

```
(eval):5: file exists: /dev/tty
```

This caused `spawn pick` to always exit 1, so `picked` was always empty, and the picker silently fell through to the `_display_and_select` numbered-list fallback every time.

## Why the redirect was wrong

`spawn pick` renders its arrow-key UI by opening `/dev/tty` directly via `fs.openSync('/dev/tty', 'r+')` in `picker.ts` — it never uses stderr for UI output. The `2>/dev/tty` redirect served no purpose and only broke the call.

## Fix

Remove `2>/dev/tty` from the `spawn pick` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)