### PR TITLE
feat: add dedicated CPU VM tiers for Fly.io

### DIFF
--- a/cli/src/__tests__/fly.test.ts
+++ b/cli/src/__tests__/fly.test.ts
@@ -142,26 +142,23 @@ describe("fly/lib/fly", () => {
   });
 
   describe("FLY_VM_TIERS", () => {
-    it("has 3 tiers", () => {
-      expect(FLY_VM_TIERS.length).toBe(3);
+    it("has shared and dedicated tiers", () => {
+      expect(FLY_VM_TIERS.length).toBe(6);
+      expect(FLY_VM_TIERS.filter((t) => t.cpuKind === "shared").length).toBe(3);
+      expect(FLY_VM_TIERS.filter((t) => t.cpuKind === "performance").length).toBe(3);
     });
 
-    it("default tier is shared-cpu-2x", () => {
-      expect(DEFAULT_VM_TIER.id).toBe("shared-cpu-2x");
+    it("default tier is performance-2x", () => {
+      expect(DEFAULT_VM_TIER.id).toBe("performance-2x");
+      expect(DEFAULT_VM_TIER.cpuKind).toBe("performance");
       expect(DEFAULT_VM_TIER.cpus).toBe(2);
       expect(DEFAULT_VM_TIER.memoryMb).toBe(4096);
-    });
-
-    it("tiers have increasing resources", () => {
-      for (let i = 1; i < FLY_VM_TIERS.length; i++) {
-        expect(FLY_VM_TIERS[i].cpus).toBeGreaterThan(FLY_VM_TIERS[i - 1].cpus);
-        expect(FLY_VM_TIERS[i].memoryMb).toBeGreaterThan(FLY_VM_TIERS[i - 1].memoryMb);
-      }
     });
 
     it("all tiers have required fields", () => {
       for (const tier of FLY_VM_TIERS) {
         expect(tier.id).toBeTruthy();
+        expect(tier.cpuKind === "shared" || tier.cpuKind === "performance").toBe(true);
         expect(tier.cpus).toBeGreaterThan(0);
         expect(tier.memoryMb).toBeGreaterThan(0);
         expect(tier.label).toBeTruthy();

--- a/cli/src/fly/main.ts
+++ b/cli/src/fly/main.ts
@@ -29,11 +29,11 @@ async function promptVmOptions(): Promise<ServerOptions> {
   if (process.env.FLY_VM_MEMORY) {
     const memoryMb = parseInt(process.env.FLY_VM_MEMORY, 10);
     const tier = FLY_VM_TIERS.find((t) => t.memoryMb === memoryMb) || DEFAULT_VM_TIER;
-    return { cpus: tier.cpus, memoryMb: tier.memoryMb };
+    return { cpuKind: tier.cpuKind, cpus: tier.cpus, memoryMb: tier.memoryMb };
   }
 
   if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    return { cpus: DEFAULT_VM_TIER.cpus, memoryMb: DEFAULT_VM_TIER.memoryMb };
+    return { cpuKind: DEFAULT_VM_TIER.cpuKind, cpus: DEFAULT_VM_TIER.cpus, memoryMb: DEFAULT_VM_TIER.memoryMb };
   }
 
   // VM size prompt
@@ -42,7 +42,7 @@ async function promptVmOptions(): Promise<ServerOptions> {
   const tierId = await selectFromList(tierItems, "VM size", DEFAULT_VM_TIER.id);
   const selectedTier = FLY_VM_TIERS.find((t) => t.id === tierId) || DEFAULT_VM_TIER;
 
-  return { cpus: selectedTier.cpus, memoryMb: selectedTier.memoryMb };
+  return { cpuKind: selectedTier.cpuKind, cpus: selectedTier.cpus, memoryMb: selectedTier.memoryMb };
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

- Add 3 dedicated (performance) CPU tiers alongside the existing 3 shared tiers:
  - `performance-1x`: 1 dedicated vCPU, 2 GB (~$32/mo)
  - `performance-2x`: 2 dedicated vCPUs, 4 GB (~$63/mo)
  - `performance-4x`: 4 dedicated vCPUs, 8 GB (~$126/mo)
- Thread `cpuKind` (`"shared"` | `"performance"`) through `ServerOptions` → `createMachine` → Machines API `cpu_kind`
- **Default changed from `shared-cpu-2x` to `performance-2x`** (dedicated 4 GB)

## Test plan

- [x] `bun test` — 3647 tests pass
- [ ] `spawn claude fly` → select a `performance-*` tier → verify machine created with `cpu_kind: "performance"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)