### PR TITLE
fix: save connection info for all Sprite agents in cloud_provision

### DIFF
--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -32,10 +32,6 @@ agent_configure() {
     setup_claude_code_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
 
-agent_save_connection() {
-    save_vm_connection "sprite-console" "${USER:-root}" "" "${SPRITE_NAME}" "sprite"
-}
-
 agent_launch_cmd() {
     if [[ -n "${SPAWN_PROMPT:-}" ]]; then
         local escaped; escaped=$(printf '%q' "${SPAWN_PROMPT}")

--- a/sprite/lib/common.sh
+++ b/sprite/lib/common.sh
@@ -364,6 +364,7 @@ cloud_provision() {
     ensure_sprite_exists "${SPRITE_NAME}"
     verify_sprite_connectivity "${SPRITE_NAME}"
     setup_shell_environment "${SPRITE_NAME}"
+    save_vm_connection "sprite-console" "${USER:-root}" "" "${SPRITE_NAME}" "sprite"
 }
 cloud_wait_ready() { :; }
 cloud_run() { run_sprite "${SPRITE_NAME}" "$1"; }


### PR DESCRIPTION
**Why:** \`spawn list\` silently shows no connection info for 5 of 6 Sprite agent scripts (codex, openclaw, opencode, kilocode, zeroclaw). Only \`sprite/claude.sh\` worked because it was the only script defining the \`agent_save_connection\` hook. Every other cloud (Hetzner, DigitalOcean, GCP, AWS, Fly, Daytona, local) calls \`save_vm_connection\` from their \`create_server()\` equivalent, so all their agents get connection info saved automatically.

## Changes
- **\`sprite/lib/common.sh\`**: Add \`save_vm_connection "sprite-console" "\${USER:-root}" "" "\${SPRITE_NAME}" "sprite"\` at the end of \`cloud_provision()\` — covers all 6 agents automatically
- **\`sprite/claude.sh\`**: Remove now-redundant \`agent_save_connection()\` (3 lines)

## Verification
```
bash -n sprite/lib/common.sh   # OK
bash -n sprite/claude.sh        # OK
bash test/run.sh                # 110 passed, 0 failed
```

-- refactor/code-health