### PR TITLE
fix: replace printf -v with bash 3.2-compatible eval

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1991,12 +1991,6 @@ calculate_retry_backoff() {
         return 0
     fi
 
-    # Calculate next interval with exponential backoff
-    local next_interval=$((interval * 2))
-    if [[ "${next_interval}" -gt "${max_interval}" ]]; then
-        next_interval="${max_interval}"
-    fi
-
     # Add jitter: ±20% randomization to prevent thundering herd
     # Fallback to no-jitter interval if python3 is unavailable
     python3 -c "import random; print(int(${interval} * (0.8 + random.random() * 0.4)))" 2>/dev/null || printf '%s' "${interval}"
@@ -2040,7 +2034,7 @@ _update_retry_interval() {
         current_interval="${max_interval}"
     fi
 
-    printf -v "${interval_var}" '%s' "${current_interval}"
+    eval "${interval_var}=\${current_interval}"
 }
 
 # Helper to extract HTTP status code and response body from curl output

--- a/shared/key-request.sh
+++ b/shared/key-request.sh
@@ -90,9 +90,9 @@ print(v)
                 log "SECURITY: Invalid characters in config value for ${var_name}"
                 return 1
             fi
-            # SECURITY: Use printf to safely assign value without command injection risk
-            # Direct export with = operator doesn't quote the value, allowing injection via $()
-            printf -v "${var_name}" '%s' "${val}"
+            # SECURITY: val is already validated against ^[a-zA-Z0-9._/@-]+$ above,
+            # and var_name is validated against ^[A-Z_][A-Z0-9_]*$ by the caller.
+            eval "${var_name}=\${val}"
             export "${var_name}"
             return 0
         fi

--- a/test/macos-compat.sh
+++ b/test/macos-compat.sh
@@ -147,6 +147,10 @@ while IFS= read -r _f; do
     grep_rule "error" "MC012" "'|&' (pipe stderr) requires bash 4.0+ — use 2>&1 | instead" \
         "$_f" "$_r" '\|&[^&]'
 
+    # MC013: printf -v (variable assignment via printf)
+    grep_rule "error" "MC013" "'printf -v' requires bash 4.0+ — use eval or stdout capture" \
+        "$_f" "$_r" 'printf[[:space:]]+-v[[:space:]]'
+
 done <<FILELIST
 $_all_files
 FILELIST


### PR DESCRIPTION
**Why:** `printf -v` (bash 4.0+) in `_update_retry_interval()` breaks SSH connectivity checks and cloud API retries on macOS bash 3.2 — every Mac user hitting a transient network issue, slow server boot, or rate limit sees `printf: -v: invalid option` and provisioning fails.

## Changes

### `shared/common.sh`
- Replace `printf -v` in `_update_retry_interval()` with `eval` (bash 3.2 compatible)
- Remove dead code in `calculate_retry_backoff()` — `next_interval` was computed but never used (the caller handles doubling via `_update_retry_interval`)

### `shared/key-request.sh`
- Same `printf -v` → `eval` fix (CI/QA script path)

### `test/macos-compat.sh`
- Add MC013 rule to detect `printf -v` usage, preventing future regressions

## Safety

The `eval` replacements are safe because:
- Variable names are always literal strings from controlled callers within the same file
- Values are always integers (retry intervals) or pre-validated against strict allowlists

## Test results

- `bash -n` passes on all modified files
- `bash test/macos-compat.sh` passes (0 printf -v findings after fix)
- `bash test/run.sh` passes: 110/110 tests, 0 failures

-- refactor/code-health