### PR TITLE
fix: update test to match canonical path cleanup in install.sh

### DIFF
--- a/cli/src/__tests__/install-script-validation.test.ts
+++ b/cli/src/__tests__/install-script-validation.test.ts
@@ -324,7 +324,7 @@ describe("install.sh validation", () => {
       const fnStart = content.indexOf("clone_cli()");
       const fnBody = content.slice(fnStart);
       // Should remove the temporary repo dir (uses safe canonical path validation)
-      expect(fnBody).toContain('rm -rf "${repo_dir}"');
+      expect(fnBody).toContain('rm -rf "${canonical_repo}"');
     });
   });
 


### PR DESCRIPTION
## Summary

One-line test fix: `clone_cli()` in install.sh was updated to use `rm -rf "${canonical_repo}"` (resolved real path) instead of `"${repo_dir}"` for safer cleanup. The test assertion still checked for the old string.

## Test plan

- [x] `bun test` — 76/76 install validation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)