### PR TITLE
fix: extract command substitution from sed in security.sh

### DIFF
--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -220,7 +220,12 @@ elif [[ "${RUN_MODE}" == "review_all" ]]; then
     sed -i "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
     sed -i "s|REPO_ROOT_PLACEHOLDER|${REPO_ROOT}|g" "${PROMPT_FILE}"
     sed -i "s|SLACK_WEBHOOK_PLACEHOLDER|${SLACK_WEBHOOK:-NOT_SET}|g" "${PROMPT_FILE}"
-    sed -i "s|SLACK_WEBHOOK_STATUS_PLACEHOLDER|$(if [ -n "${SLACK_WEBHOOK}" ]; then echo "yes"; else echo "no"; fi)|g" "${PROMPT_FILE}"
+    if [ -n "${SLACK_WEBHOOK:-}" ]; then
+        SLACK_STATUS="yes"
+    else
+        SLACK_STATUS="no"
+    fi
+    sed -i "s|SLACK_WEBHOOK_STATUS_PLACEHOLDER|${SLACK_STATUS}|g" "${PROMPT_FILE}"
 
 else
     # --- Scan mode: full repo security audit + issue filing ---


### PR DESCRIPTION
## Summary

- Replaces inline `$(if ...; fi)` command substitution inside a `sed` replacement string with an intermediate `SLACK_STATUS` variable
- Also adds `:-` default to the `SLACK_WEBHOOK` check for bash `set -u` safety

Fixes #1767

## Test plan

- [ ] `bash -n security.sh` passes (verified locally)
- [ ] Review-all mode correctly substitutes `SLACK_WEBHOOK_STATUS_PLACEHOLDER` with "yes" or "no"

🤖 Generated with [Claude Code](https://claude.com/claude-code)