### PR TITLE
fix: remove git dependency from install script

### DIFF
--- a/cli/src/__tests__/install-script-validation.test.ts
+++ b/cli/src/__tests__/install-script-validation.test.ts
@@ -279,24 +279,16 @@ describe("install.sh validation", () => {
   // ── clone_cli function ──────────────────────────────────────────────
 
   describe("clone_cli", () => {
-    it("should check for git availability", () => {
-      expect(content).toContain("command -v git");
+    it("should not require git (avoids macOS Xcode CLT trigger)", () => {
+      expect(content).not.toContain("command -v git");
+      expect(content).not.toContain("git clone");
+      expect(content).not.toContain("sparse-checkout");
     });
 
-    it("should use sparse checkout for git clone", () => {
-      expect(content).toContain("sparse-checkout");
-    });
-
-    it("should use --depth 1 for shallow clone", () => {
-      expect(content).toContain("--depth 1");
-    });
-
-    it("should fall back to curl download when git is not available", () => {
-      // Extract clone_cli function body up to the next top-level function
+    it("should download source via curl and GitHub API", () => {
       const fnStart = content.indexOf("clone_cli()");
       const fnEnd = content.indexOf("\n# --- Helper: build", fnStart);
       const fnBody = content.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined);
-      // Should have an else branch that uses curl
       expect(fnBody).toContain("curl");
       expect(fnBody).toContain("api.github.com");
     });
@@ -312,13 +304,6 @@ describe("install.sh validation", () => {
 
     it("should exclude __tests__ directory from downloads", () => {
       expect(content).toContain("__tests__");
-    });
-
-    it("should clean up temporary repo directory after sparse checkout", () => {
-      const fnStart = content.indexOf("clone_cli()");
-      const fnBody = content.slice(fnStart);
-      // Should remove the temporary repo dir (uses safe canonical path validation)
-      expect(fnBody).toContain('rm -rf "${canonical_repo}"');
     });
   });
 


### PR DESCRIPTION
## Summary
- macOS ships a `/usr/bin/git` shim that triggers a ~1.5GB Xcode CLT download when invoked, even without CLT installed
- The install script's `command -v git` check was fooled by this shim, causing `curl | bash` to hang or silently exit on fresh macOS
- Removed the git clone path entirely — the curl-based download via GitHub API is fast, reliable, and has zero dependencies beyond curl and bun
- Updated tests: replaced 4 git-specific assertions with a test that verifies git is **not** used

Closes #1768

## Test plan
- [ ] Run `curl -fsSL .../cli/install.sh | bash` on a machine without git — should install cleanly
- [ ] Run on macOS without Xcode CLT — should NOT trigger CLT dialog
- [ ] Run on Linux with git installed — should still work (curl path only)
- [ ] `bun test` passes (1826 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)