### PR TITLE
fix: add 5s delay between DigitalOcean and OpenRouter OAuth flows

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/digitalocean/main.ts
+++ b/cli/src/digitalocean/main.ts
@@ -16,6 +16,7 @@ import {
 import { resolveAgent } from "./agents";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
+import { logStep } from "../shared/ui";
 
 async function main() {
   const agentName = process.argv[2];
@@ -33,8 +34,12 @@ async function main() {
     runner: { runServer, uploadFile },
     async authenticate() {
       await promptSpawnName();
-      await ensureDoToken();
+      const usedBrowserAuth = await ensureDoToken();
       await ensureSshKey();
+      if (usedBrowserAuth) {
+        logStep("Next step: OpenRouter authentication (opening browser in 5s)...");
+        await new Promise((r) => setTimeout(r, 5000));
+      }
     },
     async promptSize() {},
     async createServer(name: string) {


### PR DESCRIPTION
## Summary

- **Problem:** DigitalOcean is the only cloud with two back-to-back browser OAuth flows (DO auth + OpenRouter auth). When the first tab closes/completes, the second opens immediately — users may reactively dismiss it thinking it's a duplicate.
- **Fix:** `ensureDoToken()` now returns `boolean` indicating whether browser OAuth was used. The DO orchestrator adds a 5-second pause with a `"Next step: OpenRouter authentication (opening browser in 5s)..."` message before the OpenRouter OAuth kicks in.
- The delay is **only triggered when browser OAuth was actually used** — env var, saved token, and manual entry paths skip it entirely.

## Test plan

- [x] `bun test` — full suite (3046 tests), no regressions
- [ ] Manual: first-time DO flow shows 5s delay message between the two OAuth popups
- [ ] Manual: returning user with saved DO token skips the delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)