### PR TITLE
fix: harden credential file permissions and curl SSL error visibility

### DIFF
--- a/aws/claude.sh
+++ b/aws/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/aws/codex.sh
+++ b/aws/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/aws/kilocode.sh
+++ b/aws/kilocode.sh
@@ -7,7 +7,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/aws/openclaw.sh
+++ b/aws/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/aws/opencode.sh
+++ b/aws/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/aws/zeroclaw.sh
+++ b/aws/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/daytona/claude.sh
+++ b/daytona/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/daytona/codex.sh
+++ b/daytona/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/daytona/kilocode.sh
+++ b/daytona/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/daytona/openclaw.sh
+++ b/daytona/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/daytona/opencode.sh
+++ b/daytona/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/daytona/zeroclaw.sh
+++ b/daytona/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/digitalocean/claude.sh
+++ b/digitalocean/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/digitalocean/codex.sh
+++ b/digitalocean/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/digitalocean/kilocode.sh
+++ b/digitalocean/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/digitalocean/openclaw.sh
+++ b/digitalocean/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/digitalocean/opencode.sh
+++ b/digitalocean/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/digitalocean/zeroclaw.sh
+++ b/digitalocean/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/fly/claude.sh
+++ b/fly/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/fly/codex.sh
+++ b/fly/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/fly/kilocode.sh
+++ b/fly/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/fly/openclaw.sh
+++ b/fly/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/fly/opencode.sh
+++ b/fly/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/fly/zeroclaw.sh
+++ b/fly/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/gcp/claude.sh
+++ b/gcp/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/gcp/codex.sh
+++ b/gcp/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/gcp/kilocode.sh
+++ b/gcp/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/gcp/openclaw.sh
+++ b/gcp/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/gcp/opencode.sh
+++ b/gcp/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/gcp/zeroclaw.sh
+++ b/gcp/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/hetzner/claude.sh
+++ b/hetzner/claude.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
     export PATH="$HOME/.bun/bin:$PATH"
 }
 _ensure_bun

--- a/hetzner/codex.sh
+++ b/hetzner/codex.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
     export PATH="$HOME/.bun/bin:$PATH"
 }
 _ensure_bun

--- a/hetzner/kilocode.sh
+++ b/hetzner/kilocode.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
     export PATH="$HOME/.bun/bin:$PATH"
 }
 _ensure_bun

--- a/hetzner/openclaw.sh
+++ b/hetzner/openclaw.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
     export PATH="$HOME/.bun/bin:$PATH"
 }
 _ensure_bun

--- a/hetzner/opencode.sh
+++ b/hetzner/opencode.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
     export PATH="$HOME/.bun/bin:$PATH"
 }
 _ensure_bun

--- a/hetzner/zeroclaw.sh
+++ b/hetzner/zeroclaw.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
     export PATH="$HOME/.bun/bin:$PATH"
 }
 _ensure_bun

--- a/local/claude.sh
+++ b/local/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/local/codex.sh
+++ b/local/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/local/kilocode.sh
+++ b/local/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/local/openclaw.sh
+++ b/local/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/local/opencode.sh
+++ b/local/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/local/zeroclaw.sh
+++ b/local/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/shared/github-auth.sh
+++ b/shared/github-auth.sh
@@ -238,6 +238,8 @@ ensure_gh_auth() {
             export GITHUB_TOKEN="${_gh_token}"
             return 1
         }
+        # Restrict token file permissions to owner-only (prevents exposure on multi-user systems)
+        chmod 600 "${HOME}/.config/gh/hosts.yml" 2>/dev/null || true
         export GITHUB_TOKEN="${_gh_token}"
     elif gh auth status &>/dev/null; then
         log_info "Authenticated with GitHub CLI"

--- a/sprite/claude.sh
+++ b/sprite/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sprite/codex.sh
+++ b/sprite/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sprite/kilocode.sh
+++ b/sprite/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sprite/openclaw.sh
+++ b/sprite/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sprite/opencode.sh
+++ b/sprite/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sprite/zeroclaw.sh
+++ b/sprite/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }


### PR DESCRIPTION
**Why:** File permission hardening prevents token exposure on multi-user systems; SSL error visibility prevents silent MitM attacks during bun installation.

Fixes #1801 - Add chmod 600 to github-auth.sh after gh auth login
Fixes #1798 - Remove 2>&1 from curl|bash bun install across agent scripts

## Changes
- `shared/github-auth.sh`: chmod 600 on hosts.yml after token write
- 48 agent scripts across aws/, daytona/, digitalocean/, fly/, gcp/, hetzner/, local/, sprite/: replace `curl -fsSL` with `curl -fsSL --show-error` and remove `2>&1` stderr suppression from bun install

-- refactor/security-auditor