### PR TITLE
fix: confirm kebab resource name + improve Fly.io sandbox auth

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -546,9 +546,17 @@ prompt_spawn_name() {
     kebab=$(_to_kebab_case "${display_name}")
     [[ -z "${kebab}" ]] && kebab="spawn"
 
+    # Confirm the kebab-case resource name — user can press Enter to accept or type a custom value
+    local confirmed
+    confirmed=$(safe_read "Resource name [${kebab}]: ") || confirmed=""
+    if [[ -n "${confirmed}" ]]; then
+        kebab=$(_to_kebab_case "${confirmed}")
+        [[ -z "${kebab}" ]] && kebab="spawn"
+    fi
+
     export SPAWN_NAME_DISPLAY="${display_name}"
     export SPAWN_NAME_KEBAB="${kebab}"
-    log_info "Resource name: ${kebab}"
+    log_info "Using resource name: ${kebab}"
 }
 
 # Generic function to get resource name from environment or prompt


### PR DESCRIPTION
## 1. Spawn name confirmation (all clouds)

`prompt_spawn_name()` in `shared/common.sh` now asks the user to confirm the derived kebab-case name instead of silently logging it:

```
Spawn name (e.g. "My Dev Box"): My Claude Box
Resource name [my-claude-box]: ⏎   ← press Enter to accept, or type to override
```

If the user types a custom value it is also run through `_to_kebab_case` so it always produces a valid resource identifier.

## 2. Fly.io sandbox auth (`fly/lib/common.sh`)

`_try_fly_browser_auth()` improvements:

- **URL printed prominently** on its own line (not just a dim warning) so users running in a sandbox can easily copy it
- **`open_browser` errors suppressed** (`|| true`) — sandboxes have no browser; this was causing noisy failures
- **Explicit sandbox hint** shown while polling: _"Running in a sandbox? Copy the URL above into your local browser."_
- **Manual token entry fallback** after the 120s polling timeout: prompts for a Fly.io API token with a direct link to `fly.io/dashboard → Tokens`

Before (sandbox experience):
```
Opening browser for Fly.io login...
[dim] If the browser doesn't open, visit: https://fly.io/cli-sessions/...
[120s silence]
Browser login timed out after 120 seconds
```

After:
```
→ Fly.io login required. Open this URL in your browser:

  https://fly.io/cli-sessions/abc123...

ℹ Waiting for browser authentication (up to 120s)...
⚠ Running in a sandbox? Copy the URL above into your local browser.
[if timeout]
⚠ Browser login timed out. You can paste a token manually.
⚠ Generate one at: https://fly.io/dashboard → Tokens → Create token
Paste Fly.io API token (or press Enter to skip):
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)