### PR TITLE
fix: re-apply npm prefix for kilocode/codex after shared refactor

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/shared/agent-setup.ts
+++ b/cli/src/shared/agent-setup.ts
@@ -281,7 +281,7 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
 
     codex: {
       name: "Codex CLI",
-      install: () => installAgent(runner, "Codex CLI", "npm install -g @openai/codex"),
+      install: () => installAgent(runner, "Codex CLI", "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @openai/codex"),
       envVars: (apiKey) => [`OPENROUTER_API_KEY=${apiKey}`],
       configure: (apiKey) => setupCodexConfig(runner, apiKey),
       launchCmd: () =>
@@ -316,7 +316,7 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
 
     kilocode: {
       name: "Kilo Code",
-      install: () => installAgent(runner, "Kilo Code", "npm install -g @kilocode/cli"),
+      install: () => installAgent(runner, "Kilo Code", "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @kilocode/cli"),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,
         "KILO_PROVIDER_TYPE=openrouter",


### PR DESCRIPTION
**Why:** PR #1699's fix (npm-global prefix for non-root GCP installs) was lost when agent configs were refactored from `cli/src/gcp/agents.ts` into `cli/src/shared/agent-setup.ts`.

## Root Cause

The shared `createAgents()` in `agent-setup.ts` uses bare `npm install -g` for kilocode and codex — without first setting `npm config set prefix ~/.npm-global`. On GCP, SSH users are non-root, so npm tries to write to `/usr/lib/node_modules` and fails with EACCES.

This also breaks kilocode's `postinstall.mjs`, which uses `require.resolve()` to find `@kilocode/cli-linux-x64` and then verifies/symlinks the platform binary. When the install targets a system directory the non-root user can't write to, the postinstall fails.

## Investigation of kilocode source

Per maintainer request to "read their source code":

- **`postinstall.mjs`**: Calls `findBinary()` → `require.resolve('@kilocode/cli-linux-x64/package.json')` → checks for `bin/kilo` binary. This works fine when packages are in a user-writable prefix (`~/.npm-global`), but fails with EACCES on system prefix.
- **`bin/kilo`** (wrapper script): Traverses up from its own directory looking for `node_modules/@kilocode/cli-linux-x64/bin/kilo`. This directory traversal works correctly as long as both `@kilocode/cli` and `@kilocode/cli-linux-x64` land in the same `node_modules`.
- **No deep post-install bug in kilocode itself** — the issue is entirely that npm's global prefix points to a system directory on GCP VMs.

## Changes

- `cli/src/shared/agent-setup.ts`: Add `mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global` before `npm install -g` for both kilocode and codex (re-applying the PR #1699 fix)
- `cli/package.json`: Bump version 0.6.3 → 0.6.4

Fixes #1698

-- refactor/code-health