### PR TITLE
fix: re-exec after update + add Biome linter with noExplicitAny

### DIFF
--- a/cli/biome.json
+++ b/cli/biome.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.3/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"includes": ["src/**/*.ts"]
+	},
+	"formatter": {
+		"enabled": false
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"suspicious": {
+				"noExplicitAny": "error"
+			}
+		}
+	},
+	"assist": {
+		"enabled": false
+	}
+}

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -9,11 +9,30 @@
         "picocolors": "^1.1.1",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.3",
         "@types/bun": "^1.3.8",
       },
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.3", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.3", "@biomejs/cli-darwin-x64": "2.4.3", "@biomejs/cli-linux-arm64": "2.4.3", "@biomejs/cli-linux-arm64-musl": "2.4.3", "@biomejs/cli-linux-x64": "2.4.3", "@biomejs/cli-linux-x64-musl": "2.4.3", "@biomejs/cli-win32-arm64": "2.4.3", "@biomejs/cli-win32-x64": "2.4.3" }, "bin": { "biome": "bin/biome" } }, "sha512-cBrjf6PNF6yfL8+kcNl85AjiK2YHNsbU0EvDOwiZjBPbMbQ5QcgVGFpjD0O52p8nec5O8NYw7PKw3xUR7fPAkQ=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eOafSFlI/CF4id2tlwq9CVHgeEqvTL5SrhWff6ZORp6S3NL65zdsR3ugybItkgF8Pf4D9GSgtbB6sE3UNgOM9w=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-V2+av4ilbWcBMNufTtMMXVW00nPwyIjI5qf7n9wSvUaZ+tt0EvMGk46g9sAFDJBEDOzSyoRXiSP6pCvKTOEbPA=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-0m+O0x9FgK99FAwDK+fiDtjs2wnqq7bvfj17KJVeCkTwT/liI+Q9njJG7lwXK0iSJVXeFNRIxukpVI3SifMYAA=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-QuFzvsGo8BA4Xm7jGX5idkw6BqFblcCPySMTvq0AhGYnhUej5VJIDJbmTKfHqwjHepZiC4fA+T5i6wmiZolZNw=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-NVqh0saIU0u5OfOp/0jFdlKRE59+XyMvWmtx0f6Nm/2OpdxBl04coRIftBbY9d1gfu+23JVv4CItAqPYrjYh5w=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-qEc0OCpj/uytruQ4wLM0yWNJLZy0Up8H1Er5MW3SrstqM6J2d4XqdNA86xzCy8MQCHpoVZ3lFye3GBlIL4/ljw=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gRO96vrIARilv/Cp2ZnmNNL5LSZg3RO75GPp13hsLO3N4YVpE7saaMDp2bcyV48y2N2Pbit1brkGVGta0yd6VQ=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.3", "", { "os": "win32", "cpu": "x64" }, "sha512-vSm/vOJe06pf14aGHfHl3Ar91Nlx4YYmohElDJ+17UbRwe99n987S/MhAlQOkONqf1utJor04ChkCPmKb8SWdw=="],
+
     "@clack/core": ["@clack/core@1.0.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ=="],
 
     "@clack/prompts": ["@clack/prompts@1.0.0", "", { "dependencies": { "@clack/core": "1.0.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A=="],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "type": "module",
   "bin": {
     "spawn": "cli.js"
@@ -9,6 +9,7 @@
     "dev": "bun run src/index.ts",
     "build": "bun build src/index.ts --outfile cli.js --target bun --minify --packages bundle",
     "compile": "bun build src/index.ts --compile --outfile spawn",
+    "lint": "biome lint src/",
     "test": "bun test",
     "test:watch": "bun test --watch"
   },
@@ -17,6 +18,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.3",
     "@types/bun": "^1.3.8"
   }
 }

--- a/cli/src/__tests__/agent-info-quickstart.test.ts
+++ b/cli/src/__tests__/agent-info-quickstart.test.ts
@@ -269,7 +269,7 @@ function setupManifest(manifest: Manifest) {
     ok: true,
     json: async () => manifest,
     text: async () => JSON.stringify(manifest),
-  })) as any;
+  })) as unknown as typeof global.fetch;
   return loadManifest(true);
 }
 
@@ -283,11 +283,11 @@ describe("cmdAgentInfo - printAgentQuickStart", () => {
   let savedEnv: Record<string, string | undefined>;
 
   function getOutput(): string {
-    return consoleSpy.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+    return consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
   }
 
   function getOutputLines(): string[] {
-    return consoleSpy.mock.calls.map((c: any[]) => c.join(" "));
+    return consoleSpy.mock.calls.map((c: unknown[]) => c.join(" "));
   }
 
   beforeEach(async () => {
@@ -302,7 +302,7 @@ describe("cmdAgentInfo - printAgentQuickStart", () => {
 
     processExitSpy = spyOn(process, "exit").mockImplementation((() => {
       throw new Error("process.exit");
-    }) as any);
+    }) as unknown as (code?: number) => never);
 
     originalFetch = global.fetch;
 

--- a/cli/src/__tests__/check-entity-messages.test.ts
+++ b/cli/src/__tests__/check-entity-messages.test.ts
@@ -98,11 +98,11 @@ function createManifest(): Manifest {
 }
 
 function infoCalls(): string[] {
-  return mockLogInfo.mock.calls.map((c: any[]) => c.join(" "));
+  return mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
 }
 
 function errorCalls(): string[] {
-  return mockLogError.mock.calls.map((c: any[]) => c.join(" "));
+  return mockLogError.mock.calls.map((c: unknown[]) => c.join(" "));
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Changes

### 1. Re-exec after auto-update (always triggers new flow)

**Bug:** Running bare \`spawn\` (interactive mode) after an auto-update would print _"Run your spawn command again"_ and exit — the user had to manually re-invoke to get the new code.

**Fix:** Remove the \`args.length === 0\` early-exit. Always re-exec into the updated binary.

```
✓ Updated successfully!
  Restarting spawn with updated version...  ← was: exit + "run again"
```

### 2. Re-exec uses the newly installed binary (not the stale one)

**Bug:** \`process.argv[1]\` may point to the old binary if the installer placed the update in a different directory, causing re-exec to silently run stale code.

**Fix:** \`findUpdatedBinary()\` resolves via \`which spawn\` (PATH lookup) first, falling back to \`process.argv[1]\` only if \`which\` fails.

### 3. Remove all \`as any\` / \`: any\`

- \`executor\` in \`update-check.ts\`: replaced \`options?: any\` with \`ExecSyncOptions\` / \`ExecFileSyncOptions\` from \`child_process\`
- Test files: \`any[]\` → \`unknown[]\` for mock call args; \`as any\` casts replaced with proper type assertions

### 4. Add Biome linter with \`noExplicitAny: "error"\`

- \`@biomejs/biome\` added as dev dependency
- \`cli/biome.json\` configured: \`noExplicitAny\` as error, formatter disabled, scoped to \`src/\`
- \`bun lint\` script added to \`package.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)