### PR TITLE
fix: use TypeScript modules for spawn delete instead of removed bash libs

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
**Why:** `spawn delete` is broken for 6 out of 8 clouds (hetzner, digitalocean, gcp, aws, daytona, sprite). The `buildDeleteScript()` function references `{cloud}/lib/common.sh` files that were removed during the TypeScript rewrite. Only Fly.io worked because it had a separate TS code path.

**What changed:**
- Replaced `buildDeleteScript()` (which generated bash scripts curling non-existent files) with `cloudDelete()` that calls each cloud module's TypeScript `destroyServer`/`destroyInstance` functions directly
- Removed dead `runBashTrusted()` helper (only used by the removed `buildDeleteScript`)
- Unified the delete flow: all clouds now follow the same pattern as Fly.io (auth → destroy via TS module)
- Added imports for each cloud's auth + destroy functions
- Bumped CLI version to 0.6.9

**All 1824 tests pass.**

Fixes #1729

-- refactor/code-health