### PR TITLE
fix: skip unnecessary apt recommends (python3) during fly VM setup

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -129,7 +129,7 @@ async function installClaudeCode(): Promise<void> {
     `export PATH="${claudePath}:$PATH"`,
     `if command -v claude >/dev/null 2>&1; then ${finalize}; exit 0; fi`,
     // Ensure Node.js for npm method
-    `if ! command -v node >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs npm 2>/dev/null && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx || true; fi`,
+    `if ! command -v node >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs npm 2>/dev/null && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx || true; fi`,
     // Method 2: npm
     `echo "==> Installing Claude Code (method 2/2: npm)..."`,
     `npm install -g @anthropic-ai/claude-code || true`,

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -749,9 +749,9 @@ export async function waitForCloudInit(): Promise<void> {
   const setupScript = [
     `echo "==> Installing base packages..."`,
     `export DEBIAN_FRONTEND=noninteractive`,
-    `apt-get update -y && apt-get install -y curl unzip git || true`,
+    `apt-get update -y && apt-get install -y --no-install-recommends curl unzip git ca-certificates || true`,
     `echo "==> Checking Node.js..."`,
-    `if ! command -v node >/dev/null 2>&1; then { curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y nodejs; } || apt-get install -y nodejs || true; fi`,
+    `if ! command -v node >/dev/null 2>&1; then { curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y --no-install-recommends nodejs; } || apt-get install -y --no-install-recommends nodejs || true; fi`,
     `echo "node: $(node --version 2>/dev/null || echo not installed)"`,
     `echo "==> Checking bun..."`,
     `if ! command -v bun >/dev/null 2>&1 && [ ! -f "$HOME/.bun/bin/bun" ]; then curl -fsSL https://bun.sh/install | bash || true; fi`,


### PR DESCRIPTION
## Summary
- `apt-get install -y git` on Ubuntu 24.04 pulls in `python3` via recommended packages — adds ~50MB and install time for something we never use
- Added `--no-install-recommends` to all `apt-get install` calls (base setup in `fly.ts` and fallback Node install in `agents.ts`)
- Added `ca-certificates` explicitly since it's needed for HTTPS but won't be auto-pulled without recommends
- Bumps CLI to v0.5.25

## Test plan
- [x] `bun test` passes (3,644 tests)
- [ ] `spawn claude fly` installs without python3 in apt output

🤖 Generated with [Claude Code](https://claude.com/claude-code)