### PR TITLE
fix: spawn delete broken for Fly.io after TypeScript rewrite

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.25",
+  "version": "0.5.26",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
**Why:** `spawn delete` always fails for Fly.io servers with a silent curl error (exit 22). After PR #1602 converted fly/ from bash to TypeScript, `fly/lib/common.sh` was removed — but `buildDeleteScript()` still generates a bash script that `eval "$(curl ...)"` it. The curl returns 404, the script fails, and users are left with orphaned Fly.io apps incurring charges.

## Root cause

`buildDeleteScript("fly", ...)` generates:
```bash
eval "$(curl -fsSL 'https://.../fly/lib/common.sh')"  # 404
ensure_fly_cli
ensure_fly_token
destroy_server "APP_NAME"
```
The file was removed in #1602 (TypeScript rewrite). The 404 error from curl doesn't match the `"404"/"not found"` string patterns in `execDeleteServer`, so it propagates as a raw failure.

## Fix

Add a fly-specific path in `execDeleteServer()` that calls `ensureFlyCli()`, `ensureFlyToken()`, and `destroyServer()` directly from the TypeScript `./fly/fly.js` module. Remove the dead `case "fly"` from `buildDeleteScript()`.

## Test plan
- [x] `bun test src/__tests__/fly*.test.ts` — 45 pass, 0 fail
- [x] `bun test src/__tests__/commands*.test.ts` — 293 pass, 0 fail
- [x] `bash test/run.sh` — 110 passed, 0 failed

-- refactor/code-health