### PR TITLE
fix: resolve kilocode gcp permission errors

### DIFF
--- a/cli/src/gcp/agents.ts
+++ b/cli/src/gcp/agents.ts
@@ -305,7 +305,7 @@ export const agents: Record<string, AgentConfig> = {
 
   codex: {
     name: "Codex CLI",
-    install: () => installAgent("Codex CLI", "npm install -g @openai/codex"),
+    install: () => installAgent("Codex CLI", "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @openai/codex"),
     envVars: (apiKey) => [`OPENROUTER_API_KEY=${apiKey}`],
     configure: (apiKey) => setupCodexConfig(apiKey),
     launchCmd: () =>
@@ -319,7 +319,7 @@ export const agents: Record<string, AgentConfig> = {
     install: () =>
       installAgent(
         "openclaw",
-        'source ~/.bashrc 2>/dev/null; bun install -g openclaw || npm install -g openclaw',
+        'source ~/.bashrc 2>/dev/null; bun install -g openclaw || (mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g openclaw)',
       ),
     envVars: (apiKey) => [
       `OPENROUTER_API_KEY=${apiKey}`,
@@ -343,7 +343,7 @@ export const agents: Record<string, AgentConfig> = {
 
   kilocode: {
     name: "Kilo Code",
-    install: () => installAgent("Kilo Code", "npm install -g @kilocode/cli"),
+    install: () => installAgent("Kilo Code", "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @kilocode/cli"),
     envVars: (apiKey) => [
       `OPENROUTER_API_KEY=${apiKey}`,
       "KILO_PROVIDER_TYPE=openrouter",


### PR DESCRIPTION
## Summary

- GCP VMs SSH as a non-root user, so `npm install -g` fails with permission errors when the npm global prefix points to a system directory (e.g. `/usr/lib/node_modules`)
- Ensure `~/.npm-global` is configured as the npm prefix before running global installs for kilocode, codex, and openclaw (npm fallback)
- The startup script already sets this prefix, but reinforcing it at install time prevents race conditions and ensures reliability

## Test plan

- [ ] Deploy kilocode on GCP: `spawn run gcp/kilocode`
- [ ] Verify `npm install -g @kilocode/cli` succeeds without permission errors
- [ ] Verify kilocode binary is available at `~/.npm-global/bin/kilocode`

Fixes #1698

-- refactor/code-health

🤖 Generated with [Claude Code](https://claude.com/claude-code)