### PR TITLE
fix: accept comma in Fly.io macaroon tokens & handle flat org dict

### DIFF
--- a/fly/lib/common.sh
+++ b/fly/lib/common.sh
@@ -190,16 +190,23 @@ _fly_list_orgs() {
 import json, sys
 try:
     data = json.loads(sys.stdin.read())
-    orgs = data if isinstance(data, list) else data.get('nodes', data.get('organizations', []))
-    if not orgs:
-        sys.exit(1)
-    for o in orgs:
-        slug = o.get('slug') or o.get('name') or ''
-        name = o.get('name') or slug
-        otype = o.get('type') or ''
-        suffix = ' (' + otype + ')' if otype else ''
-        if slug:
-            print(slug + '|' + name + suffix)
+    if isinstance(data, dict) and not any(k in data for k in ('nodes', 'organizations')):
+        # Flat dict format: {'slug': 'Display Name', ...}
+        if not data:
+            sys.exit(1)
+        for slug, name in data.items():
+            print(slug + '|' + str(name))
+    else:
+        orgs = data if isinstance(data, list) else data.get('nodes', data.get('organizations', []))
+        if not orgs:
+            sys.exit(1)
+        for o in orgs:
+            slug = o.get('slug') or o.get('name') or ''
+            name = o.get('name') or slug
+            otype = o.get('type') or ''
+            suffix = ' (' + otype + ')' if otype else ''
+            if slug:
+                print(slug + '|' + name + suffix)
 except Exception:
     sys.exit(1)
 " 2>/dev/null

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -2766,10 +2766,11 @@ _load_token_from_config() {
     # SECURITY: Validate token characters to prevent curl config injection via -K -
     # Similar to key-request.sh _try_load_env_var (^[a-zA-Z0-9._/@-]+$) but also
     # allows colon (:) for Fly.io FlyV1 tokens and URL-style formats,
-    # plus (+) / equals (=) for base64-encoded token segments, and
+    # plus (+) / equals (=) for base64-encoded token segments,
+    # comma (,) for multi-segment macaroon tokens (fm2_...,fm2_...,fo1_...), and
     # space ( ) for Fly.io "FlyV1 <macaroon>" prefixed tokens.
-    # Space is safe inside curl -K double-quoted values: header = "Authorization: FlyV1 fm2_..."
-    if [[ ! "${saved_token}" =~ ^[a-zA-Z0-9._/@:+=\ -]+$ ]]; then
+    # Space and comma are safe inside curl -K double-quoted values.
+    if [[ ! "${saved_token}" =~ ^[a-zA-Z0-9._/@:+=,\ -]+$ ]]; then
         log_warn "Saved ${provider_name} token is malformed — clearing cached credentials."
         rm -f "${config_file}" 2>/dev/null || true
         return 1


### PR DESCRIPTION
## Summary

- **Token validation**: Add comma (`,`) to the allowed character set in `_load_token_from_config()` so multi-segment macaroon tokens from `fly auth token` (e.g. `fm2_...,fm2_...,fo1_...`) are no longer rejected as "malformed", which was forcing re-auth on every run.
- **Org picker**: Handle the flat dict format (`{"slug": "Display Name"}`) returned by `fly orgs list --json` on some flyctl versions, in addition to the existing list/nodes formats. This fixes the org picker always failing with an empty result.

## Test plan

- [x] `bash -n` syntax check on both modified files
- [x] Comma-containing token matches updated regex
- [x] Flat dict org format parses correctly (`personal|Name`)
- [x] List format still works (backward compatible)
- [x] All 112 mock tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)