### PR TITLE
fix: install OpenClaw via bun on Fly.io

### DIFF
--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -347,7 +347,7 @@ export const agents: Record<string, AgentConfig> = {
     install: () =>
       installAgent(
         "openclaw",
-        "curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard",
+        'export PATH="$HOME/.bun/bin:$HOME/.local/bin:$PATH" && bun install -g openclaw && command -v openclaw',
       ),
     envVars: (apiKey) => [
       `OPENROUTER_API_KEY=${apiKey}`,


### PR DESCRIPTION
## Summary

- Replace `curl -fsSL https://openclaw.ai/install.sh | bash` with `bun install -g openclaw` for Fly.io OpenClaw installs
- Consistent with how Hetzner, AWS, and other VM clouds install OpenClaw
- Bun and Node.js are already installed during Fly's cloud-init phase (`waitForCloudInit`)

## Test plan

- [x] `bun test` — fly tests pass
- [ ] `spawn openclaw fly` → verify OpenClaw installs via bun and launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)