### PR TITLE
fix: use child_process.spawn for interactive sessions to fix TTY passthrough

### DIFF
--- a/cli/src/daytona/daytona.ts
+++ b/cli/src/daytona/daytona.ts
@@ -1,6 +1,7 @@
 // daytona/daytona.ts — Core Daytona provider: API, SSH, provisioning, execution
 
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { spawn } from "node:child_process";
 import {
   logInfo,
   logWarn,
@@ -519,14 +520,13 @@ export async function interactiveSession(cmd: string): Promise<number> {
     fullCmd,
   ];
 
-  const proc = Bun.spawn(args, {
-    stdio: [
-      "inherit",
-      "inherit",
-      "inherit",
-    ],
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn(args[0], args.slice(1), {
+      stdio: "inherit",
+    });
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
   });
-  const exitCode = await proc.exited;
 
   // Post-session summary
   process.stderr.write("\n");

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -1,6 +1,7 @@
 // digitalocean/digitalocean.ts — Core DigitalOcean provider: API, auth, SSH, provisioning
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 import * as v from "valibot";
 import {
   logInfo,
@@ -1034,23 +1035,13 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
-  const proc = Bun.spawn(
-    [
-      "ssh",
-      ...SSH_OPTS,
-      "-t",
-      `root@${serverIp}`,
-      fullCmd,
-    ],
-    {
-      stdio: [
-        "inherit",
-        "inherit",
-        "inherit",
-      ],
-    },
-  );
-  const exitCode = await proc.exited;
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn("ssh", [...SSH_OPTS, "-t", `root@${serverIp}`, fullCmd], {
+      stdio: "inherit",
+    });
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 
   // Post-session summary
   process.stderr.write("\n");

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -1,6 +1,7 @@
 // gcp/gcp.ts — Core GCP Compute Engine provider: gcloud CLI wrapper, auth, provisioning, SSH
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 import {
   logInfo,
   logWarn,
@@ -919,24 +920,19 @@ export async function interactiveSession(cmd: string): Promise<number> {
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
 
-  const proc = Bun.spawn(
-    [
-      "ssh",
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn("ssh", [
       ...SSH_OPTS,
       "-t",
       `${username}@${gcpServerIp}`,
       `bash -c ${shellQuote(fullCmd)}`,
-    ],
-    {
-      stdio: [
-        "inherit",
-        "inherit",
-        "inherit",
-      ],
+    ], {
+      stdio: "inherit",
       env: process.env,
-    },
-  );
-  const exitCode = await proc.exited;
+    });
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 
   // Post-session summary
   process.stderr.write("\n");

--- a/cli/src/local/local.ts
+++ b/cli/src/local/local.ts
@@ -2,6 +2,7 @@
 
 import { copyFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
+import { spawn } from "node:child_process";
 
 // ─── Execution ───────────────────────────────────────────────────────────────
 
@@ -68,22 +69,14 @@ export function uploadFile(localPath: string, remotePath: string): void {
 
 /** Launch an interactive shell session locally. */
 export async function interactiveSession(cmd: string): Promise<number> {
-  const proc = Bun.spawn(
-    [
-      "bash",
-      "-c",
-      cmd,
-    ],
-    {
-      stdio: [
-        "inherit",
-        "inherit",
-        "inherit",
-      ],
+  return new Promise<number>((resolve, reject) => {
+    const child = spawn("bash", ["-c", cmd], {
+      stdio: "inherit",
       env: process.env,
-    },
-  );
-  return proc.exited;
+    });
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 }
 
 // ─── Connection Tracking ─────────────────────────────────────────────────────

--- a/cli/src/sprite/sprite.ts
+++ b/cli/src/sprite/sprite.ts
@@ -1,6 +1,7 @@
 // sprite/sprite.ts — Core Sprite provider: CLI installation, auth, provisioning, execution
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { spawn } from "node:child_process";
 import {
   logInfo,
   logWarn,
@@ -592,14 +593,13 @@ export async function interactiveSession(cmd: string): Promise<number> {
         cmd,
       ];
 
-  const proc = Bun.spawn(args, {
-    stdio: [
-      "inherit",
-      "inherit",
-      "inherit",
-    ],
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn(args[0], args.slice(1), {
+      stdio: "inherit",
+    });
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
   });
-  const exitCode = await proc.exited;
 
   // Post-session summary
   process.stderr.write("\n");


### PR DESCRIPTION
## Summary

- Switch all 8 `interactiveSession()` functions from `Bun.spawn()` to Node's `child_process.spawn()` to fix laggy/broken keyboard input during SSH sessions after `spawn run`
- Root cause: `Bun.spawn()` doesn't properly restore TTY state after `@clack/prompts` manipulates stdin raw mode during the provisioning flow. `child_process.spawn()` with `stdio: "inherit"` does a clean FD handoff — matching the already-working pattern in `runInteractiveCommand()` used by `spawn ls` resume
- Bump version to 0.7.1

## Files changed

- `cli/src/digitalocean/digitalocean.ts`
- `cli/src/hetzner/hetzner.ts`
- `cli/src/gcp/gcp.ts`
- `cli/src/fly/fly.ts`
- `cli/src/aws/aws.ts`
- `cli/src/daytona/daytona.ts`
- `cli/src/sprite/sprite.ts`
- `cli/src/local/local.ts`
- `cli/package.json` (0.7.0 → 0.7.1)

## Test plan

- [x] `bunx @biomejs/biome lint src/` — zero errors
- [x] `bun test` — 1851 tests pass
- [ ] Manual: `spawn run` on any cloud → verify keyboard input is responsive in the SSH session

🤖 Generated with [Claude Code](https://claude.com/claude-code)