### PR TITLE
feat: unify list/delete with inline delete picker

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Both `spawn list` and `spawn delete` now share a single interactive picker backed by `getActiveServers()`, eliminating the data-source discrepancy between the two commands
- Added `pickToTTYWithActions()` to the picker module — pressing `d` triggers inline delete, removes the item, and re-shows the list without restarting
- Failed deletions now mark entries as deleted so users aren't stuck with phantom servers they can't clear

## Test plan
- [x] `bun test` — all 1819 tests pass
- [x] `bun run lint` — no new errors (pre-existing `noExplicitAny` warnings unchanged)
- [ ] Manual: `spawn list` shows active servers, press `d` → confirm → item removed from list
- [ ] Manual: `spawn delete` shows same list, same behavior
- [ ] Manual: failed delete still removes entry from history

🤖 Generated with [Claude Code](https://claude.com/claude-code)