### PR TITLE
fix: cloud-init fails with HOME unbound variable on DigitalOcean

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -619,6 +619,7 @@ function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
   const lines = [
     "#!/bin/bash",
     "set -e",
+    "export HOME=/root",
     "export DEBIAN_FRONTEND=noninteractive",
     "apt-get update -y",
     `apt-get install -y --no-install-recommends ${packages.join(" ")}`,

--- a/cli/src/hetzner/hetzner.ts
+++ b/cli/src/hetzner/hetzner.ts
@@ -290,6 +290,7 @@ function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
   const lines = [
     "#!/bin/bash",
     "set -e",
+    "export HOME=/root",
     "export DEBIAN_FRONTEND=noninteractive",
     "apt-get update -y",
     `apt-get install -y --no-install-recommends ${packages.join(" ")}`,


### PR DESCRIPTION
## Summary
DigitalOcean's cloud-init environment doesn't set `HOME`. Combined with `set -e`, the bun install script and `~/.bashrc` writes fail with `HOME: unbound variable`, causing cloud-init to silently abort. Bun never gets installed, leading to `bun: command not found` when agents try to start.

- Add `export HOME=/root` to cloud-init userdata for DigitalOcean and Hetzner
- AWS is unaffected (doesn't use `set -e`)

## Test plan
- [ ] `spawn digitalocean openclaw` — verify cloud-init completes and bun is installed
- [ ] `spawn hetzner claude-code` — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)