### PR TITLE
fix: capture interactive_pick output and export FLY_ORG in _fly_prompt_org

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -194,8 +194,13 @@ list.forEach(o => {
 # Prompt user to select their Fly.io organization using the shared picker.
 # Follows the same interactive_pick pattern as Hetzner/GCP pickers.
 _fly_prompt_org() {
-    interactive_pick "FLY_ORG" "personal" "Fly.io organizations" _fly_list_orgs "personal"
-    log_info "Using Fly.io org: ${FLY_ORG:-personal}"
+    if [[ -n "${FLY_ORG:-}" || "${SPAWN_NON_INTERACTIVE:-}" == "1" ]]; then
+        return 0
+    fi
+    local org
+    org=$(interactive_pick "FLY_ORG" "personal" "Fly.io organizations" _fly_list_orgs "personal")
+    export FLY_ORG="${org:-personal}"
+    log_info "Using Fly.io org: ${FLY_ORG}"
 }
 
 # Browser-based auth — delegates to flyctl when available (correct token exchange),


### PR DESCRIPTION
## Bug

`interactive_pick` **echoes** the selected value to stdout — it does not export the env var. `_fly_prompt_org` called it without capturing the output, so `FLY_ORG` was never exported and the echoed value printed as a raw string to the terminal.

## Fix

```bash
org=$(interactive_pick "FLY_ORG" "personal" "Fly.io organizations" _fly_list_orgs "personal")
export FLY_ORG="${org:-personal}"
```

Also adds the standard `FLY_ORG` / `SPAWN_NON_INTERACTIVE` early-exit guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)