### PR TITLE
fix: pass spawn name through cmdRun and headless flows

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -69,6 +69,7 @@ const KNOWN_FLAGS = new Set([
   "--debug",
   "--headless",
   "--output",
+  "--name",
   "--default",
   "-a", "-c", "--agent", "--cloud",
   "--clear",
@@ -101,6 +102,7 @@ function checkUnknownFlags(args: string[]): void {
       console.error(`    ${pc.cyan("--debug")}             Show all commands being executed`);
       console.error(`    ${pc.cyan("--headless")}          Non-interactive mode (no prompts, no SSH session)`);
       console.error(`    ${pc.cyan("--output json")}       Output structured JSON to stdout`);
+      console.error(`    ${pc.cyan("--name")}              Set the spawn/resource name`);
       console.error(`    ${pc.cyan("--help, -h")}          Show help information`);
       console.error(`    ${pc.cyan("--version, -v")}       Show version`);
       console.error();
@@ -169,7 +171,7 @@ async function handleDefaultCommand(agent: string, cloud: string | undefined, pr
       }
       process.exit(3);
     }
-    await cmdRunHeadless(agent, cloud, { prompt, debug, outputFormat });
+    await cmdRunHeadless(agent, cloud, { prompt, debug, outputFormat, spawnName: process.env.SPAWN_NAME });
     return;
   }
   if (cloud) {
@@ -569,6 +571,18 @@ async function main(): Promise<void> {
     console.error(pc.red(`Error: --output only supports "json" (got "${outputFormat}")`));
     console.error(`\nUsage: ${pc.cyan("spawn <agent> <cloud> --headless --output json")}`);
     process.exit(1);
+  }
+
+  // Extract --name <value> flag
+  const [nameFlag, nameFilteredArgs] = extractFlagValue(
+    filteredArgs,
+    ["--name"],
+    "spawn name",
+    'spawn <agent> <cloud> --name "my-dev-box"'
+  );
+  filteredArgs.splice(0, filteredArgs.length, ...nameFilteredArgs);
+  if (nameFlag) {
+    process.env.SPAWN_NAME = nameFlag;
   }
 
   // --output implies --headless


### PR DESCRIPTION
## Summary
- `cmdRun` (`spawn <agent> <cloud>`) was not collecting or passing the spawn name — `SPAWN_NAME` was never set in the script env, and the history record had no name
- `cmdRunHeadless` had the same gap, so headless spawns all defaulted to "spawn"
- Adds `--name` CLI flag for explicitly setting the spawn name (useful for headless/CI flows)
- `promptSpawnName()` now skips the interactive prompt when `SPAWN_NAME` is already set

## Test plan
- [x] `bun test` — 3647 tests pass
- [x] `bash test/run.sh` — 110 tests pass
- [ ] Manual: `spawn claude aws` prompts for name and passes it to the script
- [ ] Manual: `spawn claude aws --name "my-box"` skips name prompt, uses "my-box"
- [ ] Manual: `spawn claude aws --headless --name "ci-box"` sets SPAWN_NAME in script env

🤖 Generated with [Claude Code](https://claude.com/claude-code)