### PR TITLE
fix: fly machine wait timeout exceeds API max of 60s

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- The Fly Machines API enforces a `[1s, 1m0s]` range on `WaitMachineRequest.Timeout`. We were passing `90` (seconds), causing an `invalid_argument` rejection that prevented any machine from starting.
- Lowered default timeout to `60s` (the API maximum) and added retry logic (3 attempts × 60s = up to 3 minutes total) so slow-starting machines still succeed.
- Bumps CLI to v0.5.22.

## Test plan
- [x] `bun test` passes
- [ ] `spawn claude fly` provisions successfully without the `invalid_argument` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)