### PR TITLE
fix: source .spawnrc directly in agent launch commands

### DIFF
--- a/aws/codex.sh
+++ b/aws/codex.sh
@@ -20,6 +20,6 @@ agent_env_vars() {
 agent_configure() {
     setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && codex'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex'; }
 
 spawn_agent "Codex CLI"

--- a/aws/kilocode.sh
+++ b/aws/kilocode.sh
@@ -20,6 +20,6 @@ agent_env_vars() {
         "KILO_PROVIDER_TYPE=openrouter" \
         "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && kilocode'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode'; }
 
 spawn_agent "Kilo Code"

--- a/aws/openclaw.sh
+++ b/aws/openclaw.sh
@@ -28,6 +28,6 @@ agent_pre_launch() {
     start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; openclaw tui'; }
 
 spawn_agent "OpenClaw"

--- a/aws/opencode.sh
+++ b/aws/opencode.sh
@@ -14,6 +14,6 @@ echo ""
 
 agent_install() { install_agent "OpenCode" "$(opencode_install_cmd)" cloud_run; }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
-agent_launch_cmd() { echo 'source ~/.zshrc && opencode'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode'; }
 
 spawn_agent "OpenCode"

--- a/daytona/codex.sh
+++ b/daytona/codex.sh
@@ -26,7 +26,7 @@ agent_configure() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.zshrc && codex'
+    echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex'
 }
 
 spawn_agent "Codex CLI"

--- a/daytona/kilocode.sh
+++ b/daytona/kilocode.sh
@@ -24,7 +24,7 @@ agent_env_vars() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.zshrc && kilocode'
+    echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode'
 }
 
 spawn_agent "Kilo Code"

--- a/daytona/openclaw.sh
+++ b/daytona/openclaw.sh
@@ -36,7 +36,7 @@ agent_pre_launch() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.zshrc && openclaw tui'
+    echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; openclaw tui'
 }
 
 spawn_agent "OpenClaw"

--- a/daytona/opencode.sh
+++ b/daytona/opencode.sh
@@ -22,7 +22,7 @@ agent_env_vars() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.zshrc && opencode'
+    echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode'
 }
 
 spawn_agent "OpenCode"

