### PR TITLE
fix: restore npm-global prefix for kilocode/codex in shared agent-setup

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/shared/agent-setup.ts
+++ b/cli/src/shared/agent-setup.ts
@@ -281,11 +281,11 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
 
     codex: {
       name: "Codex CLI",
-      install: () => installAgent(runner, "Codex CLI", "npm install -g @openai/codex"),
+      install: () => installAgent(runner, "Codex CLI", "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @openai/codex"),
       envVars: (apiKey) => [`OPENROUTER_API_KEY=${apiKey}`],
       configure: (apiKey) => setupCodexConfig(runner, apiKey),
       launchCmd: () =>
-        "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex",
+        "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$(npm prefix -g 2>/dev/null)/bin:$PATH; codex",
     },
 
     openclaw: {
@@ -316,14 +316,14 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
 
     kilocode: {
       name: "Kilo Code",
-      install: () => installAgent(runner, "Kilo Code", "npm install -g @kilocode/cli"),
+      install: () => installAgent(runner, "Kilo Code", "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @kilocode/cli"),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,
         "KILO_PROVIDER_TYPE=openrouter",
         `KILO_OPEN_ROUTER_API_KEY=${apiKey}`,
       ],
       launchCmd: () =>
-        "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode",
+        "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$(npm prefix -g 2>/dev/null)/bin:$PATH; kilocode",
     },
 
     zeroclaw: {


### PR DESCRIPTION
## Summary

- PR #1699 fixed npm permission errors for kilocode on GCP by adding `~/.npm-global` prefix to npm global installs
- PR #1704 (deduplicate clouds into shared agent-setup) replaced the GCP-specific `agents.ts` with a thin wrapper, **losing the npm prefix fix**
- `shared/agent-setup.ts` still had bare `npm install -g @kilocode/cli` and `npm install -g @openai/codex` without the prefix setup
- This restores the fix in `shared/agent-setup.ts` so it applies to **all clouds** (GCP, AWS, Fly, Hetzner, DigitalOcean, Sprite, Daytona)
- Also updates `launchCmd` for kilocode and codex to explicitly include `~/.npm-global/bin` in PATH

## Test plan

- [ ] Deploy kilocode on GCP: `spawn run gcp/kilocode`
- [ ] Verify `npm install -g @kilocode/cli` succeeds without permission errors
- [ ] Verify kilocode binary is found at launch: `~/.npm-global/bin/kilocode`
- [ ] Deploy codex on GCP: `spawn run gcp/codex`
- [ ] Verify same fix applies

Fixes #1698

Agent: issue-fixer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>