### PR TITLE
fix: bash 3.2 compat — sed pattern sub + split local var=$(cmd) (#1572, #1571)

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -654,8 +654,10 @@ except Exception:
 
 # List all Fly.io apps and machines
 list_servers() {
-    local org=$(get_fly_org)
-    local response=$(fly_api GET "/apps?org_slug=$org")
+    local org
+    org=$(get_fly_org)
+    local response
+    response=$(fly_api GET "/apps?org_slug=$org")
 
     printf '%s' "$response" | python3 -c "
 import json, sys

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -1278,7 +1278,9 @@ generate_env_config() {
         fi
 
         # Escape any single quotes in the value: replace ' with '\''
-        local escaped_value="${value//\'/\'\\\'\'}"
+        # Use sed instead of ${//} pattern substitution for bash 3.2 (macOS) compat
+        local escaped_value
+        escaped_value=$(printf '%s' "$value" | sed "s/'/'\\\\''/g")
         echo "export ${key}='${escaped_value}'"
     done
 }


### PR DESCRIPTION
**Why:** Two bash 3.2 incompatibilities break spawn on macOS (which ships with bash 3.2):
1. `${var//pattern/replace}` in `generate_env_config` is bash 4+ only — silently produces wrong output on macOS
2. `local var=$(cmd)` in `fly/lib/common.sh` masks exit codes — errors from `get_fly_org` and `fly_api` are silently swallowed

Fixes #1572
Fixes #1571

Changes:
- `shared/common.sh`: Replace `${value//\'/...}` with `sed` in `generate_env_config`
- `fly/lib/common.sh`: Split all `local var=$(cmd)` into two-line form so exit codes propagate

-- refactor/code-health