### PR TITLE
fix: pin Codex to 0.94.0 + wire_api=chat for multi-turn stability

### DIFF
--- a/aws/codex.sh
+++ b/aws/codex.sh
@@ -12,7 +12,7 @@ fi
 log_info "Codex CLI on AWS Lightsail"
 echo ""
 
-agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
+agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run; }
 agent_env_vars() {
     generate_env_config \
         "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/daytona/codex.sh
+++ b/daytona/codex.sh
@@ -13,7 +13,7 @@ log_info "Codex CLI on Daytona"
 echo ""
 
 agent_install() {
-    install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run
+    install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run
 }
 
 agent_env_vars() {

--- a/digitalocean/codex.sh
+++ b/digitalocean/codex.sh
@@ -12,7 +12,7 @@ fi
 log_info "Codex CLI on DigitalOcean"
 echo ""
 
-agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
+agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run; }
 agent_env_vars() {
     generate_env_config \
         "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/fly/codex.sh
+++ b/fly/codex.sh
@@ -13,7 +13,7 @@ log_info "Codex CLI on Fly.io"
 echo ""
 
 agent_install() {
-    install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run
+    install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run
 }
 
 agent_env_vars() {

--- a/gcp/codex.sh
+++ b/gcp/codex.sh
@@ -12,7 +12,7 @@ fi
 log_info "Codex CLI on GCP Compute Engine"
 echo ""
 
-agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
+agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run; }
 agent_env_vars() {
     generate_env_config \
         "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/hetzner/codex.sh
+++ b/hetzner/codex.sh
@@ -12,7 +12,7 @@ fi
 log_info "Codex CLI on Hetzner Cloud"
 echo ""
 
-agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
+agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run; }
 agent_env_vars() {
     generate_env_config \
         "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/local/codex.sh
+++ b/local/codex.sh
@@ -13,7 +13,7 @@ log_info "Codex CLI on local machine"
 echo ""
 
 agent_install() {
-    install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run
+    install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run
 }
 
 agent_env_vars() {

--- a/manifest.json
+++ b/manifest.json
@@ -105,7 +105,7 @@
       "name": "Codex CLI",
       "description": "OpenAI's open-source coding agent",
       "url": "https://github.com/openai/codex",
-      "install": "npm install -g @openai/codex",
+      "install": "npm install -g @openai/codex@0.94.0",
       "launch": "codex",
       "env": {
         "OPENAI_API_KEY": "${OPENROUTER_API_KEY}",

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -3291,9 +3291,12 @@ wait_for_openclaw_gateway() {
 # ============================================================
 
 # Setup Codex CLI config.toml for OpenRouter
-# Uses the native model_provider config with wire_api="chat" (Chat Completions
-# format) instead of "responses" (Responses API), which avoids conversation
-# history serialisation errors on multi-turn sessions through OpenRouter.
+# Uses wire_api="chat" (Chat Completions) because OpenRouter's Responses API
+# proxy drops required fields (id, content) from conversation-history items on
+# multi-turn requests, causing "Invalid Responses API request" errors.
+# Codex >=0.97.0 removed "chat" support, so scripts pin @openai/codex@0.94.0.
+# TODO: unpin once OpenRouter's /responses proxy handles round-trip correctly.
+# Tracking: https://github.com/openai/codex/issues/12114
 # Usage: setup_codex_config OPENROUTER_KEY UPLOAD_CALLBACK RUN_CALLBACK
 setup_codex_config() {
     local openrouter_key="${1}"

--- a/sprite/codex.sh
+++ b/sprite/codex.sh
@@ -13,7 +13,7 @@ log_info "Codex CLI on Sprite"
 echo ""
 
 agent_install() {
-    install_agent "Codex CLI" "export PATH=\$(npm prefix -g 2>/dev/null)/bin:\$PATH && npm install -g @openai/codex" cloud_run
+    install_agent "Codex CLI" "export PATH=\$(npm prefix -g 2>/dev/null)/bin:\$PATH && npm install -g @openai/codex@0.94.0" cloud_run
 }
 
 agent_env_vars() {


### PR DESCRIPTION
## Summary
- OpenRouter's Responses API proxy drops required fields (`id`, `content`) from conversation-history items on multi-turn requests, causing `Invalid Responses API request` at `input[6]+`
- Codex >=0.97.0 removed `wire_api=chat` support ([openai/codex#10157](https://github.com/openai/codex/pull/10157)), so we pin to **0.94.0** — the last release where Chat Completions format still works
- Updates all 8 cloud scripts + manifest.json install command
- Tracking upstream: [openai/codex#12114](https://github.com/openai/codex/issues/12114)
- **TODO**: unpin once OpenRouter `/responses` handles round-trip correctly

## Test plan
- [ ] Deploy Codex on any cloud (e.g. `spawn codex aws`)
- [ ] Verify install uses `@openai/codex@0.94.0`
- [ ] Send first prompt — should get a response
- [ ] Send second+ prompts — should no longer fail with `Invalid Responses API request`
- [ ] Verify multi-turn conversation works (3+ turns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)