### PR TITLE
fix: use openclaw curl installer to prevent fly ssh hang

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -349,7 +349,7 @@ export const agents: Record<string, AgentConfig> = {
     install: () =>
       installAgent(
         "openclaw",
-        "source ~/.bashrc && { (bun install -g openclaw >/dev/null 2>&1) || npm install -g openclaw@latest; }",
+        "curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard",
       ),
     envVars: (apiKey) => [
       `OPENROUTER_API_KEY=${apiKey}`,

--- a/test/mock-curl-script.sh
+++ b/test/mock-curl-script.sh
@@ -34,7 +34,7 @@ _parse_args() {
 _maybe_inject_error() {
     [ -n "${MOCK_ERROR_SCENARIO:-}" ] || return 1
     case "$URL" in
-        *openrouter.ai*|*raw.githubusercontent.com*|*claude.ai/install*|*bun.sh*|*nodesource*|*nodejs.org*|*opencode*|*zeroclaw*|*pip.pypa.io*|*get.docker.com*|*npmjs.org*|*github.com/*/releases*)
+        *openrouter.ai*|*raw.githubusercontent.com*|*claude.ai/install*|*bun.sh*|*nodesource*|*nodejs.org*|*openclaw.ai*|*opencode*|*zeroclaw*|*pip.pypa.io*|*get.docker.com*|*npmjs.org*|*github.com/*/releases*)
             return 1 ;;
     esac
     case "${MOCK_ERROR_SCENARIO}" in
@@ -65,7 +65,7 @@ _maybe_inject_error() {
 
 _handle_special_urls() {
     case "$URL" in
-        *claude.ai/install*|*bun.sh*|*nodesource*|*nodejs.org*|*opencode*install*|*zeroclaw*install*|\
+        *claude.ai/install*|*bun.sh*|*nodesource*|*nodejs.org*|*openclaw.ai*|*opencode*install*|*zeroclaw*install*|\
         *pip.pypa.io*|*get.docker.com*|*install.python-poetry.org*|\
         *npmjs.org*|*deb.nodesource.com*|*github.com/*/releases*|*cli.github.com*)
             printf '#!/bin/bash\nexit 0\n'


### PR DESCRIPTION
## Summary

- Replace `bun install -g openclaw` with `curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard`
- `bun install -g` spawns child processes that keep stdout/stderr FDs open, preventing `fly ssh console -C` from detecting EOF — causing the install step to hang indefinitely
- The official curl installer handles Node detection, installs cleanly, and `--no-onboard` skips the interactive wizard
- Added `*openclaw.ai*` to mock test URL passthrough patterns
- Bump CLI version to 0.5.28

Ref: https://docs.openclaw.ai/install

## Test plan

- [x] `bun test` — 3,644 tests pass
- [x] `bash test/run.sh` — 110 shell tests pass
- [ ] Manual: `spawn openclaw fly` completes install without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)