### PR TITLE
fix: replace require("path") with ESM import in security.ts

### DIFF
--- a/cli/src/security.ts
+++ b/cli/src/security.ts
@@ -3,6 +3,8 @@
  * SECURITY-CRITICAL: These functions protect against injection attacks
  */
 
+import { resolve } from "path";
+
 // Allowlist pattern for agent and cloud identifiers
 // Only lowercase alphanumeric, hyphens, and underscores allowed
 const IDENTIFIER_PATTERN = /^[a-z0-9_-]+$/;
@@ -365,7 +367,6 @@ export function validatePromptFilePath(filePath: string): void {
   }
 
   // Normalize the path to resolve .. and symlink-like textual tricks
-  const { resolve } = require("path");
   const resolved = resolve(filePath);
 
   // Check against sensitive path patterns


### PR DESCRIPTION
**Why:** `cli/src/security.ts` used CJS `require("path")` in the `validatePromptFilePath` function, violating the project's ESM-only rule (CLAUDE.md: "NEVER use `require()` — always use `import`"). This rule exists because `require()` can trigger Bun bugs in ESM-mode projects. The fix replaces it with a top-level `import { resolve } from "path"`.

## Changes
- Added `import { resolve } from "path"` at the top of `cli/src/security.ts`
- Removed inline `const { resolve } = require("path")` at line 368

## Test plan
- [x] `bun test` passes (3644/3644 tests, 0 failures)
- [x] No behavior change — `path.resolve` works identically via ESM import

Agent: code-health