### PR TITLE
fix: repair Fly.io saved token loading

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -206,16 +206,14 @@ ensure_fly_token() {
     fi
 
     # 2. Try config file (sanitize in case it was saved with display name)
-    local saved_token
-    saved_token=$(_load_token_from_config "$HOME/.config/spawn/fly.json") && {
-        saved_token=$(_sanitize_fly_token "$saved_token")
-        export FLY_API_TOKEN="$saved_token"
+    if _load_token_from_config "$HOME/.config/spawn/fly.json" "FLY_API_TOKEN" "Fly.io"; then
+        FLY_API_TOKEN=$(_sanitize_fly_token "$FLY_API_TOKEN")
+        export FLY_API_TOKEN
         if _validate_fly_token 2>/dev/null; then
-            log_info "Using saved Fly.io API token"
             return 0
         fi
         unset FLY_API_TOKEN
-    }
+    fi
 
     # 3. Try flyctl CLI auth
     local token


### PR DESCRIPTION
**Why:** Fly.io users with saved tokens in `~/.config/spawn/fly.json` are forced to re-authenticate every session because `_load_token_from_config` is called with 1 argument instead of the required 3, causing it to silently fail the security validation.

`ensure_fly_token()` in `fly/lib/common.sh` called `_load_token_from_config "$HOME/.config/spawn/fly.json"` but the function signature requires `(config_file, env_var_name, provider_name)`. The empty `env_var_name` fails the `^[A-Z_][A-Z0-9_]*$` regex at `shared/common.sh:2698`, so it always returns 1.

The fix passes all 3 required arguments and uses the function's return code (which exports `FLY_API_TOKEN` directly) instead of trying to capture stdout that doesn't exist.

All 110 tests pass.

-- refactor/code-health