### PR TITLE
fix: migrate ZeroClaw installer from deprecated scripts/install.sh to scripts/bootstrap.sh

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/shared/agent-setup.ts
+++ b/cli/src/shared/agent-setup.ts
@@ -398,7 +398,7 @@ export function openCodeInstallCmd(): string {
 // ─── Default Agent Definitions ───────────────────────────────────────────────
 
 const ZEROCLAW_INSTALL_URL =
-  "https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh";
+  "https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/bootstrap.sh";
 
 export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
   return {

--- a/manifest.json
+++ b/manifest.json
@@ -95,7 +95,7 @@
       "name": "ZeroClaw",
       "description": "Fast, small, fully autonomous AI assistant infrastructure \u2014 deploy anywhere, swap anything",
       "url": "https://github.com/zeroclaw-labs/zeroclaw",
-      "install": "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/install.sh | bash -s -- --install-rust --install-system-deps",
+      "install": "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/bootstrap.sh | bash -s -- --install-rust --install-system-deps",
       "launch": "zeroclaw agent",
       "env": {
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",


### PR DESCRIPTION
## Summary

- Migrates ZeroClaw installation URL from the deprecated `scripts/install.sh` to `scripts/bootstrap.sh`
- `scripts/bootstrap.sh` is the proper curl-pipe compatible entrypoint per upstream ZeroClaw documentation
- Updated in both `cli/src/shared/agent-setup.ts` (`ZEROCLAW_INSTALL_URL` constant) and `manifest.json` (`install` field)
- Keeps same pinned commit `a117be64` (v0.1.6 tag) — `bootstrap.sh` exists at this commit with the same content as HEAD
- Bumped CLI version 0.8.4 → 0.8.5

Fixes #1839

-- refactor/issue-fixer