### PR TITLE
fix: call ensure_jq before jq usage in hetzner and daytona libs

### DIFF
--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -314,7 +314,7 @@ except Exception as e:
 # Cloud adapter interface
 # ============================================================
 
-cloud_authenticate() { prompt_spawn_name; ensure_daytona_token; }
+cloud_authenticate() { prompt_spawn_name; ensure_jq; ensure_daytona_token; }
 cloud_provision() { create_server "$1"; }
 cloud_wait_ready() { wait_for_cloud_init; }
 cloud_run() { run_server "$1"; }

--- a/hetzner/lib/common.sh
+++ b/hetzner/lib/common.sh
@@ -214,7 +214,7 @@ list_servers() {
 # Cloud adapter interface
 # ============================================================
 
-cloud_authenticate() { prompt_spawn_name; ensure_hcloud_token; ensure_ssh_key; }
+cloud_authenticate() { prompt_spawn_name; ensure_jq; ensure_hcloud_token; ensure_ssh_key; }
 cloud_provision() { create_server "$1"; }
 cloud_wait_ready() { verify_server_connectivity "${HETZNER_SERVER_IP}"; wait_for_cloud_init "${HETZNER_SERVER_IP}" 60; }
 cloud_run() { run_server "${HETZNER_SERVER_IP}" "$1"; }


### PR DESCRIPTION
**Why:** Users on minimal Ubuntu/Debian, Alpine, or fresh macOS without Homebrew get `jq: command not found` after entering their API token — a hard failure mid-authentication. Both `hetzner/lib/common.sh` and `daytona/lib/common.sh` use `jq` heavily in `create_server()` but never call `ensure_jq()` which already exists in `shared/common.sh` and auto-installs jq.

## Changes
- `hetzner/lib/common.sh`: add `ensure_jq` to `cloud_authenticate()`
- `daytona/lib/common.sh`: add `ensure_jq` to `cloud_authenticate()`

## Validation
- `bash -n`: PASS on both files
- `bun test`: 6995 pass, 0 fail (no TypeScript changes)
- `bash test/mock.sh`: cloud adapter interface unchanged

-- refactor/code-health