### PR TITLE
feat: configure zeroclaw for full autonomy in spawned VMs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -101,6 +101,18 @@
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
         "ZEROCLAW_PROVIDER": "openrouter"
       },
+      "config_files": {
+        "~/.zeroclaw/config.toml": {
+          "security": {
+            "autonomy": "full",
+            "supervised": false,
+            "allow_destructive": true
+          },
+          "shell": {
+            "policy": "allow_all"
+          }
+        }
+      },
       "notes": "Rust-based agent framework built by Harvard/MIT/Sundai.Club communities. Natively supports OpenRouter via OPENROUTER_API_KEY + ZEROCLAW_PROVIDER=openrouter. Requires compilation from source (~5-10 min).",
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/zeroclaw.png",
       "featured_cloud": [


### PR DESCRIPTION
## Summary
- Adds `setupZeroclawConfig()` to write `~/.zeroclaw/config.toml` with full autonomy settings after onboarding, equivalent to Claude Code's `dangerouslySkipPermissions`
- Documents the config in `manifest.json` under zeroclaw's `config_files` field
- Extracts the inline configure lambda into a named function following the pattern of other agents (setupCodexConfig, setupClaudeCodeConfig, etc.)

## Test plan
- [x] `bunx @biomejs/biome lint` passes with zero errors
- [x] `bun test` passes all 1869 tests
- [ ] Deploy zeroclaw on a cloud VM and verify `~/.zeroclaw/config.toml` is written with correct contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)