### PR TITLE
fix: validate RAW_BASE URL in update-check to prevent future injection

### DIFF
--- a/cli/src/manifest.ts
+++ b/cli/src/manifest.ts
@@ -56,7 +56,7 @@ export interface Manifest {
 // ── Constants ──────────────────────────────────────────────────────────────────
 
 const REPO = "OpenRouterTeam/spawn";
-const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/main`;
+const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/main` as const;
 // Dynamic getters so tests can override XDG_CACHE_HOME at runtime
 function getCacheDir(): string {
   return join(process.env.XDG_CACHE_HOME || join(homedir(), ".cache"), "spawn");

--- a/cli/src/update-check.ts
+++ b/cli/src/update-check.ts
@@ -16,6 +16,12 @@ export const executor = {
 
 const FETCH_TIMEOUT = 5000; // 5 seconds
 
+// Validate RAW_BASE matches expected GitHub raw content URL pattern (defense-in-depth, CWE-78)
+const GITHUB_RAW_URL_PATTERN = /^https:\/\/raw\.githubusercontent\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+if (!GITHUB_RAW_URL_PATTERN.test(RAW_BASE)) {
+  throw new Error(`RAW_BASE URL does not match expected GitHub raw URL pattern: ${RAW_BASE}`);
+}
+
 // Use ASCII-safe symbols when unicode is disabled (SSH, dumb terminals)
 const isAscii = process.env.TERM === "linux";
 const CHECK_MARK = isAscii ? "*" : "\u2713";


### PR DESCRIPTION
**Why:** Prevents future command injection if RAW_BASE is ever sourced from user input or config; adds defense-in-depth per OWASP CWE-78.

Fixes #1528

## Changes

1. **`cli/src/manifest.ts`**: Added `as const` assertion to `RAW_BASE` constant, narrowing its type from `string` to a string literal. This provides compile-time safety against accidental reassignment.

2. **`cli/src/update-check.ts`**: Added runtime validation that `RAW_BASE` matches the expected GitHub raw content URL pattern (`https://raw.githubusercontent.com/{owner}/{repo}/{branch}`) before it is used in shell command interpolation on line 133. If the pattern doesn't match, the module throws immediately at import time rather than passing an untrusted URL to `execSync`.

## Test plan

- [x] All 11 existing `update-check.test.ts` tests pass
- [x] Full test suite (6954 pass) — no regressions from this change
- [x] Validation regex tested against the actual `RAW_BASE` value

-- refactor/security-auditor