### PR TITLE
fix: bun mock shim for CI node fallback

### DIFF
--- a/test/mock.sh
+++ b/test/mock.sh
@@ -252,11 +252,13 @@ setup_mock_agents() {
     # log all other invocations as no-ops.
     # Fallback chain: real bun → node (with Bun.stdin polyfill) → exit 0
     # CI (GitHub Actions ubuntu-latest) has node but not bun, so the node
-    # fallback is essential for `_fly_json_get` / `_fly_build_machine_body`.
+    # fallback is essential for _fly_json / _fly_list_orgs / list_servers.
     cat > "${TEST_DIR}/bun" << 'MOCKBUN'
 #!/bin/bash
 echo "bun $*" >> "${MOCK_LOG}"
 if [[ "$1" == "-e" ]]; then
+    _code="$2"
+    shift 2  # remove -e and the code, leaving extra args (e.g. -- field default)
     # Walk PATH, skip our own directory, find the real bun
     _self_dir="$(cd "$(dirname "$0")" && pwd)"
     _real_bun=""
@@ -268,7 +270,7 @@ if [[ "$1" == "-e" ]]; then
         fi
     done
     if [[ -n "$_real_bun" ]]; then
-        exec "$_real_bun" "$@"
+        exec "$_real_bun" -e "$_code" "$@"
     fi
     # No real bun found — try node with a Bun.stdin polyfill
     _real_node=""
@@ -282,7 +284,9 @@ if [[ "$1" == "-e" ]]; then
         # Polyfill Bun.stdin.text() for node: read all of stdin as a string.
         # --input-type=module enables top-level await (used by fly/lib scripts).
         _polyfill='globalThis.Bun={stdin:{text:()=>new Promise(r=>{let d="";process.stdin.setEncoding("utf8");process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>r(d))})}};'
-        exec "$_real_node" --input-type=module -e "${_polyfill}${2}"
+        # Strip TypeScript type annotations for node compatibility.
+        _js_code=$(printf '%s' "$_code" | sed -E 's/: (any\[\]|any|string|number|void)//g; s/ as any//g')
+        exec "$_real_node" --input-type=module -e "${_polyfill}${_js_code}" "$@"
     fi
 fi
 exit 0


### PR DESCRIPTION
## Summary

Fixes CI test failures introduced by #1596 (python3 → bun+TS migration).

The mock bun shim in `test/mock.sh` had two issues when falling back to node on CI (ubuntu-latest has no real bun):

- **Missing args**: Only passed `$2` (the code) to node, dropping `-- field default` arguments needed by `_fly_json` for `process.argv` access
- **TypeScript syntax**: Didn't strip TS annotations (`: any[]`, `as any`, `: string`) that node can't parse

Fixes:
- `shift 2` to preserve extra args, forward them to both real bun and node exec
- `sed -E` strips TypeScript type annotations before passing to `node --input-type=module`

## Test plan

- [x] `bash test/mock.sh fly` — 40/40 pass
- [x] `bash test/mock.sh` — 112/112 pass
- [x] Verified node fallback path works with all bun -e code: `_fly_json`, `_fly_json_ids`, `_fly_list_orgs`, `list_servers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)