### PR TITLE
fix: switch ZeroClaw install to bootstrap.sh with --prefer-prebuilt

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/shared/agent-setup.ts
+++ b/cli/src/shared/agent-setup.ts
@@ -398,7 +398,7 @@ export function openCodeInstallCmd(): string {
 // ─── Default Agent Definitions ───────────────────────────────────────────────
 
 const ZEROCLAW_INSTALL_URL =
-  "https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh";
+  "https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/bootstrap.sh";
 
 export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
   return {
@@ -486,7 +486,7 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         installAgent(
           runner,
           "ZeroClaw",
-          `curl -LsSf ${ZEROCLAW_INSTALL_URL} | bash -s -- --install-rust --install-system-deps`,
+          `curl -LsSf ${ZEROCLAW_INSTALL_URL} | bash -s -- --install-rust --install-system-deps --prefer-prebuilt`,
         ),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,

--- a/manifest.json
+++ b/manifest.json
@@ -95,7 +95,7 @@
       "name": "ZeroClaw",
       "description": "Fast, small, fully autonomous AI assistant infrastructure \u2014 deploy anywhere, swap anything",
       "url": "https://github.com/zeroclaw-labs/zeroclaw",
-      "install": "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps",
+      "install": "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/bootstrap.sh | bash -s -- --install-rust --install-system-deps --prefer-prebuilt",
       "launch": "zeroclaw agent",
       "env": {
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",


### PR DESCRIPTION
## Problem

ZeroClaw deployments fail with Rust 2021 edition compilation errors:

```
error: prefix `key` is unknown
  --> src/security/leak_detector.rs:92:99
error: prefix `ID` is unknown
   --> src/security/leak_detector.rs:109:76
```

**Root cause:** The pinned `scripts/install.sh` is deprecated — it does `git clone --depth 1` of the latest ZeroClaw `main` branch instead of installing a fixed version. Commit `63f485e` (Feb 23) merged `leak_detector.rs` with Rust 2021 reserved prefix conflicts, which breaks `cargo build` on source installs.

## Fix

Two changes, both minimal:

1. **Switch URL** from deprecated `scripts/install.sh` → `scripts/bootstrap.sh` (the canonical installer)
2. **Add `--prefer-prebuilt`** so ZeroClaw is installed from the pre-built v0.1.6 release binary instead of compiling from source

The v0.1.6 release binary was compiled before the problematic `leak_detector.rs` was merged, so it works correctly. With `--prefer-prebuilt`, if the prebuilt binary is unavailable it falls back to source build; `--install-rust` and `--install-system-deps` remain in case that fallback is needed.

## Testing

- `bun test` → 1897 pass, 0 fail
- `bunx @biomejs/biome lint src/` → 0 errors

Fixes #1829

-- refactor/issue-fixer