### PR TITLE
fix: align Fly.io Node.js install with other clouds

### DIFF
--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -127,8 +127,8 @@ async function installClaudeCode(): Promise<void> {
     `curl -fsSL https://claude.ai/install.sh | bash || true`,
     `export PATH="${claudePath}:$PATH"`,
     `if command -v claude >/dev/null 2>&1; then ${finalize}; exit 0; fi`,
-    // Ensure Node.js for npm method
-    `if ! command -v node >/dev/null 2>&1; then curl -fsSL https://nodejs.org/dist/v22.15.0/node-v22.15.0-linux-x64.tar.xz | tar -xJ -C /usr/local --strip-components=1 || true; fi`,
+    // Ensure Node.js for npm method (should already be installed by cloud-init)
+    `if ! command -v node >/dev/null 2>&1; then apt-get update -y && apt-get install -y --no-install-recommends nodejs npm && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx || true; fi`,
     // Method 2: npm
     `echo "==> Installing Claude Code (method 2/2: npm)..."`,
     `npm install -g @anthropic-ai/claude-code || true`,

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -866,19 +866,18 @@ export async function waitForCloudInit(): Promise<void> {
   logStep("Installing packages (bun, Node.js)...");
   // Batch all package installs into a single remote script to avoid multiple
   // round-trips (each of which was previously a separate fly machine exec call).
-  // Install bun first (single binary, no deps), then Node.js as a direct binary
-  // download from nodejs.org — no apt nodejs/npm/python3, no NodeSource, no n.
+  // Aligned with other clouds: apt for base Node.js, then `n` to upgrade to v22 LTS.
   const setupScript = [
     `echo "==> Setting up workspace volume..."`,
     `if [ -d /data ]; then mkdir -p /data/work && ln -sf /data/work /root/work && echo 'cd /root/work 2>/dev/null' >> ~/.bashrc; fi`,
     `echo "==> Installing base packages..."`,
     `export DEBIAN_FRONTEND=noninteractive`,
-    `apt-get update -y && apt-get install -y --no-install-recommends curl unzip git ca-certificates xz-utils || true`,
+    `apt-get update -y && apt-get install -y --no-install-recommends curl unzip git ca-certificates zsh nodejs npm || true`,
+    `echo "==> Upgrading Node.js to v22 LTS..."`,
+    `npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx || true`,
     `echo "==> Checking bun..."`,
     `if ! command -v bun >/dev/null 2>&1 && [ ! -f "$HOME/.bun/bin/bun" ]; then curl -fsSL https://bun.sh/install | bash || true; fi`,
     `for rc in ~/.bashrc ~/.zshrc; do grep -q '.bun/bin' "$rc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"' >> "$rc"; done`,
-    `echo "==> Checking Node.js..."`,
-    `if ! command -v node >/dev/null 2>&1; then curl -fsSL https://nodejs.org/dist/v22.15.0/node-v22.15.0-linux-x64.tar.xz | tar -xJ -C /usr/local --strip-components=1 || true; fi`,
     `echo "node: $(node --version 2>/dev/null || echo not installed)"`,
   ].join('\n');
 


### PR DESCRIPTION
## Summary

- Replace direct nodejs.org tarball download with `apt install nodejs npm` + `n 22` upgrade — same approach used by all other clouds in `shared/common.sh` cloud-init
- Add `zsh` to base apt packages (matching other clouds' cloud-init userdata)
- Remove `xz-utils` (was only needed for the `.tar.xz` tarball)
- Align Claude Code's Node.js fallback in `agents.ts` to use apt+n too

## Test plan

- [x] `bun test` — fly tests pass
- [ ] `spawn claude fly` → verify Node.js v22 installed via apt+n
- [ ] `spawn openclaw fly` → verify bun + node both available

🤖 Generated with [Claude Code](https://claude.com/claude-code)