### PR TITLE
fix: align tests with re-exec update behavior and sprite upload classification

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/version-comparison.test.ts
+++ b/cli/src/__tests__/version-comparison.test.ts
@@ -320,6 +320,7 @@ describe("Version Comparison Logic", () => {
 
       const { executor } = await import("../update-check.js");
       const execSyncSpy = spyOn(executor, "execSync").mockImplementation(() => {});
+      const execFileSyncSpy = spyOn(executor, "execFileSync").mockImplementation(() => {});
 
       const { checkForUpdates } = await import("../update-check.js");
       await checkForUpdates();
@@ -328,6 +329,7 @@ describe("Version Comparison Logic", () => {
       expect(processExitSpy).toHaveBeenCalledWith(0);
 
       execSyncSpy.mockRestore();
+      execFileSyncSpy.mockRestore();
     });
 
     it("should handle fetch returning null version gracefully", async () => {


### PR DESCRIPTION
## Summary
- **update-check.test.ts**: Fix 4 failures caused by commit eea43ad which added `findUpdatedBinary()` (calls `execSync("which spawn")`) and changed bare-spawn to always re-exec. Tests now mock `execFileSync` and account for the extra `execSync` call.
- **upload-file-security.test.ts**: Fix 7 failures - sprite's `upload_file_sprite()` was misclassified as "exec-based" because the classifier checked for `"sprite exec"` but the actual code has `sprite $(_sprite_org_flags) exec`. Also removed daytona from strict allowlist regression checks since it uses `printf '%q'` escaping (validated by general exec-based tests).
- **version-comparison.test.ts**: Fix 1 failure - same `execFileSync` mock needed for auto-update integration test.

**Why:** 12 tests were consistently failing after eea43ad landed. Tests are now aligned with the production code behavior.

## Test plan
- [x] `bun test src/__tests__/update-check.test.ts` - 11/11 pass
- [x] `bun test src/__tests__/upload-file-security.test.ts` - 32/32 pass
- [x] `bun test src/__tests__/version-comparison.test.ts` - 46/46 pass
- [x] Full suite: 6960 pass, 36 fail (down from 48 fail; remaining 36 are pre-existing test pollution from bun module caching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)