### PR TITLE
fix: prevent GCP delete from hanging on interactive project prompt

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/gcp/gcp.ts
+++ b/cli/src/gcp/gcp.ts
@@ -436,6 +436,14 @@ export async function resolveProject(): Promise<void> {
   }
 
   if (!project) {
+    // In non-interactive mode (e.g. during deletion), fail fast instead of prompting
+    if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+      logError("No GCP project found in metadata or gcloud config");
+      logError("Set one before retrying:");
+      logError("  export GCP_PROJECT=your-project-id");
+      throw new Error("No GCP project");
+    }
+
     logInfo("Fetching your GCP projects...");
     const listResult = await gcloud([
       "projects",


### PR DESCRIPTION
## Summary
- Fixes `spawn delete` hanging for GCP instances when `resolveProject()` triggers an interactive prompt under the deletion spinner
- Sets `SPAWN_NON_INTERACTIVE=1` during GCP deletion so `resolveProject()` auto-accepts the gcloud config default project instead of prompting
- Only sets `GCP_PROJECT` env var when metadata actually contains a project (avoids setting it to empty string which bypasses the env var check)
- Adds fast-fail in `resolveProject()` when non-interactive and no project is available from gcloud config, instead of falling through to the interactive `selectFromList()` picker

## Root cause
When deleting a GCP instance created before #1809 (or with missing metadata), `conn.metadata?.project` is undefined, so `GCP_PROJECT` was set to `""`. This is falsy, so `resolveProject()` fell through to the interactive prompt path (`Use project 'X'? [Y/n]:`), which collided with the spinner and hung indefinitely.

## Test plan
- [x] `bunx @biomejs/biome lint` passes with zero errors
- [x] `bun test` passes all 1897 tests
- [ ] `spawn delete` a GCP instance with project metadata → deletes without prompts
- [ ] `spawn delete` a GCP instance without project metadata → auto-uses gcloud default project

🤖 Generated with [Claude Code](https://claude.com/claude-code)