### PR TITLE
fix: aws safe_read calls discard user input

### DIFF
--- a/aws/lib/common.sh
+++ b/aws/lib/common.sh
@@ -232,7 +232,7 @@ ensure_aws_cli() {
     if ! command -v aws &>/dev/null; then
         log_warn "AWS CLI is not installed."
         local install_choice
-        safe_read "Install AWS CLI now? [Y/n] " install_choice || install_choice="y"
+        install_choice=$(safe_read "Install AWS CLI now? [Y/n] ") || install_choice="y"
         install_choice="${install_choice:-y}"
 
         case "${install_choice}" in
@@ -244,8 +244,8 @@ ensure_aws_cli() {
                     # Installed — now prompt for credentials
                     log_info "Run 'aws configure' to set your AWS credentials."
                     local access_key secret_key
-                    safe_read "AWS Access Key ID: " access_key || return 1
-                    safe_read "AWS Secret Access Key: " secret_key || return 1
+                    access_key=$(safe_read "AWS Access Key ID: ") || return 1
+                    secret_key=$(safe_read "AWS Secret Access Key: ") || return 1
                     export AWS_ACCESS_KEY_ID="${access_key}"
                     export AWS_SECRET_ACCESS_KEY="${secret_key}"
                     export AWS_DEFAULT_REGION="${region}"


### PR DESCRIPTION
## Summary
- Fixed 3 incorrect `safe_read` calls in `aws/lib/common.sh` that passed a variable name as a second argument instead of using command substitution
- `safe_read` outputs via stdout and only takes one argument (the prompt), so `safe_read "prompt" varname` never assigns `varname`
- The install choice prompt always defaulted to "y" regardless of user input
- AWS credential prompts (Access Key ID / Secret Access Key) after CLI install never captured user input, leaving env vars empty and causing silent auth failure

## Test plan
- [x] `bash -n aws/lib/common.sh` passes
- [x] `bash test/run.sh` -- 110 passed, 0 failed
- [ ] Manual: run `spawn claude aws` without AWS CLI installed, verify "Install AWS CLI?" prompt respects "n" answer
- [ ] Manual: run same flow, answer "y", verify credential prompts capture input correctly

-- refactor/code-health