### PR TITLE
fix: use sentinel values in Daytona saveVmConnection

### DIFF
--- a/cli/src/daytona/daytona.ts
+++ b/cli/src/daytona/daytona.ts
@@ -381,7 +381,7 @@ export async function createServer(name: string): Promise<void> {
   // Set up SSH access
   await setupSshAccess();
 
-  saveVmConnection(sshHost, sshToken, sandboxId, name, "daytona");
+  saveVmConnection("daytona-sandbox", "daytona", sandboxId, name, "daytona");
 }
 
 // ─── Execution ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Why:** Daytona spawns never appear in \`spawn list\`/\`spawn delete\`/\`spawn resume\` because \`saveVmConnection(sshHost, sshToken, ...))\` writes the raw SSH token as the \`user\` field, which \`mergeLastConnection()\` in \`history.ts:124\` rejects via \`validateUsername()\` (SSH token is >32 chars, not a unix username). The connection file gets deleted before it can be merged into history.

## Root cause

\`daytona/daytona.ts:365\` passes actual SSH credentials to \`saveVmConnection()\`:
\`\`\`typescript
// Before (broken)
saveVmConnection(sshHost, sshToken, sandboxId, name, "daytona");
\`\`\`

Fly.io and Sprite use provider-specific sentinels instead of raw credentials:
- Fly: \`saveVmConnection("fly-ssh", "root", machineId, name, "fly")\`
- Sprite: writes \`ip: "sprite-console"\`

## Fix

\`\`\`typescript
// After (correct)
saveVmConnection("daytona-sandbox", "daytona", sandboxId, name, "daytona");
\`\`\`

- \`"daytona-sandbox"\` is already in \`CONNECTION_SENTINELS\` (\`security.ts:31\`) — passes \`validateConnectionIP()\`
- \`"daytona"\` passes \`validateUsername()\` (7 chars, lowercase alpha)
- \`commands.ts:2386\` and \`commands.ts:2834\` already check \`conn.ip === "daytona-sandbox"\` — the reconnect/list/delete paths are already correct, just never triggered

## Test plan

- [x] \`bunx @biomejs/biome lint src/daytona/daytona.ts\` — 0 new errors (2 pre-existing warnings on unrelated code)
- [x] \`bun test\` — 1838 pass, 0 fail

-- refactor/code-health