### PR TITLE
feat: enforce worktree-first workflow via PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'BRANCH=$(git -C \"$CLAUDE_PROJECT_DIR\" rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$BRANCH\" = \"main\" ]; then echo \"BLOCKED: You are on main. Create a feature branch first (git checkout -b branch-name), then retry your edit. If you already committed to main by mistake, use: git checkout -b branch-name && git cherry-pick main\" >&2; exit 2; fi'"
+            "command": "bash -c 'INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r \".tool_input.file_path // empty\"); [ -z \"$FILE\" ] && exit 0; DIR=$(dirname \"$FILE\"); [ ! -d \"$DIR\" ] && exit 0; GD=$(cd \"$DIR\" && git rev-parse --git-dir 2>/dev/null) || exit 0; GC=$(cd \"$DIR\" && git rev-parse --git-common-dir 2>/dev/null) || exit 0; AGD=$(cd \"$DIR\" && cd \"$GD\" && pwd); AGC=$(cd \"$DIR\" && cd \"$GC\" && pwd); if [ \"$AGD\" = \"$AGC\" ]; then echo \"BLOCKED: Edits must happen in a git worktree, not the main checkout.\" >&2; echo \"Create a worktree first: git worktree add /tmp/spawn-worktrees/FEATURE -b branch-name\" >&2; echo \"Then use absolute paths under /tmp/spawn-worktrees/FEATURE/ for all edits.\" >&2; exit 2; fi; BRANCH=$(cd \"$DIR\" && git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$BRANCH\" = \"main\" ]; then echo \"BLOCKED: Cannot edit on main branch, even in a worktree.\" >&2; echo \"Create a worktree with a feature branch: git worktree add /tmp/spawn-worktrees/FEATURE -b branch-name\" >&2; exit 2; fi'"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,40 +340,51 @@ refactor.yml        — GitHub Actions workflow that POSTs to the trigger server
 
 ## Git Workflow
 
-- Always work on a feature branch — never commit directly to main (except urgent one-line fixes)
+- Always work in a **git worktree** — never edit files in the main checkout
 - Before creating a PR, check `git status` and `git log` to verify branch state
-- Use `gh pr create` from the feature branch, then `gh pr merge --squash`
+- Use `gh pr create` from the worktree, then `gh pr merge --squash`
 - **Every PR must be MERGED or CLOSED with a comment** — never close silently
 - If a PR can't be merged (conflicts, superseded, wrong approach), close it with `gh pr close {number} --comment "Reason"`
 - Never rebase main or use `--force` unless explicitly asked
 
-### EVERY Change Goes Through a PR — NO EXCEPTIONS
+### Worktree-First Workflow — MANDATORY
 
-**This is the #1 most important workflow rule.** A PreToolUse hook in `.claude/settings.json` **blocks all Write/Edit calls while on `main`**. If you hit this block:
+**This is the #1 most important workflow rule.** A PreToolUse hook in `.claude/settings.json` **blocks all Write/Edit calls unless the target file is inside a git worktree**. Edits to the main checkout are always blocked.
 
-1. **Create a branch** — `git checkout -b descriptive-branch-name`
-2. **Retry your edit** — the hook will allow it now
+Before editing ANY files:
 
-**If you already committed to `main` by mistake** — cherry-pick the commits onto a new branch:
-```bash
-git checkout -b descriptive-branch-name
-git cherry-pick main
-```
-
-Then follow this workflow:
-1. **Make your changes** on the branch
-2. **Commit** after the first meaningful change
-3. **Push and open a draft PR** — `git push -u origin HEAD && gh pr create --draft`
-4. **Push incremental commits** as you work
-5. **When done: convert from draft, then merge** — `gh pr ready NUMBER && gh pr merge --squash NUMBER`
+1. **Create a worktree** with a feature branch:
+   ```bash
+   git worktree add /tmp/spawn-worktrees/FEATURE -b descriptive-branch-name
+   ```
+2. **Edit files using absolute paths** into the worktree:
+   ```
+   /tmp/spawn-worktrees/FEATURE/cli/src/foo.ts   ← YES
+   /home/sprite/spawn/cli/src/foo.ts              ← BLOCKED
+   ```
+3. **Commit and push** from the worktree:
+   ```bash
+   git -C /tmp/spawn-worktrees/FEATURE add -A
+   git -C /tmp/spawn-worktrees/FEATURE commit -m "message"
+   git -C /tmp/spawn-worktrees/FEATURE push -u origin HEAD
+   ```
+4. **Open a draft PR, then merge when done:**
+   ```bash
+   gh pr create --draft --repo OpenRouterTeam/spawn
+   gh pr ready NUMBER && gh pr merge --squash NUMBER
+   ```
+5. **Clean up** the worktree:
+   ```bash
+   git worktree remove /tmp/spawn-worktrees/FEATURE
+   ```
 
 **There is NO category of change exempt from this rule:**
-- CLAUDE.md edits → PR
-- Config file tweaks → PR
-- One-line bug fixes → PR
-- Test additions → PR
-- Documentation updates → PR
-- Manifest changes → PR
+- CLAUDE.md edits → worktree + PR
+- Config file tweaks → worktree + PR
+- One-line bug fixes → worktree + PR
+- Test additions → worktree + PR
+- Documentation updates → worktree + PR
+- Manifest changes → worktree + PR
 
 **A finished PR (tests pass, lint clean) MUST be converted from draft and merged immediately.** Do not leave completed PRs in draft state.
 


### PR DESCRIPTION
## Summary
- Replace the "block edits on main branch" PreToolUse hook with a stricter **worktree check**: Write/Edit are only allowed when the target file is inside a git worktree, not the main checkout
- Also blocks edits on the `main` branch even within a worktree (defense in depth)
- Update CLAUDE.md with the new worktree-first workflow: create worktree → edit there → commit/push → PR → cleanup

## How the hook works
The hook reads `tool_input.file_path` from stdin, resolves the git directory for that path, and compares `git rev-parse --git-dir` vs `--git-common-dir`. In the main checkout they're equal (blocked); in a worktree they differ (allowed).

## Test plan
- [x] Verified hook blocks edits in main checkout (exit 2)
- [x] Verified hook allows edits in a worktree (exit 0)
- [x] Verified hook blocks edits on main branch in a worktree
- [x] Verified files outside git repos pass through (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)