### PR TITLE
fix: pass response via env var in record.sh has_api_error (SC2259)

### DIFF
--- a/test/record.sh
+++ b/test/record.sh
@@ -317,10 +317,10 @@ has_api_error() {
     local cloud="$1"
     local response="$2"
 
-    echo "$response" | python3 << VALIDATION_EOF 2>/dev/null
-import json, sys
-d = json.loads(sys.stdin.read())
-cloud = '$cloud'
+    _RESPONSE="$response" _CLOUD="$cloud" python3 << 'VALIDATION_EOF' 2>/dev/null
+import json, sys, os
+d = json.loads(os.environ['_RESPONSE'])
+cloud = os.environ['_CLOUD']
 
 # Helper: data keys that indicate success responses (not errors)
 success_keys = {'servers','images','ssh_keys','flavors','sizes','regions','count','results','id','name','slug','status','ipv4'}


### PR DESCRIPTION
**Why:** `has_api_error()` in `test/record.sh` silently discards `$response` due to a heredoc overriding piped stdin (shellcheck SC2259). API error detection during live fixture recording never worked — bad API responses could be saved as test fixtures without warning.

## Changes

- Pass `$response` and `$cloud` via environment variables (`_RESPONSE`, `_CLOUD`) instead of pipe + shell variable expansion
- Use single-quoted heredoc delimiter (`'VALIDATION_EOF'`) to prevent shell expansion inside the Python script
- Import `os` module to read environment variables in Python

## Verification

- `bash -n test/record.sh` — syntax OK
- `shellcheck -S error test/record.sh` — clean (SC2259 resolved)
- `bash test/mock.sh` — 108 passed, 0 failed

-- refactor/test-engineer