### PR TITLE
fix: validate env-var tokens and align cloud_authenticate patterns

### DIFF
--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -266,7 +266,7 @@ except Exception as e:
 # Cloud adapter interface
 # ============================================================
 
-cloud_authenticate() { ensure_daytona_token; }
+cloud_authenticate() { prompt_spawn_name; ensure_daytona_token; }
 cloud_provision() { create_server "$1"; }
 cloud_wait_ready() { wait_for_cloud_init; }
 cloud_run() { run_server "$1"; }

--- a/digitalocean/lib/common.sh
+++ b/digitalocean/lib/common.sh
@@ -259,7 +259,7 @@ for d in droplets:
 # Cloud adapter interface
 # ============================================================
 
-cloud_authenticate() { prompt_spawn_name; register_cleanup_trap; ensure_do_token; ensure_ssh_key; }
+cloud_authenticate() { prompt_spawn_name; ensure_do_token; ensure_ssh_key; }
 cloud_provision() { create_server "$1"; }
 cloud_wait_ready() { verify_server_connectivity "${DO_SERVER_IP}"; wait_for_cloud_init "${DO_SERVER_IP}" 60; }
 cloud_run() { run_server "${DO_SERVER_IP}" "$1"; }

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -214,7 +214,7 @@ list_servers() {
 # Cloud adapter interface
 # ============================================================
 
-cloud_authenticate() { ensure_hcloud_token; ensure_ssh_key; }
+cloud_authenticate() { prompt_spawn_name; ensure_hcloud_token; ensure_ssh_key; }
 cloud_provision() { create_server "$1"; }
 cloud_wait_ready() { verify_server_connectivity "${HETZNER_SERVER_IP}"; wait_for_cloud_init "${HETZNER_SERVER_IP}" 60; }
 cloud_run() { run_server "${HETZNER_SERVER_IP}" "$1"; }

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2798,9 +2798,13 @@ ensure_api_token_with_provider() {
 
     check_python_available || return 1
 
-    # Try environment variable
+    # Try environment variable (validate if test function provided)
     if _load_token_from_env "${env_var_name}" "${provider_name}"; then
-        return 0
+        if [[ -z "${test_func}" ]] || "${test_func}" 2>/dev/null; then
+            return 0
+        fi
+        log_warn "${provider_name} token from environment is invalid or expired"
+        unset "${env_var_name}"
     fi
 
     # Try config file (validate if test function provided, fall through to prompt on failure)


### PR DESCRIPTION
**Why:** Expired/invalid cloud API tokens from environment variables silently pass authentication and fail at server creation with cryptic errors. Users waste time waiting for provisioning before discovering their token is bad.

## Changes

1. **Validate env-var tokens** (`shared/common.sh`): `ensure_api_token_with_provider` now runs the provider's test function on env-var tokens, matching config-file behavior. Affects Hetzner, DigitalOcean, and Daytona. Invalid tokens get a clear error and fall through to the prompt flow.

2. **Add `prompt_spawn_name` to Hetzner and Daytona** (`hetzner/lib/common.sh`, `daytona/lib/common.sh`): 5 of 7 clouds already call this in `cloud_authenticate`. Without it, `SPAWN_NAME_KEBAB` is never set and server name prompts have no pre-filled default.

3. **Remove redundant `register_cleanup_trap`** (`digitalocean/lib/common.sh`): `shared/common.sh` auto-registers the cleanup trap at source time (line 3696). The explicit call in DigitalOcean was dead code.

## Test plan

- [x] `bash -n` passes on all 4 changed files
- [x] `bash test/run.sh` -- 110/110 passing
- [x] `bash test/mock.sh` -- 108/108 passing

-- refactor/code-health