### PR TITLE
fix: prevent terminal hang during fly agent install + fatal preLaunch

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.23",
+  "version": "0.5.24",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -615,7 +615,9 @@ export async function runServer(
   // 408 deadline_exceeded on long-running commands.
   const args = [flyCmd, "ssh", "console", "-a", flyAppName, "-C", `bash -c '${escapedCmd}'`];
 
-  const proc = Bun.spawn(args, { stdio: ["inherit", "inherit", "inherit"], env: process.env });
+  // Pipe /dev/null to stdin so commands that try to read input (e.g. claude
+  // install, npm postinstall hooks) don't hang waiting on the terminal.
+  const proc = Bun.spawn(args, { stdio: ["ignore", "inherit", "inherit"], env: process.env });
   // Local safety timer — WireGuard has no HTTP deadline but we still want a ceiling.
   const timeout = (timeoutSecs || 300) * 1000;
   const timer = setTimeout(() => { try { proc.kill(); } catch {} }, timeout);

--- a/cli/src/fly/main.ts
+++ b/cli/src/fly/main.ts
@@ -102,13 +102,9 @@ async function main() {
     }
   }
 
-  // 10. Pre-launch hooks
+  // 10. Pre-launch hooks (e.g. OpenClaw gateway — must succeed before TUI)
   if (agent.preLaunch) {
-    try {
-      await agent.preLaunch();
-    } catch {
-      logWarn("Pre-launch hook failed (continuing)");
-    }
+    await agent.preLaunch();
   }
 
   // 11. Launch interactive session


### PR DESCRIPTION
## Summary
- **Terminal hang fix**: `runServer()` inherited stdin, so commands like `claude install --force` that try to read input would hang the terminal indefinitely. Changed stdin to `"ignore"` for non-interactive remote commands — only `interactiveSession()` should have stdin.
- **Fatal preLaunch**: `preLaunch` failures (e.g. OpenClaw gateway not starting) were silently swallowed with `logWarn("Pre-launch hook failed (continuing)")`, dropping users into a broken TUI. Now errors propagate so users get a clear failure message.
- Bumps CLI to v0.5.24.

## Test plan
- [x] `bun test` passes (4,453 tests)
- [ ] `spawn claude fly` installs without hanging at `claude install`
- [ ] `spawn openclaw fly` fails clearly if gateway doesn't start

🤖 Generated with [Claude Code](https://claude.com/claude-code)