### PR TITLE
fix: add SSH keepalives, increase cloud-init patience, simplify openclaw launch

### DIFF
--- a/cli/src/aws/aws.ts
+++ b/cli/src/aws/aws.ts
@@ -122,6 +122,10 @@ const SSH_OPTS = [
   "LogLevel=ERROR",
   "-o",
   "ConnectTimeout=10",
+  "-o",
+  "ServerAliveInterval=15",
+  "-o",
+  "ServerAliveCountMax=3",
   "-i",
   SSH_KEY_PATH,
 ];

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -837,6 +837,10 @@ const SSH_OPTS = [
   "LogLevel=ERROR",
   "-o",
   "ConnectTimeout=10",
+  "-o",
+  "ServerAliveInterval=15",
+  "-o",
+  "ServerAliveCountMax=3",
 ];
 
 export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<void> {
@@ -917,8 +921,8 @@ export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<v
     logWarn("Could not stream cloud-init log, falling back to polling...");
   }
 
-  // Brief fallback poll if streaming failed (e.g. log file not yet created)
-  for (let attempt = 1; attempt <= 6; attempt++) {
+  // Fallback poll if streaming failed (e.g. log file not yet created)
+  for (let attempt = 1; attempt <= 20; attempt++) {
     try {
       const proc = Bun.spawn(
         [
@@ -943,7 +947,7 @@ export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<v
     } catch {
       /* ignore */
     }
-    logStep(`Cloud-init in progress (${attempt}/6)`);
+    logStep(`Cloud-init in progress (${attempt}/20)`);
     await sleep(5000);
   }
   logWarn("Cloud-init marker not found, continuing anyway...");

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -772,7 +772,7 @@ export async function createInstance(
 
 // ─── SSH Operations ─────────────────────────────────────────────────────────
 
-const SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR";
+const SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ServerAliveInterval=15 -o ServerAliveCountMax=3";
 
 export async function waitForSsh(maxAttempts = 30): Promise<void> {
   logStep("Waiting for SSH connectivity...");

--- a/cli/src/hetzner/hetzner.ts
+++ b/cli/src/hetzner/hetzner.ts
@@ -457,6 +457,10 @@ const SSH_OPTS = [
   "LogLevel=ERROR",
   "-o",
   "ConnectTimeout=10",
+  "-o",
+  "ServerAliveInterval=15",
+  "-o",
+  "ServerAliveCountMax=3",
 ];
 
 export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<void> {

--- a/cli/src/shared/agent-setup.ts
+++ b/cli/src/shared/agent-setup.ts
@@ -330,7 +330,7 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       ],
       configure: (apiKey, modelId) => setupOpenclawConfig(runner, apiKey, modelId || "openrouter/auto"),
       preLaunch: () => startGateway(runner),
-      launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; openclaw tui",
+      launchCmd: () => "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.bun/bin:$HOME/.local/bin:$PATH; openclaw tui",
     },
 
     opencode: {


### PR DESCRIPTION
## Summary
- **SSH keepalives** on all SSH-based clouds (DO, Hetzner, AWS, GCP): `ServerAliveInterval=15` + `ServerAliveCountMax=3` prevents silent TCP drops from NAT/firewall timeouts during long idle periods — the main cause of SSH shell flakiness when the TUI is waiting on slow LLM API calls. (Daytona already had these.)
- **Cloud-init fallback patience** on DigitalOcean: bumped fallback poll from 6×5s (30s) to 20×5s (100s) so `full`-tier cloud-init (build-essential + bun + node) has time to finish when the streaming `tail -f` path fails.
- **Simplified openclaw launch**: replaced `source ~/.zshrc` with explicit `PATH` export to avoid side effects from sourcing zshrc inside `bash -l`.

## Test plan
- [x] `bun test` — all 1819 tests pass
- [ ] Manual: deploy openclaw on DigitalOcean, verify SSH session survives idle periods
- [ ] Manual: verify cloud-init completes on a fresh DO droplet with `full` tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)