### PR TITLE
fix: add concurrency guard to CLI release workflow

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -7,6 +7,11 @@ on:
       - 'cli/src/**'
       - 'cli/package.json'
       - 'cli/bun.lock'
+  workflow_dispatch:
+
+concurrency:
+  group: cli-release
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/cli/src/update-check.ts
+++ b/cli/src/update-check.ts
@@ -79,7 +79,7 @@ function compareVersions(current: string, latest: string): boolean {
     }
   }
 
-  return false; // Versions are equal
+  return false;
 }
 
 // ── Failure Backoff ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `concurrency` group to the CLI Release workflow so concurrent runs cancel the older one
- Adds `workflow_dispatch` trigger for manual re-runs

### Root cause

Two PRs (#1810 and #1811) merged 3 seconds apart. Both triggered the CLI Release workflow. #1811 (v0.7.12) finished last and overwrote the `cli-latest` release with a stale binary, even though the repo HEAD was already at v0.8.0 from #1810.

Users running `spawn` see "Update available: v0.7.12 -> v0.8.0", the auto-update runs, downloads the `cli-latest` release binary... which is still v0.7.12. Loop.

### Fix

`concurrency: { group: cli-release, cancel-in-progress: true }` ensures only the latest push's workflow run completes. `workflow_dispatch` allows manual re-triggering when needed.

## Test plan

- [x] Merge this PR (triggers release workflow with correct v0.8.0)
- [ ] Verify `gh release view cli-latest` shows "CLI v0.8.0" after workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)