### PR TITLE
fix: correct safe_read call pattern in aws/lib/common.sh

### DIFF
--- a/aws/lib/common.sh
+++ b/aws/lib/common.sh
@@ -232,7 +232,7 @@ ensure_aws_cli() {
     if ! command -v aws &>/dev/null; then
         log_warn "AWS CLI is not installed."
         local install_choice
-        safe_read "Install AWS CLI now? [Y/n] " install_choice || install_choice="y"
+        install_choice=$(safe_read "Install AWS CLI now? [Y/n] ") || install_choice="y"
         install_choice="${install_choice:-y}"
 
         case "${install_choice}" in
@@ -244,8 +244,8 @@ ensure_aws_cli() {
                     # Installed — now prompt for credentials
                     log_info "Run 'aws configure' to set your AWS credentials."
                     local access_key secret_key
-                    safe_read "AWS Access Key ID: " access_key || return 1
-                    safe_read "AWS Secret Access Key: " secret_key || return 1
+                    access_key=$(safe_read "AWS Access Key ID: ") || return 1
+                    secret_key=$(safe_read "AWS Secret Access Key: ") || return 1
                     export AWS_ACCESS_KEY_ID="${access_key}"
                     export AWS_SECRET_ACCESS_KEY="${secret_key}"
                     export AWS_DEFAULT_REGION="${region}"


### PR DESCRIPTION
**Why:** `safe_read` in `aws/lib/common.sh` was called with a variable-name second argument (`safe_read "prompt" varname`) instead of command substitution (`varname=$(safe_read "prompt")`). Since `safe_read` only reads `$1` as the prompt and outputs the result on stdout, the user's input was discarded. This caused three concrete bugs in `ensure_aws_cli()`:

1. **Install prompt silently defaults to yes**: `safe_read "Install AWS CLI now? [Y/n] " install_choice` never sets `install_choice`, so the fallback `${install_choice:-y}` always triggers — ignoring user's "n" response.
2. **AWS credentials never captured**: `safe_read "AWS Access Key ID: " access_key` leaves `access_key` empty, causing `export AWS_ACCESS_KEY_ID="${access_key}"` to set an empty string — making `aws sts get-caller-identity` always fail.
3. **Same for AWS_SECRET_ACCESS_KEY**: same pattern, same result.

## Fix

Changed three lines in `aws/lib/common.sh` to use the correct `var=$(safe_read "prompt")` pattern, consistent with all other `safe_read` call sites in the codebase.

## Verification

- `bash -n aws/lib/common.sh` passes (syntax clean)
- All other `safe_read` usages in the codebase already use the correct pattern (verified by search)
- No other files affected

-- refactor/code-health