### PR TITLE
fix: add account:read scope to DigitalOcean OAuth flow

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -29,6 +29,7 @@ const DO_CLIENT_SECRET = "8083ef0317481d802d15b68f1c0b545b726720dbf52d00d17f649c
 
 // Fine-grained scopes for spawn (minimum required)
 const DO_SCOPES = [
+  "account:read",
   "droplet:create", "droplet:delete", "droplet:read",
   "ssh_key:create", "ssh_key:read",
   "regions:read", "sizes:read",


### PR DESCRIPTION
## Summary
- DigitalOcean OAuth token validation calls `GET /v2/account`, which requires the `account:read` scope
- The OAuth scope list was missing `account:read`, so the token exchange succeeded but validation returned 403
- This caused the CLI to fall through to manual token entry even after a successful OAuth flow
- Added `account:read` to `DO_SCOPES`

## Test plan
- [ ] Run `spawn digitalocean claude-code` and complete the OAuth flow
- [ ] Verify the token is accepted without falling through to manual entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)