### PR TITLE
feat: interactive VM size and volume prompts for Fly.io

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -21,8 +21,6 @@ import {
 
 export interface AgentConfig {
   name: string;
-  /** Override default VM memory (1024 MB). */
-  vmMemory?: number;
   /** If true, prompt for model selection before provisioning. */
   modelPrompt?: boolean;
   /** Default model ID when modelPrompt is true. */
@@ -323,7 +321,6 @@ export const agents: Record<string, AgentConfig> = {
 
   openclaw: {
     name: "OpenClaw",
-    vmMemory: 2048,
     modelPrompt: true,
     modelDefault: "openrouter/auto",
     install: () =>


### PR DESCRIPTION
## Summary
- Users now choose VM size from 3 tiers (1x/2x/4x shared CPU) via interactive prompt instead of getting a hardcoded default
- Volume creation is opt-in: users are asked whether to mount a persistent volume, and can create new or attach existing
- `FLY_VM_MEMORY` env var skips the prompt for CI/headless use
- Removed `vmMemory` from `AgentConfig` — VM sizing is user-chosen, not agent-dictated

## Test plan
- [x] `bun test` passes (49 fly tests, 3648 total)
- [ ] `spawn claude fly` prompts for VM size (default 2x/4GB) and volume (default no)
- [ ] `FLY_VM_MEMORY=4096 spawn claude fly` skips VM size prompt
- [ ] Selecting "existing volume" lists volumes from a specified app

🤖 Generated with [Claude Code](https://claude.com/claude-code)