### PR TITLE
fix: use SSH_INTERACTIVE_OPTS in interactiveSession() for hetzner/do/aws/gcp

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/aws/aws.ts
+++ b/cli/src/aws/aws.ts
@@ -18,7 +18,7 @@ import {
 } from "../shared/ui";
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
-import { SSH_BASE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
+import { SSH_BASE_OPTS, SSH_INTERACTIVE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
 import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys";
 import * as v from "valibot";
 import { parseJsonWith } from "../shared/parse";
@@ -989,9 +989,8 @@ export async function interactiveSession(cmd: string): Promise<number> {
     const child = spawn(
       "ssh",
       [
-        ...SSH_BASE_OPTS,
+        ...SSH_INTERACTIVE_OPTS,
         ...keyOpts,
-        "-t",
         `${SSH_USER}@${instanceIp}`,
         `bash -c '${escapedCmd}'`,
       ],

--- a/cli/src/digitalocean/digitalocean.ts
+++ b/cli/src/digitalocean/digitalocean.ts
@@ -20,7 +20,7 @@ import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
 import { parseJsonWith } from "../shared/parse";
 import { isString, isNumber } from "../shared/type-guards";
-import { SSH_BASE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
+import { SSH_BASE_OPTS, SSH_INTERACTIVE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
 import { ensureSshKeys, getSshFingerprint, getSshKeyOpts } from "../shared/ssh-keys";
 import { saveVmConnection } from "../history.js";
 
@@ -942,9 +942,8 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
     const child = spawn(
       "ssh",
       [
-        ...SSH_BASE_OPTS,
+        ...SSH_INTERACTIVE_OPTS,
         ...keyOpts,
-        "-t",
         `root@${serverIp}`,
         fullCmd,
       ],

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -16,7 +16,7 @@ import {
 } from "../shared/ui";
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
-import { SSH_BASE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
+import { SSH_BASE_OPTS, SSH_INTERACTIVE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
 import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys";
 import { saveVmConnection } from "../history.js";
 
@@ -898,9 +898,8 @@ export async function interactiveSession(cmd: string): Promise<number> {
     const child = spawn(
       "ssh",
       [
-        ...SSH_BASE_OPTS,
+        ...SSH_INTERACTIVE_OPTS,
         ...keyOpts,
-        "-t",
         `${username}@${gcpServerIp}`,
         `bash -c ${shellQuote(fullCmd)}`,
       ],

--- a/cli/src/hetzner/hetzner.ts
+++ b/cli/src/hetzner/hetzner.ts
@@ -17,7 +17,7 @@ import {
 } from "../shared/ui";
 import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
-import { SSH_BASE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
+import { SSH_BASE_OPTS, SSH_INTERACTIVE_OPTS, sleep, waitForSsh as sharedWaitForSsh } from "../shared/ssh";
 import { ensureSshKeys, getSshFingerprint, getSshKeyOpts } from "../shared/ssh-keys";
 import * as v from "valibot";
 import { parseJsonWith } from "../shared/parse";
@@ -539,9 +539,8 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
     const child = spawn(
       "ssh",
       [
-        ...SSH_BASE_OPTS,
+        ...SSH_INTERACTIVE_OPTS,
         ...keyOpts,
-        "-t",
         `root@${serverIp}`,
         fullCmd,
       ],


### PR DESCRIPTION
**Why:** `SSH_BASE_OPTS` includes `BatchMode=yes` which actively blocks TTY prompts and user interaction — exactly wrong for `interactiveSession()`. Four cloud providers were never updated after PR #1795 introduced `SSH_INTERACTIVE_OPTS` for this purpose. This means interactive sessions on Hetzner, DigitalOcean, AWS, and GCP could silently fail to handle TTY prompts.

## Changes

- `hetzner.ts`, `digitalocean.ts`, `aws.ts`, `gcp.ts`: In `interactiveSession()`, replace `...SSH_BASE_OPTS, ...keyOpts, "-t"` with `...SSH_INTERACTIVE_OPTS, ...keyOpts`
- Add `SSH_INTERACTIVE_OPTS` to imports in all 4 files
- Version bump: 0.7.10 → 0.7.11

`SSH_INTERACTIVE_OPTS` (from `shared/ssh.ts`) already includes `-t`, `Compression=yes`, `IPQoS=lowdelay`, `StrictHostKeyChecking=accept-new`, and omits `BatchMode=yes`. Non-interactive functions (`runServer`, `runServerCapture`, `uploadFile`, `waitForCloudInit`) are unaffected and correctly keep `SSH_BASE_OPTS`.

## Test plan
- [x] `bunx @biomejs/biome lint src/` — 0 errors across 4 changed files
- [x] `bun test` — 1866 pass, 0 fail

-- refactor/code-health