### PR TITLE
fix: auto-update silently fails in multiple scenarios

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -99,7 +99,7 @@ ensure_in_path() {
     local install_dir="$1"
     if echo "${PATH}" | tr ':' '\n' | grep -qx "${install_dir}"; then
         echo ""
-        "${install_dir}/spawn" version
+        SPAWN_NO_UPDATE_CHECK=1 "${install_dir}/spawn" version
         echo ""
         printf "${GREEN}[spawn]${NC} Run ${BOLD}spawn${NC} to get started\n"
     else

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/update-check.test.ts
+++ b/cli/src/__tests__/update-check.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import fs from "fs";
+import path from "path";
 
 // ── Test Helpers ───────────────────────────────────────────────────────────────
+
+/** Remove the .update-failed backoff file so it doesn't interfere with tests */
+function clearUpdateBackoff() {
+  try {
+    fs.unlinkSync(path.join(process.env.HOME || "/tmp", ".config", "spawn", ".update-failed"));
+  } catch {
+    // File may not exist
+  }
+}
 
 function mockEnv() {
   const originalEnv = { ...process.env };
@@ -23,6 +34,7 @@ describe("update-check", () => {
 
   beforeEach(() => {
     originalEnv = mockEnv();
+    clearUpdateBackoff();
     consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
     // Mock process.exit to prevent tests from exiting
     processExitSpy = spyOn(process, "exit").mockImplementation((() => {}) as any);


### PR DESCRIPTION
## Summary

- **Prevent recursive update check during install**: `ensure_in_path()` runs `spawn version` which triggers `checkForUpdates()` inside the install process — now suppressed with `SPAWN_NO_UPDATE_CHECK=1`
- **Increase fetch timeout from 5s to 10s**: The 5-second timeout on `raw.githubusercontent.com` is too aggressive for slow/cold connections, silently returning `null` and skipping the update
- **Add 1-hour failure backoff**: When auto-update fails (network error, build failure), writes a timestamp to `~/.config/spawn/.update-failed` and skips auto-update for 1 hour — prevents repeated 10+ second failed attempts on every invocation
- **Version bump**: 0.6.5 → 0.6.6

## Test plan

- [x] `bash -n cli/install.sh` — syntax check passes
- [x] `bun test cli/src/__tests__/update-check.test.ts` — all 11 tests pass
- [x] `bun test` — full suite (3046 tests), no regressions
- [ ] Manual: `spawn update` still works
- [ ] Manual: verify backoff file written on failed update, cleared on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)