### PR TITLE
docs: add CLAUDE.md rule — always use bun+ts, never python

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,14 @@ macOS ships bash 3.2. All scripts MUST work on it:
 - Remote fallback URL: `https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/{path}`
 - All env vars documented in the cloud's README.md
 
+### Use Bun + TypeScript for Inline Scripting — NEVER python/python3
+When shell scripts need JSON processing, HTTP calls, crypto, or any non-trivial logic:
+- **ALWAYS** use `bun eval '...'` or write a temp `.ts` file and `bun run` it
+- **NEVER** use `python3 -c` or `python -c` for inline scripting — python is not a project dependency
+- Prefer `jq` for simple JSON extraction; fall back to `bun eval` when jq is unavailable
+- Pass data to bun via environment variables (e.g., `_DATA="${var}" bun eval "..."`) or temp files — never interpolate untrusted values into JS strings
+- For complex operations (SigV4 signing, API calls with retries), write a heredoc `.ts` file and `bun run` it
+
 ## Testing
 
 - **NEVER use vitest** — use Bun's built-in test runner (`bun:test`) exclusively


### PR DESCRIPTION
## Summary

- Adds a new non-negotiable rule under **Shell Script Rules**: always use `bun eval` / `bun run` for inline scripting in shell scripts — never `python3 -c` or `python -c`
- python is not a project dependency; bun is already required everywhere

## Test plan

- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)