### PR TITLE
fix: symlink bun alongside spawn in /usr/local/bin during install

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -102,16 +102,28 @@ ensure_in_path() {
 
     # 2. If not in PATH, symlink into /usr/local/bin for immediate availability
     #    Try in order: direct write → passwordless sudo → prompt for password
+    #    Also symlink bun so that spawn's #!/usr/bin/env bun shebang resolves
     local linked=false
+    local bun_path
+    bun_path="$(command -v bun 2>/dev/null || true)"
     if [ "$already_in_path" = false ]; then
         if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
             ln -sf "${install_dir}/spawn" /usr/local/bin/spawn && linked=true
+            if [ -n "$bun_path" ] && [ ! -x /usr/local/bin/bun ]; then
+                ln -sf "$bun_path" /usr/local/bin/bun 2>/dev/null || true
+            fi
         elif has_passwordless_sudo; then
             sudo ln -sf "${install_dir}/spawn" /usr/local/bin/spawn 2>/dev/null && linked=true
+            if [ -n "$bun_path" ] && [ ! -x /usr/local/bin/bun ]; then
+                sudo ln -sf "$bun_path" /usr/local/bin/bun 2>/dev/null || true
+            fi
         elif command -v sudo &>/dev/null; then
             # Last resort: ask for password
             log_step "Adding spawn to /usr/local/bin (may require your password)..."
             sudo ln -sf "${install_dir}/spawn" /usr/local/bin/spawn && linked=true || true
+            if [ "$linked" = true ] && [ -n "$bun_path" ] && [ ! -x /usr/local/bin/bun ]; then
+                sudo ln -sf "$bun_path" /usr/local/bin/bun 2>/dev/null || true
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Summary
- When `~/.local/bin` isn't in PATH, the installer symlinks `spawn` into `/usr/local/bin` for immediate use
- But `spawn` has a `#!/usr/bin/env bun` shebang, so `bun` must also be reachable — otherwise users get `bun: not found`
- Now also symlinks `bun` (typically `~/.bun/bin/bun`) into `/usr/local/bin` alongside `spawn`
- Skips if `/usr/local/bin/bun` already exists (won't clobber a system install)
- Best-effort (`|| true`) — won't block the install if the bun symlink fails

## Test plan
- [ ] Fresh install on a machine where `~/.local/bin` is not in PATH — verify both `spawn` and `bun` symlinks created in `/usr/local/bin`
- [ ] Install where `/usr/local/bin/bun` already exists — verify it's not overwritten
- [ ] Install where `~/.local/bin` is already in PATH — verify no symlinks created (unchanged behavior)
- [ ] `bun test` passes (1819/1819)

🤖 Generated with [Claude Code](https://claude.com/claude-code)