### PR TITLE
fix: Fly.io architectural brittleness — exec, /wait, python3, destroy errors (#1581)

### DIFF
--- a/test/fixtures/fly/_env.sh
+++ b/test/fixtures/fly/_env.sh
@@ -1,5 +1,6 @@
 export FLY_API_TOKEN="test-token-fly"
 export FLY_APP_NAME="test-app"
+export FLY_MACHINE_ID="test-machine-id"
 export FLY_REGION="iad"
 export FLY_VM_SIZE="shared-cpu-1x"
 export FLY_VM_MEMORY="1024"

--- a/test/mock.sh
+++ b/test/mock.sh
@@ -324,6 +324,17 @@ case "$1" in
         case "${2:-}" in
             token) echo "test-token-fly" ;;
         esac ;;
+    machine)
+        case "${2:-}" in
+            exec)
+                # fly machine exec MACHINE_ID --app APP -- bash -c CMD
+                all_args="$*"
+                if [[ "$all_args" == *"echo ok"* ]] || [[ "$all_args" == *'echo\ ok'* ]]; then
+                    echo "ok"
+                fi
+                ;;
+            list) echo "[]" ;;
+        esac ;;
     ssh)
         # fly ssh console -a APP -C "bash -c CMD" --quiet
         # Extract the command and simulate its output


### PR DESCRIPTION
Resolves sub-issues from #1581. Addresses the root-cause architectural problems rather than symptom-fixing.

## Changes

### #1569 — `/wait` endpoint replaces 90s polling loop
`_fly_wait_for_machine_start` now uses the Machines API blocking wait endpoint:
```
GET /apps/{app}/machines/{id}/wait?state=started&timeout=90
```
One blocking server-side call instead of 30 × 3s client-side polls.

### #1570 — `fly machine exec` replaces WireGuard tunnel for `run_server`
`run_server` now uses `fly machine exec MACHINE_ID --app APP -- bash -c cmd` (direct API, no WireGuard/SSH tunnel) when `FLY_MACHINE_ID` is set. Falls back to `fly ssh console -C` when machine ID is unavailable.

### #1576 — App name collision loop capped at 5 retries
Prevents infinite re-prompt; suggests `FLY_APP_NAME=my-name` env var after 5 failures.

### #1577 — `destroy_server` errors are now reported
All `fly_api` calls check `"error"` in response. Machine deletion failures are reported; app deletion failure exits non-zero. No more `|| true`-silenced orphaned resources.

### #1578 — bun replaced with python3 for all JSON parsing
`_fly_json_get`, `_fly_build_machine_body`, `_fly_list_orgs`, `destroy_server`, `list_servers` all use `python3 -c` now. `python3` is universally available; `bun` was only available after cloud-init completed on the target machine, creating a circular dependency.

### #1580 — `upload_file` uses stdin pipe instead of base64 string injection
```bash
fly machine exec $ID --app $APP -- bash -c "cat > $path" < local_file
```
Eliminates command-length limits and injection risk from embedding base64 content in a shell argument.

## Test changes
- `test/mock.sh`: added `fly machine exec` handling to fly CLI mock
- `test/fixtures/fly/_env.sh`: added `FLY_MACHINE_ID` to test env

**Tests: 36/36 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)