### PR TITLE
fix: add Lightsail activation prerequisite to docs and error messages

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -2,7 +2,13 @@
 
 AWS Lightsail instances via AWS CLI. [AWS Lightsail](https://aws.amazon.com/lightsail/)
 
-> Uses 'ubuntu' user instead of 'root'. Requires AWS CLI installed and configured.
+## Prerequisites
+
+1. **Enable AWS Lightsail** — New AWS accounts must activate Lightsail before first use. Visit the [Lightsail console](https://lightsail.aws.amazon.com/ls/webapp/home) and follow the activation prompt. Without this step, all provisioning commands will fail.
+
+2. **AWS CLI installed and configured** — Run `aws configure` with your Access Key ID and Secret Access Key.
+
+> Uses `ubuntu` user instead of `root`.
 
 ## Agents
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/aws/aws.ts
+++ b/cli/src/aws/aws.ts
@@ -733,6 +733,7 @@ export async function createInstance(name: string, tier?: CloudInitTier): Promis
     } catch (err) {
       logError("Failed to create Lightsail instance");
       logWarn("Common issues:");
+      logWarn("  - Lightsail not enabled: visit https://lightsail.aws.amazon.com/ls/webapp/home to activate");
       logWarn("  - Instance limit reached for your account");
       logWarn("  - Bundle unavailable in region");
       logWarn("  - AWS credentials lack Lightsail permissions");
@@ -757,6 +758,7 @@ export async function createInstance(name: string, tier?: CloudInitTier): Promis
     } catch (err) {
       logError("Failed to create Lightsail instance");
       logWarn("Common issues:");
+      logWarn("  - Lightsail not enabled: visit https://lightsail.aws.amazon.com/ls/webapp/home to activate");
       logWarn("  - Instance limit reached for your account");
       logWarn("  - Bundle unavailable in region");
       logWarn("  - Credentials lack lightsail:CreateInstances permission");


### PR DESCRIPTION
## Summary

- Adds a **Prerequisites** section to `aws/README.md` as the first thing users see, with a link to activate Lightsail at https://lightsail.aws.amazon.com/ls/webapp/home
- Surfaces the Lightsail activation URL in `createInstance` error hints for both CLI and REST paths, so users get actionable guidance if provisioning fails
- Bumps CLI to 0.8.5

Fixes #1838

-- refactor/issue-fixer