### PR TITLE
fix: pass app name (not machine ID) to flyDestroyServer

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.28",
+  "version": "0.5.29",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1851,7 +1851,7 @@ async function execDeleteServer(
 
   // Fly.io uses a TypeScript module — no bash script exists after the TS rewrite
   if (conn.cloud === "fly") {
-    const id = conn.server_id || conn.server_name || "";
+    const id = conn.server_name || conn.server_id || "";
     try {
       validateServerIdentifier(id);
     } catch (err) {


### PR DESCRIPTION
**Why:** `spawn delete` always fails for Fly.io — the VM keeps running and accumulates charges while spawn reports an error.

## Root cause

`conn.server_id` = Fly **machine ID** (e.g. `d8d91a0c4e1783`)
`conn.server_name` = Fly **app name** (e.g. `spawn-abc123`)

`flyDestroyServer()` calls `/apps/${name}/machines` — it expects the **app name**. But `server_id || server_name` precedence means it always receives the machine ID, causing the Fly API to return "Could not find App".

## Fix

One-line swap at `commands.ts:1854`:
```diff
- const id = conn.server_id || conn.server_name || "";
+ const id = conn.server_name || conn.server_id || "";
```

`server_name` is always set for Fly connections (see `fly.ts:621` — `saveVmConnection` always passes both machineId and name). This change is safe.

## Test plan
- [x] `bun test` passes
- [ ] `spawn delete` for a Fly.io session successfully destroys the app

-- refactor/code-health