### PR TITLE
feat: add "Enter agent" option to spawn ls

### DIFF
--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -233,6 +233,7 @@ export function saveVmConnection(
   serverId: string,
   serverName: string,
   cloud: string,
+  launchCmd?: string,
 ): void {
   const dir = `${process.env.HOME}/.spawn`;
   mkdirSync(dir, { recursive: true });
@@ -240,7 +241,20 @@ export function saveVmConnection(
   if (serverId) json.server_id = serverId;
   if (serverName) json.server_name = serverName;
   if (cloud) json.cloud = cloud;
+  if (launchCmd) json.launch_cmd = launchCmd;
   writeFileSync(`${dir}/last-connection.json`, JSON.stringify(json) + "\n");
+}
+
+/** Append launch_cmd to the last-connection.json file */
+export function saveLaunchCmd(launchCmd: string): void {
+  const connFile = `${process.env.HOME}/.spawn/last-connection.json`;
+  try {
+    const data = JSON.parse(readFileSync(connFile, "utf-8"));
+    data.launch_cmd = launchCmd;
+    writeFileSync(connFile, JSON.stringify(data) + "\n");
+  } catch {
+    // Connection file may not exist — non-fatal
+  }
 }
 
 // ─── Authentication ──────────────────────────────────────────────────────────

--- a/cli/src/fly/main.ts
+++ b/cli/src/fly/main.ts
@@ -11,6 +11,7 @@ import {
   waitForCloudInit,
   runServer,
   interactiveSession,
+  saveLaunchCmd,
   listVolumes,
   FLY_VM_TIERS,
   DEFAULT_VM_TIER,
@@ -185,7 +186,9 @@ async function main() {
   logStep("Starting agent...");
   await new Promise((r) => setTimeout(r, 1000));
 
-  const exitCode = await interactiveSession(agent.launchCmd());
+  const launchCmd = agent.launchCmd();
+  saveLaunchCmd(launchCmd);
+  const exitCode = await interactiveSession(launchCmd);
   process.exit(exitCode);
 }
 

--- a/cli/src/history.ts
+++ b/cli/src/history.ts
@@ -11,6 +11,7 @@ export interface VMConnection {
   cloud?: string;
   deleted?: boolean;
   deleted_at?: string;
+  launch_cmd?: string;
   metadata?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary
- Adds **"Enter {agent}"** as the first option when selecting a spawn from `spawn ls`, which SSHes into the VM and launches the agent directly (instead of just opening a plain SSH shell)
- Captures the exact launch command at spawn time and stores it in `~/.spawn/last-connection.json`, so dynamic state (PATH setup, env sourcing, pre-launch daemons) is preserved for reconnection
- Renames the old "Reconnect to existing VM" to "SSH into VM" for clarity

## Test plan
- [x] `bun test` — 3648 tests pass
- [x] `bash test/run.sh` — 110 tests pass
- [x] `bash -n shared/common.sh` — syntax OK
- [ ] Manual: `spawn ls` → select entry → verify "Enter agent" appears as first option
- [ ] Manual: select "Enter agent" → verify agent launches over SSH
- [ ] Manual: select "SSH into VM" → verify plain SSH shell (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)