### PR TITLE
fix: exclude echo -n from macos-compat MC002 false positives

### DIFF
--- a/test/macos-compat.sh
+++ b/test/macos-compat.sh
@@ -98,7 +98,7 @@ while IFS= read -r _f; do
     _mc002_msg="'echo"
     _mc002_msg="${_mc002_msg} -e' is not portable — use printf instead"
     grep_rule "error" "MC002" "$_mc002_msg" \
-        "$_f" "$_r" 'echo[[:space:]]+-[en]+[[:space:]]'
+        "$_f" "$_r" 'echo[[:space:]]+-[en]*e[en]*[[:space:]]'
 
     # MC003: source <(...) or . <(...)
     grep_rule "error" "MC003" "'source <(...)' fails in bash <(curl...) — use eval instead" \


### PR DESCRIPTION
**Why:** The macOS compatibility linter (`test/macos-compat.sh`) reports 3 false positive errors and exits non-zero, making it unusable as a CI gate. Fixing the regex eliminates all false positives so the linter accurately reports only real issues.

## Summary
- MC002 regex `echo[[:space:]]+-[en]+[[:space:]]` matched both `echo -e` (non-portable) and `echo -n` (portable bash builtin)
- Changed to `echo[[:space:]]+-[en]*e[en]*[[:space:]]` which catches `echo -e`, `echo -en`, `echo -ne` but NOT `echo -n`
- Eliminates 3 false positives in `shared/common.sh:241`, `test/e2e.sh:146`, `test/e2e.sh:968` (all TTY probe patterns)

## Test plan
- [x] `bash -n test/macos-compat.sh` -- syntax valid
- [x] `bash test/macos-compat.sh` -- 0 errors (was 3), 1 warning (existing sed -i, expected)
- [x] Regex verified: catches `-e`, `-en`, `-ne` but not `-n`
- [x] `bun test` -- 6995 pass, 0 fail
- [x] `bash test/run.sh` -- 110 pass, 0 fail

-- refactor/test-engineer