### PR TITLE
feat: user-friendly cloud descriptions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -234,7 +234,7 @@
   "clouds": {
     "local": {
       "name": "Local Machine",
-      "description": "Run agents directly on your local machine without cloud provisioning",
+      "description": "Run agents on your own machine — no cloud needed",
       "url": "https://github.com/OpenRouterTeam/spawn",
       "type": "local",
       "auth": "none",
@@ -245,7 +245,7 @@
     },
     "hetzner": {
       "name": "Hetzner Cloud",
-      "description": "Hetzner Cloud servers via REST API",
+      "description": "Affordable European cloud servers from ~€3/mo",
       "url": "https://www.hetzner.com/cloud/",
       "type": "api",
       "auth": "HCLOUD_TOKEN",
@@ -261,7 +261,7 @@
     },
     "fly": {
       "name": "Fly.io",
-      "description": "Fly.io Machines via REST API and flyctl CLI",
+      "description": "Deploy globally on Fly.io with free-tier VMs",
       "url": "https://fly.io",
       "type": "api+cli",
       "auth": "FLY_API_TOKEN",
@@ -279,7 +279,7 @@
     },
     "aws": {
       "name": "AWS Lightsail",
-      "description": "AWS Lightsail instances via AWS CLI",
+      "description": "Simple AWS instances starting at $3.50/mo",
       "url": "https://aws.amazon.com/lightsail/",
       "type": "cli",
       "auth": "aws configure (AWS credentials)",
@@ -296,7 +296,7 @@
     },
     "daytona": {
       "name": "Daytona",
-      "description": "Daytona sandboxed environments for AI code execution",
+      "description": "Instant sandboxes with pay-per-second pricing",
       "url": "https://www.daytona.io/",
       "type": "sandbox",
       "auth": "DAYTONA_API_KEY",
@@ -313,7 +313,7 @@
     },
     "digitalocean": {
       "name": "DigitalOcean",
-      "description": "DigitalOcean Droplets via REST API",
+      "description": "Developer-friendly Droplets from $4/mo",
       "url": "https://www.digitalocean.com/",
       "type": "api",
       "auth": "DO_API_TOKEN",
@@ -329,7 +329,7 @@
     },
     "gcp": {
       "name": "GCP Compute Engine",
-      "description": "Google Cloud Compute Engine instances via gcloud CLI",
+      "description": "Google Cloud VMs with $300 free trial credit",
       "url": "https://cloud.google.com/compute",
       "type": "cli",
       "auth": "gcloud auth login",
@@ -346,7 +346,7 @@
     },
     "sprite": {
       "name": "Sprite",
-      "description": "Sprites.dev managed VMs with CLI",
+      "description": "Managed cloud VMs — one command to deploy",
       "url": "https://sprites.dev",
       "type": "cli",
       "auth": "sprite login",


### PR DESCRIPTION
## Summary
- Replace technical cloud descriptions (e.g. "Hetzner Cloud servers via REST API") with user-friendly ones that highlight pricing and key benefits
- Descriptions now match the concise, helpful style used for agent descriptions

| Cloud | Before | After |
|-------|--------|-------|
| local | Run agents directly on your local machine without cloud provisioning | Run agents on your own machine — no cloud needed |
| hetzner | Hetzner Cloud servers via REST API | Affordable European cloud servers from ~€3/mo |
| fly | Fly.io Machines via REST API and flyctl CLI | Deploy globally on Fly.io with free-tier VMs |
| aws | AWS Lightsail instances via AWS CLI | Simple AWS instances starting at $3.50/mo |
| daytona | Daytona sandboxed environments for AI code execution | Instant sandboxes with pay-per-second pricing |
| digitalocean | DigitalOcean Droplets via REST API | Developer-friendly Droplets from $4/mo |
| gcp | Google Cloud Compute Engine instances via gcloud CLI | Google Cloud VMs with $300 free trial credit |
| sprite | Sprites.dev managed VMs with CLI | Managed cloud VMs — one command to deploy |

## Test plan
- [x] All manifest integrity tests pass (`bun test manifest-integrity`)
- [ ] Verify descriptions render well in `spawn list` and interactive cloud selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)