### PR TITLE
fix: add process supervision restart loop to agent scripts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -21,6 +21,32 @@ export interface CloudOrchestrator {
   saveLaunchCmd(launchCmd: string): void;
 }
 
+/**
+ * Wrap a launch command in a restart loop for cloud VMs.
+ * Restarts the agent on non-zero exit (crash, SIGTERM, OOM) up to MAX_RESTARTS times.
+ * Clean exits (exit code 0) break out of the loop immediately.
+ * Skipped for local execution where the user controls the process directly.
+ */
+function wrapWithRestartLoop(cmd: string): string {
+  // Shell restart loop — bash 3.x compatible (no ((var++)), no set -u)
+  return [
+    "_spawn_restarts=0",
+    "_spawn_max=10",
+    'while [ "$_spawn_restarts" -lt "$_spawn_max" ]; do',
+    `  ${cmd}`,
+    "  _spawn_exit=$?",
+    '  if [ "$_spawn_exit" -eq 0 ]; then break; fi',
+    "  _spawn_restarts=$((_spawn_restarts + 1))",
+    '  printf "\\n[spawn] Agent exited with code %d. Restarting in 5s (%d/%d)...\\n" "$_spawn_exit" "$_spawn_restarts" "$_spawn_max" >&2',
+    "  sleep 5",
+    "done",
+    'if [ "$_spawn_restarts" -ge "$_spawn_max" ]; then',
+    '  printf "\\n[spawn] Agent crashed %d times. Giving up.\\n" "$_spawn_max" >&2',
+    "fi",
+    'exit "${_spawn_exit:-0}"',
+  ].join("\n");
+}
+
 export async function runOrchestration(cloud: CloudOrchestrator, agent: AgentConfig, agentName: string): Promise<void> {
   logInfo(`${agent.name} on ${cloud.cloudLabel}`);
   process.stderr.write("\n");
@@ -118,6 +144,9 @@ export async function runOrchestration(cloud: CloudOrchestrator, agent: AgentCon
 
   const launchCmd = agent.launchCmd();
   cloud.saveLaunchCmd(launchCmd);
-  const exitCode = await cloud.interactiveSession(launchCmd);
+
+  // Wrap in restart loop for cloud VMs — not for local execution
+  const sessionCmd = cloud.cloudName === "local" ? launchCmd : wrapWithRestartLoop(launchCmd);
+  const exitCode = await cloud.interactiveSession(sessionCmd);
   process.exit(exitCode);
 }


### PR DESCRIPTION
**Why:** Agent processes die silently on cloud VMs with no recovery mechanism — a single SIGTERM, OOM kill, or crash permanently kills the agent, requiring manual VM restart or SSH reconnect.

## Summary

- Added a `wrapWithRestartLoop()` function in `orchestrate.ts` that wraps the agent launch command in a bash restart loop for cloud VMs
- On non-zero exit (crash/SIGTERM/OOM), the agent automatically restarts after 5 seconds, up to 10 times
- Clean exits (exit code 0) break out immediately — normal user-initiated exits are unaffected
- Local execution (`spawn local`) is excluded from the restart loop since the user controls the process directly
- Shell loop is bash 3.x compatible (no `((var++))`, uses `$((...))` arithmetic)
- Version bumped to 0.10.3

## Test plan

- [x] All 1908 existing tests pass (0 failures)
- [x] Biome lint passes with 0 errors on full `src/`
- [ ] Manual: deploy agent on any cloud VM, kill agent process (`kill -TERM <pid>`), verify it restarts
- [ ] Manual: deploy agent on any cloud VM, exit cleanly (Ctrl+D / `/exit`), verify no restart

Fixes #1860

-- refactor/code-health