### PR TITLE
feat: Windows PowerShell installer (install.ps1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Launch any AI agent on any cloud with a single command. Coding agents, research 
 
 ## Install
 
+**macOS / Linux — and Windows users inside a WSL2 terminal (Ubuntu, Debian, etc.):**
 ```bash
 curl -fsSL https://openrouter.ai/labs/spawn/cli/install.sh | bash
 ```
 
-Or install directly from GitHub:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cli/install.sh | bash
+**Windows PowerShell (outside WSL):**
+```powershell
+irm https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cli/install.ps1 | iex
 ```
 
 ## Usage

--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -1,0 +1,193 @@
+# Spawn CLI installer for Windows PowerShell
+#
+# Usage (PowerShell):
+#   irm https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cli/install.ps1 | iex
+#
+# Or download and run:
+#   Invoke-WebRequest -Uri https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cli/install.ps1 -OutFile install.ps1
+#   .\install.ps1
+#
+# Override install directory:
+#   $env:SPAWN_INSTALL_DIR = "C:\Users\you\bin"; irm .../install.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+
+$SPAWN_REPO    = "OpenRouterTeam/spawn"
+$SPAWN_RAW_BASE = "https://raw.githubusercontent.com/$SPAWN_REPO/main"
+$MIN_BUN_VERSION = [version]"1.2.0"
+
+function Write-Step  { param($msg) Write-Host "[spawn] $msg" -ForegroundColor Cyan }
+function Write-Info  { param($msg) Write-Host "[spawn] $msg" -ForegroundColor Green }
+function Write-Warn  { param($msg) Write-Host "[spawn] $msg" -ForegroundColor Yellow }
+function Write-Err   { param($msg) Write-Host "[spawn] $msg" -ForegroundColor Red }
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+function Test-BunAvailable {
+    try { $null = Get-Command bun -ErrorAction Stop; return $true } catch { return $false }
+}
+
+function Get-BunVersion {
+    $v = (bun --version 2>$null).Trim()
+    try { return [version]$v } catch { return [version]"0.0.0" }
+}
+
+function Install-Bun {
+    Write-Step "Installing bun for Windows..."
+    $bunInstaller = "https://bun.sh/install.ps1"
+    try {
+        Invoke-RestMethod $bunInstaller | Invoke-Expression
+    } catch {
+        Write-Err "Failed to install bun automatically."
+        Write-Err "Install bun manually from: https://bun.sh"
+        Write-Err "Then re-run this installer."
+        exit 1
+    }
+    # Refresh PATH so bun is available in this session
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" +
+                [System.Environment]::GetEnvironmentVariable("Path","User")
+}
+
+function Find-InstallDir {
+    if ($env:SPAWN_INSTALL_DIR) { return $env:SPAWN_INSTALL_DIR }
+
+    # Prefer %USERPROFILE%\.local\bin (mirrors unix behaviour) or bun's global bin
+    $candidates = @(
+        "$env:USERPROFILE\.local\bin",
+        (& bun pm bin -g 2>$null)
+    )
+    $pathDirs = $env:Path -split ";"
+
+    foreach ($dir in $candidates) {
+        if ($dir -and $pathDirs -contains $dir) { return $dir }
+    }
+
+    # Default — will be added to PATH below
+    return "$env:USERPROFILE\.local\bin"
+}
+
+function Add-ToUserPath {
+    param([string]$Dir)
+    $currentPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+    $dirs = $currentPath -split ";"
+    if ($dirs -notcontains $Dir) {
+        $newPath = ($dirs + $Dir) -join ";"
+        [System.Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        $env:Path = "$env:Path;$Dir"
+        Write-Warn "$Dir added to your user PATH. Restart your terminal to use 'spawn'."
+    }
+}
+
+function Install-SpawnCli {
+    $tmpDir = Join-Path $env:TEMP ("spawn-install-" + [System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmpDir | Out-Null
+
+    try {
+        $cliDir = Join-Path $tmpDir "cli"
+
+        # Download CLI source via git (preferred) or individual files
+        Write-Step "Downloading spawn CLI source..."
+        $gitAvailable = $null -ne (Get-Command git -ErrorAction SilentlyContinue)
+        if ($gitAvailable) {
+            $repoDir = Join-Path $tmpDir "repo"
+            git clone --depth 1 --filter=blob:none --sparse `
+                "https://github.com/$SPAWN_REPO.git" $repoDir 2>$null
+            Push-Location $repoDir
+            git sparse-checkout set cli 2>$null
+            Pop-Location
+            Move-Item (Join-Path $repoDir "cli") $cliDir
+            Remove-Item $repoDir -Recurse -Force -ErrorAction SilentlyContinue
+        } else {
+            # Fallback: download individual source files
+            New-Item -ItemType Directory -Path (Join-Path $cliDir "src") | Out-Null
+            $apiUrl = "https://api.github.com/repos/$SPAWN_REPO/contents/cli/src"
+            $files = (Invoke-RestMethod $apiUrl) |
+                Where-Object { $_.name -match '\.ts$' -and $_.name -notmatch '__tests__' } |
+                Select-Object -ExpandProperty name
+
+            foreach ($f in @("package.json","bun.lock","tsconfig.json")) {
+                Invoke-WebRequest "$SPAWN_RAW_BASE/cli/$f" -OutFile (Join-Path $cliDir $f)
+            }
+            foreach ($f in $files) {
+                # SECURITY: block path traversal
+                if ($f -match '\.\.' -or $f -match '[/\\]') {
+                    Write-Err "Security: invalid filename from API: $f — aborting."
+                    exit 1
+                }
+                Invoke-WebRequest "$SPAWN_RAW_BASE/cli/src/$f" -OutFile (Join-Path $cliDir "src" $f)
+            }
+        }
+
+        # Build with bun
+        Write-Step "Building spawn CLI..."
+        Push-Location $cliDir
+        bun install
+        $buildOk = $false
+        try { bun run build; $buildOk = $true } catch { }
+        if (-not $buildOk) {
+            Write-Warn "Local build failed — downloading pre-built binary..."
+            Invoke-WebRequest "https://github.com/$SPAWN_REPO/releases/download/cli-latest/cli.js" `
+                -OutFile "cli.js"
+            if ((Get-Item "cli.js").Length -eq 0) {
+                Write-Err "Failed to download pre-built binary."
+                exit 1
+            }
+        }
+        Pop-Location
+
+        # Install
+        $installDir = Find-InstallDir
+        New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+
+        # Copy cli.js as the spawn script; create a .cmd wrapper so it's invokable from cmd.exe too
+        $cliJs    = Join-Path $installDir "spawn"
+        $cliCmd   = Join-Path $installDir "spawn.cmd"
+
+        Copy-Item (Join-Path $cliDir "cli.js") $cliJs -Force
+
+        # spawn.cmd — lets users run `spawn` from cmd.exe and PowerShell without specifying bun
+        Set-Content $cliCmd "@bun `"%~dp0spawn`" %*"
+
+        Write-Info "Installed spawn to $installDir"
+        Add-ToUserPath $installDir
+
+        # Show version
+        try {
+            Write-Host ""
+            & bun $cliJs version
+            Write-Host ""
+            Write-Info "Run 'spawn' to get started"
+        } catch { }
+    } finally {
+        Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+Write-Host ""
+
+if (-not (Test-BunAvailable)) {
+    Install-Bun
+    if (-not (Test-BunAvailable)) {
+        Write-Err "bun is not available after installation. Please install bun manually: https://bun.sh"
+        exit 1
+    }
+    Write-Info "bun installed successfully"
+}
+
+$bunVer = Get-BunVersion
+if ($bunVer -lt $MIN_BUN_VERSION) {
+    Write-Warn "bun $bunVer is below minimum $MIN_BUN_VERSION — upgrading..."
+    bun upgrade
+    $bunVer = Get-BunVersion
+    if ($bunVer -lt $MIN_BUN_VERSION) {
+        Write-Err "Failed to upgrade bun to >= $MIN_BUN_VERSION (got $bunVer)"
+        Write-Err "Please run: bun upgrade"
+        exit 1
+    }
+    Write-Info "bun upgraded to $bunVer"
+}
+
+Write-Step "Installing spawn via bun..."
+Install-SpawnCli

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -208,13 +208,17 @@ build_and_install() {
     ensure_in_path "${INSTALL_DIR}"
 }
 
-# --- Install bun if not present ---
+# --- Locate or install bun ---
+# When running via `curl | bash`, subshells may not inherit PATH updates,
+# so we always prepend the standard bun install locations explicitly.
+export BUN_INSTALL="${BUN_INSTALL:-${HOME}/.bun}"
+export PATH="${BUN_INSTALL}/bin:${HOME}/.local/bin:${PATH}"
+
 if ! command -v bun &>/dev/null; then
     log_step "bun not found. Installing bun..."
     curl -fsSL https://bun.sh/install | bash
 
-    # Source the updated PATH so bun is available immediately
-    export BUN_INSTALL="${HOME}/.bun"
+    # Re-export so bun is available in this session immediately
     export PATH="${BUN_INSTALL}/bin:${PATH}"
 
     if ! command -v bun &>/dev/null; then
@@ -223,7 +227,7 @@ if ! command -v bun &>/dev/null; then
         echo "Please install bun manually:"
         echo "  curl -fsSL https://bun.sh/install | bash"
         echo ""
-        echo "Then re-run:"
+        echo "Then reopen your terminal and re-run:"
         echo "  curl -fsSL ${SPAWN_RAW_BASE}/cli/install.sh | bash"
         exit 1
     fi


### PR DESCRIPTION
## Problem

The only installer is \`install.sh\` (bash). On Windows PowerShell:

\`\`\`
curl -fsSL ... | bash   # ❌ no bash.exe unless WSL is installed
irm ... | iex           # ❌ .sh script is not valid PowerShell
\`\`\`

Windows users have no supported install path.

## Solution

New \`cli/install.ps1\` — a PowerShell equivalent of \`install.sh\`:

\`\`\`powershell
irm https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/cli/install.ps1 | iex
\`\`\`

**What it does:**
1. Checks bun ≥ 1.2.0; auto-installs via \`bun.sh/install.ps1\` if missing
2. Downloads CLI source via \`git sparse-checkout\` (falls back to GitHub API)
3. \`bun install && bun run build\` → \`cli.js\`; falls back to pre-built binary
4. Installs to \`%USERPROFILE%\.local\bin\` (or \`$env:SPAWN_INSTALL_DIR\`)
5. Creates \`spawn.cmd\` wrapper for \`cmd.exe\` compatibility
6. Adds install dir to user's persistent PATH if needed

**README** updated to show both macOS/Linux and Windows install commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)