### PR TITLE
fix: fly ssh console hangs with stdin /dev/null

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.25",
+  "version": "0.5.26",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- `fly ssh console -C` with stdin as `/dev/null` (`"ignore"`) causes the SSH session to hang after the remote command finishes — flyctl doesn't get a clean EOF to close the WireGuard transport
- Reproduced on `spawn openclaw fly`: hangs at "Installing openclaw..." after the SSH connection succeeds
- Fix: use `"pipe"` + `stdin.end()` so flyctl gets an explicit EOF signal
- Applied to all three non-interactive fly SSH functions: `runServer`, `runServerCapture`, `uploadFile`
- Bumps CLI to v0.5.26

## Test plan
- [x] `bun test` passes (3,644 tests)
- [ ] `spawn openclaw fly` installs without hanging
- [ ] `spawn claude fly` still works (no stdin hang regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)