### PR TITLE
refactor: extract saveLaunchCmd to history.ts

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/aws/aws.ts
+++ b/cli/src/aws/aws.ts
@@ -1,6 +1,6 @@
 // aws/aws.ts — Core AWS Lightsail provider: auth, provisioning, SSH execution
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { createHash, createHmac } from "node:crypto";
 import {
@@ -21,7 +21,7 @@ import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../sh
 import { SSH_BASE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
 import * as v from "valibot";
 import { parseJsonWith } from "../shared/parse";
-import { getConnectionPath, saveVmConnection } from "../history.js";
+import { saveVmConnection } from "../history.js";
 
 const DASHBOARD_URL = "https://lightsail.aws.amazon.com/";
 
@@ -859,19 +859,6 @@ export async function waitForInstance(maxAttempts = 60): Promise<void> {
 
   logError(`Instance did not become running after ${maxAttempts} checks`);
   throw new Error("Instance start timeout");
-}
-
-// ─── Connection Tracking ────────────────────────────────────────────────────
-
-export function saveLaunchCmd(launchCmd: string): void {
-  const connFile = getConnectionPath();
-  try {
-    const data = JSON.parse(readFileSync(connFile, "utf-8"));
-    data.launch_cmd = launchCmd;
-    writeFileSync(connFile, JSON.stringify(data) + "\n");
-  } catch {
-    // non-fatal
-  }
 }
 
 // ─── SSH Execution ──────────────────────────────────────────────────────────

--- a/cli/src/aws/main.ts
+++ b/cli/src/aws/main.ts
@@ -15,9 +15,9 @@ import {
   runServer,
   uploadFile,
   interactiveSession,
-  saveLaunchCmd,
 } from "./aws";
 import { resolveAgent } from "./agents";
+import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
 

--- a/cli/src/daytona/daytona.ts
+++ b/cli/src/daytona/daytona.ts
@@ -1,6 +1,6 @@
 // daytona/daytona.ts — Core Daytona provider: API, SSH, provisioning, execution
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import {
   logInfo,
@@ -18,7 +18,7 @@ import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
 import { parseJsonWith, parseJsonRaw } from "../shared/parse";
 import * as v from "valibot";
-import { getConnectionPath, saveVmConnection } from "../history.js";
+import { saveVmConnection } from "../history.js";
 
 const DAYTONA_API_BASE = "https://app.daytona.io/api";
 const DAYTONA_DASHBOARD_URL = "https://app.daytona.io/";
@@ -212,17 +212,6 @@ export async function ensureDaytonaToken(): Promise<void> {
 }
 
 // ─── Connection Tracking ─────────────────────────────────────────────────────
-
-export function saveLaunchCmd(launchCmd: string): void {
-  const connFile = getConnectionPath();
-  try {
-    const data = JSON.parse(readFileSync(connFile, "utf-8"));
-    data.launch_cmd = launchCmd;
-    writeFileSync(connFile, JSON.stringify(data) + "\n");
-  } catch {
-    // non-fatal
-  }
-}
 
 // ─── SSH Helpers ─────────────────────────────────────────────────────────────
 

--- a/cli/src/daytona/main.ts
+++ b/cli/src/daytona/main.ts
@@ -10,9 +10,9 @@ import {
   runServer,
   uploadFile,
   interactiveSession,
-  saveLaunchCmd,
 } from "./daytona";
 import { resolveAgent } from "./agents";
+import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
 

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -1,6 +1,6 @@
 // digitalocean/digitalocean.ts — Core DigitalOcean provider: API, auth, SSH, provisioning
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import * as v from "valibot";
 import {
@@ -20,7 +20,7 @@ import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
 import { parseJsonWith } from "../shared/parse";
 import { SSH_BASE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
-import { getConnectionPath, saveVmConnection } from "../history.js";
+import { saveVmConnection } from "../history.js";
 
 const DO_API_BASE = "https://api.digitalocean.com/v2";
 const DO_DASHBOARD_URL = "https://cloud.digitalocean.com/droplets";
@@ -685,19 +685,6 @@ export async function ensureSshKey(): Promise<void> {
   }
 
   logWarn("SSH key registration may have failed, continuing...");
-}
-
-// ─── Connection Tracking ─────────────────────────────────────────────────────
-
-export function saveLaunchCmd(launchCmd: string): void {
-  const connFile = getConnectionPath();
-  try {
-    const data = JSON.parse(readFileSync(connFile, "utf-8"));
-    data.launch_cmd = launchCmd;
-    writeFileSync(connFile, JSON.stringify(data) + "\n");
-  } catch {
-    // Connection file may not exist — non-fatal
-  }
 }
 
 // ─── Provisioning ────────────────────────────────────────────────────────────

--- a/cli/src/digitalocean/main.ts
+++ b/cli/src/digitalocean/main.ts
@@ -11,9 +11,9 @@ import {
   runServer,
   uploadFile,
   interactiveSession,
-  saveLaunchCmd,
 } from "./digitalocean";
 import { resolveAgent } from "./agents";
+import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
 import { logStep } from "../shared/ui";

--- a/cli/src/fly/fly.ts
+++ b/cli/src/fly/fly.ts
@@ -1,6 +1,6 @@
 // fly/lib/fly.ts — Core Fly.io provider: API, auth, orgs, provisioning, execution
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import {
   logInfo,
@@ -20,7 +20,7 @@ import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
 import * as v from "valibot";
 import { parseJsonWith, parseJsonRaw } from "../shared/parse";
-import { getConnectionPath, saveVmConnection } from "../history.js";
+import { saveVmConnection } from "../history.js";
 
 const FLY_API_BASE = "https://api.machines.dev/v1";
 const FLY_DASHBOARD_URL = "https://fly.io/dashboard";
@@ -313,20 +313,6 @@ function loadTokenFromConfig(): string | null {
     return token;
   } catch {
     return null;
-  }
-}
-
-// ─── Connection Tracking ─────────────────────────────────────────────────────
-
-/** Append launch_cmd to the last-connection.json file */
-export function saveLaunchCmd(launchCmd: string): void {
-  const connFile = getConnectionPath();
-  try {
-    const data = JSON.parse(readFileSync(connFile, "utf-8"));
-    data.launch_cmd = launchCmd;
-    writeFileSync(connFile, JSON.stringify(data) + "\n");
-  } catch {
-    // Connection file may not exist — non-fatal
   }
 }
 

--- a/cli/src/fly/main.ts
+++ b/cli/src/fly/main.ts
@@ -13,12 +13,12 @@ import {
   runServer,
   uploadFile,
   interactiveSession,
-  saveLaunchCmd,
   FLY_VM_TIERS,
   DEFAULT_VM_TIER,
 } from "./fly";
 import type { ServerOptions } from "./fly";
 import { resolveAgent } from "./agents";
+import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
 import { selectFromList } from "../shared/ui";

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -17,7 +17,7 @@ import {
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
 import { SSH_BASE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
-import { getConnectionPath, saveVmConnection } from "../history.js";
+import { saveVmConnection } from "../history.js";
 
 const DASHBOARD_URL = "https://console.cloud.google.com/compute/instances";
 
@@ -988,19 +988,6 @@ export async function destroyInstance(name?: string): Promise<void> {
     throw new Error("Instance deletion failed");
   }
   logInfo(`Instance '${instanceName}' destroyed`);
-}
-
-// ─── Connection Tracking ────────────────────────────────────────────────────
-
-export function saveLaunchCmd(launchCmd: string): void {
-  const connFile = getConnectionPath();
-  try {
-    const data = JSON.parse(readFileSync(connFile, "utf-8"));
-    data.launch_cmd = launchCmd;
-    writeFileSync(connFile, JSON.stringify(data) + "\n");
-  } catch {
-    // non-fatal
-  }
 }
 
 // ─── Shell Quoting ──────────────────────────────────────────────────────────

--- a/cli/src/gcp/main.ts
+++ b/cli/src/gcp/main.ts
@@ -14,9 +14,9 @@ import {
   runServer,
   uploadFile,
   interactiveSession,
-  saveLaunchCmd,
 } from "./gcp";
 import { resolveAgent } from "./agents";
+import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
 

--- a/cli/src/hetzner/hetzner.ts
+++ b/cli/src/hetzner/hetzner.ts
@@ -1,6 +1,6 @@
 // hetzner/hetzner.ts — Core Hetzner Cloud provider: API, auth, SSH, provisioning
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import {
   logInfo,
@@ -20,7 +20,7 @@ import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../sh
 import { SSH_BASE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
 import * as v from "valibot";
 import { parseJsonWith } from "../shared/parse";
-import { getConnectionPath, saveVmConnection } from "../history.js";
+import { saveVmConnection } from "../history.js";
 
 const HETZNER_API_BASE = "https://api.hetzner.cloud/v1";
 const HETZNER_DASHBOARD_URL = "https://console.hetzner.cloud/";
@@ -328,19 +328,6 @@ export async function ensureSshKey(): Promise<void> {
     throw new Error("SSH key registration failed");
   }
   logInfo("SSH key registered with Hetzner");
-}
-
-// ─── Connection Tracking ─────────────────────────────────────────────────────
-
-export function saveLaunchCmd(launchCmd: string): void {
-  const connFile = getConnectionPath();
-  try {
-    const data = JSON.parse(readFileSync(connFile, "utf-8"));
-    data.launch_cmd = launchCmd;
-    writeFileSync(connFile, JSON.stringify(data) + "\n");
-  } catch {
-    // non-fatal
-  }
 }
 
 // ─── Cloud Init Userdata ────────────────────────────────────────────────────

--- a/cli/src/hetzner/main.ts
+++ b/cli/src/hetzner/main.ts
@@ -11,9 +11,9 @@ import {
   runServer,
   uploadFile,
   interactiveSession,
-  saveLaunchCmd,
 } from "./hetzner";
 import { resolveAgent } from "./agents";
+import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
 

--- a/cli/src/history.ts
+++ b/cli/src/history.ts
@@ -93,6 +93,18 @@ export function saveVmConnection(
   writeFileSync(join(dir, "last-connection.json"), JSON.stringify(json) + "\n");
 }
 
+/** Save launch command to the last-connection.json file. */
+export function saveLaunchCmd(launchCmd: string): void {
+  const connFile = getConnectionPath();
+  try {
+    const data = JSON.parse(readFileSync(connFile, "utf-8"));
+    data.launch_cmd = launchCmd;
+    writeFileSync(connFile, JSON.stringify(data) + "\n");
+  } catch {
+    // non-fatal
+  }
+}
+
 export function loadHistory(): SpawnRecord[] {
   const path = getHistoryPath();
   if (!existsSync(path)) {

--- a/cli/src/local/local.ts
+++ b/cli/src/local/local.ts
@@ -1,9 +1,9 @@
 // local/local.ts — Core local provider: runs commands on the user's machine
 
-import { copyFileSync, mkdirSync, readFileSync } from "node:fs";
+import { copyFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { spawn } from "node:child_process";
-import { getSpawnDir, getConnectionPath } from "../history.js";
+import { getSpawnDir } from "../history.js";
 
 // ─── Execution ───────────────────────────────────────────────────────────────
 
@@ -110,14 +110,3 @@ export function saveLocalConnection(): void {
   Bun.write(`${dir}/last-connection.json`, json + "\n");
 }
 
-/** Save launch command to the last-connection.json file. */
-export function saveLaunchCmd(launchCmd: string): void {
-  const connFile = getConnectionPath();
-  try {
-    const data = JSON.parse(readFileSync(connFile, "utf-8"));
-    data.launch_cmd = launchCmd;
-    Bun.write(connFile, JSON.stringify(data) + "\n");
-  } catch {
-    // non-fatal
-  }
-}

--- a/cli/src/local/main.ts
+++ b/cli/src/local/main.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 // local/main.ts — Orchestrator: deploys an agent on the local machine
 
-import { runLocal, uploadFile, interactiveSession, saveLocalConnection, saveLaunchCmd } from "./local";
+import { runLocal, uploadFile, interactiveSession, saveLocalConnection } from "./local";
 import { resolveAgent } from "./agents";
+import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
 

--- a/cli/src/sprite/main.ts
+++ b/cli/src/sprite/main.ts
@@ -10,12 +10,12 @@ import {
   verifySpriteConnectivity,
   setupShellEnvironment,
   saveVmConnection,
-  saveLaunchCmd,
   runSprite,
   uploadFileSprite,
   interactiveSession,
 } from "./sprite";
 import { resolveAgent } from "./agents";
+import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
 

--- a/cli/src/sprite/sprite.ts
+++ b/cli/src/sprite/sprite.ts
@@ -1,6 +1,6 @@
 // sprite/sprite.ts — Core Sprite provider: CLI installation, auth, provisioning, execution
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { spawn } from "node:child_process";
 import {
   logInfo,
@@ -14,7 +14,7 @@ import {
 } from "../shared/ui";
 import { sleep } from "../shared/ssh";
 import { hasMessage } from "../shared/type-guards";
-import { getSpawnDir, getConnectionPath } from "../history.js";
+import { getSpawnDir } from "../history.js";
 
 // ─── Configurable Constants ──────────────────────────────────────────────────
 
@@ -439,17 +439,6 @@ export function saveVmConnection(): void {
     cloud: "sprite",
   };
   writeFileSync(`${dir}/last-connection.json`, JSON.stringify(json) + "\n");
-}
-
-export function saveLaunchCmd(launchCmd: string): void {
-  const connFile = getConnectionPath();
-  try {
-    const data = JSON.parse(readFileSync(connFile, "utf-8"));
-    data.launch_cmd = launchCmd;
-    writeFileSync(connFile, JSON.stringify(data) + "\n");
-  } catch {
-    // Connection file may not exist — non-fatal
-  }
 }
 
 // ─── Execution ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Why:** `saveLaunchCmd` was copy-pasted in 8 cloud files and had already diverged (`local/local.ts` used `Bun.write()` instead of `writeFileSync()`) — a real maintenance bug waiting to happen. Extracting to `history.ts` prevents drift across all cloud providers.

Fixes #1786

## Changes
- `cli/src/history.ts`: Add and export `saveLaunchCmd()`
- 8 cloud files (`fly`, `hetzner`, `digitalocean`, `aws`, `gcp`, `daytona`, `sprite`, `local`): Remove local `saveLaunchCmd` copy
- 8 main.ts files: Import `saveLaunchCmd` from `../history.js` instead of from cloud module
- Cleaned up unused imports (`readFileSync` in `local.ts`, `sprite.ts`; `getConnectionPath` in all 8)
- `cli/package.json`: Bump version 0.7.4 → 0.7.5

## Tests
- `bun test`: 1851 pass, 0 fail
- `biome lint`: zero errors

-- refactor/code-health