### PR TITLE
fix: replace fly machine exec with fly ssh console to fix 408 timeouts

### DIFF
--- a/fly/main.ts
+++ b/fly/main.ts
@@ -10,7 +10,6 @@ import {
   getServerName,
   waitForCloudInit,
   runServer,
-  uploadFile,
   interactiveSession,
 } from "./lib/fly";
 import { getOrPromptApiKey, getModelIdInteractive } from "./lib/oauth";
@@ -76,29 +75,19 @@ async function main() {
   await agent.install();
 
   // 8. Inject environment variables via .spawnrc
+  // Inline base64 write + shell hook in a single remote call instead of
+  // separate uploadFile + mv + 2× shell hook calls.
   logStep("Setting up environment variables...");
   const envContent = generateEnvConfig(agent.envVars(apiKey));
-  const fs = require("fs");
-  const os = require("os");
-  const path = require("path");
-  const tmpFile = path.join(os.tmpdir(), `spawn_env_${Date.now()}`);
-  fs.writeFileSync(tmpFile, envContent, { mode: 0o600 });
-
-  const tempRemote = `/tmp/spawn_env_${Date.now()}`;
+  const envB64 = Buffer.from(envContent).toString("base64");
   try {
-    await uploadFile(tmpFile, tempRemote);
     await runServer(
-      `cp '${tempRemote}' ~/.spawnrc && chmod 600 ~/.spawnrc; rm -f '${tempRemote}'`,
+      `printf '%s' '${envB64}' | base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc; ` +
+      `grep -q 'source ~/.spawnrc' ~/.bashrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.bashrc; ` +
+      `grep -q 'source ~/.spawnrc' ~/.zshrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.zshrc`,
     );
-    // Hook .spawnrc into shell configs
-    await runServer(
-      "grep -q 'source ~/.spawnrc' ~/.bashrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.bashrc",
-    ).catch(() => logWarn("Could not hook .spawnrc into .bashrc"));
-    await runServer(
-      "grep -q 'source ~/.spawnrc' ~/.zshrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.zshrc",
-    ).catch(() => logWarn("Could not hook .spawnrc into .zshrc"));
-  } finally {
-    try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+  } catch {
+    logWarn("Environment setup had errors");
   }
 
   // GitHub CLI setup


### PR DESCRIPTION
## Summary

- **Switch transport**: `fly machine exec` (HTTP exec API) → `fly ssh console -C` (WireGuard SSH) for all non-interactive remote execution (`runServer`, `runServerCapture`, `uploadFile`). The HTTP API randomly returns 408 `deadline_exceeded` on commands >30s, causing cascading failures (Node.js not installed, bun not installed, claude not found). WireGuard tunneling has no such limitation.
- **Batch remote calls**: Collapse ~25 individual remote exec calls into ~4 combined shell scripts, reducing round-trips and failure surface area.
- **Delete `finalizeClaudeInstall()`**: Logic inlined into the batched install script.

## Call count reduction

| Phase | Before | After |
|-------|--------|-------|
| waitForCloudInit (packages) | ~8 | 1 |
| installClaudeCode | ~8 | 1 |
| env setup | 4 | 1 |
| setupClaudeCodeConfig | ~5 | 1 |

## Test plan

- [x] `bash test/run.sh` — 110 passed, 0 failed
- [x] `bun build fly/main.ts` — compiles cleanly
- [ ] Manual: `bash ./fly/claude.sh` — confirm no 408 errors, all tools installed, claude launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)