--- a/digitalocean/codex.sh
+++ b/digitalocean/codex.sh
@@ -20,6 +20,6 @@ agent_env_vars() {
 agent_configure() {
     setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && codex'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex'; }
 
 spawn_agent "Codex CLI"

--- a/digitalocean/kilocode.sh
+++ b/digitalocean/kilocode.sh
@@ -20,6 +20,6 @@ agent_env_vars() {
         "KILO_PROVIDER_TYPE=openrouter" \
         "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && kilocode'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode'; }
 
 spawn_agent "Kilo Code"

--- a/digitalocean/openclaw.sh
+++ b/digitalocean/openclaw.sh
@@ -28,6 +28,6 @@ agent_pre_launch() {
     start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; openclaw tui'; }
 
 spawn_agent "OpenClaw"

--- a/digitalocean/opencode.sh
+++ b/digitalocean/opencode.sh
@@ -14,6 +14,6 @@ echo ""
 
 agent_install() { install_agent "OpenCode" "$(opencode_install_cmd)" cloud_run; }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
-agent_launch_cmd() { echo 'source ~/.zshrc && opencode'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode'; }
 
 spawn_agent "OpenCode"

--- a/fly/codex.sh
+++ b/fly/codex.sh
@@ -26,7 +26,7 @@ agent_configure() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.zshrc && codex'
+    echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex'
 }
 
 spawn_agent "Codex CLI"

--- a/fly/kilocode.sh
+++ b/fly/kilocode.sh
@@ -24,7 +24,7 @@ agent_env_vars() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.zshrc && kilocode'
+    echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode'
 }
 
 spawn_agent "Kilo Code"

--- a/fly/openclaw.sh
+++ b/fly/openclaw.sh
@@ -41,7 +41,7 @@ agent_pre_launch() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.zshrc && openclaw tui'
+    echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; openclaw tui'
 }
 
 spawn_agent "OpenClaw"

--- a/fly/opencode.sh
+++ b/fly/opencode.sh
@@ -22,7 +22,7 @@ agent_env_vars() {
 }
 
 agent_launch_cmd() {
-    echo 'source ~/.zshrc && opencode'
+    echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode'
 }
 
 spawn_agent "OpenCode"

--- a/gcp/codex.sh
+++ b/gcp/codex.sh
@@ -20,6 +20,6 @@ agent_env_vars() {
 agent_configure() {
     setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && codex'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex'; }
 
 spawn_agent "Codex CLI"

--- a/gcp/kilocode.sh
+++ b/gcp/kilocode.sh
@@ -20,6 +20,6 @@ agent_env_vars() {
         "KILO_PROVIDER_TYPE=openrouter" \
         "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && kilocode'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode'; }
 
 spawn_agent "Kilo Code"

--- a/gcp/openclaw.sh
+++ b/gcp/openclaw.sh
@@ -28,6 +28,6 @@ agent_pre_launch() {
     start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; openclaw tui'; }
 
 spawn_agent "OpenClaw"

--- a/gcp/opencode.sh
+++ b/gcp/opencode.sh
@@ -14,6 +14,6 @@ echo ""
 
 agent_install() { install_agent "OpenCode" "$(opencode_install_cmd)" cloud_run; }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
-agent_launch_cmd() { echo 'source ~/.zshrc && opencode'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode'; }
 
 spawn_agent "OpenCode"

--- a/hetzner/codex.sh
+++ b/hetzner/codex.sh
@@ -20,6 +20,6 @@ agent_env_vars() {
 agent_configure() {
     setup_codex_config "${OPENROUTER_API_KEY}" cloud_upload cloud_run
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && codex'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex'; }
 
 spawn_agent "Codex CLI"

--- a/hetzner/kilocode.sh
+++ b/hetzner/kilocode.sh
@@ -20,6 +20,6 @@ agent_env_vars() {
         "KILO_PROVIDER_TYPE=openrouter" \
         "KILO_OPEN_ROUTER_API_KEY=${OPENROUTER_API_KEY}"
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && kilocode'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode'; }
 
 spawn_agent "Kilo Code"

--- a/hetzner/openclaw.sh
+++ b/hetzner/openclaw.sh
@@ -28,6 +28,6 @@ agent_pre_launch() {
     start_openclaw_gateway cloud_run
     wait_for_openclaw_gateway cloud_run
 }
-agent_launch_cmd() { echo 'source ~/.zshrc && openclaw tui'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; openclaw tui'; }
 
 spawn_agent "OpenClaw"

--- a/hetzner/opencode.sh
+++ b/hetzner/opencode.sh
@@ -14,6 +14,6 @@ echo ""
 
 agent_install() { install_agent "OpenCode" "$(opencode_install_cmd)" cloud_run; }
 agent_env_vars() { generate_env_config "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"; }
-agent_launch_cmd() { echo 'source ~/.zshrc && opencode'; }
+agent_launch_cmd() { echo 'source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode'; }
 
 spawn_agent "OpenCode"


### PR DESCRIPTION
**Why:** 24 agent scripts load env vars indirectly via `source ~/.zshrc && <agent>`, which fails silently when `.zshrc` has errors or the `.spawnrc` hook install was non-fatal — causing agents to launch without `OPENROUTER_API_KEY` and produce confusing "unauthorized" LLM API errors.

## Summary
- Standardize codex, opencode, kilocode, and openclaw launch commands across all 6 SSH-based clouds (AWS, DigitalOcean, Fly, GCP, Hetzner, Daytona)
- Change from `source ~/.zshrc && <agent>` to `source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; <agent>`
- This matches the pattern already used by `claude` and `zeroclaw` agents
- Env vars are loaded directly from `.spawnrc`, immune to `.zshrc` failures

## Test plan
- [x] `bash -n` on all 24 changed files — all pass
- [x] `bash test/run.sh` — 109 passed, 0 failed
- [x] `bash test/mock.sh` — 108 passed, 0 failed

-- refactor/code-health