### PR TITLE
fix: unpin Codex version, restore wire_api=responses

### DIFF
--- a/aws/codex.sh
+++ b/aws/codex.sh
@@ -12,7 +12,7 @@ fi
 log_info "Codex CLI on AWS Lightsail"
 echo ""
 
-agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run; }
+agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
 agent_env_vars() {
     generate_env_config \
         "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/daytona/codex.sh
+++ b/daytona/codex.sh
@@ -13,7 +13,7 @@ log_info "Codex CLI on Daytona"
 echo ""
 
 agent_install() {
-    install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run
+    install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run
 }
 
 agent_env_vars() {

--- a/digitalocean/codex.sh
+++ b/digitalocean/codex.sh
@@ -12,7 +12,7 @@ fi
 log_info "Codex CLI on DigitalOcean"
 echo ""
 
-agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run; }
+agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
 agent_env_vars() {
     generate_env_config \
         "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/fly/lib/agents.ts
+++ b/fly/lib/agents.ts
@@ -364,7 +364,7 @@ export const agents: Record<string, AgentConfig> = {
 
   codex: {
     name: "Codex CLI",
-    install: () => installAgent("Codex CLI", "npm install -g @openai/codex@0.94.0"),
+    install: () => installAgent("Codex CLI", "npm install -g @openai/codex"),
     envVars: (apiKey) => [`OPENROUTER_API_KEY=${apiKey}`],
     configure: (apiKey) => setupCodexConfig(apiKey),
     launchCmd: () =>

--- a/gcp/codex.sh
+++ b/gcp/codex.sh
@@ -12,7 +12,7 @@ fi
 log_info "Codex CLI on GCP Compute Engine"
 echo ""
 
-agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run; }
+agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
 agent_env_vars() {
     generate_env_config \
         "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/hetzner/codex.sh
+++ b/hetzner/codex.sh
@@ -12,7 +12,7 @@ fi
 log_info "Codex CLI on Hetzner Cloud"
 echo ""
 
-agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run; }
+agent_install() { install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run; }
 agent_env_vars() {
     generate_env_config \
         "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}"

--- a/local/codex.sh
+++ b/local/codex.sh
@@ -13,7 +13,7 @@ log_info "Codex CLI on local machine"
 echo ""
 
 agent_install() {
-    install_agent "Codex CLI" "npm install -g @openai/codex@0.94.0" cloud_run
+    install_agent "Codex CLI" "npm install -g @openai/codex" cloud_run
 }
 
 agent_env_vars() {

--- a/manifest.json
+++ b/manifest.json
@@ -130,7 +130,7 @@
       "name": "Codex CLI",
       "description": "OpenAI's open-source coding agent",
       "url": "https://github.com/openai/codex",
-      "install": "npm install -g @openai/codex@0.94.0",
+      "install": "npm install -g @openai/codex",
       "launch": "codex",
       "env": {
         "OPENAI_API_KEY": "${OPENROUTER_API_KEY}",

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -3359,12 +3359,7 @@ wait_for_openclaw_gateway() {
 # ============================================================
 
 # Setup Codex CLI config.toml for OpenRouter
-# Uses wire_api="chat" (Chat Completions) because OpenRouter's Responses API
-# proxy drops required fields (id, content) from conversation-history items on
-# multi-turn requests, causing "Invalid Responses API request" errors.
-# Codex >=0.97.0 removed "chat" support, so scripts pin @openai/codex@0.94.0.
-# TODO: unpin once OpenRouter's /responses proxy handles round-trip correctly.
-# Tracking: https://github.com/openai/codex/issues/12114
+# Uses the native model_provider config instead of OPENAI_BASE_URL env var.
 # Usage: setup_codex_config OPENROUTER_KEY UPLOAD_CALLBACK RUN_CALLBACK
 setup_codex_config() {
     local openrouter_key="${1}"
@@ -3382,7 +3377,7 @@ model_provider = "openrouter"
 name = "OpenRouter"
 base_url = "https://openrouter.ai/api/v1"
 env_key = "OPENROUTER_API_KEY"
-wire_api = "chat"
+wire_api = "responses"
 TOML
 )
 

--- a/sprite/codex.sh
+++ b/sprite/codex.sh
@@ -13,7 +13,7 @@ log_info "Codex CLI on Sprite"
 echo ""
 
 agent_install() {
-    install_agent "Codex CLI" "export PATH=\$(npm prefix -g 2>/dev/null)/bin:\$PATH && npm install -g @openai/codex@0.94.0" cloud_run
+    install_agent "Codex CLI" "export PATH=\$(npm prefix -g 2>/dev/null)/bin:\$PATH && npm install -g @openai/codex" cloud_run
 }
 
 agent_env_vars() {


### PR DESCRIPTION
## Summary
- Reverts the 0.94.0 version pin from #1518
- Installs latest Codex (`@openai/codex`) instead of `@openai/codex@0.94.0`
- Restores `wire_api = "responses"` (required by Codex >=0.97.0)
- Updates all 8 cloud scripts + manifest.json + fly/lib/agents.ts

## Test plan
- [ ] `spawn codex aws` installs latest Codex (not 0.94.0)
- [ ] Codex launches without config.toml errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)