### PR TITLE
fix: reject non-2xx responses in Fly.io token validation

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -143,8 +143,10 @@ async function testFlyToken(): Promise<boolean> {
       headers: { Authorization: authHeader },
       signal: AbortSignal.timeout(10_000),
     });
-    const text = await resp.text();
-    if (text && !hasError(text)) return true;
+    if (resp.ok) {
+      const text = await resp.text();
+      if (text && !hasError(text)) return true;
+    }
   } catch {
     // fall through
   }


### PR DESCRIPTION
## Summary
- `testFlyToken()` fallback to `https://api.fly.io/v1/user` accepted 404 plain text responses because `hasError()` only checks for JSON `"error"`/`"errors"` keys
- Added `resp.ok` check so non-2xx responses are correctly rejected before inspecting the body
- Bumped CLI version to 0.5.21

## Test plan
- [x] `bun test` passes (5 pre-existing unrelated failures only)
- [x] Verified fix logic: `resp.ok` is false for 404, 401, 403 — all correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)