### PR TITLE
fix: pin zeroclaw installer to stable commit SHA

### DIFF
--- a/aws/zeroclaw.sh
+++ b/aws/zeroclaw.sh
@@ -16,7 +16,7 @@ echo ""
 
 agent_install() {
     install_agent "ZeroClaw" \
-        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
+        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
         cloud_run
 }
 

--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -386,7 +386,7 @@ export const agents: Record<string, AgentConfig> = {
     install: () =>
       installAgent(
         "ZeroClaw",
-        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash -s -- --install-rust --install-system-deps",
+        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps",
       ),
     envVars: (apiKey) => [
       `OPENROUTER_API_KEY=${apiKey}`,

--- a/daytona/zeroclaw.sh
+++ b/daytona/zeroclaw.sh
@@ -16,7 +16,7 @@ echo ""
 
 agent_install() {
     install_agent "ZeroClaw" \
-        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
+        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
         cloud_run
 }
 

--- a/digitalocean/zeroclaw.sh
+++ b/digitalocean/zeroclaw.sh
@@ -16,7 +16,7 @@ echo ""
 
 agent_install() {
     install_agent "ZeroClaw" \
-        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
+        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
         cloud_run
 }
 

--- a/gcp/zeroclaw.sh
+++ b/gcp/zeroclaw.sh
@@ -16,7 +16,7 @@ echo ""
 
 agent_install() {
     install_agent "ZeroClaw" \
-        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
+        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
         cloud_run
 }
 

--- a/hetzner/zeroclaw.sh
+++ b/hetzner/zeroclaw.sh
@@ -17,7 +17,7 @@ echo ""
 
 agent_install() {
     install_agent "ZeroClaw" \
-        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
+        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
         cloud_run
 }
 

--- a/local/zeroclaw.sh
+++ b/local/zeroclaw.sh
@@ -16,7 +16,7 @@ echo ""
 
 agent_install() {
     install_agent "ZeroClaw" \
-        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash -s -- --install-rust" \
+        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust" \
         cloud_run
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -95,7 +95,7 @@
       "name": "ZeroClaw",
       "description": "Fast, small, fully autonomous AI assistant infrastructure \u2014 deploy anywhere, swap anything",
       "url": "https://github.com/zeroclaw-labs/zeroclaw",
-      "install": "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash -s -- --install-rust --install-system-deps",
+      "install": "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps",
       "launch": "zeroclaw agent",
       "env": {
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",

--- a/sprite/zeroclaw.sh
+++ b/sprite/zeroclaw.sh
@@ -16,7 +16,7 @@ echo ""
 
 agent_install() {
     install_agent "ZeroClaw" \
-        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
+        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps" \
         cloud_run
 }
 


### PR DESCRIPTION
## Summary

- Pins all zeroclaw installer URLs from mutable `main` branch to commit SHA `a117be64fdaa31779204beadf2942c8aef57d0e5`
- Prevents supply chain attack vector where a compromised `main` branch could inject malicious code via `curl|bash` installer
- Updated across 7 shell scripts, `cli/src/fly/agents.ts`, and `manifest.json`

## What about bun.sh, claude.ai, sprites.dev?

These use HTTPS to vendor-controlled domains with no stable commit SHA to pin to. They follow industry-standard installer patterns (same as Homebrew, Rust, Node.js installers) and are left as-is. The primary risk vector (DNS poisoning) is already mitigated by HTTPS.

## Test plan

- [x] `bash -n` syntax check on all 7 modified shell scripts
- [x] All 67 tests pass via `bash test/run.sh` (0 failures)
- [x] Verified no remaining references to `zeroclaw-labs/zeroclaw/main`

Fixes #1670

-- refactor/ux-engineer