### PR TITLE
fix: restore gateway port wait, batch openclaw setup into 2 SSH sessions

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/fly/agents.ts
+++ b/cli/src/fly/agents.ts
@@ -4,6 +4,7 @@ import { runServer, uploadFile } from "./fly";
 import {
   createAgents,
   installAgent,
+  setupOpenclawBatched,
   resolveAgent as _resolveAgent,
   offerGithubAuth as _offerGithubAuth,
 } from "../shared/agent-setup";
@@ -32,7 +33,7 @@ export const agents: Record<string, FlyAgentConfig> = (() => {
     ...base,
   };
 
-  // Fly openclaw uses a pre-built Docker image
+  // Fly openclaw uses a pre-built Docker image + batched setup (2 SSH sessions total)
   fly.openclaw = {
     ...base.openclaw,
     image: "ghcr.io/openrouterteam/spawn-openclaw:latest",
@@ -50,6 +51,8 @@ export const agents: Record<string, FlyAgentConfig> = (() => {
         );
       }
     },
+    setup: (envContent, apiKey, modelId) =>
+      setupOpenclawBatched(runner, envContent, apiKey, modelId || "openrouter/auto"),
   };
 
   return fly;

--- a/cli/src/shared/agents.ts
+++ b/cli/src/shared/agents.ts
@@ -21,6 +21,11 @@ export interface AgentConfig {
   envVars: (apiKey: string) => string[];
   /** Agent-specific configuration (settings files, etc.). */
   configure?: (apiKey: string, modelId?: string) => Promise<void>;
+  /**
+   * Batched setup: install + env + configure in a single SSH session.
+   * When provided, orchestrate.ts calls this instead of the separate install / env / configure steps.
+   */
+  setup?: (envContent: string, apiKey: string, modelId?: string) => Promise<void>;
   /** Pre-launch hook (e.g., start gateway daemon). */
   preLaunch?: () => Promise<void>;
   /** Shell command to launch the agent interactively. */

--- a/cli/src/shared/orchestrate.ts
+++ b/cli/src/shared/orchestrate.ts
@@ -56,42 +56,48 @@ export async function runOrchestration(cloud: CloudOrchestrator, agent: AgentCon
   // 7. Wait for readiness
   await cloud.waitForReady();
 
-  // 8. Install agent
-  await agent.install();
-
-  // 9. Inject environment variables via .spawnrc
-  logStep("Setting up environment variables...");
   const envContent = generateEnvConfig(agent.envVars(apiKey));
-  const envB64 = Buffer.from(envContent).toString("base64");
-  try {
-    await withRetry(
-      "env setup",
-      () =>
-        wrapSshCall(
-          cloud.runner.runServer(
-            `printf '%s' '${envB64}' | base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc; ` +
-              `grep -q 'source ~/.spawnrc' ~/.bashrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.bashrc; ` +
-              `grep -q 'source ~/.spawnrc' ~/.zshrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.zshrc`,
+
+  if (agent.setup) {
+    // Batched path: install + env + config in a single SSH session
+    await agent.setup(envContent, apiKey, modelId);
+  } else {
+    // 8. Install agent
+    await agent.install();
+
+    // 9. Inject environment variables via .spawnrc
+    logStep("Setting up environment variables...");
+    const envB64 = Buffer.from(envContent).toString("base64");
+    try {
+      await withRetry(
+        "env setup",
+        () =>
+          wrapSshCall(
+            cloud.runner.runServer(
+              `printf '%s' '${envB64}' | base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc; ` +
+                `grep -q 'source ~/.spawnrc' ~/.bashrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.bashrc; ` +
+                `grep -q 'source ~/.spawnrc' ~/.zshrc 2>/dev/null || echo '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.zshrc`,
+            ),
           ),
-        ),
-      2,
-      5,
-    );
-  } catch {
-    logWarn("Environment setup had errors");
+        2,
+        5,
+      );
+    } catch {
+      logWarn("Environment setup had errors");
+    }
+
+    // 10. Agent-specific configuration
+    if (agent.configure) {
+      try {
+        await withRetry("agent config", () => wrapSshCall(agent.configure!(apiKey, modelId)), 2, 5);
+      } catch {
+        logWarn("Agent configuration failed (continuing with defaults)");
+      }
+    }
   }
 
   // GitHub CLI setup
   await offerGithubAuth(cloud.runner);
-
-  // 10. Agent-specific configuration
-  if (agent.configure) {
-    try {
-      await withRetry("agent config", () => wrapSshCall(agent.configure!(apiKey, modelId)), 2, 5);
-    } catch {
-      logWarn("Agent configuration failed (continuing with defaults)");
-    }
-  }
 
   // 11. Pre-launch hooks (e.g. OpenClaw gateway)
   if (agent.preLaunch) {


### PR DESCRIPTION
## Summary

- **Restores the gateway port wait** that was accidentally deleted in b43d3f1. That commit claimed to combine gateway start + port wait into one SSH session but actually just deleted the wait, causing the TUI to launch before the gateway was listening on port 18789.
- **Batches openclaw setup** (install check + env vars + config) into a single SSH session via a new `setup` hook. Reduces total SSH sessions from 6 to 2 for the openclaw Fly.io flow.

### Before (6 SSH sessions)
1. `command -v openclaw` — install verify
2. `base64 > ~/.spawnrc` — env vars
3. `mkdir -p ~/.openclaw` — config dir
4. upload config file
5. `mv` config into place
6. `setsid openclaw gateway &` — fire-and-forget, **no port wait**

### After (2 SSH sessions)
1. `setupOpenclawBatched` — install check + env + config in one call, with `==>` progress output
2. `startGateway` — starts daemon + polls port 18789 via `/dev/tcp` (no netcat needed) for up to 60s, fails with gateway log tail on timeout

Other agents are unaffected — they still use the individual install/env/configure hooks.

## Test plan

- [ ] `spawn fly openclaw` — verify gateway comes up and TUI launches
- [ ] Check output shows `==>` progress steps and `Gateway ready after Ns`
- [ ] `spawn fly claude` — verify non-openclaw agents still work (uses old path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)