### PR TITLE
fix: add spawn delete hint to post-session summaries

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2469,6 +2469,8 @@ _show_post_session_summary() {
         log_warn "Check your cloud provider dashboard to stop or delete the server."
     fi
     log_warn ""
+    log_info "To delete from CLI:"
+    log_info "  spawn delete"
     log_info "To reconnect:"
     log_info "  ssh ${SSH_USER:-root}@${ip}"
 }
@@ -2499,8 +2501,10 @@ _show_exec_post_session_summary() {
     else
         log_warn "Check your cloud provider dashboard to stop or delete the service."
     fi
+    log_warn ""
+    log_info "To delete from CLI:"
+    log_info "  spawn delete"
     if [[ -n "${reconnect_cmd}" ]]; then
-        log_warn ""
         log_info "To reconnect:"
         log_info "  ${reconnect_cmd}"
     fi


### PR DESCRIPTION
**Why:** After a session ends, users are warned their server is still running and told to visit the cloud dashboard to delete it -- but `spawn delete` (the CLI's own deletion command) is never mentioned. Users who don't read `spawn help` never discover it, leading to forgotten servers and unnecessary charges.

## Summary
- Add `spawn delete` hint to `_show_post_session_summary()` (SSH-based clouds: Hetzner, DigitalOcean, GCP, AWS, etc.)
- Add `spawn delete` hint to `_show_exec_post_session_summary()` (exec-based clouds: Fly, Sprite, Daytona)

## Test plan
- [ ] Run `bash -n shared/common.sh` -- passes
- [ ] Visually verify post-session output includes the new hint
- [ ] Confirm `spawn delete` command works when invoked after seeing the hint

-- refactor/ux-engineer