### PR TITLE
fix: allow space in token regex for FlyV1 prefixed tokens

### DIFF
--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2763,9 +2763,11 @@ _load_token_from_config() {
 
     # SECURITY: Validate token characters to prevent curl config injection via -K -
     # Similar to key-request.sh _try_load_env_var (^[a-zA-Z0-9._/@-]+$) but also
-    # allows colon (:) for Fly.io FlyV1 tokens and URL-style formats, and
-    # plus (+) / equals (=) for base64-encoded token segments.
-    if [[ ! "${saved_token}" =~ ^[a-zA-Z0-9._/@:+=-]+$ ]]; then
+    # allows colon (:) for Fly.io FlyV1 tokens and URL-style formats,
+    # plus (+) / equals (=) for base64-encoded token segments, and
+    # space ( ) for Fly.io "FlyV1 <macaroon>" prefixed tokens.
+    # Space is safe inside curl -K double-quoted values: header = "Authorization: FlyV1 fm2_..."
+    if [[ ! "${saved_token}" =~ ^[a-zA-Z0-9._/@:+=\ -]+$ ]]; then
         log_error "SECURITY: Invalid characters in saved token for ${provider_name}"
         return 1
     fi


### PR DESCRIPTION
**Why:** Fly.io browser-auth users are forced to re-authenticate every session because saved `FlyV1 fm2_xxx` tokens (containing a space) are rejected by the `_load_token_from_config` regex added in #1547.

-- refactor/code-health

## Root Cause

`shared/common.sh:2768` validates saved tokens with regex `^[a-zA-Z0-9._/@:+=-]+$` which does NOT allow space characters. The Fly.io browser OAuth flow (`fly/lib/common.sh:220`) wraps raw macaroon tokens as `FlyV1 fm2_xxx` (with a space), and this prefixed token is saved to `~/.config/spawn/fly.json`. On the next run, `_load_token_from_config` reads the token correctly from JSON but rejects it at the regex check.

## Fix

Allow space character in the token validation regex. This is safe because:
1. The token is used in curl's `-K -` config format where values are double-quoted (`header = "Authorization: FlyV1 fm2_xxx"`) — spaces inside quotes are fine
2. The regex still blocks all dangerous shell metacharacters (`;|&$()><`)
3. The space only appears in the well-defined `FlyV1 ` prefix format

## Test Results

- `bash -n shared/common.sh` — syntax check passes
- `bash test/mock.sh` — 108/108 passed
- `bash test/run.sh` — 110/110 passed