### PR TITLE
feat: pre-built Docker image for OpenClaw on Fly.io

### DIFF
--- a/.github/workflows/fly-docker.yml
+++ b/.github/workflows/fly-docker.yml
@@ -1,0 +1,34 @@
+name: Build Fly Docker Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "fly/docker/openclaw.Dockerfile"
+  schedule:
+    # Daily: pick up new openclaw releases
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  build-openclaw:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: fly/docker/openclaw.Dockerfile
+          push: true
+          tags: ghcr.io/openrouterteam/spawn-openclaw:latest

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -567,11 +567,12 @@ async function createMachine(
   cpus: number,
   vmMemory: number,
   volumeId?: string,
+  image?: string,
 ): Promise<string> {
   const kindLabel = cpuKind === "performance" ? "dedicated" : "shared";
   logStep(`Creating Fly.io machine (region: ${region}, ${cpus} ${kindLabel} vCPU, ${vmMemory}MB)...`);
   const config: Record<string, unknown> = {
-    image: "ubuntu:24.04",
+    image: image || "ubuntu:24.04",
     guest: { cpu_kind: cpuKind, cpus, memory_mb: vmMemory },
     init: { exec: ["/bin/sleep", "inf"] },
     auto_destroy: false,
@@ -675,7 +676,7 @@ export async function listVolumes(appName: string): Promise<Array<{ id: string; 
     }));
 }
 
-export async function createServer(name: string, opts: ServerOptions): Promise<void> {
+export async function createServer(name: string, opts: ServerOptions, image?: string): Promise<void> {
   const region = process.env.FLY_REGION || "iad";
 
   if (!validateRegionName(region)) {
@@ -698,7 +699,7 @@ export async function createServer(name: string, opts: ServerOptions): Promise<v
 
   let machineId: string;
   try {
-    machineId = await createMachine(name, region, opts.cpuKind, opts.cpus, opts.memoryMb, volumeId);
+    machineId = await createMachine(name, region, opts.cpuKind, opts.cpus, opts.memoryMb, volumeId, image);
   } catch (err) {
     await cleanupOnFailure(name);
     throw err;

--- a/cli/src/fly/main.ts
+++ b/cli/src/fly/main.ts
@@ -9,6 +9,7 @@ import {
   createServer,
   getServerName,
   waitForCloudInit,
+  waitForSsh,
   runServer,
   interactiveSession,
   saveLaunchCmd,
@@ -89,10 +90,15 @@ async function main() {
 
   // 6. Provision server
   const serverName = await getServerName();
-  await createServer(serverName, serverOpts);
+  await createServer(serverName, serverOpts, agent.image);
 
   // 7. Wait for readiness
-  await waitForCloudInit();
+  if (agent.image) {
+    // Custom image already has packages baked in — just wait for SSH
+    await waitForSsh();
+  } else {
+    await waitForCloudInit();
+  }
 
   // 8. Install agent
   await agent.install();

--- a/fly/docker/openclaw.Dockerfile
+++ b/fly/docker/openclaw.Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base packages (matches waitForCloudInit in fly.ts)
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      curl git ca-certificates build-essential unzip xz-utils zsh && \
+    rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 via apt + n (matches fly.ts cloud-init strategy)
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends nodejs npm && \
+    npm install -g n && n 22 && \
+    ln -sf /usr/local/bin/node /usr/bin/node && \
+    ln -sf /usr/local/bin/npm /usr/bin/npm && \
+    ln -sf /usr/local/bin/npx /usr/bin/npx && \
+    rm -rf /var/lib/apt/lists/*
+
+# Bun
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:/root/.local/bin:${PATH}"
+
+# OpenClaw via bun (matches agents.ts install strategy)
+RUN bun install -g openclaw
+# Ensure tools are on PATH for all shells
+RUN for rc in /root/.bashrc /root/.zshrc; do \
+      grep -q '.bun/bin' "$rc" 2>/dev/null || \
+        echo 'export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"' >> "$rc"; \
+    done
+
+CMD ["/bin/sleep", "inf"]


### PR DESCRIPTION
## Summary
- Adds a Dockerfile (`fly/docker/openclaw.Dockerfile`) that pre-bakes Node.js, bun, and openclaw into an image
- Adds a GitHub Action (`.github/workflows/fly-docker.yml`) to build and push `ghcr.io/openrouterteam/spawn-openclaw:latest` daily + on Dockerfile changes
- Adds `image` field to `AgentConfig`, sets it on the openclaw agent
- Passes the image through `createServer` → `createMachine` to the Fly API
- Skips `waitForCloudInit()` when a custom image is set (just `waitForSsh()` instead)
- `install()` verifies openclaw is present (fast `command -v`), falls back to `bun install -g` if missing

## Test plan
- [ ] `docker build -f fly/docker/openclaw.Dockerfile -t spawn-openclaw .` builds locally
- [ ] `docker run --rm spawn-openclaw bash -c "command -v openclaw && openclaw --version"` — openclaw present
- [ ] `bun test` — existing tests pass
- [ ] Manual Fly.io deploy with openclaw confirms faster boot (skips cloud-init)
- [ ] Non-openclaw agents (claude, codex, etc.) still use ubuntu:24.04 + waitForCloudInit

🤖 Generated with [Claude Code](https://claude.com/claude-code)