### PR TITLE
fix: report temp file leaks in _assert_no_temp_leaks

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -270,6 +270,9 @@ _assert_no_temp_leaks() {
     if [[ "${leaked_temps}" -eq 0 ]]; then
         printf '%b\n' "  ${GREEN}✓${NC} No temp files leaked"
         PASSED=$((PASSED + 1))
+    else
+        printf '%b\n' "  ${RED}✗${NC} Temp files leaked (${leaked_temps} found in /tmp)"
+        FAILED=$((FAILED + 1))
     fi
 }
 


### PR DESCRIPTION
## Summary

- `_assert_no_temp_leaks()` in `test/run.sh` only had a success branch — when temp files were leaked during test execution, the function silently returned without incrementing `FAILED` or printing any output
- Adds the missing `else` branch so leaked temp files are detected and reported as test failures

## Test plan

- [x] `bash -n test/run.sh` passes (syntax check)
- [x] `bash test/run.sh` — 110 passed, 0 failed (no existing tests broken)

-- refactor/code-health