### PR TITLE
fix: apply default spawn name when user presses Enter

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -459,9 +459,12 @@ async function selectCloud(manifest: Manifest, cloudList: string[], hintOverride
 // Any string is allowed (spaces, uppercase, etc.) — the shell scripts
 // derive a kebab-case slug for the actual cloud resource name.
 async function promptSpawnName(): Promise<string | undefined> {
+  const suffix = Math.random().toString(36).slice(2, 6);
+  const defaultName = `spawn-${suffix}`;
   const spawnName = await p.text({
     message: "Name your spawn",
-    placeholder: "My Spawn",
+    placeholder: defaultName,
+    defaultValue: defaultName,
     validate: (value) => {
       if (!value) return undefined;
       if (value.length > 128) {


### PR DESCRIPTION
## Summary
- `promptSpawnName()` used `placeholder: "My Spawn"` but no `defaultValue`, so pressing Enter without typing returned an empty string instead of applying the default
- Now generates a unique default name like `spawn-a3f2` with a random 4-char suffix, avoiding Fly.io global app name collisions
- Bumps CLI to v0.5.20

## Test plan
- [ ] Run `spawn` interactively, press Enter at "Name your spawn" without typing — should use generated default (e.g. `spawn-x9kp`)
- [ ] Type a custom name — should use the typed name as before
- [ ] Verify the placeholder text shows the generated default

🤖 Generated with [Claude Code](https://claude.com/claude-code)