### PR TITLE
fix: repair Daytona delete and Fly.io/Daytona reconnect in spawn list

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1816,7 +1816,7 @@ function buildDeleteScript(cloud: string, connection: VMConnection): string {
       return `${sourceLib}\nensure_aws_cli\ndestroy_server "${id}"`;
 
     case "daytona":
-      return `${sourceLib}\nensure_daytona_cli\nensure_daytona_token\ndestroy_server "${id}"`;
+      return `${sourceLib}\nensure_daytona_token\ndestroy_server "${id}"`;
     case "sprite":
       return `${sourceLib}\nensure_sprite_installed\nsprite destroy "${id}"`;
     default:
@@ -2159,6 +2159,17 @@ async function cmdConnect(connection: VMConnection): Promise<void> {
       ["console", "-s", connection.server_name],
       "Sprite console connection failed",
       `sprite console -s ${connection.server_name}`
+    );
+  }
+
+  // Handle Fly.io SSH connections (uses flyctl, not direct SSH)
+  if (connection.ip === "fly-ssh" && connection.server_name) {
+    p.log.step(`Connecting to Fly.io app ${pc.bold(connection.server_name)}...`);
+    return runInteractiveCommand(
+      "fly",
+      ["ssh", "console", "-a", connection.server_name, "--pty"],
+      "Fly.io SSH connection failed",
+      `fly ssh console -a ${connection.server_name}`
     );
   }
 


### PR DESCRIPTION
**Why:** Fixes `spawn delete` crashing with "ensure_daytona_cli: command not found" on Daytona, and fixes silently broken reconnect for Fly.io instances in `spawn list`.

## Summary

- **Daytona delete**: Remove nonexistent `ensure_daytona_cli` call from `buildDeleteScript`. Daytona is a REST API-only provider with no CLI — only `ensure_daytona_token` is needed for `destroy_server`. Without this fix, `spawn delete` always fails for Daytona sandboxes, leaving them running and incurring charges.

- **Fly.io reconnect**: Add `fly-ssh` handler in `cmdConnect` to use `fly ssh console -a NAME --pty` instead of falling through to the generic SSH path which runs `ssh root@fly-ssh` (a nonsensical command — "fly-ssh" is a sentinel value, not a hostname). The UI hint already showed the correct command, but the execution path didn't match.

## Test plan

- [x] `bun test` — 6962 pass, 43 fail (all failures are pre-existing and unrelated)
- [x] Pre-existing test failures confirmed on main branch (e.g., `daytona _show_exec_post_session_summary`, `cmdRun argument swapping` timeouts, `opencode_install_cmd` OS detection)
- [x] No new test failures introduced

-- refactor/code-health