### PR TITLE
fix: clear corrupt saved Fly.io token + capture only first line from fly auth token

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -110,7 +110,7 @@ _try_flyctl_auth() {
     fly_cmd=$(_get_fly_cmd) || return 1
 
     local token
-    token=$("$fly_cmd" auth token 2>/dev/null || true)
+    token=$("$fly_cmd" auth token 2>/dev/null | head -1 || true)
     if [[ -n "$token" ]]; then
         echo "$token"
         return 0
@@ -227,7 +227,7 @@ _try_fly_browser_auth() {
         log_step "Opening Fly.io browser login via flyctl..."
         if "$fly_cmd" auth login </dev/tty >/dev/tty 2>&1; then
             local token
-            token=$("$fly_cmd" auth token 2>/dev/null) || true
+            token=$("$fly_cmd" auth token 2>/dev/null | head -1) || true
             if [[ -n "$token" ]]; then
                 echo "$token"
                 return 0

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2768,7 +2768,8 @@ _load_token_from_config() {
     # space ( ) for Fly.io "FlyV1 <macaroon>" prefixed tokens.
     # Space is safe inside curl -K double-quoted values: header = "Authorization: FlyV1 fm2_..."
     if [[ ! "${saved_token}" =~ ^[a-zA-Z0-9._/@:+=\ -]+$ ]]; then
-        log_error "SECURITY: Invalid characters in saved token for ${provider_name}"
+        log_warn "Saved ${provider_name} token is malformed — clearing cached credentials."
+        rm -f "${config_file}" 2>/dev/null || true
         return 1
     fi
 


### PR DESCRIPTION
## Fixes persistent 'SECURITY: Invalid characters in saved token for Fly.io'

### 1. Auto-clear corrupt saved token

When \`_load_token_from_config\` finds a saved token with invalid characters, it now **deletes the corrupt file** instead of silently returning 1. Previously: the user was stuck — every run loaded the bad token, failed security check, and fell through to manual entry. Now: the file is cleared and auth re-runs cleanly on the next attempt.

### 2. Capture only first line from \`fly auth token\`

Newer flyctl may print warnings or metadata after the token:
\`\`\`
FlyV1 fm2_abc123...
Warning: your token expires in 30 days
\`\`\`
Using \`| head -1\` prevents the concatenated warning text from being stored as part of the token value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)