### PR TITLE
fix: strip ANSI codes in CI test assertions

### DIFF
--- a/cli/src/__tests__/cmd-help-content.test.ts
+++ b/cli/src/__tests__/cmd-help-content.test.ts
@@ -41,6 +41,11 @@ mock.module("@clack/prompts", () => ({
 
 const { cmdHelp } = await import("../commands.js");
 
+/** Strip ANSI escape codes from a string so assertions work regardless of color support. */
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
 describe("cmdHelp - content completeness", () => {
   let consoleMocks: ReturnType<typeof createConsoleMocks>;
 
@@ -54,7 +59,7 @@ describe("cmdHelp - content completeness", () => {
 
   function getHelpOutput(): string {
     cmdHelp();
-    return consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+    return stripAnsi(consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n"));
   }
 
   // ── Required sections ──────────────────────────────────────────────

--- a/cli/src/__tests__/commands-info-details.test.ts
+++ b/cli/src/__tests__/commands-info-details.test.ts
@@ -244,6 +244,11 @@ mock.module("@clack/prompts", () => ({
 // Import commands after mock setup
 const { cmdCloudInfo, cmdAgentInfo, parseAuthEnvVars } = await import("../commands.js");
 
+/** Strip ANSI escape codes from a string so assertions work regardless of color support. */
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
 describe("parseAuthEnvVars", () => {
   it("should extract single env var", () => {
     expect(parseAuthEnvVars("HCLOUD_TOKEN")).toEqual(["HCLOUD_TOKEN"]);
@@ -301,7 +306,7 @@ describe("cmdCloudInfo - missing agents display", () => {
   }
 
   function getOutput(): string {
-    return consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+    return stripAnsi(consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n"));
   }
 
   beforeEach(async () => {
@@ -507,7 +512,7 @@ describe("cmdAgentInfo - URL and count details", () => {
   }
 
   function getOutput(): string {
-    return consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+    return stripAnsi(consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n"));
   }
 
   beforeEach(async () => {

--- a/cli/src/__tests__/commands-list-grid.test.ts
+++ b/cli/src/__tests__/commands-list-grid.test.ts
@@ -186,6 +186,11 @@ const { cmdMatrix, cmdClouds } = await import("../commands.js");
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/** Strip ANSI escape codes from a string so assertions work regardless of color support. */
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
 function setManifest(manifest: any) {
   global.fetch = mock(async () => ({
     ok: true,
@@ -196,11 +201,11 @@ function setManifest(manifest: any) {
 }
 
 function getOutput(consoleMocks: ReturnType<typeof createConsoleMocks>): string {
-  return consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n");
+  return stripAnsi(consoleMocks.log.mock.calls.map((c: any[]) => c.join(" ")).join("\n"));
 }
 
 function getLines(consoleMocks: ReturnType<typeof createConsoleMocks>): string[] {
-  return consoleMocks.log.mock.calls.map((c: any[]) => c.join(" "));
+  return consoleMocks.log.mock.calls.map((c: any[]) => stripAnsi(c.join(" ")));
 }
 
 // ── cmdList Grid View ────────────────────────────────────────────────────────

--- a/cli/src/__tests__/index-main-routing.test.ts
+++ b/cli/src/__tests__/index-main-routing.test.ts
@@ -38,6 +38,8 @@ function runCli(
         // Prevent local manifest.json from being used
         NODE_ENV: "test",
         BUN_ENV: "test",
+        // Prevent ANSI color codes in output (CI sets FORCE_COLOR/CI vars)
+        NO_COLOR: "1",
       },
       encoding: "utf-8",
       timeout: 15000,

--- a/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/cli/src/__tests__/script-failure-guidance.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from "bun:test";
-import { getScriptFailureGuidance, getSignalGuidance, getStatusDescription, buildRetryCommand } from "../commands";
+import { getScriptFailureGuidance as _getScriptFailureGuidance, getSignalGuidance as _getSignalGuidance, getStatusDescription, buildRetryCommand } from "../commands";
+
+/** Strip ANSI escape codes from a string so assertions work regardless of color support. */
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/** Wrapper that strips ANSI codes from all returned lines. */
+function getScriptFailureGuidance(...args: Parameters<typeof _getScriptFailureGuidance>): string[] {
+  return _getScriptFailureGuidance(...args).map(stripAnsi);
+}
+
+/** Wrapper that strips ANSI codes from all returned lines. */
+function getSignalGuidance(...args: Parameters<typeof _getSignalGuidance>): string[] {
+  return _getSignalGuidance(...args).map(stripAnsi);
+}
 
 /**
  * Tests for getScriptFailureGuidance() in commands.ts.

--- a/cli/src/__tests__/shared-common-env-inject.test.ts
+++ b/cli/src/__tests__/shared-common-env-inject.test.ts
@@ -34,6 +34,7 @@ function runBash(script: string): { exitCode: number; stdout: string; stderr: st
       encoding: "utf-8",
       timeout: 10000,
       stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, NO_COLOR: "1" },
     });
     return { exitCode: 0, stdout: stdout.trim(), stderr: "" };
   } catch (err: any) {


### PR DESCRIPTION
## Summary

- On CI (`CI=true`), picocolors enables ANSI output, causing 21 test failures where assertions compare plain text against ANSI-wrapped output
- Subprocess tests: add `NO_COLOR=1` to child process env
- Mock capture tests: add `stripAnsi()` helper to output getters
- 6 test files fixed, 0 production code changes

## Test plan

- [x] `FORCE_COLOR=1 bun test` — 6948 pass, 0 fail
- [x] `bun test` — 6948 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)