### PR TITLE
fix: suppress interactive dpkg prompts during fly VM setup

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -129,7 +129,7 @@ async function installClaudeCode(): Promise<void> {
     `export PATH="${claudePath}:$PATH"`,
     `if command -v claude >/dev/null 2>&1; then ${finalize}; exit 0; fi`,
     // Ensure Node.js for npm method
-    `if ! command -v node >/dev/null 2>&1; then apt-get install -y nodejs npm 2>/dev/null && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx || true; fi`,
+    `if ! command -v node >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs npm 2>/dev/null && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx || true; fi`,
     // Method 2: npm
     `echo "==> Installing Claude Code (method 2/2: npm)..."`,
     `npm install -g @anthropic-ai/claude-code || true`,

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -746,6 +746,7 @@ export async function waitForCloudInit(): Promise<void> {
   // round-trips (each of which was previously a separate fly machine exec call).
   const setupScript = [
     `echo "==> Installing base packages..."`,
+    `export DEBIAN_FRONTEND=noninteractive`,
     `apt-get update -y && apt-get install -y curl unzip git || true`,
     `echo "==> Checking Node.js..."`,
     `if ! command -v node >/dev/null 2>&1; then { curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y nodejs; } || apt-get install -y nodejs || true; fi`,


### PR DESCRIPTION
## Summary
- `tzdata` (a Node.js dependency) tries to run `dpkg-reconfigure` interactively during `apt-get install`, which fails on headless Fly machines with `debconf: unable to initialize frontend: Dialog`
- Set `DEBIAN_FRONTEND=noninteractive` so apt silently picks defaults (UTC timezone)
- Applied to both `fly.ts` (base package setup) and `agents.ts` (fallback Node.js install)
- Bumps CLI to v0.5.23

## Test plan
- [x] `bun test` passes (4,453 tests)
- [ ] `spawn claude fly` installs Node.js without interactive prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)