### PR TITLE
fix: display spawn names in list output

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1685,6 +1685,9 @@ function renderListTable(records: SpawnRecord[], manifest: Manifest | null): voi
       pc.green(agentDisplay.padEnd(20)) +
       cloudDisplay.padEnd(20) +
       pc.dim(relative);
+    if (r.name) {
+      line += pc.cyan(`  "${r.name}"`);
+    }
     if (r.connection) {
       if (r.connection.ip === "sprite-console" && r.connection.server_name) {
         line += pc.green(`  sprite console -s ${r.connection.server_name}`);
@@ -1709,7 +1712,9 @@ export function isInteractiveTTY(): boolean {
 export function buildRecordLabel(r: SpawnRecord, manifest: Manifest | null): string {
   const agentDisplay = resolveDisplayName(manifest, r.agent, "agent");
   const cloudDisplay = resolveDisplayName(manifest, r.cloud, "cloud");
-  return `${agentDisplay} on ${cloudDisplay}`;
+  let label = `${agentDisplay} on ${cloudDisplay}`;
+  if (r.name) label += ` -- ${r.name}`;
+  return label;
 }
 
 /** Build a hint string (relative timestamp + connection status + optional prompt preview) for the interactive picker */


### PR DESCRIPTION
**Why:** Users who name their spawns via the interactive "Name your spawn" prompt cannot see those names in `spawn list` output. Multiple spawns of the same agent/cloud combo (e.g., two "Claude Code on Hetzner") are indistinguishable despite having different names like "Frontend Refactor" and "Backend Migration". This makes the name prompt effectively useless.

## Summary

- Show the spawn `name` field in the interactive picker label (`buildRecordLabel`): "Claude Code on Hetzner -- My Server"
- Show the spawn `name` field in the non-interactive table output (`renderListTable`): displayed as cyan text after the timestamp

## Changes

- `cli/src/commands.ts`: `buildRecordLabel()` — append ` -- name` when the record has a name
- `cli/src/commands.ts`: `renderListTable()` — append cyan `"name"` after the time column

## Test plan

- [x] `bun test` — all related tests pass (list-display, list-table-rendering, commands-helpers: 150 pass, 0 fail)
- [x] Pre-existing test failures confirmed on main branch (unrelated)

-- refactor/ux-engineer