### PR TITLE
fix: add --no-install-recommends to all apt calls across clouds

### DIFF
--- a/aws/lib/common.sh
+++ b/aws/lib/common.sh
@@ -177,7 +177,7 @@ _install_aws_cli() {
     else
         if ! command -v unzip &>/dev/null; then
             log_info "Installing unzip (required for AWS CLI)..."
-            sudo apt-get update -y && sudo apt-get install -y unzip || {
+            sudo DEBIAN_FRONTEND=noninteractive apt-get update -y && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends unzip || {
                 log_error "Could not install unzip. Install it manually, then re-run."
                 return 1
             }
@@ -378,8 +378,9 @@ get_server_name() {
 get_cloud_init_userdata() {
     cat << 'CLOUD_INIT_EOF'
 #!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y curl unzip git zsh nodejs npm
+apt-get install -y --no-install-recommends curl unzip git zsh nodejs npm ca-certificates
 # Upgrade Node.js to v22 LTS (apt has v18, agents like Cline need v20+)
 # n installs to /usr/local/bin but apt's v18 at /usr/bin can shadow it, so symlink over
 npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx

--- a/daytona/lib/common.sh
+++ b/daytona/lib/common.sh
@@ -206,7 +206,7 @@ wait_for_cloud_init() {
     # so we MUST consolidate commands here to stay under the limit.
     # This single SSH call replaces what was 6 separate connections.
     log_step "Installing base tools in sandbox..."
-    ssh_run_server "${DAYTONA_SSH_HOST}" "apt-get update -y && apt-get install -y curl unzip git zsh nodejs npm && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx && curl -fsSL https://bun.sh/install | bash && echo 'export PATH=\"\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.bashrc && echo 'export PATH=\"\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.zshrc" >/dev/null 2>&1 || true
+    ssh_run_server "${DAYTONA_SSH_HOST}" "export DEBIAN_FRONTEND=noninteractive && apt-get update -y && apt-get install -y --no-install-recommends curl unzip git zsh nodejs npm ca-certificates && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx && curl -fsSL https://bun.sh/install | bash && echo 'export PATH=\"\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.bashrc && echo 'export PATH=\"\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}\"' >> ~/.zshrc" >/dev/null 2>&1 || true
     log_info "Base tools installed"
 }
 

--- a/gcp/lib/common.sh
+++ b/gcp/lib/common.sh
@@ -214,8 +214,9 @@ get_server_name() {
 get_cloud_init_userdata() {
     cat << 'CLOUD_INIT_EOF'
 #!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y curl unzip git zsh nodejs npm
+apt-get install -y --no-install-recommends curl unzip git zsh nodejs npm ca-certificates
 # Upgrade Node.js to v22 LTS (apt has v18, agents like Cline need v20+)
 # n installs to /usr/local/bin but apt's v18 at /usr/bin can shadow it, so symlink over
 npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx

--- a/shared/common.sh
+++ b/shared/common.sh
@@ -152,7 +152,7 @@ _install_jq_brew() {
 }
 
 _install_jq_apt() {
-    sudo apt-get update -qq && sudo apt-get install -y jq || {
+    sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends jq || {
         log_error "Failed to install jq via apt. Run 'sudo apt-get install -y jq' manually."
         return 1
     }
@@ -1566,7 +1566,7 @@ _ensure_nodejs_runtime() {
     local claude_path="$2"
     if ! ${run_cb} "${claude_path} && command -v node" >/dev/null 2>&1; then
         log_step "Installing Node.js runtime (required for claude package)..."
-        if ${run_cb} "apt-get install -y nodejs npm && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx" >/dev/null 2>&1; then
+        if ${run_cb} "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs npm && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx" >/dev/null 2>&1; then
             log_info "Node.js installed via n"
         else
             log_warn "Could not install Node.js - bun method may fail"

--- a/shared/github-auth.sh
+++ b/shared/github-auth.sh
@@ -61,7 +61,7 @@ _install_gh_apt() {
         "$(dpkg --print-architecture)" \
         | ${SUDO} tee /etc/apt/sources.list.d/github-cli.list > /dev/null
     ${SUDO} apt-get update -qq
-    ${SUDO} apt-get install -y gh || {
+    DEBIAN_FRONTEND=noninteractive ${SUDO} apt-get install -y --no-install-recommends gh || {
         log_error "Failed to install gh via apt"
         return 1
     }


### PR DESCRIPTION
## Summary
- Same fix as #1629 (fly) applied to all bash-based cloud providers
- Without `--no-install-recommends`, `git` pulls in `python3` (~50MB) via recommended packages on Ubuntu 24.04
- Also added `DEBIAN_FRONTEND=noninteractive` and `ca-certificates` where missing

### Files changed
| File | What |
|------|------|
| `gcp/lib/common.sh` | cloud-init userdata |
| `aws/lib/common.sh` | cloud-init userdata + unzip install |
| `daytona/lib/common.sh` | sandbox base tools |
| `shared/common.sh` | jq install + Node.js fallback |
| `shared/github-auth.sh` | gh CLI install |

## Test plan
- [x] `bash -n` passes on all modified scripts
- [x] `bun test` passes (3,644 tests)
- [ ] Verify provisioning on at least one cloud (GCP or AWS) skips python3

🤖 Generated with [Claude Code](https://claude.com/claude-code)