### PR TITLE
fix: preserve spawn name when rerunning from list

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -784,7 +784,7 @@ export async function preflightCredentialCheck(manifest: Manifest, cloud: string
   }
 }
 
-export async function cmdRun(agent: string, cloud: string, prompt?: string, dryRun?: boolean, debug?: boolean): Promise<void> {
+export async function cmdRun(agent: string, cloud: string, prompt?: string, dryRun?: boolean, debug?: boolean, name?: string): Promise<void> {
   const manifest = await loadManifestWithSpinner();
   ({ agent, cloud } = resolveAndLog(manifest, agent, cloud));
 
@@ -799,7 +799,7 @@ export async function cmdRun(agent: string, cloud: string, prompt?: string, dryR
 
   await preflightCredentialCheck(manifest, cloud);
 
-  const spawnName = await promptSpawnName();
+  const spawnName = name !== undefined ? name : await promptSpawnName();
 
   const agentName = manifest.agents[agent].name;
   const cloudName = manifest.clouds[cloud].name;
@@ -1951,7 +1951,7 @@ async function handleRecordAction(
   if (!selected.connection) {
     // No connection info -- just rerun
     p.log.step(`Spawning ${pc.bold(buildRecordLabel(selected, manifest))}`);
-    await cmdRun(selected.agent, selected.cloud, selected.prompt);
+    await cmdRun(selected.agent, selected.cloud, selected.prompt, undefined, undefined, selected.name);
     return;
   }
 
@@ -2041,7 +2041,7 @@ async function handleRecordAction(
 
   // Rerun (create new spawn)
   p.log.step(`Spawning ${pc.bold(buildRecordLabel(selected, manifest))}`);
-  await cmdRun(selected.agent, selected.cloud, selected.prompt);
+  await cmdRun(selected.agent, selected.cloud, selected.prompt, undefined, undefined, selected.name);
 }
 
 /** Show interactive picker to select and reconnect/rerun a previous spawn */
@@ -2182,7 +2182,7 @@ export async function cmdLast(): Promise<void> {
   const label = buildRecordLabel(latest, manifest);
   const hint = buildRecordHint(latest);
   p.log.step(`Rerunning last spawn: ${pc.bold(label)} ${pc.dim(hint)}`);
-  await cmdRun(latest.agent, latest.cloud, latest.prompt);
+  await cmdRun(latest.agent, latest.cloud, latest.prompt, undefined, undefined, latest.name);
 }
 
 // ── Connect ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When selecting a failed spawn (or any previous spawn) from `spawn list` and choosing "Spawn a new VM", the CLI prompted for the spawn name again — even though the name was already recorded in history.
- `cmdRun` always calls `promptSpawnName()` unconditionally. When called from `handleRecordAction` or `cmdLast`, the existing record's `name` was discarded.
- Added an optional `name?: string` parameter to `cmdRun`. When provided, it skips the `promptSpawnName()` prompt and uses the stored name directly.
- Updated all three call sites in `handleRecordAction` (no-connection path + rerun action) and `cmdLast` to pass `selected.name` / `latest.name`.

## Test plan

- [x] All 3046 existing tests pass (`bun test`)
- [x] TypeScript compiles without errors
- [x] Behavior unchanged for fresh `spawn <agent> <cloud>` runs (no `name` passed, still prompts)
- [x] Re-runs from history skip the name prompt and reuse the stored name

Fixes #1712

-- refactor/issue-fixer

🤖 Generated with [Claude Code](https://claude.com/claude-code)