### PR TITLE
fix: show Fly.io login URL immediately (remove 2>/dev/null suppression)

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -149,6 +149,8 @@ _validate_fly_token() {
 _try_fly_browser_auth() {
     local fly_api_base="https://api.fly.io"
 
+    log_step "Fetching Fly.io login URL..."
+
     # Create a CLI session
     local hostname
     hostname=$(hostname 2>/dev/null || echo "spawn")
@@ -239,7 +241,7 @@ ensure_fly_token() {
 
     # 4. Try browser-based OAuth (like `fly auth login`)
     log_step "Authenticating with Fly.io via browser..."
-    token=$(_try_fly_browser_auth 2>/dev/null) && {
+    token=$(_try_fly_browser_auth) && {
         export FLY_API_TOKEN="$token"
         if _validate_fly_token 2>/dev/null; then
             log_info "Authenticated with Fly.io via browser"


### PR DESCRIPTION
## Root cause

`_try_fly_browser_auth()` was called with `2>/dev/null` which silenced all stderr output, including:

- `log_step "Fetching Fly.io login URL..."` — immediate feedback while waiting for API
- `printf '\n  %s\n\n' "$auth_url"` — the URL the user needs to copy in a sandbox
- `log_info "Waiting for browser authentication..."`
- `log_warn "Running in a sandbox? Copy the URL above..."`

So users saw **"Authenticating with Fly.io via browser..."** and then nothing — no URL, no progress — until the 120s timeout or browser auth completed.

## Fix

1. Remove `2>/dev/null` from the call site so all instructional output reaches the terminal
2. Add `log_step "Fetching Fly.io login URL..."` inside the function before the API call, so there's immediate feedback during the 1-2s session creation curl call

## After fix

```
→ Authenticating with Fly.io via browser...
→ Fetching Fly.io login URL...           ← immediate, before curl
→ Fly.io login required. Open this URL in your browser:

  https://fly.io/cli-sessions/abc123...   ← shown as soon as URL is ready

ℹ Waiting for browser authentication (up to 120s)...
⚠ Running in a sandbox? Copy the URL above into your local browser.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)