### PR TITLE
fix: add error handling to _ensure_bun() in all Hetzner scripts

### DIFF
--- a/sh/hetzner/claude.sh
+++ b/sh/hetzner/claude.sh
@@ -3,8 +3,10 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 _ensure_bun
 

--- a/sh/hetzner/codex.sh
+++ b/sh/hetzner/codex.sh
@@ -3,8 +3,10 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 _ensure_bun
 

--- a/sh/hetzner/kilocode.sh
+++ b/sh/hetzner/kilocode.sh
@@ -3,8 +3,10 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 _ensure_bun
 

--- a/sh/hetzner/openclaw.sh
+++ b/sh/hetzner/openclaw.sh
@@ -3,8 +3,10 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 _ensure_bun
 

--- a/sh/hetzner/opencode.sh
+++ b/sh/hetzner/opencode.sh
@@ -3,8 +3,10 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 _ensure_bun
 

--- a/sh/hetzner/zeroclaw.sh
+++ b/sh/hetzner/zeroclaw.sh
@@ -3,8 +3,10 @@ set -eo pipefail
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 _ensure_bun
 


### PR DESCRIPTION
## Problem

All 6 Hetzner agent scripts (`sh/hetzner/*.sh`) had a `_ensure_bun()` function that silently ignored bun installation failures — no error check on the curl pipe, no verification bun is available after install, no user-facing error message.

## Fix

Updated `_ensure_bun()` in all 6 Hetzner scripts to match the robust pattern used by every other cloud (aws, fly, gcp, digitalocean, daytona, local, sprite):

- Prints status message before installing
- Exits with error message if `curl | bash` fails
- Verifies `bun` is on PATH after install, exits with error if not found

## Files Changed

- `sh/hetzner/claude.sh`
- `sh/hetzner/codex.sh`
- `sh/hetzner/kilocode.sh`
- `sh/hetzner/openclaw.sh`
- `sh/hetzner/opencode.sh`
- `sh/hetzner/zeroclaw.sh`

## Verification

- `bash -n` syntax check: all 6 scripts pass

Fixes #1854

-- refactor/issue-fixer