### PR TITLE
fix: confirm cloud resource name even when SPAWN_NAME is set

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/aws/aws.ts
+++ b/cli/src/aws/aws.ts
@@ -813,12 +813,11 @@ export async function promptSpawnName(): Promise<void> {
   if (process.env.SPAWN_NAME_KEBAB) return;
 
   let kebab: string;
-  if (process.env.SPAWN_NAME) {
-    kebab = toKebabCase(process.env.SPAWN_NAME) || defaultSpawnName();
-  } else if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = defaultSpawnName();
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
   } else {
-    const fallback = defaultSpawnName();
+    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
+    const fallback = derived || defaultSpawnName();
     process.stderr.write("\n");
     const answer = await prompt(`AWS instance name [${fallback}]: `);
     kebab = toKebabCase(answer || fallback) || defaultSpawnName();

--- a/cli/src/daytona/daytona.ts
+++ b/cli/src/daytona/daytona.ts
@@ -527,12 +527,11 @@ export async function promptSpawnName(): Promise<void> {
   if (process.env.SPAWN_NAME_KEBAB) return;
 
   let kebab: string;
-  if (process.env.SPAWN_NAME) {
-    kebab = toKebabCase(process.env.SPAWN_NAME) || defaultSpawnName();
-  } else if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = defaultSpawnName();
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
   } else {
-    const fallback = defaultSpawnName();
+    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
+    const fallback = derived || defaultSpawnName();
     process.stderr.write("\n");
     const answer = await prompt(`Daytona workspace name [${fallback}]: `);
     kebab = toKebabCase(answer || fallback) || defaultSpawnName();

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -953,12 +953,11 @@ export async function promptSpawnName(): Promise<void> {
   if (process.env.SPAWN_NAME_KEBAB) return;
 
   let kebab: string;
-  if (process.env.SPAWN_NAME) {
-    kebab = toKebabCase(process.env.SPAWN_NAME) || defaultSpawnName();
-  } else if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = defaultSpawnName();
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
   } else {
-    const fallback = defaultSpawnName();
+    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
+    const fallback = derived || defaultSpawnName();
     process.stderr.write("\n");
     const answer = await prompt(`DigitalOcean droplet name [${fallback}]: `);
     kebab = toKebabCase(answer || fallback) || defaultSpawnName();

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -918,12 +918,11 @@ export async function promptSpawnName(): Promise<void> {
   if (process.env.SPAWN_NAME_KEBAB) return;
 
   let kebab: string;
-  if (process.env.SPAWN_NAME) {
-    kebab = toKebabCase(process.env.SPAWN_NAME) || defaultSpawnName();
-  } else if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = defaultSpawnName();
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
   } else {
-    const fallback = defaultSpawnName();
+    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
+    const fallback = derived || defaultSpawnName();
     process.stderr.write("\n");
     const answer = await prompt(`Fly machine name [${fallback}]: `);
     kebab = toKebabCase(answer || fallback) || defaultSpawnName();

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -387,12 +387,11 @@ export async function promptSpawnName(): Promise<void> {
   if (process.env.SPAWN_NAME_KEBAB) return;
 
   let kebab: string;
-  if (process.env.SPAWN_NAME) {
-    kebab = toKebabCase(process.env.SPAWN_NAME) || defaultSpawnName();
-  } else if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = defaultSpawnName();
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
   } else {
-    const fallback = defaultSpawnName();
+    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
+    const fallback = derived || defaultSpawnName();
     process.stderr.write("\n");
     const answer = await prompt(`GCP instance name [${fallback}]: `);
     kebab = toKebabCase(answer || fallback) || defaultSpawnName();

--- a/cli/src/hetzner/hetzner.ts
+++ b/cli/src/hetzner/hetzner.ts
@@ -584,12 +584,11 @@ export async function promptSpawnName(): Promise<void> {
   if (process.env.SPAWN_NAME_KEBAB) return;
 
   let kebab: string;
-  if (process.env.SPAWN_NAME) {
-    kebab = toKebabCase(process.env.SPAWN_NAME) || defaultSpawnName();
-  } else if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = defaultSpawnName();
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
   } else {
-    const fallback = defaultSpawnName();
+    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
+    const fallback = derived || defaultSpawnName();
     process.stderr.write("\n");
     const answer = await prompt(`Hetzner server name [${fallback}]: `);
     kebab = toKebabCase(answer || fallback) || defaultSpawnName();

--- a/cli/src/sprite/sprite.ts
+++ b/cli/src/sprite/sprite.ts
@@ -195,12 +195,11 @@ export async function promptSpawnName(): Promise<void> {
   if (process.env.SPAWN_NAME_KEBAB) return;
 
   let kebab: string;
-  if (process.env.SPAWN_NAME) {
-    kebab = toKebabCase(process.env.SPAWN_NAME) || defaultSpawnName();
-  } else if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = defaultSpawnName();
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
   } else {
-    const fallback = defaultSpawnName();
+    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
+    const fallback = derived || defaultSpawnName();
     process.stderr.write("\n");
     const answer = await prompt(`Sprite name [${fallback}]: `);
     kebab = toKebabCase(answer || fallback) || defaultSpawnName();


### PR DESCRIPTION
## Summary

- When CLI collects a display name (`SPAWN_NAME`), each cloud now shows the kebab-case derivative as the **default** in the resource name prompt — user can hit Enter to accept or type an override
- Previously this path silently accepted the derived kebab with no confirmation
- Non-interactive mode (`SPAWN_NON_INTERACTIVE=1`) still skips the prompt

**Before:** "My Dev Box" → silently becomes `my-dev-box`, no chance to change it  
**After:** "My Dev Box" → `DigitalOcean droplet name [my-dev-box]: ` — user confirms or overrides

Closes #1753

## Test plan

- [x] `bun test` — 1819 pass, 0 fail
- [x] All 7 clouds updated: DO, Hetzner, AWS, GCP, Fly, Daytona, Sprite

🤖 Generated with [Claude Code](https://claude.com/claude-code)