### PR TITLE
fix: correct spawn clear-history to spawn list --clear in error messages

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1794,7 +1794,7 @@ function buildDeleteScript(cloud: string, connection: VMConnection): string {
       `Invalid server identifier in history: ${getErrorMessage(err)}\n\n` +
       `Your spawn history file may be corrupted or tampered with.\n` +
       `Location: ${getHistoryPath()}\n` +
-      `To fix: edit the file and remove the invalid entry, or run 'spawn clear-history'`
+      `To fix: edit the file and remove the invalid entry, or run 'spawn list --clear'`
     );
   }
 
@@ -2149,7 +2149,7 @@ async function cmdConnect(connection: VMConnection): Promise<void> {
     p.log.error(`Security validation failed: ${getErrorMessage(err)}`);
     p.log.info(`Your spawn history file may be corrupted or tampered with.`);
     p.log.info(`Location: ${getHistoryPath()}`);
-    p.log.info(`To fix: edit the file and remove the invalid entry, or run 'spawn clear-history'`);
+    p.log.info(`To fix: edit the file and remove the invalid entry, or run 'spawn list --clear'`);
     process.exit(1);
   }
 


### PR DESCRIPTION
**Why:** Users encountering corrupted history files get an error message saying to run \`spawn clear-history\`, but that command does not exist — they get a confusing \"Unknown agent or cloud: clear-history\" error. The correct command is \`spawn list --clear\`.

## Changes
- `cli/src/commands.ts` line 1797: fix error message in `buildDeleteScript`
- `cli/src/commands.ts` line 2152: fix error message in `cmdConnect` security validation
- `cli/package.json`: bump version 0.5.14 → 0.5.15

## Test
Pre-existing test failures unrelated to this change. The fix is two string replacements in error messages.

-- refactor/ux-engineer