### PR TITLE
fix: remove 2>/dev/null from token validation calls (4 high-severity suppressions)

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -224,7 +224,7 @@ ensure_fly_token() {
     if _load_token_from_config "$HOME/.config/spawn/fly.json" "FLY_API_TOKEN" "Fly.io"; then
         FLY_API_TOKEN=$(_sanitize_fly_token "$FLY_API_TOKEN")
         export FLY_API_TOKEN
-        if _validate_fly_token 2>/dev/null; then
+        if _validate_fly_token; then
             return 0
         fi
         unset FLY_API_TOKEN
@@ -243,7 +243,7 @@ ensure_fly_token() {
     log_step "Authenticating with Fly.io via browser..."
     token=$(_try_fly_browser_auth) && {
         export FLY_API_TOKEN="$token"
-        if _validate_fly_token 2>/dev/null; then
+        if _validate_fly_token; then
             log_info "Authenticated with Fly.io via browser"
             _save_token_to_config "$HOME/.config/spawn/fly.json" "$token"
             return 0

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2851,7 +2851,7 @@ ensure_api_token_with_provider() {
 
     # Try environment variable (validate if test function provided)
     if _load_token_from_env "${env_var_name}" "${provider_name}"; then
-        if [[ -z "${test_func}" ]] || "${test_func}" 2>/dev/null; then
+        if [[ -z "${test_func}" ]] || "${test_func}"; then
             return 0
         fi
         log_warn "${provider_name} token from environment is invalid or expired"
@@ -2860,7 +2860,7 @@ ensure_api_token_with_provider() {
 
     # Try config file (validate if test function provided, fall through to prompt on failure)
     if _load_token_from_config "${config_file}" "${env_var_name}" "${provider_name}"; then
-        if [[ -z "${test_func}" ]] || "${test_func}" 2>/dev/null; then
+        if [[ -z "${test_func}" ]] || "${test_func}"; then
             return 0
         fi
         log_warn "Saved ${provider_name} token is invalid or expired, requesting a new one..."


### PR DESCRIPTION
## Problem

A repo-wide audit found 5 places where `2>/dev/null` was suppressing stderr from **token validation functions** that contain `log_error`/`log_warn` with detailed diagnostics, API error messages, and remediation instructions. Users with invalid/expired tokens saw no explanation — the auth flow silently fell through to the next method.

## Fixed (4 high-severity)

### `shared/common.sh` — `ensure_api_token_with_provider()` (2 locations)

Used by Hetzner, DigitalOcean, Daytona, and Fly.io manual entry. The `test_func` argument (e.g. `test_hcloud_token`, `test_do_token`, `test_daytona_token`) was called with `2>/dev/null`, swallowing messages like:

```
✗ Hetzner token is invalid or expired
  API Error: unauthorized (401)
  How to fix:
    1. Generate a new token at https://console.hetzner.cloud/
    2. Or set: export HCLOUD_TOKEN=...
```

### `fly/lib/common.sh` — `ensure_fly_token()` (2 locations)

`_validate_fly_token` was suppressed both when loading from config and after browser OAuth, hiding:
```
✗ Authentication failed: Invalid Fly.io API token
  How to fix:
    1. Run: fly tokens deploy
    2. Or generate a token at: https://fly.io/dashboard
```

## Not fixed (intentional)

`_poll_instance_once()` in `shared/common.sh` keeps `2>/dev/null` on the API call — suppressing curl errors during a 60-iteration polling loop prevents terminal flooding, and `|| true` already handles failures gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)