### PR TITLE
fix: Claude Code OOM on fly + visible keepalive dots

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- `claude install` downloads and runs a native binary that was getting OOM-killed on the default 1024MB Fly VM (`bash: line 150: 3731 Killed`). Bumped Claude's `vmMemory` to 2048MB.
- The SSH keepalive was printing visible dots (`.`) to stderr every 10s. Changed to spaces so they're invisible.
- Bumps CLI to v0.5.30

## Test plan
- [x] `bun test` passes (3,644 tests)
- [ ] `spawn claude fly` installs without OOM kill
- [ ] No visible dots in terminal output during install

🤖 Generated with [Claude Code](https://claude.com/claude-code)