### PR TITLE
security: add defensive guards to rm -rf cleanup paths

### DIFF
--- a/.claude/skills/setup-agent-team/qa.sh
+++ b/.claude/skills/setup-agent-team/qa.sh
@@ -55,6 +55,17 @@ log() {
     printf '[%s] [qa/%s] %s\n' "$(date +'%Y-%m-%d %H:%M:%S')" "${RUN_MODE}" "$*" | tee -a "${LOG_FILE}"
 }
 
+# --- Safe rm -rf for worktree paths (defense-in-depth) ---
+safe_rm_worktree() {
+    local target="${1:-}"
+    if [[ -z "${target}" ]]; then return; fi
+    if [[ "${target}" != /tmp/spawn-worktrees/* ]]; then
+        log "ERROR: Refusing to rm -rf: '${target}' is not under /tmp/spawn-worktrees/"
+        return 1
+    fi
+    rm -rf "${target}" 2>/dev/null || true
+}
+
 # Cleanup function — runs on normal exit, SIGTERM, and SIGINT
 cleanup() {
     # Guard against re-entry (SIGTERM trap calls exit, which fires EXIT trap again)
@@ -68,7 +79,7 @@ cleanup() {
 
     # Prune worktrees and clean up only OUR worktree base
     git worktree prune 2>/dev/null || true
-    rm -rf "${WORKTREE_BASE}" 2>/dev/null || true
+    safe_rm_worktree "${WORKTREE_BASE}"
 
     # Clean up test directories from CLI integration tests
     TEST_DIR_COUNT=$(find "${HOME}" -maxdepth 1 -type d -name 'spawn-cmdlist-test-*' 2>/dev/null | wc -l)
@@ -110,7 +121,7 @@ fi
 # Clean stale worktrees
 git worktree prune 2>&1 | tee -a "${LOG_FILE}" || true
 if [[ -d "${WORKTREE_BASE}" ]]; then
-    rm -rf "${WORKTREE_BASE}" 2>&1 | tee -a "${LOG_FILE}" || true
+    safe_rm_worktree "${WORKTREE_BASE}"
     log "Removed stale ${WORKTREE_BASE} directory"
 fi
 


### PR DESCRIPTION
## Summary

- Adds `safe_rm_worktree()` helper function to all 4 agent team scripts
- The helper validates that the target path is non-empty and starts with `/tmp/spawn-worktrees/` before executing `rm -rf`
- If validation fails, it logs an error and refuses to delete

### Files changed

| File | `rm -rf` instances guarded |
|---|---|
| `discovery.sh` | 4 (cleanup trap, pre-cycle, post-cycle, between-cycles) |
| `refactor.sh` | 2 (cleanup trap, pre-cycle) |
| `security.sh` | 2 (cleanup trap, pre-cycle) |
| `qa.sh` | 2 (cleanup trap, pre-cycle) |

### What the guard does

```bash
safe_rm_worktree() {
    local target="${1:-}"
    if [[ -z "${target}" ]]; then return; fi
    if [[ "${target}" != /tmp/spawn-worktrees/* ]]; then
        log "ERROR: Refusing to rm -rf: '${target}' is not under /tmp/spawn-worktrees/"
        return 1
    fi
    rm -rf "${target}" 2>/dev/null || true
}
```

### Not changed

- `find ... -exec rm -rf {} +` for test directory cleanup (already guarded by `-name` pattern matching and count checks)
- `rm -f "${PROMPT_FILE:-}"` (uses `-f` not `-rf`, and deletes a single file)
- Markdown prompt templates that mention `rm -rf` (not executed as shell)

Fixes #1791

## Test plan

- [x] `bash -n` passes on all 4 scripts
- [x] Verified no unguarded `rm -rf $WORKTREE_BASE` remains in any `.sh` file
- [ ] Deploy to staging VM and verify cleanup trap works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)