### PR TITLE
fix: replace printf -v with export for bash 3.2 compat in key-request.sh

### DIFF
--- a/shared/key-request.sh
+++ b/shared/key-request.sh
@@ -92,9 +92,8 @@ print(v)
             fi
             # SECURITY: val is already validated against ^[a-zA-Z0-9._/@-]+$ above,
             # and var_name is validated against ^[A-Z_][A-Z0-9_]*$ by the caller.
-            # Use printf -v for safe variable assignment (no command substitution/expansion).
-            printf -v "${var_name}" '%s' "${val}"
-            export "${var_name}"
+            # Use export NAME=VALUE (bash 3.2 compatible; printf -v requires bash 4.0+).
+            export "${var_name}=${val}"
             return 0
         fi
     fi


### PR DESCRIPTION
**Why:** `printf -v` requires bash 4.0+; macOS ships bash 3.2, so `_try_load_env_var()` fails with `printf: -v: invalid option` — breaking saved API key loading for all cloud providers on macOS.

## Root cause

PR #1522 fixed this by replacing `printf -v` with `eval`. PR #1557 then replaced `eval` with `declare` (to avoid eval), but `declare` creates a local-scoped variable whose export has no effect. The reviewer caught this and changed it to `printf -v` — inadvertently re-introducing the original bash 3.2 incompatibility.

The macos-compat linter already flags this as **MC013 error**: `'printf -v' requires bash 4.0+ -- use eval or stdout capture`

## Fix

Replace:
```bash
printf -v "${var_name}" '%s' "${val}"
export "${var_name}"
```

With:
```bash
export "${var_name}=${val}"
```

**Why this is safe:** Both `var_name` and `val` are validated against strict regexes immediately above:
- `var_name` → `^[A-Z_][A-Z0-9_]*$` (line 65)
- `val` → `^[a-zA-Z0-9._/@-]+$` (line 89)

Neither can contain shell metacharacters, so `export "NAME=VALUE"` is injection-safe and works on bash 3.2+.

## Testing

- `bash -n shared/key-request.sh` — syntax OK
- `bash test/run.sh` — 110 passed, 0 failed

-- refactor/code-health (implemented by team-lead)