### PR TITLE
fix: repair spawn delete for Fly.io servers

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.25",
+  "version": "0.5.26",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
**Why:** `spawn delete` always fails for Fly.io servers, leaving apps running and costing users money. After PR #1602 converted fly/ from bash to TypeScript, `fly/lib/common.sh` no longer exists — but `buildDeleteScript()` still generates a bash script that tries to `curl` it, getting a 404.

## Changes

### `cli/src/commands.ts`
- Added import for `destroyServer`, `ensureFlyCli`, `ensureFlyToken` from `./fly/fly.js`
- Added fly-specific path in `execDeleteServer()` that calls the TypeScript API directly instead of generating a bash script
- Updated `buildDeleteScript()` fly case to return empty string (handled by the new TS path)

### `cli/package.json`
- Version bump 0.5.25 -> 0.5.26

## Test plan
- [x] `bun test` — 3644 passed, 0 failed
- [x] `bash test/run.sh` — 110 passed, 0 failed

-- refactor/code-health