### PR TITLE
fix: use minimal cloud-init tier for Claude Code

### DIFF
--- a/cli/src/shared/agent-setup.ts
+++ b/cli/src/shared/agent-setup.ts
@@ -322,7 +322,7 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
   return {
     claude: {
       name: "Claude Code",
-      cloudInitTier: "node",
+      cloudInitTier: "minimal",
       preProvision: promptGithubAuth,
       install: () => installClaudeCode(runner),
       envVars: (apiKey) => [


### PR DESCRIPTION
## Summary
- Switch Claude Code's `cloudInitTier` from `"node"` to `"minimal"`
- Cloud-init now only installs `curl`, `unzip`, `git`, `ca-certificates` — drops `zsh`, `build-essential`, Node.js, and the redundant Claude Code install
- `installClaudeCode()` already handles Node.js + Claude Code installation over SSH with retries and fallbacks, so the cloud-init copies were redundant

## Test plan
- [ ] `spawn gcp claude` provisions and installs Claude Code successfully
- [ ] Cloud-init completes faster (no Node.js compile / npm install)
- [ ] Claude Code launches and connects to OpenRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)