### PR TITLE
feat: draft PR workflow + stale PR cleanup for agent teams

### DIFF
--- a/.claude/skills/setup-agent-team/discovery-team-prompt.txt
+++ b/.claude/skills/setup-agent-team/discovery-team-prompt.txt
@@ -72,10 +72,13 @@ Complete within 45 minutes. At 35 min tell teammates to wrap up, at 40 min shutd
 
 ## No Self-Merge Rule
 
-Teammates NEVER merge their own PRs. After creating a PR:
-1. Self-review: `gh pr review NUMBER --repo OpenRouterTeam/spawn --comment --body "Self-review by AGENT-NAME: [summary]\n\n-- discovery/AGENT-NAME"`
-2. Label: `gh pr edit NUMBER --repo OpenRouterTeam/spawn --add-label "needs-team-review"`
-3. Leave open — merging is handled externally.
+Teammates NEVER merge their own PRs. Use the draft-first workflow:
+1. After first commit, open a draft PR: `gh pr create --draft --title "title" --body "body\n\n-- discovery/AGENT-NAME"`
+2. Keep pushing commits as work progresses
+3. When complete: `gh pr ready NUMBER`
+4. Self-review: `gh pr review NUMBER --repo OpenRouterTeam/spawn --comment --body "Self-review by AGENT-NAME: [summary]\n\n-- discovery/AGENT-NAME"`
+5. Label: `gh pr edit NUMBER --repo OpenRouterTeam/spawn --add-label "needs-team-review"`
+6. Leave open — merging is handled externally.
 
 ## Phase 1: Check Upvote Thresholds (ALWAYS DO FIRST)
 
@@ -189,8 +192,10 @@ Values: cloud-scout, agent-scout, issue-responder, implementer, team-lead.
 git fetch origin main
 git worktree add WORKTREE_BASE_PLACEHOLDER/BRANCH -b BRANCH origin/main
 cd WORKTREE_BASE_PLACEHOLDER/BRANCH
-# ... work, commit, push ...
-gh pr create --title "title" --body "body\n\n-- discovery/AGENT-NAME"
+# ... first commit, push ...
+gh pr create --draft --title "title" --body "body\n\n-- discovery/AGENT-NAME"
+# ... keep pushing commits ...
+gh pr ready NUMBER  # when work is complete
 gh pr review NUMBER --comment --body "Self-review: [summary]\n\n-- discovery/AGENT-NAME"
 gh pr edit NUMBER --add-label "needs-team-review"
 git worktree remove WORKTREE_BASE_PLACEHOLDER/BRANCH

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -209,7 +209,7 @@ Complete within 12 minutes. At 9 min wrap up, at 11 min shutdown, at 12 min forc
 
 ## Team Structure
 
-1. **implementer** (Opus) — Identify target script (`.claude/skills/setup-agent-team/{team}.sh`), implement changes in worktree, update workflows if needed, run `bash -n`, create PR: `gh pr create --title "feat: [desc]" --body "Implements #ISSUE_NUM_PLACEHOLDER\n\n-- security/implementer"`
+1. **implementer** (Opus) — Identify target script (`.claude/skills/setup-agent-team/{team}.sh`), implement changes in worktree, update workflows if needed, run `bash -n`. Open a draft PR immediately after first commit: `gh pr create --draft --title "feat: [desc]" --body "Implements #ISSUE_NUM_PLACEHOLDER\n\n-- security/implementer"`. Keep pushing commits. When complete: `gh pr ready NUMBER`
 2. **reviewer** (Opus) — Wait for PR, review for security/correctness/macOS compat/consistency. Approve or request-changes. If approved, merge: `gh pr merge NUMBER --repo OpenRouterTeam/spawn --squash --delete-branch`
 
 ## Workflow
@@ -356,9 +356,11 @@ cd REPO_ROOT_PLACEHOLDER && git worktree remove WORKTREE_BASE_PLACEHOLDER/pr-NUM
 
 ## Step 1 — Discover Open PRs
 
-\`gh pr list --repo OpenRouterTeam/spawn --state open --json number,title,headRefName,updatedAt,mergeable\`
+\`gh pr list --repo OpenRouterTeam/spawn --state open --json number,title,headRefName,updatedAt,mergeable,isDraft\`
 
-If zero PRs, skip to Step 3.
+**Skip draft PRs** — draft PRs are work-in-progress and not ready for security review. Only review PRs where \`isDraft\` is \`false\`.
+
+If zero non-draft PRs, skip to Step 3.
 
 ## Step 2 — Create Team and Spawn Reviewers
 
@@ -431,6 +433,13 @@ Spawn **branch-cleaner** (model=sonnet):
 - List remote branches: \`git branch -r --format='%(refname:short) %(committerdate:unix)'\`
 - For each non-main branch: if no open PR + stale >48h → \`git push origin --delete BRANCH\`
 - Report summary.
+
+## Step 3.5 — Close Stale Draft PRs
+
+From the PR list in Step 1, for each draft PR (\`isDraft\`=true) with \`updatedAt\` older than 7 days:
+\`\`\`bash
+gh pr close NUMBER --repo OpenRouterTeam/spawn --delete-branch --comment "Closing stale draft PR (no updates for 7+ days). Re-open or create a new PR when ready to continue.\n\n-- security/pr-reviewer"
+\`\`\`
 
 ## Step 4 — Stale Issue Re-triage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,14 @@ refactor.yml        — GitHub Actions workflow that POSTs to the trigger server
 - If a PR can't be merged (conflicts, superseded, wrong approach), close it with `gh pr close {number} --comment "Reason"`
 - Never rebase main or use `--force` unless explicitly asked
 
+### Draft PR Workflow (for autonomous agents)
+
+- **Commit early and often** — make small, incremental commits as you work
+- **Push and open a draft PR immediately** — `gh pr create --draft` after your first commit
+- **Keep working on the draft PR** — push additional commits to the same branch
+- **Convert to non-draft when ready for review** — `gh pr ready NUMBER`
+- Draft PRs that go stale (no updates for 1 week) will be auto-closed
+
 ## After Each Change
 
 1. `bash -n {file}` syntax check on all modified scripts


### PR DESCRIPTION
## Summary

- Agents now open **draft PRs** (`gh pr create --draft`) immediately after first commit, then `gh pr ready` when complete
- Security reviewer **skips draft PRs** — only reviews non-draft PRs
- **Stale draft PRs** (7+ days with no updates) are auto-closed by the security team
- Refactor **pr-maintainer picks up stale non-draft PRs** (3+ days, no review) to continue work
- Added "Draft PR Workflow" subsection to CLAUDE.md Git Workflow section

## Files changed

| File | What changed |
|------|-------------|
| `CLAUDE.md` | Added "Draft PR Workflow (for autonomous agents)" subsection |
| `.claude/skills/setup-agent-team/security.sh` | `isDraft` in queries, skip drafts in review, close 7d stale drafts, implementer uses draft PR |
| `.claude/skills/setup-agent-team/refactor.sh` | Issue-fixer + teammates use draft PR, pr-maintainer picks up 3d stale PRs |
| `.claude/skills/setup-agent-team/discovery-team-prompt.txt` | Draft-first PR workflow in No Self-Merge Rule + Git Worktrees |

## Test plan

- [x] `bash -n` passes on security.sh, refactor.sh, discovery.sh
- [ ] Verify agent teams open draft PRs on next cycle
- [ ] Verify security reviewer skips draft PRs
- [ ] Verify stale draft cleanup triggers after 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)