### PR TITLE
fix: fly CLI not found after install and token not passed to subprocesses

### DIFF
--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -1,5 +1,8 @@
 // fly/lib/agents.ts — Agent configs + shared install/config helpers
 
+import { writeFileSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   logInfo,
   logWarn,
@@ -87,12 +90,8 @@ async function uploadConfigFile(
   content: string,
   remotePath: string,
 ): Promise<void> {
-  const fs = require("fs");
-  const os = require("os");
-  const path = require("path");
-
-  const tmpFile = path.join(os.tmpdir(), `spawn_config_${Date.now()}_${Math.random().toString(36).slice(2)}`);
-  fs.writeFileSync(tmpFile, content, { mode: 0o600 });
+  const tmpFile = join(tmpdir(), `spawn_config_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+  writeFileSync(tmpFile, content, { mode: 0o600 });
 
   const tempRemote = `/tmp/spawn_config_${Date.now()}`;
   try {
@@ -102,7 +101,7 @@ async function uploadConfigFile(
       `mkdir -p $(dirname "${remotePath}") && chmod 600 '${tempRemote}' && mv '${tempRemote}' "${remotePath}"`,
     );
   } finally {
-    try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+    try { unlinkSync(tmpFile); } catch { /* ignore */ }
   }
 }
 

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -1,5 +1,6 @@
 // fly/lib/fly.ts — Core Fly.io provider: API, auth, orgs, provisioning, execution
 
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import {
   logInfo,
   logWarn,
@@ -97,10 +98,18 @@ function hasError(text: string): boolean {
 }
 
 function getCmd(): string | null {
+  // Check PATH first
   for (const name of ["fly", "flyctl"]) {
     if (Bun.spawnSync(["which", name], { stdio: ["ignore", "pipe", "ignore"] }).exitCode === 0) {
       return name;
     }
+  }
+  // Bun.spawnSync inherits the original PATH, not process.env mutations.
+  // Check the default install location directly.
+  const flyBin = `${process.env.HOME}/.fly/bin`;
+  for (const name of ["fly", "flyctl"]) {
+    const fullPath = `${flyBin}/${name}`;
+    if (existsSync(fullPath)) return fullPath;
   }
   return null;
 }
@@ -168,10 +177,17 @@ async function saveTokenToConfig(token: string): Promise<void> {
   );
 }
 
+/** Sync the resolved token to process.env so fly CLI subprocesses (ssh console) can authenticate. */
+function syncTokenToEnv(): void {
+  if (flyApiToken) {
+    process.env.FLY_API_TOKEN = flyApiToken;
+  }
+}
+
 function loadTokenFromConfig(): string | null {
   try {
     const data = JSON.parse(
-      require("fs").readFileSync(FLY_CONFIG_PATH, "utf-8"),
+      readFileSync(FLY_CONFIG_PATH, "utf-8"),
     );
     const token = data.api_key || data.token || "";
     if (!token) return null;
@@ -193,13 +209,12 @@ export function saveVmConnection(
   cloud: string,
 ): void {
   const dir = `${process.env.HOME}/.spawn`;
-  const fs = require("fs");
-  fs.mkdirSync(dir, { recursive: true });
+  mkdirSync(dir, { recursive: true });
   const json: Record<string, string> = { ip, user };
   if (serverId) json.server_id = serverId;
   if (serverName) json.server_name = serverName;
   if (cloud) json.cloud = cloud;
-  fs.writeFileSync(`${dir}/last-connection.json`, JSON.stringify(json) + "\n");
+  writeFileSync(`${dir}/last-connection.json`, JSON.stringify(json) + "\n");
 }
 
 // ─── Authentication ──────────────────────────────────────────────────────────
@@ -275,6 +290,7 @@ export async function ensureFlyToken(): Promise<void> {
     if (await testFlyToken()) {
       logInfo("Using Fly.io API token from environment");
       await saveTokenToConfig(flyApiToken);
+      syncTokenToEnv();
       return;
     }
     logWarn("FLY_API_TOKEN from environment is invalid or expired");
@@ -287,6 +303,7 @@ export async function ensureFlyToken(): Promise<void> {
     flyApiToken = sanitizeFlyToken(saved);
     if (await testFlyToken()) {
       logInfo("Using saved Fly.io API token");
+      syncTokenToEnv();
       return;
     }
     logWarn("Saved Fly.io token is invalid or expired");
@@ -308,6 +325,7 @@ export async function ensureFlyToken(): Promise<void> {
         if (await testFlyToken()) {
           logInfo("Using Fly.io API token from fly CLI");
           await saveTokenToConfig(flyApiToken);
+          syncTokenToEnv();
           return;
         }
         flyApiToken = "";
@@ -334,6 +352,7 @@ export async function ensureFlyToken(): Promise<void> {
       if (token) {
         flyApiToken = sanitizeFlyToken(token);
         await saveTokenToConfig(flyApiToken);
+        syncTokenToEnv();
         logInfo("Authenticated with Fly.io via OAuth");
         return;
       }
@@ -354,6 +373,7 @@ export async function ensureFlyToken(): Promise<void> {
     throw new Error("Invalid Fly.io token");
   }
   await saveTokenToConfig(flyApiToken);
+  syncTokenToEnv();
   logInfo("Using manually entered Fly.io API token");
 }
 
@@ -663,8 +683,7 @@ export async function uploadFile(
     throw new Error("Invalid remote path");
   }
   const flyCmd = getCmd()!;
-  const fs = require("fs");
-  const content: Buffer = fs.readFileSync(localPath);
+  const content: Buffer = readFileSync(localPath);
   const b64 = content.toString("base64");
   const proc = Bun.spawn(
     [flyCmd, "ssh", "console", "-a", flyAppName, "-C", `bash -c 'printf "%s" ${b64} | base64 -d > ${remotePath}'`],


### PR DESCRIPTION
## Summary

- **`getCmd()` filesystem fallback**: After `ensureFlyCli()` installs flyctl to `~/.fly/bin` and adds it to `process.env.PATH`, subprocess calls to `which` still can't find it because `Bun.spawnSync` inherits the original PATH from process start. Added a direct filesystem check of `~/.fly/bin/{fly,flyctl}` as a fallback.
- **`syncTokenToEnv()`**: `ensureFlyToken()` resolves the API token and saves it to config, but never writes it to `process.env.FLY_API_TOKEN`. When `fly ssh console` runs as a subprocess, it has no token and can't authenticate. Added `syncTokenToEnv()` on all 5 token resolution paths (env var, saved config, CLI session, OAuth login, manual paste).

## Test plan

- [x] `bash test/run.sh` — 110 passed, 0 failed
- [x] `bun build cli/src/fly/main.ts` — compiles cleanly
- [ ] Manual: fresh machine without flyctl, run `bash ./fly/claude.sh` — confirm flyctl installs and token passes through

🤖 Generated with [Claude Code](https://claude.com/claude-code)