### PR TITLE
fix: replace bun -e with python3 in fly/lib/common.sh to fix 18 CI mock test failures

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -59,11 +59,14 @@ _get_fly_cmd() {
 _fly_json_get() {
     local field="$1" default="${2:-}"
     _FLY_FIELD="$field" _FLY_DEFAULT="$default" \
-    bun -e "
-const text = await Bun.stdin.text();
-const d = JSON.parse(text);
-const v = d[process.env._FLY_FIELD] ?? process.env._FLY_DEFAULT ?? '';
-process.stdout.write(String(v) + '\n');
+    python3 -c "
+import json, sys, os
+d = json.loads(sys.stdin.read())
+v = d.get(os.environ['_FLY_FIELD'])
+if v is None:
+    print(os.environ.get('_FLY_DEFAULT', ''))
+else:
+    print(str(v))
 " 2>/dev/null || echo "$default"
 }
 
@@ -338,22 +341,23 @@ _fly_create_app() {
 _fly_build_machine_body() {
     local name="$1" region="$2" vm_memory="$3"
     _FLY_NAME="$name" _FLY_REGION="$region" _FLY_MEM="$vm_memory" \
-    bun -e "
-const body = {
-    name: process.env._FLY_NAME,
-    region: process.env._FLY_REGION,
-    config: {
-        image: 'ubuntu:24.04',
-        guest: {
-            cpu_kind: 'shared',
-            cpus: 1,
-            memory_mb: Number(process.env._FLY_MEM),
+    python3 -c "
+import json, os, sys
+body = {
+    'name': os.environ['_FLY_NAME'],
+    'region': os.environ['_FLY_REGION'],
+    'config': {
+        'image': 'ubuntu:24.04',
+        'guest': {
+            'cpu_kind': 'shared',
+            'cpus': 1,
+            'memory_mb': int(os.environ['_FLY_MEM']),
         },
-        init: { exec: ['/bin/sleep', 'inf'] },
-        auto_destroy: false,
+        'init': {'exec': ['/bin/sleep', 'inf']},
+        'auto_destroy': False,
     },
-};
-process.stdout.write(JSON.stringify(body) + '\n');
+}
+print(json.dumps(body))
 "
 }
 
@@ -578,10 +582,11 @@ destroy_server() {
     local machines
     machines=$(fly_api GET "/apps/$app_name/machines")
     local machine_ids
-    machine_ids=$(echo "$machines" | bun -e "
-const data = JSON.parse(await Bun.stdin.text());
-const ids = Array.isArray(data) ? data.map((m: {id: string}) => m.id).join('\n') : '';
-if (ids) process.stdout.write(ids + '\n');
+    machine_ids=$(echo "$machines" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+ids = [m['id'] for m in data if isinstance(data, list) and 'id' in m] if isinstance(data, list) else []
+print('\n'.join(ids))
 " 2>/dev/null || true)
 
     for mid in $machine_ids; do
@@ -602,21 +607,22 @@ list_servers() {
     local org=$(get_fly_org)
     local response=$(fly_api GET "/apps?org_slug=$org")
 
-    echo "$response" | bun -e "
-const data = JSON.parse(await Bun.stdin.text());
-const apps: {name?:string;id?:string;status?:string;network?:string}[] =
-    Array.isArray(data) ? data : (data.apps ?? []);
-if (!apps.length) { console.log('No apps found'); process.exit(0); }
-console.log('NAME'.padEnd(25) + 'ID'.padEnd(20) + 'STATUS'.padEnd(12) + 'NETWORK'.padEnd(20));
-console.log('-'.repeat(77));
-for (const a of apps) {
-    console.log(
-        String(a.name ?? 'N/A').padEnd(25) +
-        String(a.id ?? 'N/A').padEnd(20) +
-        String(a.status ?? 'N/A').padEnd(12) +
-        String(a.network ?? 'N/A').padEnd(20)
-    );
-}
+    echo "$response" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+apps = data if isinstance(data, list) else data.get('apps', [])
+if not apps:
+    print('No apps found')
+    sys.exit(0)
+print('NAME'.ljust(25) + 'ID'.ljust(20) + 'STATUS'.ljust(12) + 'NETWORK'.ljust(20))
+print('-' * 77)
+for a in apps:
+    print(
+        str(a.get('name', 'N/A')).ljust(25) +
+        str(a.get('id', 'N/A')).ljust(20) +
+        str(a.get('status', 'N/A')).ljust(12) +
+        str(a.get('network', 'N/A')).ljust(20)
+    )
 " 2>/dev/null
 }
 


### PR DESCRIPTION
**Why:** bash test/mock.sh fly → 18 passed, 18 failed on every CI run since #1551 merged. Blocks PR #1552 from passing CI. After this fix: 36 passed, 0 failed.

## Root Cause

PR #1551 introduced \`_fly_json_get()\` using \`bun -e\` for JSON parsing. The mock test harness (\`test/mock.sh\`) stubs \`bun\` as a no-op logging mock (line 249), so \`_fly_json_get\` always returned empty string. This caused \`FLY_MACHINE_ID\` to be empty → "Failed to extract machine ID from API response" → every fly script exits 1 → 18 test failures.

## Fix

Replace all 4 \`bun -e\` invocations in \`fly/lib/common.sh\` with equivalent \`python3\` code:
- \`_fly_json_get\`: extract top-level JSON field from stdin
- \`_fly_build_machine_body\`: build machine creation JSON body  
- \`_fly_destroy_app\`: extract machine IDs from array response
- \`list_servers\`: format apps table with ljust

\`python3\` is always available in CI and already has a pass-through mock in \`test/mock.sh\` (delegates to real \`/usr/bin/python3\`). No behavior change for real production runs — both \`bun\` and \`python3\` are available on production machines.

## Test Results

```
Before: bash test/mock.sh fly → 18 passed, 18 failed
After:  bash test/mock.sh fly → 36 passed, 0 failed
Full:   bash test/mock.sh     → 108 passed, 0 failed
```

-- refactor/code-health