### PR TITLE
fix: use correct default server type in Hetzner createServer fallback

### DIFF
--- a/cli/src/hetzner/hetzner.ts
+++ b/cli/src/hetzner/hetzner.ts
@@ -408,7 +408,7 @@ export async function createServer(
   location?: string,
   tier?: CloudInitTier,
 ): Promise<void> {
-  const sType = serverType || process.env.HETZNER_SERVER_TYPE || "cx23";
+  const sType = serverType || process.env.HETZNER_SERVER_TYPE || DEFAULT_SERVER_TYPE;
   const loc = location || process.env.HETZNER_LOCATION || "nbg1";
   const image = "ubuntu-24.04";
 


### PR DESCRIPTION
**Why:** The hardcoded fallback `"cx23"` in `createServer()` references a non-existent Hetzner server type, causing API errors when the function is called without an explicit server type parameter. Hetzner renamed `cx23` to `cx22` in their lineup.

## Summary
- Replace stale `"cx23"` string literal with `DEFAULT_SERVER_TYPE` (`"cx22"`) in `cli/src/hetzner/hetzner.ts:411`
- This makes the fallback consistent with `SERVER_TYPES`, `promptServerType()`, and `DEFAULT_SERVER_TYPE`

## Test plan
- [x] `bunx @biomejs/biome lint src/` passes (0 errors)
- [x] `bun test` passes (1897 tests, 0 failures)
- [x] Verified all other cloud providers have consistent fallback values

Agent: code-health