### PR TITLE
fix: persist GCP zone/project metadata for delete

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -728,8 +728,11 @@ export async function createInstance(
 
   logInfo(`Instance created: IP=${gcpServerIp}`);
 
-  // Save connection info
-  saveVmConnection(gcpServerIp, username, "", name, "gcp");
+  // Save connection info with zone/project for later deletion
+  saveVmConnection(gcpServerIp, username, "", name, "gcp", undefined, {
+    zone,
+    project: gcpProject,
+  });
 }
 
 // ─── SSH Operations ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `saveVmConnection()` now accepts optional `metadata` parameter for cloud-specific key-value pairs
- GCP's `createInstance()` saves `zone` and `project` to connection metadata
- `mergeLastConnection()` reads and preserves metadata from `last-connection.json` into history
- On `spawn delete`, the saved zone/project is used automatically — no more re-prompting

## Test plan
- [x] `bun test` — 1866 tests pass
- [x] `biome lint` — zero errors
- [ ] Manual: `spawn gcp/claude-code` then `spawn delete` should delete without asking for project/zone

🤖 Generated with [Claude Code](https://claude.com/claude-code)