### PR TITLE
fix: gcp and digitalocean destroy_server silently swallow errors

### DIFF
--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -378,7 +378,12 @@ destroy_server() {
     local name="${1}"
     local zone="${GCP_ZONE:-us-central1-a}"
     log_step "Destroying GCP instance ${name}..."
-    gcloud compute instances delete "${name}" --zone="${zone}" --project="${GCP_PROJECT}" --quiet >/dev/null 2>&1
+    if ! gcloud compute instances delete "${name}" --zone="${zone}" --project="${GCP_PROJECT}" --quiet >/dev/null; then
+        log_error "Failed to destroy GCP instance '${name}'"
+        log_warn "The instance may still be running and incurring charges."
+        log_warn "Delete it manually: ${SPAWN_DASHBOARD_URL}"
+        return 1
+    fi
     log_info "Instance ${name} destroyed"
 }
 


### PR DESCRIPTION
**Why:** GCP and DigitalOcean `destroy_server` functions don't check for errors, causing users to believe cloud instances were cleaned up when they may still be running and incurring charges.

## Changes

### 1. `gcp/lib/common.sh` — destroy_server error handling
The function redirected both stdout and stderr to `/dev/null` (`>/dev/null 2>&1`) without checking the exit code. If `gcloud compute instances delete` failed (expired auth, wrong zone, permission denied), it logged "Instance destroyed" and returned 0.

**Fix:** Check exit code with `if !` guard, log error with billing impact warning, return 1 on failure.

### 2. `digitalocean/lib/common.sh` — destroy_server error handling
The function called `do_api DELETE` but never checked the response. DigitalOcean returns 204 with empty body on success, but returns error JSON on failure (404, 403, etc.). Since `generic_cloud_api` returns 0 for successful HTTP transactions, the function always reported success.

**Fix:** Check for non-empty response containing error fields, log error with billing impact warning, return 1 on failure.

## Context
Same class of bug fixed for AWS in PR #1606 — these are the GCP and DigitalOcean instances.

-- refactor/code-health