### PR TITLE
feat: multi-line layout for ls/delete picker

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/cmdlist-integration.test.ts
+++ b/cli/src/__tests__/cmdlist-integration.test.ts
@@ -232,7 +232,7 @@ describe("cmdList integration", () => {
       },
     ];
 
-    it("should render table header with AGENT, CLOUD, WHEN columns", async () => {
+    it("should render multi-line entries with name and subtitle", async () => {
       writeHistory(sampleRecords);
 
       // Mock fetch to return manifest (for display names)
@@ -247,26 +247,9 @@ describe("cmdList integration", () => {
       await cmdList();
 
       const output = consoleOutput();
-      expect(output).toContain("AGENT");
-      expect(output).toContain("CLOUD");
-      expect(output).toContain("WHEN");
-    });
-
-    it("should show separator line under header", async () => {
-      writeHistory(sampleRecords);
-
-      global.fetch = mock(
-        () =>
-          Promise.resolve({
-            ok: true,
-            json: async () => mockManifest,
-          }) as any,
-      );
-
-      await cmdList();
-
-      const output = consoleOutput();
-      expect(output).toContain("-".repeat(10));
+      // Subtitle lines should contain agent · cloud · time
+      expect(output).toContain("Claude Code");
+      expect(output).toContain("·");
     });
 
     it("should render records in reverse chronological order (newest first)", async () => {
@@ -313,7 +296,7 @@ describe("cmdList integration", () => {
       expect(output).toContain("Codex");
     });
 
-    it("should fall back to raw keys when manifest is unavailable", async () => {
+    it("should still render when manifest is unavailable", async () => {
       writeHistory(sampleRecords);
 
       // Clear in-memory cache and mock fetch to fail
@@ -323,11 +306,9 @@ describe("cmdList integration", () => {
       await cmdList();
 
       const output = consoleOutput();
-      // Should still render the table (with raw keys)
-      expect(output).toContain("AGENT");
-      expect(output).toContain("CLOUD");
-      // Raw keys should appear since manifest is unavailable
-      expect(output).toContain("claude");
+      // Should still render entries (with raw keys or cached display names)
+      expect(output).toContain("·");
+      expect(output).toContain("unnamed");
     });
 
     it("should show rerun hint in footer", async () => {
@@ -394,7 +375,7 @@ describe("cmdList integration", () => {
   // ── Prompt display in history ─────────────────────────────────────────────
 
   describe("prompt display in history records", () => {
-    it("should show prompt preview in table row", async () => {
+    it("should render multi-line entry for record with prompt", async () => {
       writeHistory([
         {
           agent: "claude",
@@ -415,32 +396,9 @@ describe("cmdList integration", () => {
       await cmdList();
 
       const output = consoleOutput();
-      expect(output).toContain("Fix all linter errors");
-    });
-
-    it("should truncate long prompts with ellipsis", async () => {
-      writeHistory([
-        {
-          agent: "claude",
-          cloud: "sprite",
-          timestamp: "2026-01-01T10:00:00Z",
-          prompt:
-            "This is a very long prompt that should be truncated because it exceeds the display limit in the table",
-        },
-      ]);
-
-      global.fetch = mock(
-        () =>
-          Promise.resolve({
-            ok: true,
-            json: async () => mockManifest,
-          }) as any,
-      );
-
-      await cmdList();
-
-      const output = consoleOutput();
-      expect(output).toContain("...");
+      // Should show agent and cloud in subtitle
+      expect(output).toContain("Claude Code");
+      expect(output).toContain("Sprite");
     });
 
     it("should include prompt in rerun hint for latest record with prompt", async () => {

--- a/cli/src/picker.ts
+++ b/cli/src/picker.ts
@@ -24,6 +24,7 @@ export interface PickOption {
   value: string;
   label: string;
   hint?: string;
+  subtitle?: string;
 }
 
 export interface PickConfig {
@@ -368,8 +369,9 @@ export function pickToTTYWithActions(config: PickConfig): PickResult {
     ? "\u2191/\u2193 move  \u23ce select  d delete  Ctrl-C cancel"
     : "\u2191/\u2193 move  \u23ce select  Ctrl-C cancel";
 
-  // header line + one line per option + footer line
-  const pickerHeight = config.options.length + 2;
+  // header line + lines per option (2 if subtitle, 1 otherwise) + footer line
+  const linesPerOption = config.options.map((o) => (o.subtitle ? 2 : 1));
+  const pickerHeight = 1 + linesPerOption.reduce((a, b) => a + b, 0) + 1;
 
   const render = (first: boolean) => {
     if (!first) {
@@ -381,16 +383,22 @@ export function pickToTTYWithActions(config: PickConfig): PickResult {
       if (i === selected) {
         const label = trunc(opt.label, maxW - 2);
         w(`${A.green}${A.bold}> ${label}${A.reset}`);
-        if (opt.hint) {
+        if (!opt.subtitle && opt.hint) {
           const remaining = maxW - 2 - label.length - 2;
           if (remaining > 3) {
             w(`  ${A.dim}${trunc(opt.hint, remaining)}${A.reset}`);
           }
         }
+        w("\r\n");
+        if (opt.subtitle) {
+          w(`  ${A.dim}${trunc(opt.subtitle, maxW - 2)}${A.reset}\r\n`);
+        }
       } else {
-        w(`  ${A.dim}${trunc(opt.label, maxW - 2)}${A.reset}`);
+        w(`  ${A.dim}${trunc(opt.label, maxW - 2)}${A.reset}\r\n`);
+        if (opt.subtitle) {
+          w(`  ${A.dim}${trunc(opt.subtitle, maxW - 2)}${A.reset}\r\n`);
+        }
       }
-      w("\r\n");
     }
     w(`${A.dim}  ${trunc(footerHint, maxW - 2)}${A.reset}\r\n`);
   };


### PR DESCRIPTION
## Summary
- Entries now display as two lines: **name** on line 1, **agent · cloud · time** on line 2
- Picker supports `subtitle` field for multi-line option rendering
- Removes SSH connection info and prompt previews from list display for cleaner output
- Bumps CLI version to 0.6.20

**Before:**
```
> Claude Code on GCP -- my-server  2h ago  ssh user@1.2.3.4
```

**After:**
```
> my-server
  Claude Code · GCP Compute Engine · 2h ago
```

## Test plan
- [x] All 1838 tests pass
- [x] Lint clean
- [ ] Manual: `spawn ls` shows multi-line entries
- [ ] Manual: `spawn delete` picker renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)