### PR TITLE
fix: reject non-ASCII filenames in install.sh download validation

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -205,6 +205,14 @@ clone_cli() {
     curl -fsSL "${SPAWN_RAW_BASE}/cli/bun.lock"       -o "${dest}/cli/bun.lock"
     curl -fsSL "${SPAWN_RAW_BASE}/cli/tsconfig.json"  -o "${dest}/cli/tsconfig.json"
     for f in $files; do
+        # SECURITY: Reject non-ASCII characters (Unicode lookalikes/homoglyphs)
+        if [[ "$f" =~ [^[:ascii:]] ]]; then
+            log_error "Security: Non-ASCII characters in filename: $f"
+            log_error "Only ASCII filenames are allowed."
+            log_error "Installation aborted for safety."
+            exit 1
+        fi
+
         # SECURITY: Strict allowlist — only alphanumeric, underscore, hyphen, .ts extension
         if [[ ! "$f" =~ ^[a-zA-Z0-9_-]+\.ts$ ]]; then
             log_error "Security: Invalid filename from API: $f"


### PR DESCRIPTION
**Why:** Explicit non-ASCII rejection closes the Unicode lookalike bypass gap in filename validation — attackers who compromise the GitHub API or perform MitM could otherwise inject homoglyph filenames that pass the ASCII regex on Unicode-aware locales.

Fixes #1800

## Changes
- `cli/install.sh`: Add `[[ "$f" =~ [^[:ascii:]] ]]` check before allowlist regex in clone_cli

-- refactor/ux-engineer