### PR TITLE
fix: SPA streaming format + stdin prompt

### DIFF
--- a/.claude/skills/setup-spa/slack-bot.ts
+++ b/.claude/skills/setup-spa/slack-bot.ts
@@ -618,7 +618,7 @@ async function runClaudeAndStream(
     await flushToSlack(":white_check_mark: Done (no text output)", true);
   }
 
-  console.log(`[spa] Claude done (thread=${threadTs}, session=${returnedSessionId}, len=${fullText.length})`);
+  console.log(`[spa] Claude done (thread=${threadTs}, session=${returnedSessionId}, len=${currentText.length})`);
 
   return returnedSessionId;
 }


### PR DESCRIPTION
## Summary

Two fixes for SPA:

1. **Wrong event format** — Was parsing Anthropic raw streaming API (`stream_event` → `content_block_delta`), but Claude Code emits complete messages (`{"type":"assistant","message":{"content":[...]}}`). Now correctly handles `assistant`, `user` (tool results), and `result` events.

2. **CLI flag parsing** — Slack thread content containing `--` was interpreted as Claude CLI options. Now pipes prompt via stdin (`-` flag) instead of as a positional argument.

## Test plan

- [ ] @mention `@spa` with thread containing `--` text → no CLI parse error
- [ ] Text responses stream to Slack
- [ ] Tool calls show name + input hint
- [ ] Tool results show in code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)