### PR TITLE
feat: shared SSH wait utility with TCP pre-check and stderr capture

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/shared/ssh.ts
+++ b/cli/src/shared/ssh.ts
@@ -1,0 +1,149 @@
+// shared/ssh.ts — Shared SSH wait utility with TCP pre-check and stderr capture
+
+import { logInfo, logStep, logError } from "./ui";
+import { connect } from "node:net";
+
+// ─── Shared SSH Options ──────────────────────────────────────────────────────
+
+/** Base SSH options shared across all clouds (array form for Bun.spawn). */
+export const SSH_BASE_OPTS: string[] = [
+  "-o", "StrictHostKeyChecking=no",
+  "-o", "UserKnownHostsFile=/dev/null",
+  "-o", "LogLevel=ERROR",
+  "-o", "ConnectTimeout=10",
+  "-o", "ServerAliveInterval=15",
+  "-o", "ServerAliveCountMax=3",
+  "-o", "BatchMode=yes",
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Async sleep — shared across all cloud providers. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ─── TCP Pre-Check ───────────────────────────────────────────────────────────
+
+/**
+ * Probe whether a TCP port is open using node:net.
+ * Returns true if the connection succeeds within `timeoutMs`, false otherwise.
+ * This is much cheaper than a full SSH handshake attempt.
+ */
+export function tcpCheck(host: string, port: number, timeoutMs = 2000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ host, port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+    socket.on("connect", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on("error", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+// ─── SSH Wait ────────────────────────────────────────────────────────────────
+
+export interface WaitForSshOpts {
+  host: string;
+  user: string;
+  /** Maximum total attempts across both phases. Default: 36 (~3 min). */
+  maxAttempts?: number;
+  /** Path to SSH identity file (e.g. ~/.ssh/id_ed25519). */
+  sshKeyPath?: string;
+  /** Extra SSH options appended after SSH_BASE_OPTS. */
+  extraSshOpts?: string[];
+}
+
+/**
+ * Two-phase SSH wait with resilience improvements:
+ *
+ * **Phase 1 (TCP probe):** Loop with cheap TCP probes until port 22 is open.
+ *   Uses 2s intervals. Avoids the 10s ConnectTimeout overhead when sshd isn't
+ *   even listening yet (VM still booting).
+ *
+ * **Phase 2 (SSH handshake):** Once port 22 is open, attempt full SSH `echo ok`.
+ *   Uses 3s intervals. Captures stderr so the user sees the actual error reason.
+ *
+ * Total budget: ~`maxAttempts` attempts spread across both phases.
+ * Effective timeout: ~3 min with defaults.
+ */
+export async function waitForSsh(opts: WaitForSshOpts): Promise<void> {
+  const { host, user, sshKeyPath, extraSshOpts } = opts;
+  const maxAttempts = opts.maxAttempts ?? 36;
+
+  // Build SSH args
+  const sshArgs: string[] = [...SSH_BASE_OPTS];
+  if (sshKeyPath) {
+    sshArgs.push("-i", sshKeyPath);
+  }
+  if (extraSshOpts) {
+    sshArgs.push(...extraSshOpts);
+  }
+
+  // ── Phase 1: TCP probe ────────────────────────────────────────────────────
+  logStep("Waiting for SSH port to open...");
+  let attempt = 0;
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    const open = await tcpCheck(host, 22, 2000);
+    if (open) {
+      logInfo("SSH port 22 is open");
+      break;
+    }
+    logStep(`SSH port closed (${attempt}/${maxAttempts})`);
+    await sleep(2000);
+  }
+
+  if (attempt >= maxAttempts) {
+    logError(`SSH port 22 never opened after ${maxAttempts} attempts`);
+    throw new Error("SSH connectivity timeout — port 22 never opened");
+  }
+
+  // ── Phase 2: SSH handshake ────────────────────────────────────────────────
+  logStep("Waiting for SSH handshake...");
+  const remaining = maxAttempts - attempt;
+  // At least 5 handshake attempts even if TCP phase used most of the budget
+  const handshakeAttempts = Math.max(remaining, 5);
+
+  for (let i = 1; i <= handshakeAttempts; i++) {
+    try {
+      const proc = Bun.spawn(
+        ["ssh", ...sshArgs, `${user}@${host}`, "echo ok"],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const exitCode = await proc.exited;
+
+      if (exitCode === 0 && stdout.includes("ok")) {
+        logInfo("SSH is ready");
+        return;
+      }
+
+      // Show the actual SSH error reason dimly so users can debug
+      const reason = stderr.trim();
+      if (reason) {
+        logStep(`SSH handshake failed (${i}/${handshakeAttempts}): ${reason}`);
+      } else {
+        logStep(`SSH handshake failed (${i}/${handshakeAttempts})`);
+      }
+    } catch {
+      logStep(`SSH handshake error (${i}/${handshakeAttempts})`);
+    }
+    await sleep(3000);
+  }
+
+  logError(`SSH handshake failed after ${handshakeAttempts} attempts`);
+  throw new Error("SSH connectivity timeout — handshake never succeeded");
+}

--- a/cli/src/sprite/sprite.ts
+++ b/cli/src/sprite/sprite.ts
@@ -11,6 +11,7 @@ import {
   toKebabCase,
   defaultSpawnName,
 } from "../shared/ui";
+import { sleep } from "../shared/ssh";
 
 // ─── Configurable Constants ──────────────────────────────────────────────────
 
@@ -29,10 +30,6 @@ export function getState() {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
 
 /** Run a command locally and return { exitCode, stdout, stderr }. */
 function spawnSync(args: string[]): {


### PR DESCRIPTION
## Summary

- Extracts duplicated SSH wait logic from 5 cloud providers (AWS, DO, Hetzner, GCP, Sprite) into `cli/src/shared/ssh.ts`
- Two-phase wait: cheap TCP port probe first (2s intervals), then SSH handshake (3s intervals) — avoids wasting 10s ConnectTimeout per attempt when sshd isn't even listening
- Captures SSH stderr so users see actual error reasons (e.g. "Connection refused") instead of just "SSH not ready yet (2/60)"
- Adds `BatchMode=yes` to prevent edge-case interactive prompt hangs
- Nets -30 lines despite adding a new file (191 added, 221 removed)

## Files changed

| File | Change |
|------|--------|
| `cli/src/shared/ssh.ts` | **New** — `SSH_BASE_OPTS`, `sleep()`, `tcpCheck()`, `waitForSsh()` |
| `cli/src/aws/aws.ts` | Use shared imports, remove local duplicates |
| `cli/src/digitalocean/digitalocean.ts` | Use shared imports, remove local duplicates |
| `cli/src/hetzner/hetzner.ts` | Use shared imports, remove local duplicates |
| `cli/src/gcp/gcp.ts` | Use shared imports, fix string→array SSH_OPTS |
| `cli/src/sprite/sprite.ts` | Use shared `sleep()` import |
| `cli/package.json` | Version bump 0.7.0 → 0.7.1 |

Daytona (token auth) and Fly (WireGuard) left unchanged — architecturally too different from the SSH key-based pattern.

## Test plan

- [x] `bunx @biomejs/biome lint src/` — zero errors (96 files)
- [x] `bun test` — 817 pass, 41 fail (pre-existing, unrelated)
- [ ] Manual test: `spawn run aws/claude-code` — verify two-phase SSH wait with TCP probe messages
- [ ] Manual test: `spawn run digitalocean/claude-code` — verify cloud-init streaming still works after SSH wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)