### PR TITLE
feat: convert aws/ cloud provider from Bash to TypeScript

### DIFF
--- a/aws/claude.sh
+++ b/aws/claude.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
 set -eo pipefail
 
-# Source common functions - try local file first, fall back to remote
+# Thin shim: ensures bun is available, runs bundled aws.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-# shellcheck source=aws/lib/common.sh
-if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
-    source "${SCRIPT_DIR}/lib/common.sh"
-else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../cli/src/aws/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../cli/src/aws/main.ts" claude "$@"
 fi
+
+# Remote — fall back to bash implementation
+eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
 
 log_info "Claude Code on AWS Lightsail"
 echo ""

--- a/aws/codex.sh
+++ b/aws/codex.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 set -eo pipefail
 
+# Thin shim: ensures bun is available, runs bundled aws.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-# shellcheck source=aws/lib/common.sh
-if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
-    source "${SCRIPT_DIR}/lib/common.sh"
-else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../cli/src/aws/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../cli/src/aws/main.ts" codex "$@"
 fi
+
+# Remote — fall back to bash implementation
+eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
 
 log_info "Codex CLI on AWS Lightsail"
 echo ""

--- a/aws/kilocode.sh
+++ b/aws/kilocode.sh
@@ -2,13 +2,27 @@
 # shellcheck disable=SC2154
 set -eo pipefail
 
+# Thin shim: ensures bun is available, runs bundled aws.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-# shellcheck source=aws/lib/common.sh
-if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
-    source "${SCRIPT_DIR}/lib/common.sh"
-else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../cli/src/aws/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../cli/src/aws/main.ts" kilocode "$@"
 fi
+
+# Remote — fall back to bash implementation
+eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
 
 log_info "Kilo Code on AWS Lightsail"
 echo ""

--- a/aws/opencode.sh
+++ b/aws/opencode.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 set -eo pipefail
 
+# Thin shim: ensures bun is available, runs bundled aws.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-# shellcheck source=aws/lib/common.sh
-if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
-    source "${SCRIPT_DIR}/lib/common.sh"
-else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../cli/src/aws/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../cli/src/aws/main.ts" opencode "$@"
 fi
+
+# Remote — fall back to bash implementation
+eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
 
 log_info "OpenCode on AWS Lightsail"
 echo ""

--- a/aws/zeroclaw.sh
+++ b/aws/zeroclaw.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 set -eo pipefail
 
-# Source common functions - try local file first, fall back to remote
+# Thin shim: ensures bun is available, runs bundled aws.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-if [[ -f "${SCRIPT_DIR}/lib/common.sh" ]]; then
-    source "${SCRIPT_DIR}/lib/common.sh"
-else
-    eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../cli/src/aws/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../cli/src/aws/main.ts" zeroclaw "$@"
 fi
