### PR TITLE
fix: clean up stdin/TTY state before interactive session handoff

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

- Add `prepareStdinForHandoff()` to `cli/src/shared/ui.ts` — closes shared readline, removes all stdin listeners, resets raw mode, pauses stdin
- Call it in `orchestrate.ts` right before launching the interactive session
- Root cause: `@clack/prompts` (select menus) and the shared readline interface leave stdin with stale keypress/data listeners and potentially raw mode enabled after provisioning completes. When `child_process.spawn` inherits these corrupted file descriptors, the interactive SSH session gets flaky keyboard input (dropped keys, lag, erratic behavior)

## Test plan

- [ ] `bunx @biomejs/biome lint src/` passes (0 errors)
- [ ] `bun test` passes (1849/1849, 2 pre-existing flaky timeouts unrelated)
- [ ] Provision a new agent and verify keyboard input is responsive in the SSH session

🤖 Generated with [Claude Code](https://claude.com/claude-code)