### PR TITLE
fix: truncate picker lines to terminal width

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Long picker labels (agent + cloud + server name) wrap to multiple terminal rows, but the redraw logic assumes each option is exactly one row — causing old content to pile up on every arrow-key press
- Query terminal width via `stty size` and truncate all labels/hints to fit within a single row (1-char margin to prevent auto-wrap edge cases)
- Both `pickToTTY` and `pickToTTYWithActions` are fixed

## Test plan
- [ ] Run `spawn ls` with 3+ servers whose labels are wider than the terminal
- [ ] Press up/down — verify clean redraw with no duplication
- [ ] Resize terminal to narrow width and repeat
- [ ] Verify hints are hidden gracefully when space is too tight
- [ ] `bun test` passes (1829 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)