### PR TITLE
fix: combine openclaw gateway start + wait into single SSH session

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.28",
+  "version": "0.5.29",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- The old `preLaunch` flow for OpenClaw opened **up to 60+ separate `fly ssh console` sessions** to poll port 18789 after starting the gateway daemon
- Each session opens a new WireGuard tunnel — slow, flaky, and prone to "session forcibly closed"
- Combined everything into a single SSH session: start the daemon, then poll the port in-band with a `for` loop
- The loop's `sleep 1` + `echo` output also serves as a keepalive for flyctl
- Removed unused `runServerCapture` import
- Bumps CLI to v0.5.29

### Before (60+ SSH sessions)
```
SSH 1: setsid openclaw gateway &
SSH 2: nc -z 127.0.0.1 18789  → fail
SSH 3: nc -z 127.0.0.1 18789  → fail
...
SSH 15: nc -z 127.0.0.1 18789 → success
```

### After (1 SSH session)
```
SSH 1: setsid openclaw gateway &; for i in 1..60; do nc -z ... && exit 0; sleep 1; done
```

## Test plan
- [x] `bun test` passes (3,644 tests)
- [ ] `spawn openclaw fly` starts gateway without hanging or session drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)