### PR TITLE
fix: allow rich text in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,6 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      placeholder: "Paste the error or describe what went wrong"
-      render: shell
+      placeholder: "Paste the error or describe what went wrong. You can drag & drop screenshots here."
     validations:
       required: true


### PR DESCRIPTION
## Summary
- Remove `render: shell` from the bug report template's "What happened?" textarea
- This was forcing the field into a plain-text code block, preventing users from pasting screenshots, dragging files, or using markdown formatting
- Updated placeholder to hint that images can be dropped in

## Test plan
- [ ] Open a new bug report issue and verify the "What happened?" field accepts markdown, images, and file uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)