### PR TITLE
feat: add delete sub-menu and spawn kill alias

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/history.ts
+++ b/cli/src/history.ts
@@ -157,6 +157,20 @@ export function mergeLastConnection(): void {
   }
 }
 
+/** Remove a record from history entirely (soft delete — no cloud API call). */
+export function removeRecord(record: SpawnRecord): boolean {
+  const history = loadHistory();
+  const index = history.findIndex(
+    (r) => r.timestamp === record.timestamp && r.agent === record.agent && r.cloud === record.cloud,
+  );
+  if (index < 0) {
+    return false;
+  }
+  history.splice(index, 1);
+  writeFileSync(getHistoryPath(), JSON.stringify(history, null, 2) + "\n");
+  return true;
+}
+
 export function markRecordDeleted(record: SpawnRecord): boolean {
   const history = loadHistory();
   const index = history.findIndex(

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -460,6 +460,7 @@ const DELETE_COMMANDS = new Set([
   "delete",
   "rm",
   "destroy",
+  "kill",
 ]);
 
 // Common verb prefixes that users naturally try (e.g. "spawn run claude sprite")


### PR DESCRIPTION
## Summary
- Pressing `d` in the server picker now shows a sub-menu: **Destroy server** (hard delete via cloud API), **Remove from history** (soft delete, no cloud call), or **Cancel**
- Added `spawn kill` as an alias for `spawn delete` / `spawn rm` / `spawn destroy`
- Added `removeRecord()` to `history.ts` for removing entries without cloud API calls
- Version bump `0.6.17` → `0.6.18`

## Test plan
- [x] `bun test` — all 1819 tests pass
- [x] `biome lint` — no errors
- [ ] Manual: `spawn ls` → press `d` → see "Destroy server / Remove from history / Cancel"
- [ ] Manual: "Remove from history" removes record without cloud API call
- [ ] Manual: `spawn kill` works identically to `spawn delete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)