### PR TITLE
fix: set TERM and use login shell for SSH sessions

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/aws/aws.ts
+++ b/cli/src/aws/aws.ts
@@ -744,7 +744,8 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 }
 
 export async function interactiveSession(cmd: string): Promise<number> {
-  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const term = process.env.TERM || "xterm-256color";
+  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
   const escapedCmd = fullCmd.replace(/'/g, "'\\''");
   const proc = Bun.spawn(
     ["ssh", ...SSH_OPTS, "-t", `${SSH_USER}@${instanceIp}`, `bash -c '${escapedCmd}'`],

--- a/cli/src/daytona/daytona.ts
+++ b/cli/src/daytona/daytona.ts
@@ -423,7 +423,8 @@ export async function uploadFile(
 }
 
 export async function interactiveSession(cmd: string): Promise<number> {
-  const fullCmd = `export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const term = process.env.TERM || "xterm-256color";
+  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
   // Interactive mode — drop BatchMode so the PTY works
   const args = [

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -881,7 +881,8 @@ export async function interactiveSession(
   ip?: string,
 ): Promise<number> {
   const serverIp = ip || doServerIp;
-  const fullCmd = `export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const term = process.env.TERM || "xterm-256color";
+  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
   const proc = Bun.spawn(
     ["ssh", ...SSH_OPTS, "-t", `root@${serverIp}`, fullCmd],

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -795,7 +795,8 @@ export async function uploadFile(
 }
 
 export async function interactiveSession(cmd: string): Promise<number> {
-  const fullCmd = `export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const term = process.env.TERM || "xterm-256color";
+  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
   // Shell-quote the command for -C
   const escapedCmd = fullCmd.replace(/'/g, "'\\''");
   const flyCmd = getCmd()!;

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -650,7 +650,8 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 
 export async function interactiveSession(cmd: string): Promise<number> {
   const username = resolveUsername();
-  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const term = process.env.TERM || "xterm-256color";
+  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
   const proc = Bun.spawn(
     ["ssh", ...SSH_OPTS.split(" "), "-t", `${username}@${gcpServerIp}`, `bash -c ${shellQuote(fullCmd)}`],

--- a/cli/src/hetzner/hetzner.ts
+++ b/cli/src/hetzner/hetzner.ts
@@ -512,7 +512,8 @@ export async function interactiveSession(
   ip?: string,
 ): Promise<number> {
   const serverIp = ip || hetznerServerIp;
-  const fullCmd = `export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const term = process.env.TERM || "xterm-256color";
+  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
   const proc = Bun.spawn(
     ["ssh", ...SSH_OPTS, "-t", `root@${serverIp}`, fullCmd],


### PR DESCRIPTION
## Summary

Interactive SSH sessions felt broken — no colors, bad line editing, missing environment. The agent command was run in a non-login, non-interactive shell via `ssh -t host "cmd"`, which skips `.bashrc`/`.profile` and often loses `TERM`.

Two fixes applied to all 6 SSH-based clouds (DO, Hetzner, AWS, GCP, Fly, Daytona):
- **Forward `TERM`**: explicitly set `TERM` on the remote to match the local terminal (defaults to `xterm-256color`)
- **Login shell**: wrap the agent command in `exec bash -l -c '...'` so `.bashrc` and `.profile` are sourced

## Test plan

- [x] `bun test` — 1819 pass, 0 fail
- [ ] Manual: deploy on DigitalOcean, verify colors and line editing work
- [ ] Manual: deploy on Hetzner, verify same improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)