### PR TITLE
fix: prevent openclaw install hang on Fly.io

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -350,7 +350,7 @@ export const agents: Record<string, AgentConfig> = {
     install: () =>
       installAgent(
         "openclaw",
-        "source ~/.bashrc && { bun install -g openclaw 2>/dev/null || npm install -g openclaw@latest; }",
+        "source ~/.bashrc && { (bun install -g openclaw >/dev/null 2>&1) || npm install -g openclaw@latest; }",
       ),
     envVars: (apiKey) => [
       `OPENROUTER_API_KEY=${apiKey}`,


### PR DESCRIPTION
## Summary

- Wrap `bun install -g openclaw` in a subshell with stdout/stderr redirected to `/dev/null` so child processes inherit closed FDs, preventing `fly ssh console -C` from hanging indefinitely
- Bump CLI version to 0.5.25

## Test plan

- [x] `bun test` — 3,644 tests pass, 0 failures
- [ ] Manual: `spawn openclaw fly` completes install step without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)