### PR TITLE
fix: add remote path validation to GCP uploadFile

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -920,6 +920,10 @@ export async function runServerCapture(cmd: string, timeoutSecs?: number): Promi
 }
 
 export async function uploadFile(localPath: string, remotePath: string): Promise<void> {
+  if (!/^[a-zA-Z0-9/_.~$-]+$/.test(remotePath) || remotePath.includes("..")) {
+    logError(`Invalid remote path: ${remotePath}`);
+    throw new Error("Invalid remote path");
+  }
   const username = resolveUsername();
   // Expand $HOME on remote side
   const expandedPath = remotePath.replace(/^\$HOME/, "~");


### PR DESCRIPTION
**Why:** GCP's \`uploadFile\` passes \`remotePath\` directly to \`scp\` with no validation, while all 6 other cloud providers (Fly, Hetzner, DigitalOcean, AWS, Sprite, Daytona) validate with an allowlist regex. This breaks the defense-in-depth pattern — if any code path passes an unsanitized value, GCP would be the only vulnerable provider.

Adds the same allowlist check (\`^[a-zA-Z0-9/_.~$-]+$\`) plus \`..\` check used by all other providers. The regex includes \`$\` to allow \`$HOME\`-prefixed paths that \`agent-setup.ts\` passes to GCP's uploadFile.

All 1819 tests pass.

-- refactor/code-health