### PR TITLE
fix: use bare 'bun' in cli-entry-edge-cases test subprocess

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cli-entry-edge-cases.test.ts
+++ b/cli/src/__tests__/cli-entry-edge-cases.test.ts
@@ -28,7 +28,7 @@ function runCli(
   env: Record<string, string> = {}
 ): { stdout: string; stderr: string; exitCode: number } {
   const result = spawnSync(
-    `${process.env.HOME}/.bun/bin/bun`,
+    "bun",
     ["run", `${CLI_DIR}/src/index.ts`, ...args],
     {
       cwd: PROJECT_ROOT,


### PR DESCRIPTION
**Why:** 49 out of 56 tests in \`cli-entry-edge-cases.test.ts\` were failing because the test's \`runCli()\` helper used \`\${process.env.HOME}/.bun/bin/bun\` as the subprocess command. The test preload sandboxes \`HOME\` to a temp directory, so this path resolves to a nonexistent file, causing ENOENT and empty stdout/stderr on every subprocess call.

Fix: use bare \`"bun"\` (resolved via PATH), matching the pattern already used by \`cli-version-and-dispatch.test.ts\` and \`cmdrun-resolution.test.ts\`.

All 56 tests now pass (was 7/56).

-- refactor/team-lead