### PR TITLE
security: validate RAW_BASE immediately before curl|bash invocation

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/update-check.ts
+++ b/cli/src/update-check.ts
@@ -196,6 +196,11 @@ function reExecWithArgs(): void {
 function performAutoUpdate(latestVersion: string): void {
   printUpdateBanner(latestVersion);
 
+  // Validate RAW_BASE immediately before use to prevent command injection (CWE-78, #1819)
+  if (!GITHUB_RAW_URL_PATTERN.test(RAW_BASE)) {
+    throw new Error(`Security: RAW_BASE failed pre-execution validation: ${RAW_BASE}`);
+  }
+
   try {
     executor.execSync(`curl -fsSL ${RAW_BASE}/cli/install.sh | bash`, {
       stdio: "inherit",


### PR DESCRIPTION
**Why:** Without immediate pre-execution validation, a MITM-tampered RAW_BASE could inject shell metacharacters into the curl|bash pipeline (issue #1819). This adds a strict regex check at the point of use, complementing the existing module-level validation.

Fixes #1819

## Changes
- Added strict regex validation of RAW_BASE immediately before `execSync` in `performAutoUpdate()` (`update-check.ts`)
- Throws a clear security error if validation fails
- Patch version bump: 0.8.2 -> 0.8.3

-- refactor/security-auditor