### PR TITLE
fix: skip symlink when ~/.local/bin already in PATH, use Touch ID

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -101,12 +101,17 @@ ensure_in_path() {
     fi
 
     # 2. If not in PATH, symlink into /usr/local/bin for immediate availability
+    #    Try in order: direct write → passwordless sudo → prompt for password
     local linked=false
     if [ "$already_in_path" = false ]; then
         if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
             ln -sf "${install_dir}/spawn" /usr/local/bin/spawn && linked=true
         elif has_passwordless_sudo; then
             sudo ln -sf "${install_dir}/spawn" /usr/local/bin/spawn 2>/dev/null && linked=true
+        elif command -v sudo &>/dev/null; then
+            # Last resort: ask for password
+            log_step "Adding spawn to /usr/local/bin (may require your password)..."
+            sudo ln -sf "${install_dir}/spawn" /usr/local/bin/spawn && linked=true || true
         fi
     fi
 


### PR DESCRIPTION
## Summary

- Skip `/usr/local/bin` symlink entirely when `~/.local/bin` is already in the user's PATH
- When symlink IS needed, try in order (never hard-fails):
  1. Direct write if `/usr/local/bin` is writable (root on cloud VMs)
  2. Passwordless sudo: `sudo -n` (NOPASSWD or cached credentials)
  3. macOS Touch ID (`pam_tid.so` in sudoers) → biometric, no typing
  4. Prompt for password as last resort (`sudo ln -sf ...`)
  5. If all fail, fall back to rc-file patching + `exec $SHELL`

## Test plan

- [x] `bun test` — 1819 tests pass
- [x] `bash -n cli/install.sh` — syntax OK
- [ ] Fresh cloud VM (root): symlinks directly, spawn works immediately
- [ ] macOS with Touch ID sudo: triggers fingerprint, no password
- [ ] macOS without Touch ID: prompts for password, then works
- [ ] No sudo at all: patches rc files, shows exec SHELL

Generated with [Claude Code](https://claude.com/claude-code)