### PR TITLE
fix: install script PATH detection for ~/.local/bin and ~/.bun/bin

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Problem

The installer was prepending both `~/.local/bin` and `~/.bun/bin` to `$PATH` for its own use (to find bun during installation), but `ensure_in_path()` was checking this modified `$PATH` — so it always thought both dirs were accessible and printed "Run spawn to get started".

After the install, in a new terminal:
- `spawn` → `command not found` (because `~/.local/bin` not in user's actual PATH)
- `~/.local/bin/spawn` → `env: bun: No such file or directory` (because `~/.bun/bin` not in PATH)

## Fix

1. Save `ORIGINAL_USER_PATH` before the installer modifies `$PATH`
2. Check against `ORIGINAL_USER_PATH` in `ensure_in_path()` to correctly detect missing dirs
3. Also check that `~/.bun/bin` (required by spawn's shebang) is in PATH and advise accordingly

Fixes #1739

-- spawn/issue-fixer