### PR TITLE
chore: disable QA workflow schedule until VM is fixed

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,8 +1,10 @@
 name: Daily QA
-on:
-  schedule:
-    - cron: '0 6 * * *'
-  workflow_dispatch:
+# Disabled until QA VM is fixed
+# on:
+#   schedule:
+#     - cron: '0 6 * * *'
+#   workflow_dispatch:
+on: workflow_dispatch
 jobs:
   trigger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Disables the daily cron schedule for the QA workflow
- Keeps `workflow_dispatch` for manual testing
- Re-enable the cron when the QA VM is back online

## Test plan
- [x] Workflow still appears in Actions tab for manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)