### PR TITLE
fix: use destroy_server for sprite delete to support org users

### DIFF
--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1834,7 +1834,7 @@ function buildDeleteScript(cloud: string, connection: VMConnection): string {
     case "daytona":
       return `${sourceLib}\nensure_daytona_token\ndestroy_server "${id}"`;
     case "sprite":
-      return `${sourceLib}\nensure_sprite_installed\nsprite destroy "${id}"`;
+      return `${sourceLib}\nensure_sprite_installed\nensure_sprite_authenticated\ndestroy_server "${id}"`;
     default:
       return "";
   }


### PR DESCRIPTION
## Summary
- Sprite `spawn delete` called `sprite destroy` directly, bypassing `ensure_sprite_authenticated` and `destroy_server()` — the only cloud to do so
- This meant `SPRITE_ORG` was never detected via `_detect_sprite_org`, so org users got "sprite not found" errors leaving orphaned sprites incurring charges
- Now calls `ensure_sprite_authenticated` then `destroy_server`, matching all other clouds (hetzner, digitalocean, fly, gcp, aws, daytona)

## Test plan
- [x] `bun test` — 6970 pass, 25 fail (all pre-existing `sandbox-verification.test.ts` env-specific failures, unchanged)
- [ ] Manual: `spawn delete` a sprite in an org account — should now pass `-o $SPRITE_ORG` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)