+
+# Remote — fall back to bash implementation
+eval "$(curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/aws/lib/common.sh)"
 
 log_info "ZeroClaw on AWS Lightsail"
 echo ""

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.5.35",
+  "version": "0.6.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/aws/agents.ts
+++ b/cli/src/aws/agents.ts
@@ -1,0 +1,375 @@
+// aws/agents.ts — Agent configs + shared install/config helpers for AWS Lightsail
+
+import { writeFileSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  logInfo,
+  logWarn,
+  logError,
+  logStep,
+  prompt,
+  jsonEscape,
+} from "../shared/ui";
+import {
+  runServer,
+  uploadFile,
+  runWithRetry,
+} from "./aws";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface AgentConfig {
+  name: string;
+  modelPrompt?: boolean;
+  modelDefault?: string;
+  preProvision?: () => Promise<void>;
+  install: () => Promise<void>;
+  envVars: (apiKey: string) => string[];
+  configure?: (apiKey: string, modelId?: string) => Promise<void>;
+  preLaunch?: () => Promise<void>;
+  launchCmd: () => string;
+}
+
+// ─── Shared Helpers ──────────────────────────────────────────────────────────
+
+export function generateEnvConfig(pairs: string[]): string {
+  const lines = [
+    "",
+    "# [spawn:env]",
+    "export IS_SANDBOX='1'",
+  ];
+  for (const pair of pairs) {
+    const eqIdx = pair.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = pair.slice(0, eqIdx);
+    const value = pair.slice(eqIdx + 1);
+    if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) {
+      logError(`SECURITY: Invalid environment variable name rejected: ${key}`);
+      continue;
+    }
+    const escaped = value.replace(/'/g, "'\\''");
+    lines.push(`export ${key}='${escaped}'`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+async function installAgent(agentName: string, installCmd: string): Promise<void> {
+  logStep(`Installing ${agentName}...`);
+  try {
+    await runServer(installCmd, 300);
+  } catch {
+    logError(`${agentName} installation failed`);
+    throw new Error(`${agentName} install failed`);
+  }
+  logInfo(`${agentName} installation completed`);
+}
+
+async function uploadConfigFile(
+  content: string,
+  remotePath: string,
+): Promise<void> {
+  const tmpFile = join(tmpdir(), `spawn_config_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+  writeFileSync(tmpFile, content, { mode: 0o600 });
+
+  const tempRemote = `/tmp/spawn_config_${Date.now()}`;
+  try {
+    await uploadFile(tmpFile, tempRemote);
+    await runServer(
+      `mkdir -p $(dirname "${remotePath}") && chmod 600 '${tempRemote}' && mv '${tempRemote}' "${remotePath}"`,
+    );
+  } finally {
+    try { unlinkSync(tmpFile); } catch { /* ignore */ }
+  }
+}
+
+// ─── Claude Code ─────────────────────────────────────────────────────────────
+
+async function installClaudeCode(): Promise<void> {
+  logStep("Installing Claude Code...");
+
+  const claudePath = '$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin';
+  const pathSetup = `for rc in ~/.bashrc ~/.zshrc; do grep -q '.claude/local/bin' "$rc" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH="$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH"\\n' >> "$rc"; done`;
+  const finalize = `claude install --force 2>/dev/null || true; ${pathSetup}`;
+
+  const script = [
+    `export PATH="${claudePath}:$PATH"`,
+    `if [ -f ~/.bash_profile ] && grep -q 'spawn:env\\|Claude Code PATH\\|spawn:path' ~/.bash_profile 2>/dev/null; then rm -f ~/.bash_profile; fi`,
+    `if command -v claude >/dev/null 2>&1; then ${finalize}; exit 0; fi`,
+    `echo "==> Installing Claude Code (method 1/2: curl installer)..."`,
+    `curl -fsSL https://claude.ai/install.sh | bash || true`,
+    `export PATH="${claudePath}:$PATH"`,
+    `if command -v claude >/dev/null 2>&1; then ${finalize}; exit 0; fi`,
+    `if ! command -v node >/dev/null 2>&1; then apt-get update -y && apt-get install -y --no-install-recommends nodejs npm && npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx || true; fi`,
+    `echo "==> Installing Claude Code (method 2/2: npm)..."`,
+    `npm install -g @anthropic-ai/claude-code || true`,
+    `export PATH="${claudePath}:$PATH"`,
+    `if command -v claude >/dev/null 2>&1; then ${finalize}; exit 0; fi`,
+    `exit 1`,
+  ].join('\n');
+
+  try {
+    await runServer(script, 300);
+    logInfo("Claude Code installed");
+  } catch {
+    logError("Claude Code installation failed");
+    throw new Error("Claude Code install failed");
+  }
+}
+
+async function setupClaudeCodeConfig(apiKey: string): Promise<void> {
+  logStep("Configuring Claude Code...");
+
+  const escapedKey = jsonEscape(apiKey);
+  const settingsJson = `{
+  "theme": "dark",
+  "editor": "vim",
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
+    "ANTHROPIC_AUTH_TOKEN": ${escapedKey}
+  },
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "dangerouslySkipPermissions": true
+  }
+}`;
+  const globalState = `{
+  "hasCompletedOnboarding": true,
+  "bypassPermissionsModeAccepted": true
+}`;
+
+  const settingsB64 = Buffer.from(settingsJson).toString("base64");
+  const stateB64 = Buffer.from(globalState).toString("base64");
+
+  await runServer(
+    `mkdir -p ~/.claude && printf '%s' '${settingsB64}' | base64 -d > ~/.claude/settings.json && chmod 600 ~/.claude/settings.json && printf '%s' '${stateB64}' | base64 -d > ~/.claude.json && chmod 600 ~/.claude.json && touch ~/.claude/CLAUDE.md`,
+  );
+  logInfo("Claude Code configured");
+}
+
+// ─── GitHub Auth ─────────────────────────────────────────────────────────────
+
+let githubAuthRequested = false;
+let githubToken = "";
+
+async function promptGithubAuth(): Promise<void> {
+  if (process.env.SPAWN_SKIP_GITHUB_AUTH) return;
+  process.stderr.write("\n");
+  const choice = await prompt("Set up GitHub CLI (gh) on this machine? (y/N): ");
+  if (/^[Yy]$/.test(choice)) {
+    githubAuthRequested = true;
+    if (process.env.GITHUB_TOKEN) {
+      githubToken = process.env.GITHUB_TOKEN;
+    } else {
+      try {
+        const result = Bun.spawnSync(["gh", "auth", "token"], {
+          stdio: ["ignore", "pipe", "ignore"],
+        });
+        if (result.exitCode === 0) {
+          githubToken = new TextDecoder().decode(result.stdout).trim();
+        }
+      } catch { /* ignore */ }
+    }
+  }
+}
+
+export async function offerGithubAuth(): Promise<void> {
+  if (process.env.SPAWN_SKIP_GITHUB_AUTH) return;
+  if (!githubAuthRequested) return;
+
+  let ghCmd = "curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/shared/github-auth.sh | bash";
+  let localTmpFile = "";
+  if (githubToken) {
+    const escaped = githubToken.replace(/'/g, "'\\''");
+    localTmpFile = join(tmpdir(), `gh_token_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+    writeFileSync(localTmpFile, `export GITHUB_TOKEN='${escaped}'`, { mode: 0o600 });
+    const remoteTmpFile = `/tmp/gh_token_${Date.now()}`;
+    try {
+      await uploadFile(localTmpFile, remoteTmpFile);
+      ghCmd = `. ${remoteTmpFile} && rm -f ${remoteTmpFile} && ${ghCmd}`;
+    } catch {
+      try { unlinkSync(localTmpFile); } catch { /* ignore */ }
+      localTmpFile = "";
+    }
+  }
+
+  logStep("Installing and authenticating GitHub CLI...");
+  try {
+    await runServer(ghCmd);
+  } catch {
+    logWarn("GitHub CLI setup failed (non-fatal, continuing)");
+  } finally {
+    if (localTmpFile) {
+      try { unlinkSync(localTmpFile); } catch { /* ignore */ }
+    }
+  }
+}
+
+// ─── Codex CLI Config ────────────────────────────────────────────────────────
+
+async function setupCodexConfig(apiKey: string): Promise<void> {
+  logStep("Configuring Codex CLI for OpenRouter...");
+  const config = `model = "openai/gpt-5-codex"
+model_provider = "openrouter"
+
+[model_providers.openrouter]
+name = "OpenRouter"
+base_url = "https://openrouter.ai/api/v1"
+env_key = "OPENROUTER_API_KEY"
+wire_api = "chat"
+`;
+  await uploadConfigFile(config, "$HOME/.codex/config.toml");
+}
+
+// ─── OpenClaw Config ─────────────────────────────────────────────────────────
+
+async function setupOpenclawConfig(
+  apiKey: string,
+  modelId: string,
+): Promise<void> {
+  logStep("Configuring openclaw...");
+  await runServer("mkdir -p ~/.openclaw");
+
+  const gatewayToken = crypto.randomUUID().replace(/-/g, "");
+  const escapedKey = jsonEscape(apiKey);
+  const escapedToken = jsonEscape(gatewayToken);
+  const escapedModel = jsonEscape(modelId);
+
+  const config = `{
+  "env": {
+    "OPENROUTER_API_KEY": ${escapedKey}
+  },
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "token": ${escapedToken}
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": ${escapedModel}
+      }
+    }
+  }
+}`;
+  await uploadConfigFile(config, "$HOME/.openclaw/openclaw.json");
+}
+
+async function startGateway(): Promise<void> {
+  logStep("Starting OpenClaw gateway daemon...");
+  await runServer(
+    `source ~/.spawnrc 2>/dev/null; export PATH=$(npm prefix -g 2>/dev/null)/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; ` +
+    `if command -v setsid >/dev/null 2>&1; then setsid openclaw gateway > /tmp/openclaw-gateway.log 2>&1 < /dev/null & ` +
+    `else nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 < /dev/null & fi`,
+  );
+  logInfo("OpenClaw gateway started");
+}
+
+// ─── OpenCode Install Command ────────────────────────────────────────────────
+
+function openCodeInstallCmd(): string {
+  return 'OC_ARCH=$(uname -m); case "$OC_ARCH" in aarch64) OC_ARCH=arm64;; x86_64) OC_ARCH=x64;; esac; OC_OS=$(uname -s | tr A-Z a-z); mkdir -p /tmp/opencode-install "$HOME/.opencode/bin" && curl -fsSL -o /tmp/opencode-install/oc.tar.gz "https://github.com/anomalyco/opencode/releases/latest/download/opencode-${OC_OS}-${OC_ARCH}.tar.gz" && tar xzf /tmp/opencode-install/oc.tar.gz -C /tmp/opencode-install && mv /tmp/opencode-install/opencode "$HOME/.opencode/bin/" && rm -rf /tmp/opencode-install && grep -q ".opencode/bin" "$HOME/.bashrc" 2>/dev/null || echo \'export PATH="$HOME/.opencode/bin:$PATH"\' >> "$HOME/.bashrc"; grep -q ".opencode/bin" "$HOME/.zshrc" 2>/dev/null || echo \'export PATH="$HOME/.opencode/bin:$PATH"\' >> "$HOME/.zshrc" 2>/dev/null; export PATH="$HOME/.opencode/bin:$PATH"';
+}
+
+// ─── Agent Definitions ───────────────────────────────────────────────────────
+
+export const agents: Record<string, AgentConfig> = {
+  claude: {
+    name: "Claude Code",
+    preProvision: promptGithubAuth,
+    install: installClaudeCode,
+    envVars: (apiKey) => [
+      `OPENROUTER_API_KEY=${apiKey}`,
+      "ANTHROPIC_BASE_URL=https://openrouter.ai/api",
+      `ANTHROPIC_AUTH_TOKEN=${apiKey}`,
+      "ANTHROPIC_API_KEY=",
+      "CLAUDE_CODE_SKIP_ONBOARDING=1",
+      "CLAUDE_CODE_ENABLE_TELEMETRY=0",
+    ],
+    configure: (apiKey) => setupClaudeCodeConfig(apiKey),
+    launchCmd: () =>
+      "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude",
+  },
+
+  codex: {
+    name: "Codex CLI",
+    install: () => installAgent("Codex CLI", "npm install -g @openai/codex"),
+    envVars: (apiKey) => [`OPENROUTER_API_KEY=${apiKey}`],
+    configure: (apiKey) => setupCodexConfig(apiKey),
+    launchCmd: () =>
+      "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex",
+  },
+
+  openclaw: {
+    name: "OpenClaw",
+    modelPrompt: true,
+    modelDefault: "openrouter/auto",
+    install: () =>
+      installAgent(
+        "openclaw",
+        'source ~/.bashrc && bun install -g openclaw',
+      ),
+    envVars: (apiKey) => [
+      `OPENROUTER_API_KEY=${apiKey}`,
+      `ANTHROPIC_API_KEY=${apiKey}`,
+      "ANTHROPIC_BASE_URL=https://openrouter.ai/api",
+    ],
+    configure: (apiKey, modelId) =>
+      setupOpenclawConfig(apiKey, modelId || "openrouter/auto"),
+    preLaunch: startGateway,
+    launchCmd: () =>
+      "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; openclaw tui",
+  },
+
+  opencode: {
+    name: "OpenCode",
+    install: () => installAgent("OpenCode", openCodeInstallCmd()),
+    envVars: (apiKey) => [`OPENROUTER_API_KEY=${apiKey}`],
+    launchCmd: () =>
+      "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode",
+  },
+
+  kilocode: {
+    name: "Kilo Code",
+    install: () => installAgent("Kilo Code", "npm install -g @kilocode/cli"),
+    envVars: (apiKey) => [
+      `OPENROUTER_API_KEY=${apiKey}`,
+      "KILO_PROVIDER_TYPE=openrouter",
+      `KILO_OPEN_ROUTER_API_KEY=${apiKey}`,
+    ],
+    launchCmd: () =>
+      "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode",
+  },
+
+  zeroclaw: {
+    name: "ZeroClaw",
+    install: () =>
+      installAgent(
+        "ZeroClaw",
+        "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps",
+      ),
+    envVars: (apiKey) => [
+      `OPENROUTER_API_KEY=${apiKey}`,
+      "ZEROCLAW_PROVIDER=openrouter",
+    ],
+    configure: async (apiKey) => {
+      await runServer(
+        `source ~/.spawnrc 2>/dev/null; export PATH="$HOME/.cargo/bin:$PATH"; zeroclaw onboard --api-key "\${OPENROUTER_API_KEY}" --provider openrouter`,
+      );
+    },
+    launchCmd: () =>
+      "source ~/.cargo/env 2>/dev/null; source ~/.spawnrc 2>/dev/null; zeroclaw agent",
+  },
+};
+
+export function resolveAgent(name: string): AgentConfig {
+  const agent = agents[name.toLowerCase()];
+  if (!agent) {
+    logError(`Unknown agent: ${name}`);
+    logError(`Available agents: ${Object.keys(agents).join(", ")}`);
+    throw new Error(`Unknown agent: ${name}`);
+  }
+  return agent;
+}

--- a/cli/src/aws/aws.ts
+++ b/cli/src/aws/aws.ts
@@ -1,0 +1,890 @@
+// aws/aws.ts — Core AWS Lightsail provider: auth, provisioning, SSH execution
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { createHash, createHmac } from "crypto";
+import {
+  logInfo,
+  logWarn,
+  logError,
+  logStep,
+  prompt,
+  selectFromList,
+  jsonEscape,
+  validateServerName,
+  validateRegionName,
+  toKebabCase,
+} from "../shared/ui";
+
+const DASHBOARD_URL = "https://lightsail.aws.amazon.com/";
+
+// ─── Lightsail Bundles ────────────────────────────────────────────────────────
+
+export interface Bundle {
+  id: string;
+  label: string;
+}
+
+export const BUNDLES: Bundle[] = [
+  { id: "nano_3_0", label: "nano \u00b7 2 vCPU \u00b7 512 MB \u00b7 $3.50/mo" },
+  { id: "micro_3_0", label: "micro \u00b7 2 vCPU \u00b7 1 GB \u00b7 $5/mo" },
+  { id: "small_3_0", label: "small \u00b7 2 vCPU \u00b7 2 GB \u00b7 $10/mo" },
+  { id: "medium_3_0", label: "medium \u00b7 2 vCPU \u00b7 4 GB \u00b7 $20/mo" },
+  { id: "large_3_0", label: "large \u00b7 2 vCPU \u00b7 8 GB \u00b7 $40/mo" },
+  { id: "xlarge_3_0", label: "xlarge \u00b7 2 vCPU \u00b7 16 GB \u00b7 $80/mo" },
+];
+
+export const DEFAULT_BUNDLE = BUNDLES[0]; // nano_3_0
+
+// ─── Lightsail Regions ────────────────────────────────────────────────────────
+
+export interface Region {
+  id: string;
+  label: string;
+}
+
+export const REGIONS: Region[] = [
+  { id: "us-east-1", label: "us-east-1 (N. Virginia)" },
+  { id: "us-west-2", label: "us-west-2 (Oregon)" },
+  { id: "eu-west-1", label: "eu-west-1 (Ireland)" },
+  { id: "eu-central-1", label: "eu-central-1 (Frankfurt)" },
+  { id: "ap-southeast-1", label: "ap-southeast-1 (Singapore)" },
+  { id: "ap-northeast-1", label: "ap-northeast-1 (Tokyo)" },
+];
+
+// ─── State ──────────────────────────────────────────────────────────────────
+
+let awsAccessKeyId = "";
+let awsSecretAccessKey = "";
+let awsSessionToken = "";
+let awsRegion = "us-east-1";
+let lightsailMode: "cli" | "rest" = "cli";
+let instanceName = "";
+let instanceIp = "";
+
+export function getState() {
+  return { awsRegion, lightsailMode, instanceName, instanceIp };
+}
+
+// ─── SSH Config ─────────────────────────────────────────────────────────────
+
+const SSH_USER = "ubuntu";
+const SSH_KEY_PATH = `${process.env.HOME}/.ssh/id_ed25519`;
+
+const SSH_OPTS = [
+  "-o", "StrictHostKeyChecking=no",
+  "-o", "UserKnownHostsFile=/dev/null",
+  "-o", "LogLevel=ERROR",
+  "-o", "ConnectTimeout=10",
+  "-i", SSH_KEY_PATH,
+];
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function parseJson(text: string): any {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+// ─── AWS CLI Wrapper ────────────────────────────────────────────────────────
+
+function awsCliSync(args: string[]): { exitCode: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync(["aws", ...args], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: process.env,
+  });
+  return {
+    exitCode: proc.exitCode,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+async function awsCli(args: string[]): Promise<string> {
+  const proc = Bun.spawn(["aws", ...args], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: process.env,
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`aws CLI failed: ${stderr.trim() || stdout.trim()}`);
+  }
+  return stdout.trim();
+}
+
+// ─── SigV4 REST API ─────────────────────────────────────────────────────────
+
+async function lightsailRest(target: string, body: string = "{}"): Promise<string> {
+  if (!awsAccessKeyId || !awsSecretAccessKey) {
+    throw new Error("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set for REST API calls");
+  }
+
+  const region = awsRegion;
+  const service = "lightsail";
+  const host = `lightsail.${region}.amazonaws.com`;
+
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const amzDate = `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}T${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}${pad(now.getUTCSeconds())}Z`;
+  const dateStamp = amzDate.slice(0, 8);
+
+  const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
+  const hmac = (k: Buffer | string, s: string) => createHmac("sha256", k).update(s).digest();
+
+  const payloadHash = sha256(body);
+  const ct = "application/x-amz-json-1.1";
+
+  const allHeaders: [string, string][] = [
+    ["content-type", ct],
+    ["host", host],
+    ["x-amz-date", amzDate],
+    ...(awsSessionToken ? [["x-amz-security-token", awsSessionToken] as [string, string]] : []),
+    ["x-amz-target", target],
+  ];
+
+  const canonicalHeaders = allHeaders.map(([k, v]) => `${k}:${v}`).join("\n") + "\n";
+  const signedHeaders = allHeaders.map(([k]) => k).join(";");
+
+  const canonicalRequest = ["POST", "/", "", canonicalHeaders, signedHeaders, payloadHash].join("\n");
+
+  const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+  const stringToSign = `AWS4-HMAC-SHA256\n${amzDate}\n${credentialScope}\n${sha256(canonicalRequest)}`;
+
+  const kDate = hmac(`AWS4${awsSecretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, service);
+  const kSigning = hmac(kService, "aws4_request");
+  const sig = hmac(kSigning, stringToSign).toString("hex");
+
+  const authHeader = `AWS4-HMAC-SHA256 Credential=${awsAccessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${sig}`;
+
+  const reqHeaders: Record<string, string> = Object.fromEntries(allHeaders.filter(([k]) => k !== "host"));
+  reqHeaders["Authorization"] = authHeader;
+
+  const resp = await fetch(`https://${host}/`, { method: "POST", headers: reqHeaders, body });
+  const text = await resp.text();
+
+  if (!resp.ok) {
+    let msg = "";
+    try {
+      const e = JSON.parse(text);
+      msg = e.message || e.Message || e.__type || "";
+    } catch { /* ignore */ }
+    throw new Error(`Lightsail API error (HTTP ${resp.status}) ${target}: ${msg || text}`);
+  }
+
+  return text;
+}
+
+// ─── AWS CLI Installation ───────────────────────────────────────────────────
+
+function hasAwsCli(): boolean {
+  return Bun.spawnSync(["which", "aws"], { stdio: ["ignore", "pipe", "ignore"] }).exitCode === 0;
+}
+
+async function installAwsCli(): Promise<void> {
+  logStep("Installing AWS CLI v2...");
+
+  // Try brew first
+  if (Bun.spawnSync(["which", "brew"], { stdio: ["ignore", "pipe", "ignore"] }).exitCode === 0) {
+    logInfo("Installing via Homebrew...");
+    const proc = Bun.spawn(["brew", "install", "awscli"], {
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+    if (await proc.exited === 0) {
+      logInfo("AWS CLI v2 installed via Homebrew");
+      return;
+    }
+    logWarn("Homebrew install failed, falling back to official installer...");
+  }
+
+  if (process.platform === "darwin") {
+    const proc = Bun.spawn(
+      ["sh", "-c", 'tmp=$(mktemp -d) && curl -fsSL "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "$tmp/AWSCLIV2.pkg" && sudo installer -pkg "$tmp/AWSCLIV2.pkg" -target / && rm -rf "$tmp"'],
+      { stdio: ["ignore", "inherit", "inherit"] },
+    );
+    if (await proc.exited !== 0) {
+      logError("AWS CLI install failed.");
+      logError("  Try manually: brew install awscli");
+      throw new Error("AWS CLI install failed");
+    }
+  } else {
+    const proc = Bun.spawn(
+      ["sh", "-c", 'tmp=$(mktemp -d) && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "$tmp/awscliv2.zip" && unzip -q "$tmp/awscliv2.zip" -d "$tmp" && sudo "$tmp/aws/install" && rm -rf "$tmp"'],
+      { stdio: ["ignore", "inherit", "inherit"] },
+    );
+    if (await proc.exited !== 0) {
+      logError("AWS CLI install failed.");
+      logError("  See: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html");
+      throw new Error("AWS CLI install failed");
+    }
+  }
+  logInfo("AWS CLI v2 installed");
+}
+
+export async function ensureAwsCli(): Promise<void> {
+  if (hasAwsCli()) {
+    logInfo("AWS CLI available");
+    return;
+  }
+
+  logWarn("AWS CLI is not installed.");
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    logInfo("Skipping AWS CLI install (non-interactive mode)");
+    return;
+  }
+
+  const choice = await prompt("Install AWS CLI now? [Y/n] ");
+  if (/^[Nn]/.test(choice)) {
+    logInfo("Skipping AWS CLI install.");
+    return;
+  }
+
+  await installAwsCli();
+}
+
+// ─── Authentication ─────────────────────────────────────────────────────────
+
+export async function authenticate(): Promise<void> {
+  const region = process.env.AWS_DEFAULT_REGION || process.env.LIGHTSAIL_REGION || "us-east-1";
+  awsRegion = region;
+
+  // 1. Try existing CLI with valid credentials
+  if (hasAwsCli()) {
+    const result = awsCliSync(["sts", "get-caller-identity"]);
+    if (result.exitCode === 0) {
+      lightsailMode = "cli";
+      process.env.AWS_DEFAULT_REGION = region;
+      logInfo(`AWS CLI ready, using region: ${region}`);
+      return;
+    }
+    logWarn("AWS CLI found but credentials invalid or expired");
+  }
+
+  // 2. Check env vars for REST mode
+  if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+    awsAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
+    awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+    awsSessionToken = process.env.AWS_SESSION_TOKEN || "";
+
+    if (hasAwsCli()) {
+      lightsailMode = "cli";
+      process.env.AWS_DEFAULT_REGION = region;
+      logInfo(`AWS CLI ready with env credentials, using region: ${region}`);
+      return;
+    }
+
+    lightsailMode = "rest";
+    logInfo("AWS CLI not available \u2014 using Lightsail REST API directly");
+    logInfo(`Using region: ${region}`);
+    return;
+  }
+
+  // 3. Interactive credential entry
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    logError("AWS credentials not found. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.");
+    throw new Error("No AWS credentials");
+  }
+
+  logStep("Enter your AWS credentials:");
+  const accessKey = await prompt("AWS Access Key ID: ");
+  if (!accessKey) throw new Error("No access key provided");
+  const secretKey = await prompt("AWS Secret Access Key: ");
+  if (!secretKey) throw new Error("No secret key provided");
+
+  process.env.AWS_ACCESS_KEY_ID = accessKey;
+  process.env.AWS_SECRET_ACCESS_KEY = secretKey;
+  process.env.AWS_DEFAULT_REGION = region;
+  awsAccessKeyId = accessKey;
+  awsSecretAccessKey = secretKey;
+
+  if (hasAwsCli()) {
+    const result = awsCliSync(["sts", "get-caller-identity"]);
+    if (result.exitCode === 0) {
+      lightsailMode = "cli";
+      logInfo(`AWS CLI configured, using region: ${region}`);
+      return;
+    }
+  }
+
+  lightsailMode = "rest";
+  logInfo("Using Lightsail REST API directly");
+  logInfo(`Using region: ${region}`);
+}
+
+// ─── Region Prompt ──────────────────────────────────────────────────────────
+
+export async function promptRegion(): Promise<void> {
+  if (process.env.AWS_DEFAULT_REGION || process.env.LIGHTSAIL_REGION) {
+    awsRegion = process.env.AWS_DEFAULT_REGION || process.env.LIGHTSAIL_REGION || "us-east-1";
+    return;
+  }
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    return;
+  }
+
+  process.stderr.write("\n");
+  const items = REGIONS.map((r) => `${r.id}|${r.label}`);
+  const selected = await selectFromList(items, "AWS region", "us-east-1");
+  awsRegion = selected;
+  process.env.AWS_DEFAULT_REGION = selected;
+  logInfo(`Using region: ${selected}`);
+}
+
+// ─── Bundle Prompt ──────────────────────────────────────────────────────────
+
+let selectedBundle = DEFAULT_BUNDLE.id;
+
+export async function promptBundle(): Promise<void> {
+  if (process.env.LIGHTSAIL_BUNDLE) {
+    selectedBundle = process.env.LIGHTSAIL_BUNDLE;
+    return;
+  }
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    return;
+  }
+
+  process.stderr.write("\n");
+  const items = BUNDLES.map((b) => `${b.id}|${b.label}`);
+  const selected = await selectFromList(items, "instance size", DEFAULT_BUNDLE.id);
+  selectedBundle = selected;
+  logInfo(`Using bundle: ${selected}`);
+}
+
+// ─── SSH Key Management ─────────────────────────────────────────────────────
+
+async function generateSshKeyIfMissing(): Promise<void> {
+  if (existsSync(SSH_KEY_PATH)) return;
+
+  logStep("Generating SSH key...");
+  const dir = SSH_KEY_PATH.replace(/\/[^/]+$/, "");
+  mkdirSync(dir, { recursive: true });
+  const proc = Bun.spawn(
+    ["ssh-keygen", "-t", "ed25519", "-f", SSH_KEY_PATH, "-N", "", "-q"],
+    { stdio: ["ignore", "ignore", "ignore"] },
+  );
+  if (await proc.exited !== 0) {
+    throw new Error("SSH key generation failed");
+  }
+  logInfo("SSH key generated");
+}
+
+export async function ensureSshKey(): Promise<void> {
+  await generateSshKeyIfMissing();
+
+  const pubPath = `${SSH_KEY_PATH}.pub`;
+  if (!existsSync(pubPath)) {
+    throw new Error(`SSH public key not found: ${pubPath}`);
+  }
+
+  const keyName = "spawn-key";
+  const pubKey = readFileSync(pubPath, "utf-8").trim();
+
+  if (lightsailMode === "cli") {
+    // Check if already registered
+    const check = awsCliSync(["lightsail", "get-key-pair", "--key-pair-name", keyName]);
+    if (check.exitCode === 0) {
+      logInfo("SSH key already registered with Lightsail");
+      return;
+    }
+
+    logStep("Importing SSH key to Lightsail...");
+    try {
+      await awsCli([
+        "lightsail", "import-key-pair",
+        "--key-pair-name", keyName,
+        "--public-key-base64", pubKey,
+      ]);
+    } catch {
+      // Race condition: another process may have imported it
+      const recheck = awsCliSync(["lightsail", "get-key-pair", "--key-pair-name", keyName]);
+      if (recheck.exitCode === 0) {
+        logInfo("SSH key already registered with Lightsail");
+        return;
+      }
+      throw new Error("Failed to import SSH key to Lightsail");
+    }
+    logInfo("SSH key imported to Lightsail");
+  } else {
+    // REST path
+    try {
+      await lightsailRest(
+        "Lightsail_20161128.GetKeyPair",
+        JSON.stringify({ keyPairName: keyName }),
+      );
+      logInfo("SSH key already registered with Lightsail");
+      return;
+    } catch {
+      // Key doesn't exist, import it
+    }
+
+    logStep("Importing SSH key to Lightsail via REST API...");
+    try {
+      await lightsailRest(
+        "Lightsail_20161128.ImportKeyPair",
+        JSON.stringify({ keyPairName: keyName, publicKeyBase64: pubKey }),
+      );
+    } catch {
+      // Race condition check
+      try {
+        await lightsailRest(
+          "Lightsail_20161128.GetKeyPair",
+          JSON.stringify({ keyPairName: keyName }),
+        );
+        logInfo("SSH key already registered with Lightsail");
+        return;
+      } catch {
+        throw new Error("Failed to import SSH key to Lightsail");
+      }
+    }
+    logInfo("SSH key imported to Lightsail");
+  }
+}
+
+// ─── Cloud-init User Data ───────────────────────────────────────────────────
+
+function getCloudInitUserdata(): string {
+  return `#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y --no-install-recommends curl unzip git zsh nodejs npm ca-certificates
+# Upgrade Node.js to v22 LTS
+npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx
+# Install Bun
+su - ubuntu -c 'curl -fsSL https://bun.sh/install | bash'
+# Install Claude Code
+su - ubuntu -c 'curl -fsSL https://claude.ai/install.sh | bash'
+# Configure npm global prefix
+su - ubuntu -c 'mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global'
+# Configure PATH
+echo 'export PATH="\${HOME}/.npm-global/bin:\${HOME}/.claude/local/bin:\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}"' >> /home/ubuntu/.bashrc
+echo 'export PATH="\${HOME}/.npm-global/bin:\${HOME}/.claude/local/bin:\${HOME}/.local/bin:\${HOME}/.bun/bin:\${PATH}"' >> /home/ubuntu/.zshrc
+chown ubuntu:ubuntu /home/ubuntu/.bashrc /home/ubuntu/.zshrc
+touch /home/ubuntu/.cloud-init-complete
+chown ubuntu:ubuntu /home/ubuntu/.cloud-init-complete
+`;
+}
+
+// ─── Provisioning ───────────────────────────────────────────────────────────
+
+export async function createInstance(name: string): Promise<void> {
+  const bundle = selectedBundle;
+  const region = awsRegion;
+  const az = `${region}a`;
+  const blueprint = "ubuntu_24_04";
+
+  if (!validateRegionName(region)) {
+    throw new Error("Invalid AWS region");
+  }
+
+  logStep(`Creating Lightsail instance '${name}' (bundle: ${bundle}, AZ: ${az})...`);
+
+  const userdata = getCloudInitUserdata();
+
+  if (lightsailMode === "cli") {
+    try {
+      await awsCli([
+        "lightsail", "create-instances",
+        "--instance-names", name,
+        "--availability-zone", az,
+        "--blueprint-id", blueprint,
+        "--bundle-id", bundle,
+        "--key-pair-name", "spawn-key",
+        "--user-data", userdata,
+      ]);
+    } catch (err) {
+      logError("Failed to create Lightsail instance");
+      logWarn("Common issues:");
+      logWarn("  - Instance limit reached for your account");
+      logWarn("  - Bundle unavailable in region");
+      logWarn("  - AWS credentials lack Lightsail permissions");
+      logWarn(`  - Instance name '${name}' already in use`);
+      throw err;
+    }
+  } else {
+    try {
+      await lightsailRest(
+        "Lightsail_20161128.CreateInstances",
+        JSON.stringify({
+          instanceNames: [name],
+          availabilityZone: az,
+          blueprintId: blueprint,
+          bundleId: bundle,
+          keyPairName: "spawn-key",
+          userData: userdata,
+        }),
+      );
+    } catch (err) {
+      logError("Failed to create Lightsail instance");
+      logWarn("Common issues:");
+      logWarn("  - Instance limit reached for your account");
+      logWarn("  - Bundle unavailable in region");
+      logWarn("  - Credentials lack lightsail:CreateInstances permission");
+      logWarn(`  - Instance name '${name}' already in use`);
+      throw err;
+    }
+  }
+
+  instanceName = name;
+  logInfo(`Instance creation initiated: ${name}`);
+}
+
+// ─── Wait for Instance ──────────────────────────────────────────────────────
+
+export async function waitForInstance(maxAttempts = 60): Promise<void> {
+  logStep("Waiting for instance to become running...");
+  const pollDelay = 5000;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let state = "";
+    let ip = "";
+
+    try {
+      if (lightsailMode === "cli") {
+        const resp = await awsCli([
+          "lightsail", "get-instance",
+          "--instance-name", instanceName,
+          "--query", "instance.state.name",
+          "--output", "text",
+        ]);
+        state = resp.trim();
+      } else {
+        const resp = await lightsailRest(
+          "Lightsail_20161128.GetInstance",
+          JSON.stringify({ instanceName }),
+        );
+        const data = parseJson(resp);
+        state = data?.instance?.state?.name || "";
+      }
+    } catch {
+      state = "";
+    }
+
+    if (state === "running") {
+      try {
+        if (lightsailMode === "cli") {
+          ip = await awsCli([
+            "lightsail", "get-instance",
+            "--instance-name", instanceName,
+            "--query", "instance.publicIpAddress",
+            "--output", "text",
+          ]);
+        } else {
+          const resp = await lightsailRest(
+            "Lightsail_20161128.GetInstance",
+            JSON.stringify({ instanceName }),
+          );
+          const data = parseJson(resp);
+          ip = data?.instance?.publicIpAddress || "";
+        }
+      } catch {
+        // ignore
+      }
+
+      instanceIp = ip.trim();
+      logInfo(`Instance running: IP=${instanceIp}`);
+
+      // Save connection info
+      saveVmConnection(instanceIp, SSH_USER, "", instanceName, "aws");
+      return;
+    }
+
+    logStep(`Instance state: ${state || "pending"} (${attempt}/${maxAttempts})`);
+    await sleep(pollDelay);
+  }
+
+  logError(`Instance did not become running after ${maxAttempts} checks`);
+  throw new Error("Instance start timeout");
+}
+
+// ─── Connection Tracking ────────────────────────────────────────────────────
+
+function saveVmConnection(
+  ip: string,
+  user: string,
+  serverId: string,
+  serverName: string,
+  cloud: string,
+): void {
+  const dir = `${process.env.HOME}/.spawn`;
+  mkdirSync(dir, { recursive: true });
+  const json: Record<string, string> = { ip, user };
+  if (serverId) json.server_id = serverId;
+  if (serverName) json.server_name = serverName;
+  if (cloud) json.cloud = cloud;
+  writeFileSync(`${dir}/last-connection.json`, JSON.stringify(json) + "\n");
+}
+
+export function saveLaunchCmd(launchCmd: string): void {
+  const connFile = `${process.env.HOME}/.spawn/last-connection.json`;
+  try {
+    const data = JSON.parse(readFileSync(connFile, "utf-8"));
+    data.launch_cmd = launchCmd;
+    writeFileSync(connFile, JSON.stringify(data) + "\n");
+  } catch {
+    // non-fatal
+  }
+}
+
+// ─── SSH Execution ──────────────────────────────────────────────────────────
+
+export async function waitForSsh(maxAttempts = 30): Promise<void> {
+  logStep("Waiting for SSH connectivity...");
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const proc = Bun.spawn(
+        ["ssh", ...SSH_OPTS, `${SSH_USER}@${instanceIp}`, "echo ok"],
+        { stdio: ["ignore", "pipe", "ignore"] },
+      );
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      if (exitCode === 0 && stdout.includes("ok")) {
+        logInfo("SSH is ready");
+        return;
+      }
+    } catch {
+      // ignore
+    }
+    logStep(`SSH not ready yet (${attempt}/${maxAttempts})`);
+    await sleep(5000);
+  }
+
+  throw new Error("SSH connectivity timeout");
+}
+
+export async function waitForCloudInit(maxAttempts = 60): Promise<void> {
+  await waitForSsh();
+
+  logStep("Waiting for cloud-init to complete...");
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const proc = Bun.spawn(
+        ["ssh", ...SSH_OPTS, `${SSH_USER}@${instanceIp}`, "test -f /home/ubuntu/.cloud-init-complete"],
+        { stdio: ["ignore", "pipe", "ignore"] },
+      );
+      if (await proc.exited === 0) {
+        logInfo("Cloud-init complete");
+        return;
+      }
+    } catch {
+      // ignore
+    }
+    logStep(`Cloud-init still running (${attempt}/${maxAttempts})`);
+    await sleep(5000);
+  }
+
+  logWarn("Cloud-init did not complete in time, continuing anyway...");
+}
+
+export async function runServer(cmd: string, timeoutSecs?: number): Promise<void> {
+  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const proc = Bun.spawn(
+    ["ssh", ...SSH_OPTS, `${SSH_USER}@${instanceIp}`, `bash -c '${fullCmd.replace(/'/g, "'\\''")}'`],
+    { stdio: ["ignore", "inherit", "inherit"] },
+  );
+  const timeout = (timeoutSecs || 300) * 1000;
+  const timer = setTimeout(() => { try { proc.kill(); } catch { /* ignore */ } }, timeout);
+  const exitCode = await proc.exited;
+  clearTimeout(timer);
+  if (exitCode !== 0) {
+    throw new Error(`run_server failed (exit ${exitCode}): ${cmd}`);
+  }
+}
+
+export async function runServerCapture(cmd: string, timeoutSecs?: number): Promise<string> {
+  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const proc = Bun.spawn(
+    ["ssh", ...SSH_OPTS, `${SSH_USER}@${instanceIp}`, `bash -c '${fullCmd.replace(/'/g, "'\\''")}'`],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const timeout = (timeoutSecs || 300) * 1000;
+  const timer = setTimeout(() => { try { proc.kill(); } catch { /* ignore */ } }, timeout);
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  clearTimeout(timer);
+  if (exitCode !== 0) throw new Error(`run_server_capture failed (exit ${exitCode})`);
+  return stdout.trim();
+}
+
+export async function uploadFile(localPath: string, remotePath: string): Promise<void> {
+  if (!/^[a-zA-Z0-9/_.~-]+$/.test(remotePath)) {
+    throw new Error(`Invalid remote path: ${remotePath}`);
+  }
+  const proc = Bun.spawn(
+    ["scp", ...SSH_OPTS, localPath, `${SSH_USER}@${instanceIp}:${remotePath}`],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+  if (await proc.exited !== 0) {
+    throw new Error(`upload_file failed for ${remotePath}`);
+  }
+}
+
+export async function interactiveSession(cmd: string): Promise<number> {
+  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const escapedCmd = fullCmd.replace(/'/g, "'\\''");
+  const proc = Bun.spawn(
+    ["ssh", ...SSH_OPTS, "-t", `${SSH_USER}@${instanceIp}`, `bash -c '${escapedCmd}'`],
+    { stdio: ["inherit", "inherit", "inherit"] },
+  );
+  const exitCode = await proc.exited;
+
+  // Post-session summary
+  process.stderr.write("\n");
+  logWarn(`Session ended. Your Lightsail instance '${instanceName}' is still running.`);
+  logWarn("Remember to delete it when you're done to avoid ongoing charges.");
+  logWarn("");
+  logWarn("Manage or delete it in your dashboard:");
+  logWarn(`  ${DASHBOARD_URL}`);
+  logWarn("");
+  logInfo("To delete from CLI:");
+  logInfo("  spawn delete");
+  logInfo("To reconnect:");
+  logInfo(`  ssh ${SSH_USER}@${instanceIp}`);
+
+  return exitCode;
+}
+
+// ─── Retry + Wait Helpers ───────────────────────────────────────────────────
+
+export async function runWithRetry(
+  maxAttempts: number,
+  sleepSec: number,
+  timeoutSecs: number,
+  cmd: string,
+): Promise<void> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await runServer(cmd, timeoutSecs);
+      return;
+    } catch {
+      logWarn(`Command failed (attempt ${attempt}/${maxAttempts}): ${cmd.slice(0, 80)}...`);
+      if (attempt < maxAttempts) await sleep(sleepSec * 1000);
+    }
+  }
+  throw new Error(`runWithRetry exhausted: ${cmd.slice(0, 80)}...`);
+}
+
+// ─── Server Name ────────────────────────────────────────────────────────────
+
+export async function getServerName(): Promise<string> {
+  if (process.env.LIGHTSAIL_SERVER_NAME) {
+    const name = process.env.LIGHTSAIL_SERVER_NAME;
+    if (!validateServerName(name)) {
+      logError(`Invalid LIGHTSAIL_SERVER_NAME: '${name}'`);
+      throw new Error("Invalid server name");
+    }
+    logInfo(`Using instance name from environment: ${name}`);
+    return name;
+  }
+
+  const kebab = process.env.SPAWN_NAME_KEBAB
+    || (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "");
+  const defaultName = kebab || "spawn";
+
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    return defaultName;
+  }
+
+  const answer = await prompt(`Enter instance name [${defaultName}]: `);
+  const name = answer || defaultName;
+
+  if (!validateServerName(name)) {
+    logError(`Invalid instance name: '${name}'`);
+    throw new Error("Invalid server name");
+  }
+  return name;
+}
+
+export async function promptSpawnName(): Promise<void> {
+  if (process.env.SPAWN_NAME_KEBAB) return;
+
+  let displayName: string;
+  if (process.env.SPAWN_NAME) {
+    displayName = process.env.SPAWN_NAME;
+    logInfo(`Spawn name: ${displayName}`);
+  } else if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    displayName = "spawn";
+  } else {
+    process.stderr.write("\n");
+    displayName = await prompt('Spawn name (e.g. "My Dev Box"): ');
+    if (!displayName) displayName = "spawn";
+  }
+
+  let kebab = toKebabCase(displayName) || "spawn";
+
+  if (process.env.SPAWN_NON_INTERACTIVE !== "1") {
+    const confirmed = await prompt(`Resource name [${kebab}]: `);
+    if (confirmed) {
+      kebab = toKebabCase(confirmed) || "spawn";
+    }
+  }
+
+  process.env.SPAWN_NAME_DISPLAY = displayName;
+  process.env.SPAWN_NAME_KEBAB = kebab;
+  logInfo(`Using resource name: ${kebab}`);
+}
+
+// ─── Lifecycle ──────────────────────────────────────────────────────────────
+
+export async function destroyServer(name?: string): Promise<void> {
+  const target = name || instanceName;
+  if (!target) throw new Error("destroy_server: no instance name provided");
+
+  logStep(`Destroying Lightsail instance '${target}'...`);
+
+  if (lightsailMode === "cli") {
+    try {
+      await awsCli(["lightsail", "delete-instance", "--instance-name", target]);
+    } catch {
+      logError(`Failed to destroy Lightsail instance '${target}'`);
+      logWarn(`Delete it manually: ${DASHBOARD_URL}`);
+      throw new Error("Instance deletion failed");
+    }
+  } else {
+    try {
+      await lightsailRest(
+        "Lightsail_20161128.DeleteInstance",
+        JSON.stringify({ instanceName: target, forceDeleteAddOns: false }),
+      );
+    } catch {
+      logError(`Failed to destroy Lightsail instance '${target}'`);
+      logWarn(`Delete it manually: ${DASHBOARD_URL}`);
+      throw new Error("Instance deletion failed");
+    }
+  }
+  logInfo(`Instance '${target}' destroyed`);
+}
+
+export async function listServers(): Promise<void> {
+  if (lightsailMode === "cli") {
+    const proc = Bun.spawn(
+      ["aws", "lightsail", "get-instances", "--query", "instances[].{Name:name,State:state.name,IP:publicIpAddress,Bundle:bundleId}", "--output", "table"],
+      { stdio: ["ignore", "inherit", "inherit"], env: process.env },
+    );
+    await proc.exited;
+  } else {
+    const resp = await lightsailRest("Lightsail_20161128.GetInstances", "{}");
+    const data = parseJson(resp);
+    const instances: any[] = data?.instances ?? [];
+    const pad = (s: string, n: number) => (s + " ".repeat(n)).slice(0, n);
+    console.log(pad("Name", 30) + pad("State", 12) + pad("IP", 16) + "Bundle");
+    console.log("-".repeat(72));
+    for (const i of instances) {
+      console.log(
+        pad(i.name || "", 30) +
+        pad(i.state?.name || "", 12) +
+        pad(i.publicIpAddress || "N/A", 16) +
+        (i.bundleId || ""),
+      );
+    }
+  }
+}

