### PR TITLE
fix: pass explicit SSH identity file for DigitalOcean

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -841,7 +841,8 @@ async function waitForDropletActive(dropletId: string, maxAttempts = 60): Promis
 
 // ─── SSH Execution ───────────────────────────────────────────────────────────
 
-const SSH_OPTS = SSH_BASE_OPTS;
+const SSH_KEY_PATH = `${process.env.HOME}/.ssh/id_ed25519`;
+const SSH_OPTS = [...SSH_BASE_OPTS, "-i", SSH_KEY_PATH];
 
 export async function waitForCloudInit(ip?: string, _maxAttempts = 60): Promise<void> {
   const serverIp = ip || doServerIp;
@@ -849,6 +850,7 @@ export async function waitForCloudInit(ip?: string, _maxAttempts = 60): Promise<
     host: serverIp,
     user: "root",
     maxAttempts: 36,
+    sshKeyPath: SSH_KEY_PATH,
   });
 
   // Stream cloud-init output so the user sees progress in real time


### PR DESCRIPTION
**Why:** DigitalOcean SSH fails with `Permission denied (publickey)` when users have multiple SSH keys or an SSH agent, because the SSH client doesn't know which key to use.

## Root Cause

DigitalOcean's `ensureSshKey()` generates/ensures `~/.ssh/id_ed25519` and registers it with the DO API, but the SSH commands never explicitly specify this key via `-i`. With `BatchMode=yes` in `SSH_BASE_OPTS`, SSH may try other keys first (from agent or default key order) and fail without ever trying the registered `id_ed25519` key.

AWS already handles this correctly by including `-i ~/.ssh/id_ed25519` in its SSH_OPTS and passing `sshKeyPath` to `waitForSsh()`. DigitalOcean was missing both.

## Fix

- Add `SSH_KEY_PATH` constant and include `-i` flag in `SSH_OPTS` (matching AWS pattern)
- Pass `sshKeyPath` to `sharedWaitForSsh()` so the handshake phase also uses the correct key

## Verification

- Biome lint: 0 errors
- `bun test`: 1851 pass, 0 fail

Fixes #1783

-- refactor/code-health