### PR TITLE
fix: Fly.io OAuth 'no tokens found in header' — handle raw m2. macaroons

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -123,17 +123,23 @@ _try_flyctl_auth() {
 
 # Sanitize a Fly.io token — the dashboard copy button may include the
 # display name before the actual token (e.g. "Deploy Token FlyV1 fm2_...")
-# Strip everything before "FlyV1" or "fm2_", and trim whitespace/newlines.
+# Also handles raw macaroon tokens returned by the CLI Sessions API
+# (e.g. "m2.XXXX" or "fm2_XXXX" without the "FlyV1 " prefix).
+# All Fly.io v2 macaroon tokens must be sent as "Authorization: FlyV1 <token>"
+# regardless of whether the raw value already includes the prefix.
 _sanitize_fly_token() {
     local raw="$1"
     # Trim leading/trailing whitespace and newlines
     raw=$(printf '%s' "$raw" | tr -d '\n\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    # If it contains "FlyV1 ", strip everything before it (display name prefix)
+    # If it already contains "FlyV1 ", strip any display name prefix before it
     if [[ "$raw" == *"FlyV1 "* ]]; then
         raw="FlyV1 ${raw##*FlyV1 }"
-    # If it contains a bare "fm2_" token without FlyV1 prefix, extract it
+    # Raw fm2_ macaroon (no FlyV1 prefix) — extract and wrap
     elif [[ "$raw" == *"fm2_"* ]]; then
         raw=$(printf '%s' "$raw" | sed 's/.*\(fm2_[^ ]*\).*/\1/')
+        raw="FlyV1 $raw"
+    # Raw m2. macaroon returned by CLI Sessions API — wrap with FlyV1 prefix
+    elif [[ "$raw" == m2.* ]]; then
         raw="FlyV1 $raw"
     fi
     printf '%s' "$raw"
@@ -209,6 +215,9 @@ _try_fly_browser_auth() {
         access_token=$(echo "$poll_response" | _fly_json_get "access_token")
 
         if [[ -n "$access_token" ]]; then
+            # Wrap raw macaroons in FlyV1 format at the source so fly_api
+            # uses the correct Authorization header (not Bearer).
+            [[ "$access_token" != FlyV1\ * ]] && access_token="FlyV1 $access_token"
             echo "$access_token"
             return 0
         fi


### PR DESCRIPTION
## Root cause

The Fly.io CLI Sessions API (`/api/v1/cli_sessions/{id}`) returns raw macaroon tokens in `m2.XXXX` format **without** the `FlyV1 ` prefix. The existing `_sanitize_fly_token` only handled `fm2_` tokens, so `m2.` tokens fell through unchanged and were sent as:

\`\`\`
Authorization: Bearer m2.XXXX
\`\`\`

The Fly.io Machines API (`api.machines.dev`) requires FlyV1 macaroon format, not Bearer:

\`\`\`
Authorization: FlyV1 m2.XXXX
\`\`\`

This caused: **\`verify: invalid token: no tokens found in header\`** on every browser OAuth attempt.

## Fix

1. **`_sanitize_fly_token`**: add `m2.*` case that wraps the token as `FlyV1 m2.XXXX`
2. **`_try_fly_browser_auth` polling loop**: eagerly wrap any non-`FlyV1` token with the prefix at the source, before returning it

## Token format matrix after fix

| Raw token | After sanitize | Result |
|---|---|---|
| `m2.XXXX` | `FlyV1 m2.XXXX` | ✅ Fixed |
| `fm2_XXXX` | `FlyV1 fm2_XXXX` | ✅ Unchanged |
| `FlyV1 fm2_XXXX` | `FlyV1 fm2_XXXX` | ✅ Unchanged |
| `eyJhbGci...` (legacy JWT) | `Bearer eyJ...` | ℹ️ Falls back to manual prompt |

🤖 Generated with [Claude Code](https://claude.com/claude-code)