--- a/cli/src/aws/main.ts
+++ b/cli/src/aws/main.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env bun
+// aws/main.ts — Orchestrator: deploys an agent on AWS Lightsail
+
+import {
+  ensureAwsCli,
+  authenticate,
+  promptRegion,
+  promptBundle,
+  ensureSshKey,
+  promptSpawnName,
+  createInstance,
+  waitForInstance,
+  waitForCloudInit,
+  getServerName,
+  runServer,
+  interactiveSession,
+  saveLaunchCmd,
+} from "./aws";
+import { getOrPromptApiKey, getModelIdInteractive } from "../shared/oauth";
+import {
+  resolveAgent,
+  generateEnvConfig,
+  offerGithubAuth,
+} from "./agents";
+import { logInfo, logStep, logWarn } from "../shared/ui";
+
+async function main() {
+  const agentName = process.argv[2];
+  if (!agentName) {
+    console.error("Usage: bun run aws/main.ts <agent>");
+    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw");
+    process.exit(1);
+  }
+
+  const agent = resolveAgent(agentName);
+  logInfo(`${agent.name} on AWS Lightsail`);
+  process.stderr.write("\n");
+
+  // 1. Authenticate with cloud provider
+  await promptSpawnName();
+  await ensureAwsCli();
+  await authenticate();
+  await promptRegion();
+  await promptBundle();
+  await ensureSshKey();
+
+  // 2. Pre-provision hooks
+  if (agent.preProvision) {
+    try {
+      await agent.preProvision();
+    } catch {
+      // non-fatal
+    }
+  }
+
+  // 3. Get API key (before provisioning so user isn't waiting)
+  const apiKey = await getOrPromptApiKey(agentName, "aws");
+
+  // 4. Model selection (if agent needs it)
+  let modelId: string | undefined;
+  if (agent.modelPrompt) {
+    modelId = await getModelIdInteractive(
+      agent.modelDefault || "openrouter/auto",
+      agent.name,
+    );
+  }
+
+  // 5. Provision server
+  const serverName = await getServerName();
+  await createInstance(serverName);
+
+  // 6. Wait for readiness
+  await waitForInstance();
+  await waitForCloudInit();
+
+  // 7. Install agent
+  await agent.install();
+
+  // 8. Inject environment variables via .spawnrc
+  logStep("Setting up environment variables...");
+  const envContent = generateEnvConfig(agent.envVars(apiKey));
+  const envB64 = Buffer.from(envContent).toString("base64");
+  try {
+    await runServer(
+      `printf '%s' '${envB64}' | base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc; ` +
+      `grep -q 'source ~/.spawnrc' ~/.bashrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.bashrc; ` +
+      `grep -q 'source ~/.spawnrc' ~/.zshrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.zshrc`,
+    );
+  } catch {
+    logWarn("Environment setup had errors");
+  }
+
+  // GitHub CLI setup
+  await offerGithubAuth();
+
+  // 9. Agent-specific configuration
+  if (agent.configure) {
+    try {
+      await agent.configure(apiKey, modelId);
+    } catch {
+      logWarn("Agent configuration failed (continuing with defaults)");
+    }
+  }
+
+  // 10. Pre-launch hooks
+  if (agent.preLaunch) {
+    await agent.preLaunch();
+  }
+
+  // 11. Launch interactive session
+  logInfo(`${agent.name} is ready`);
+  process.stderr.write("\n");
+  logInfo("AWS Lightsail instance setup completed successfully!");
+  process.stderr.write("\n");
+  logStep("Starting agent...");
+  await new Promise((r) => setTimeout(r, 1000));
+
+  const launchCmd = agent.launchCmd();
+  saveLaunchCmd(launchCmd);
+  const exitCode = await interactiveSession(launchCmd);
+  process.exit(exitCode);
+}
+
+main().catch((err) => {
+  const msg =
+    err && typeof err === "object" && "message" in err
+      ? String(err.message)
+      : String(err);
+  process.stderr.write(`\x1b[0;31mFatal: ${msg}\x1b[0m\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
**Why:** Converts AWS Lightsail from 609-line bash (aws/lib/common.sh) to TypeScript, following the Fly.io pattern. Type safety eliminates SigV4 signing bugs, @clack/prompts provides consistent interactive bundle/region pickers, and error handling is explicit.

## Changes
- `cli/src/aws/aws.ts` — Core: AWS CLI wrapper, SigV4 REST API, auth, Lightsail provisioning, SSH
- `cli/src/aws/agents.ts` — Agent configs and install helpers
- `cli/src/aws/main.ts` — Orchestrator
- `aws/*.sh` — Converted to thin bun shims (curl|bash compatible with bash fallback)
- `cli/package.json` — Version bump to 0.6.0

## Details
- **Dual-mode auth**: AWS CLI (`aws sts get-caller-identity`) or env vars (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`) with SigV4 REST fallback
- **Interactive pickers**: Region (6 curated) and bundle (6 tiers, nano $3.50/mo to xlarge $80/mo) via @clack/prompts
- **SSH execution**: Direct SSH to ubuntu@instance-ip (not WireGuard like Fly.io)
- **Shell shims preserve curl|bash compatibility**: local checkout runs TypeScript, remote falls back to bash implementation
- **aws/lib/common.sh preserved**: kept as fallback for remote execution

Fixes #1675

-- refactor/complexity-hunter