### PR TITLE
fix: fly ssh session forcibly closed during long installs

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- `fly ssh console` tears down the WireGuard transport when stdin closes, producing `session forcibly closed; the remote process may still be running`
- This killed long-running commands like `bun install -g openclaw` during provisioning
- Fix: keep the stdin pipe open for the command's lifetime instead of calling `stdin.end()` immediately. The pipe still blocks interactive prompts (no data flows), but flyctl no longer kills the session prematurely.
- Applied to `runServer`, `runServerCapture`, and `uploadFile`
- Bumps CLI to v0.5.27

## Root cause
The previous fix (#1628) changed stdin from `"inherit"` to `"pipe"` + `stdin.end()` to prevent hangs from interactive prompts. But `flyctl` interprets stdin EOF as "tear down the connection" — correct for short commands, fatal for long-running installs.

## Test plan
- [x] `bun test` passes (3,644 tests)
- [ ] `spawn openclaw fly` completes installation without "session forcibly closed"
- [ ] `spawn claude fly` still works (no interactive prompt hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)