### PR TITLE
chore: bump CLI version to 0.5.32

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Bump CLI patch version 0.5.31 → 0.5.32

🤖 Generated with [Claude Code](https://claude.com/claude-code)