### PR TITLE
fix: symlink bun to /usr/local/bin in cloud-init for all providers

### DIFF
--- a/cli/src/aws/aws.ts
+++ b/cli/src/aws/aws.ts
@@ -475,6 +475,7 @@ function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
     lines.push(
       "# Install Bun",
       "su - ubuntu -c 'curl -fsSL https://bun.sh/install | bash'",
+      "ln -sf /home/ubuntu/.bun/bin/bun /usr/local/bin/bun 2>/dev/null || true",
     );
   }
   lines.push(

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -628,7 +628,10 @@ function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
     lines.push("npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx || true");
   }
   if (needsBun(tier)) {
-    lines.push('if ! command -v bun >/dev/null 2>&1; then curl -fsSL https://bun.sh/install | bash; fi');
+    lines.push(
+      'if ! command -v bun >/dev/null 2>&1; then curl -fsSL https://bun.sh/install | bash; fi',
+      'ln -sf $HOME/.bun/bin/bun /usr/local/bin/bun 2>/dev/null || true',
+    );
   }
   lines.push(
     'for rc in ~/.bashrc ~/.zshrc; do grep -q ".bun/bin" "$rc" 2>/dev/null || echo \'export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"\' >> "$rc"; done',

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -449,6 +449,7 @@ function getStartupScript(username: string, tier: CloudInitTier = "full"): strin
     lines.push(
       `# Install Bun as the login user`,
       `su - "${username}" -c 'curl -fsSL https://bun.sh/install | bash' || true`,
+      `ln -sf /home/${username}/.bun/bin/bun /usr/local/bin/bun 2>/dev/null || true`,
     );
   }
   lines.push(

--- a/cli/src/hetzner/hetzner.ts
+++ b/cli/src/hetzner/hetzner.ts
@@ -299,7 +299,10 @@ function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
     lines.push("npm install -g n && n 22 && ln -sf /usr/local/bin/node /usr/bin/node && ln -sf /usr/local/bin/npm /usr/bin/npm && ln -sf /usr/local/bin/npx /usr/bin/npx || true");
   }
   if (needsBun(tier)) {
-    lines.push('curl -fsSL https://bun.sh/install | bash || true');
+    lines.push(
+      'curl -fsSL https://bun.sh/install | bash || true',
+      'ln -sf $HOME/.bun/bin/bun /usr/local/bin/bun 2>/dev/null || true',
+    );
   }
   lines.push(
     'echo \'export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"\' >> /root/.bashrc',


### PR DESCRIPTION
## Summary
- After bun is installed via `curl | bash` in cloud-init, it lives at `~/.bun/bin/bun` — not on the system PATH
- Agent scripts use `#!/usr/bin/env bun` and fail with `bun: not found` on fresh VMs
- Now symlinks bun into `/usr/local/bin` after install on all 4 cloud providers (AWS, DigitalOcean, GCP, Hetzner)
- Companion to #1745 which does the same for the local install.sh

## Test plan
- [ ] Provision a Hetzner VM — verify `which bun` returns `/usr/local/bin/bun` after cloud-init
- [ ] Provision an AWS VM — same check
- [ ] Provision a DigitalOcean droplet — same check
- [ ] Provision a GCP VM — same check
- [ ] `bun test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)