### PR TITLE
fix: cloud-init streaming bash syntax error

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -762,19 +762,17 @@ export async function waitForCloudInit(
 
   // Stream cloud-init output so the user sees progress in real time
   logStep("Streaming cloud-init output (timeout: 5min)...");
-  const remoteScript = [
-    'tail -f /var/log/cloud-init-output.log 2>/dev/null &',
-    'TAIL_PID=$!',
-    'for i in $(seq 1 150); do',
-    '  if [ -f /root/.cloud-init-complete ]; then',
-    '    kill $TAIL_PID 2>/dev/null; wait $TAIL_PID 2>/dev/null',
-    '    echo ""; echo "--- cloud-init complete ---"; exit 0',
-    '  fi',
-    '  sleep 2',
-    'done',
-    'kill $TAIL_PID 2>/dev/null; wait $TAIL_PID 2>/dev/null',
-    'echo ""; echo "--- cloud-init timed out ---"; exit 1',
-  ].join("; ");
+  const remoteScript =
+    'tail -f /var/log/cloud-init-output.log 2>/dev/null & TAIL_PID=$!\n' +
+    'for i in $(seq 1 150); do\n' +
+    '  if [ -f /root/.cloud-init-complete ]; then\n' +
+    '    kill $TAIL_PID 2>/dev/null; wait $TAIL_PID 2>/dev/null\n' +
+    '    echo ""; echo "--- cloud-init complete ---"; exit 0\n' +
+    '  fi\n' +
+    '  sleep 2\n' +
+    'done\n' +
+    'kill $TAIL_PID 2>/dev/null; wait $TAIL_PID 2>/dev/null\n' +
+    'echo ""; echo "--- cloud-init timed out ---"; exit 1';
 
   try {
     const proc = Bun.spawn(


### PR DESCRIPTION
## Summary
Fix bash syntax error in the cloud-init streaming script from #1734. The `.join("; ")` produced `&;` after background command, `do;` after `for`, and `then;` after `if` — all invalid bash syntax. Replaced with newline-joined string.

## Test plan
- [ ] `spawn digitalocean openclaw` — verify cloud-init streams properly without syntax error

🤖 Generated with [Claude Code](https://claude.com/claude-code)