### PR TITLE
fix: remove stale refs from agent team prompts, add issue-filing rule

### DIFF
--- a/.claude/skills/setup-agent-team/discovery-team-prompt.md
+++ b/.claude/skills/setup-agent-team/discovery-team-prompt.md
@@ -105,7 +105,7 @@ gh api graphql -f query='
 Spawn an **implementer** teammate to:
 1. Read the proposal issue for cloud/agent details
 2. Implement it following CLAUDE.md Shell Script Rules
-3. Add test coverage (test/record.sh + test/mock.sh)
+3. Add test coverage (`bun test` in `cli/src/__tests__/`)
 4. Create PR referencing the proposal issue
 5. Label the proposal `ready-for-implementation`
 6. Comment on the proposal: "Implementation PR: #NUMBER -- discovery/implementer"

--- a/.claude/skills/setup-agent-team/security-review-all-prompt.md
+++ b/.claude/skills/setup-agent-team/security-review-all-prompt.md
@@ -73,7 +73,7 @@ Each pr-reviewer MUST:
 6. **Security review** of every changed file:
    - Command injection, credential leaks, path traversal, XSS/injection, unsafe eval/source, curl|bash safety, macOS bash 3.x compat
 
-7. **Test** (in worktree): `bash -n` on .sh files, `bun test` for .ts files, verify source fallback pattern
+7. **Test** (in worktree): `bash -n` on .sh files, `bun test` for .ts files
 
 8. **Decision** — Before posting any review, verify it applies to the **current HEAD commit**:
    - CRITICAL/HIGH found → `gh pr review NUMBER --request-changes` + label `security-review-required`


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Remove entire Mock Test Infrastructure section (references deleted `test/mock.sh` and `test/record.sh`), update testing docs to unit-test-only approach, fix file structure listing, add "Filing Issues for Discovered Problems" rule
- **discovery-team-prompt.md**: Replace `test/record.sh + test/mock.sh` reference with `bun test`
- **security-review-all-prompt.md**: Remove "verify source fallback pattern" (old `lib/common.sh` architecture)

Follow-up to #1728. Filed #1729 (`spawn delete` broken) and #1730 (`discovery.sh` uses `python3`).

## Test plan
- [x] No remaining stale references to `test/run.sh`, `test/mock.sh`, `test/record.sh`, `shared/common.sh`, or `lib/common.sh` in prompts or docs
- [x] Only known exceptions: `qa-quality-prompt.md` line 102 (instruction to *find* stale refs) and `commands.ts` line 1808 (tracked as #1729)

🤖 Generated with [Claude Code](https://claude.com/claude-code)