### PR TITLE
fix: cache AWS credentials to avoid re-prompting on retry

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/cli/src/__tests__/aws.test.ts
+++ b/cli/src/__tests__/aws.test.ts
@@ -1,9 +1,117 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { unlinkSync, existsSync, readFileSync } from "node:fs";
 
-import { BUNDLES, DEFAULT_BUNDLE } from "../aws/aws";
+import { BUNDLES, DEFAULT_BUNDLE, loadCredsFromConfig, saveCredsToConfig, AWS_CONFIG_PATH } from "../aws/aws";
 
 import { resolveAgent, agents } from "../aws/agents";
 import { generateEnvConfig } from "../shared/agents";
+
+// ─── Credential caching tests ────────────────────────────────────────────────
+
+describe("aws/credential-cache", () => {
+  let originalConfig: string | null = null;
+
+  beforeEach(() => {
+    if (existsSync(AWS_CONFIG_PATH)) {
+      originalConfig = readFileSync(AWS_CONFIG_PATH, "utf-8");
+    } else {
+      originalConfig = null;
+    }
+  });
+
+  afterEach(() => {
+    if (originalConfig !== null) {
+      Bun.write(AWS_CONFIG_PATH, originalConfig);
+    } else if (existsSync(AWS_CONFIG_PATH)) {
+      unlinkSync(AWS_CONFIG_PATH);
+    }
+  });
+
+  describe("loadCredsFromConfig", () => {
+    it("returns null when config file does not exist", () => {
+      if (existsSync(AWS_CONFIG_PATH)) { unlinkSync(AWS_CONFIG_PATH); }
+      expect(loadCredsFromConfig()).toBeNull();
+    });
+
+    it("returns null for malformed JSON", async () => {
+      await Bun.write(AWS_CONFIG_PATH, "not-json", { mode: 0o600 });
+      expect(loadCredsFromConfig()).toBeNull();
+    });
+
+    it("returns null when accessKeyId is missing", async () => {
+      await Bun.write(AWS_CONFIG_PATH, JSON.stringify({ secretAccessKey: "secretsecretkey1234" }), { mode: 0o600 });
+      expect(loadCredsFromConfig()).toBeNull();
+    });
+
+    it("returns null when secretAccessKey is too short", async () => {
+      await Bun.write(
+        AWS_CONFIG_PATH,
+        JSON.stringify({ accessKeyId: "AKIAIOSFODNN7EXAMPLE", secretAccessKey: "tooshort" }),
+        { mode: 0o600 },
+      );
+      expect(loadCredsFromConfig()).toBeNull();
+    });
+
+    it("returns null for invalid accessKeyId format", async () => {
+      await Bun.write(
+        AWS_CONFIG_PATH,
+        JSON.stringify({ accessKeyId: "invalid key!", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCY" }),
+        { mode: 0o600 },
+      );
+      expect(loadCredsFromConfig()).toBeNull();
+    });
+
+    it("returns credentials for valid data", async () => {
+      await Bun.write(
+        AWS_CONFIG_PATH,
+        JSON.stringify({ accessKeyId: "AKIAIOSFODNN7EXAMPLE", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCY", region: "eu-west-1" }),
+        { mode: 0o600 },
+      );
+      const result = loadCredsFromConfig();
+      expect(result).not.toBeNull();
+      expect(result?.accessKeyId).toBe("AKIAIOSFODNN7EXAMPLE");
+      expect(result?.secretAccessKey).toBe("wJalrXUtnFEMI/K7MDENG/bPxRfiCY");
+      expect(result?.region).toBe("eu-west-1");
+    });
+
+    it("defaults region to us-east-1 when not stored", async () => {
+      await Bun.write(
+        AWS_CONFIG_PATH,
+        JSON.stringify({ accessKeyId: "AKIAIOSFODNN7EXAMPLE", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCY" }),
+        { mode: 0o600 },
+      );
+      const result = loadCredsFromConfig();
+      expect(result?.region).toBe("us-east-1");
+    });
+  });
+
+  describe("saveCredsToConfig", () => {
+    it("writes credentials to config file", async () => {
+      if (existsSync(AWS_CONFIG_PATH)) { unlinkSync(AWS_CONFIG_PATH); }
+      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCY", "us-west-2");
+      const result = loadCredsFromConfig();
+      expect(result?.accessKeyId).toBe("AKIAIOSFODNN7EXAMPLE");
+      expect(result?.secretAccessKey).toBe("wJalrXUtnFEMI/K7MDENG/bPxRfiCY");
+      expect(result?.region).toBe("us-west-2");
+    });
+
+    it("round-trips credentials with special characters in secret key", async () => {
+      if (existsSync(AWS_CONFIG_PATH)) { unlinkSync(AWS_CONFIG_PATH); }
+      const secret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCY==";
+      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE", secret, "ap-northeast-1");
+      const result = loadCredsFromConfig();
+      expect(result?.secretAccessKey).toBe(secret);
+    });
+
+    it("overwrites existing config file", async () => {
+      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCY", "us-east-1");
+      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE2", "newSecretKeyNewSecretKey1234567", "eu-central-1");
+      const result = loadCredsFromConfig();
+      expect(result?.accessKeyId).toBe("AKIAIOSFODNN7EXAMPLE2");
+      expect(result?.region).toBe("eu-central-1");
+    });
+  });
+});
 
 // ─── aws.ts tests ────────────────────────────────────────────────────────────
 

--- a/cli/src/__tests__/unknown-flags.test.ts
+++ b/cli/src/__tests__/unknown-flags.test.ts
@@ -222,6 +222,16 @@ describe("Unknown Flag Detection", () => {
         ]),
       ).toBeNull();
     });
+
+    it("should allow --reauth", () => {
+      expect(
+        findUnknownFlag([
+          "claude",
+          "aws",
+          "--reauth",
+        ]),
+      ).toBeNull();
+    });
   });
 
   describe("ignores positional arguments", () => {
@@ -339,6 +349,7 @@ describe("KNOWN_FLAGS completeness", () => {
       "--cloud",
       "--clear",
       "--custom",
+      "--reauth",
     ];
     for (const flag of expected) {
       expect(KNOWN_FLAGS.has(flag)).toBe(true);

--- a/cli/src/flags.ts
+++ b/cli/src/flags.ts
@@ -23,6 +23,7 @@ export const KNOWN_FLAGS = new Set([
   "--cloud",
   "--clear",
   "--custom",
+  "--reauth",
 ]);
 
 /** Return the first unknown flag in args, or null if all are known/positional */

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -94,6 +94,7 @@ function checkUnknownFlags(args: string[]): void {
     console.error(`    ${pc.cyan("--output json")}       Output structured JSON to stdout`);
     console.error(`    ${pc.cyan("--custom")}            Show interactive size/region pickers`);
     console.error(`    ${pc.cyan("--name")}              Set the spawn/resource name`);
+    console.error(`    ${pc.cyan("--reauth")}            Force re-prompting for cloud credentials`);
     console.error(`    ${pc.cyan("--help, -h")}          Show help information`);
     console.error(`    ${pc.cyan("--version, -v")}       Show version`);
     console.error();
@@ -724,6 +725,13 @@ async function main(): Promise<void> {
   if (custom) {
     filteredArgs.splice(customIdx, 1);
     process.env.SPAWN_CUSTOM = "1";
+  }
+
+  // Extract --reauth boolean flag
+  const reauthIdx = filteredArgs.indexOf("--reauth");
+  if (reauthIdx !== -1) {
+    filteredArgs.splice(reauthIdx, 1);
+    process.env.SPAWN_REAUTH = "1";
   }
 
   // Extract --output <format> flag


### PR DESCRIPTION
## Summary

Fixes #1841

- After successful interactive credential entry, saves credentials to `~/.config/spawn/aws.json` with `chmod 600` (user-only read/write)
- On subsequent runs, loads and validates cached credentials before prompting interactively
- Adds `--reauth` flag and `SPAWN_REAUTH=1` env var to force fresh credential entry when needed
- Also caches env-var-supplied credentials for future runs

## Test plan

- [x] Unit tests added in `src/__tests__/aws.test.ts` covering `loadCredsFromConfig` and `saveCredsToConfig`
- [x] Tests for missing file, malformed JSON, invalid key formats, valid data, round-trip with special chars
- [x] `--reauth` flag added to `KNOWN_FLAGS` with test coverage in `unknown-flags.test.ts`
- [x] Full test suite passes: 1908 tests, 0 failures
- [x] Biome lint: 0 errors

> Note: This supersedes PR #1847 which had merge conflicts after main moved forward.

-- refactor/issue-fixer