### PR TITLE
fix: validate agent.repo format before Bun.spawn in update.ts

### DIFF
--- a/.claude/skills/update-metadata/update.ts
+++ b/.claude/skills/update-metadata/update.ts
@@ -194,12 +194,19 @@ async function refreshIconsFor(
 
 // ── GitHub metadata refresh (agents only) ───────────────────────────
 
+// SECURITY: Validate GitHub repo format to prevent command injection via manifest.json
+const GITHUB_REPO_PATTERN = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+$/;
+
 async function refreshAgentStats() {
   console.log("── Refreshing agent GitHub stats ──");
   for (const id of agentIds) {
     const agent = agents[id];
     if (!agent.repo) {
       console.log(`  ⚠  ${id}: no repo field, skipping GitHub metadata`);
+      continue;
+    }
+    if (!GITHUB_REPO_PATTERN.test(agent.repo)) {
+      console.log(`  ⚠  ${id}: invalid repo format '${agent.repo}', skipping`);
       continue;
     }
     try {


### PR DESCRIPTION
**Why:** The `agent.repo` field from manifest.json was passed directly to `Bun.spawn()` in `refreshAgentStats()` without format validation. A malicious or corrupted manifest entry with shell metacharacters in the repo field (e.g. `owner/name; rm -rf /`) could cause unexpected behavior when interpolated into the `gh api repos/…` argument.

## Summary
- Adds `GITHUB_REPO_PATTERN` (`/^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+$/`) allowlist regex
- Validates `agent.repo` matches the `owner/repository` format before use
- Invalid repo values are logged and skipped instead of passed to `gh api`

## Test plan
- [ ] Verify `refreshAgentStats()` still works for valid repos (e.g. `anthropics/claude-code`)
- [ ] Verify repos with shell metacharacters (e.g. `foo/bar; echo pwned`) are rejected with a warning
- [ ] Run `bun run .claude/skills/update-metadata/update.ts --stats-only --dry-run` to confirm no regression

Fixes #1527

-- refactor/security-auditor