### PR TITLE
fix: add SIGTERM handler and restart loop to DigitalOcean agent scripts

### DIFF
--- a/sh/digitalocean/claude.sh
+++ b/sh/digitalocean/claude.sh
@@ -2,6 +2,39 @@
 set -eo pipefail
 
 # Thin shim: ensures bun is available, runs bundled digitalocean.js (local or from GitHub release)
+# Includes SIGTERM trapping + restart loop to handle unexpected termination on DigitalOcean
+
+_AGENT_NAME="claude"
+_GOT_SIGTERM=0
+_MAX_RETRIES=3
+_CHILD_PID=""
+
+_log_signal() {
+    printf '\033[0;33m[spawn/%s] Received %s (pid %s) at %s\033[0m\n' \
+        "$_AGENT_NAME" "$1" "$$" "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" >&2
+}
+
+_sigterm_handler() {
+    _GOT_SIGTERM=1
+    _log_signal "SIGTERM"
+    printf '\033[0;33m[spawn/%s] Agent process is being terminated. The droplet is likely still running.\033[0m\n' "$_AGENT_NAME" >&2
+    printf '\033[0;33m[spawn/%s] Check your DigitalOcean dashboard: https://cloud.digitalocean.com/droplets\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -TERM "$_CHILD_PID" 2>/dev/null || true
+    fi
+}
+
+_sighup_handler() {
+    _log_signal "SIGHUP"
+    printf '\033[0;33m[spawn/%s] Terminal connection lost. Agent process will exit.\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -HUP "$_CHILD_PID" 2>/dev/null || true
+    fi
+    exit 129
+}
+
+trap '_sigterm_handler' TERM
+trap '_sighup_handler' HUP
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
@@ -11,19 +44,61 @@ _ensure_bun() {
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 
+_run_with_restart() {
+    local attempt=0
+    local backoff=2
+    while [ "$attempt" -lt "$_MAX_RETRIES" ]; do
+        attempt=$((attempt + 1))
+        _GOT_SIGTERM=0
+
+        "$@" &
+        _CHILD_PID=$!
+        wait "$_CHILD_PID" 2>/dev/null
+        local exit_code=$?
+        _CHILD_PID=""
+
+        # Normal exit — do not restart
+        if [ "$exit_code" -eq 0 ]; then
+            return 0
+        fi
+
+        # If killed by SIGTERM, log and attempt restart (unless max retries reached)
+        if [ "$_GOT_SIGTERM" -eq 1 ]; then
+            if [ "$attempt" -lt "$_MAX_RETRIES" ]; then
+                printf '\033[0;33m[spawn/%s] Restarting after SIGTERM (attempt %s/%s, backoff %ss)...\033[0m\n' \
+                    "$_AGENT_NAME" "$((attempt + 1))" "$_MAX_RETRIES" "$backoff" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2))
+                continue
+            else
+                printf '\033[0;31m[spawn/%s] Max restart attempts reached (%s). Giving up.\033[0m\n' \
+                    "$_AGENT_NAME" "$_MAX_RETRIES" >&2
+                return 143
+            fi
+        fi
+
+        # Non-SIGTERM failure — exit with the original code
+        return "$exit_code"
+    done
+}
+
 _ensure_bun
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 
 # Local checkout — run from source
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" claude "$@"
+    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
+    exit $?
 fi
 
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
+trap 'rm -f "$DO_JS"; _sigterm_handler' TERM
+trap 'rm -f "$DO_JS"; _sighup_handler' HUP
 trap 'rm -f "$DO_JS"' EXIT
 curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
-exec bun run "$DO_JS" claude "$@"
+_run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"
+exit $?

--- a/sh/digitalocean/codex.sh
+++ b/sh/digitalocean/codex.sh
@@ -2,6 +2,39 @@
 set -eo pipefail
 
 # Thin shim: ensures bun is available, runs bundled digitalocean.js (local or from GitHub release)
+# Includes SIGTERM trapping + restart loop to handle unexpected termination on DigitalOcean
+
+_AGENT_NAME="codex"
+_GOT_SIGTERM=0
+_MAX_RETRIES=3
+_CHILD_PID=""
+
+_log_signal() {
+    printf '\033[0;33m[spawn/%s] Received %s (pid %s) at %s\033[0m\n' \
+        "$_AGENT_NAME" "$1" "$$" "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" >&2
+}
+
+_sigterm_handler() {
+    _GOT_SIGTERM=1
+    _log_signal "SIGTERM"
+    printf '\033[0;33m[spawn/%s] Agent process is being terminated. The droplet is likely still running.\033[0m\n' "$_AGENT_NAME" >&2
+    printf '\033[0;33m[spawn/%s] Check your DigitalOcean dashboard: https://cloud.digitalocean.com/droplets\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -TERM "$_CHILD_PID" 2>/dev/null || true
+    fi
+}
+
+_sighup_handler() {
+    _log_signal "SIGHUP"
+    printf '\033[0;33m[spawn/%s] Terminal connection lost. Agent process will exit.\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -HUP "$_CHILD_PID" 2>/dev/null || true
+    fi
+    exit 129
+}
+
+trap '_sigterm_handler' TERM
+trap '_sighup_handler' HUP
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
@@ -11,19 +44,61 @@ _ensure_bun() {
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 
+_run_with_restart() {
+    local attempt=0
+    local backoff=2
+    while [ "$attempt" -lt "$_MAX_RETRIES" ]; do
+        attempt=$((attempt + 1))
+        _GOT_SIGTERM=0
+
+        "$@" &
+        _CHILD_PID=$!
+        wait "$_CHILD_PID" 2>/dev/null
+        local exit_code=$?
+        _CHILD_PID=""
+
+        # Normal exit — do not restart
+        if [ "$exit_code" -eq 0 ]; then
+            return 0
+        fi
+
+        # If killed by SIGTERM, log and attempt restart (unless max retries reached)
+        if [ "$_GOT_SIGTERM" -eq 1 ]; then
+            if [ "$attempt" -lt "$_MAX_RETRIES" ]; then
+                printf '\033[0;33m[spawn/%s] Restarting after SIGTERM (attempt %s/%s, backoff %ss)...\033[0m\n' \
+                    "$_AGENT_NAME" "$((attempt + 1))" "$_MAX_RETRIES" "$backoff" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2))
+                continue
+            else
+                printf '\033[0;31m[spawn/%s] Max restart attempts reached (%s). Giving up.\033[0m\n' \
+                    "$_AGENT_NAME" "$_MAX_RETRIES" >&2
+                return 143
+            fi
+        fi
+
+        # Non-SIGTERM failure — exit with the original code
+        return "$exit_code"
+    done
+}
+
 _ensure_bun
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 
 # Local checkout — run from source
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" codex "$@"
+    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
+    exit $?
 fi
 
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
+trap 'rm -f "$DO_JS"; _sigterm_handler' TERM
+trap 'rm -f "$DO_JS"; _sighup_handler' HUP
 trap 'rm -f "$DO_JS"' EXIT
 curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
-exec bun run "$DO_JS" codex "$@"
+_run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"
+exit $?

--- a/sh/digitalocean/kilocode.sh
+++ b/sh/digitalocean/kilocode.sh
@@ -2,6 +2,39 @@
 set -eo pipefail
 
 # Thin shim: ensures bun is available, runs bundled digitalocean.js (local or from GitHub release)
+# Includes SIGTERM trapping + restart loop to handle unexpected termination on DigitalOcean
+
+_AGENT_NAME="kilocode"
+_GOT_SIGTERM=0
+_MAX_RETRIES=3
+_CHILD_PID=""
+
+_log_signal() {
+    printf '\033[0;33m[spawn/%s] Received %s (pid %s) at %s\033[0m\n' \
+        "$_AGENT_NAME" "$1" "$$" "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" >&2
+}
+
+_sigterm_handler() {
+    _GOT_SIGTERM=1
+    _log_signal "SIGTERM"
+    printf '\033[0;33m[spawn/%s] Agent process is being terminated. The droplet is likely still running.\033[0m\n' "$_AGENT_NAME" >&2
+    printf '\033[0;33m[spawn/%s] Check your DigitalOcean dashboard: https://cloud.digitalocean.com/droplets\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -TERM "$_CHILD_PID" 2>/dev/null || true
+    fi
+}
+
+_sighup_handler() {
+    _log_signal "SIGHUP"
+    printf '\033[0;33m[spawn/%s] Terminal connection lost. Agent process will exit.\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -HUP "$_CHILD_PID" 2>/dev/null || true
+    fi
+    exit 129
+}
+
+trap '_sigterm_handler' TERM
+trap '_sighup_handler' HUP
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
@@ -11,19 +44,61 @@ _ensure_bun() {
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 
+_run_with_restart() {
+    local attempt=0
+    local backoff=2
+    while [ "$attempt" -lt "$_MAX_RETRIES" ]; do
+        attempt=$((attempt + 1))
+        _GOT_SIGTERM=0
+
+        "$@" &
+        _CHILD_PID=$!
+        wait "$_CHILD_PID" 2>/dev/null
+        local exit_code=$?
+        _CHILD_PID=""
+
+        # Normal exit — do not restart
+        if [ "$exit_code" -eq 0 ]; then
+            return 0
+        fi
+
+        # If killed by SIGTERM, log and attempt restart (unless max retries reached)
+        if [ "$_GOT_SIGTERM" -eq 1 ]; then
+            if [ "$attempt" -lt "$_MAX_RETRIES" ]; then
+                printf '\033[0;33m[spawn/%s] Restarting after SIGTERM (attempt %s/%s, backoff %ss)...\033[0m\n' \
+                    "$_AGENT_NAME" "$((attempt + 1))" "$_MAX_RETRIES" "$backoff" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2))
+                continue
+            else
+                printf '\033[0;31m[spawn/%s] Max restart attempts reached (%s). Giving up.\033[0m\n' \
+                    "$_AGENT_NAME" "$_MAX_RETRIES" >&2
+                return 143
+            fi
+        fi
+
+        # Non-SIGTERM failure — exit with the original code
+        return "$exit_code"
+    done
+}
+
 _ensure_bun
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 
 # Local checkout — run from source
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" kilocode "$@"
+    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
+    exit $?
 fi
 
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
+trap 'rm -f "$DO_JS"; _sigterm_handler' TERM
+trap 'rm -f "$DO_JS"; _sighup_handler' HUP
 trap 'rm -f "$DO_JS"' EXIT
 curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
-exec bun run "$DO_JS" kilocode "$@"
+_run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"
+exit $?

--- a/sh/digitalocean/openclaw.sh
+++ b/sh/digitalocean/openclaw.sh
@@ -2,6 +2,39 @@
 set -eo pipefail
 
 # Thin shim: ensures bun is available, runs bundled digitalocean.js (local or from GitHub release)
+# Includes SIGTERM trapping + restart loop to handle unexpected termination on DigitalOcean
+
+_AGENT_NAME="openclaw"
+_GOT_SIGTERM=0
+_MAX_RETRIES=3
+_CHILD_PID=""
+
+_log_signal() {
+    printf '\033[0;33m[spawn/%s] Received %s (pid %s) at %s\033[0m\n' \
+        "$_AGENT_NAME" "$1" "$$" "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" >&2
+}
+
+_sigterm_handler() {
+    _GOT_SIGTERM=1
+    _log_signal "SIGTERM"
+    printf '\033[0;33m[spawn/%s] Agent process is being terminated. The droplet is likely still running.\033[0m\n' "$_AGENT_NAME" >&2
+    printf '\033[0;33m[spawn/%s] Check your DigitalOcean dashboard: https://cloud.digitalocean.com/droplets\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -TERM "$_CHILD_PID" 2>/dev/null || true
+    fi
+}
+
+_sighup_handler() {
+    _log_signal "SIGHUP"
+    printf '\033[0;33m[spawn/%s] Terminal connection lost. Agent process will exit.\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -HUP "$_CHILD_PID" 2>/dev/null || true
+    fi
+    exit 129
+}
+
+trap '_sigterm_handler' TERM
+trap '_sighup_handler' HUP
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
@@ -11,19 +44,61 @@ _ensure_bun() {
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 
+_run_with_restart() {
+    local attempt=0
+    local backoff=2
+    while [ "$attempt" -lt "$_MAX_RETRIES" ]; do
+        attempt=$((attempt + 1))
+        _GOT_SIGTERM=0
+
+        "$@" &
+        _CHILD_PID=$!
+        wait "$_CHILD_PID" 2>/dev/null
+        local exit_code=$?
+        _CHILD_PID=""
+
+        # Normal exit — do not restart
+        if [ "$exit_code" -eq 0 ]; then
+            return 0
+        fi
+
+        # If killed by SIGTERM, log and attempt restart (unless max retries reached)
+        if [ "$_GOT_SIGTERM" -eq 1 ]; then
+            if [ "$attempt" -lt "$_MAX_RETRIES" ]; then
+                printf '\033[0;33m[spawn/%s] Restarting after SIGTERM (attempt %s/%s, backoff %ss)...\033[0m\n' \
+                    "$_AGENT_NAME" "$((attempt + 1))" "$_MAX_RETRIES" "$backoff" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2))
+                continue
+            else
+                printf '\033[0;31m[spawn/%s] Max restart attempts reached (%s). Giving up.\033[0m\n' \
+                    "$_AGENT_NAME" "$_MAX_RETRIES" >&2
+                return 143
+            fi
+        fi
+
+        # Non-SIGTERM failure — exit with the original code
+        return "$exit_code"
+    done
+}
+
 _ensure_bun
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 
 # Local checkout — run from source
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" openclaw "$@"
+    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
+    exit $?
 fi
 
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
+trap 'rm -f "$DO_JS"; _sigterm_handler' TERM
+trap 'rm -f "$DO_JS"; _sighup_handler' HUP
 trap 'rm -f "$DO_JS"' EXIT
 curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
-exec bun run "$DO_JS" openclaw "$@"
+_run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"
+exit $?

--- a/sh/digitalocean/opencode.sh
+++ b/sh/digitalocean/opencode.sh
@@ -2,6 +2,39 @@
 set -eo pipefail
 
 # Thin shim: ensures bun is available, runs bundled digitalocean.js (local or from GitHub release)
+# Includes SIGTERM trapping + restart loop to handle unexpected termination on DigitalOcean
+
+_AGENT_NAME="opencode"
+_GOT_SIGTERM=0
+_MAX_RETRIES=3
+_CHILD_PID=""
+
+_log_signal() {
+    printf '\033[0;33m[spawn/%s] Received %s (pid %s) at %s\033[0m\n' \
+        "$_AGENT_NAME" "$1" "$$" "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" >&2
+}
+
+_sigterm_handler() {
+    _GOT_SIGTERM=1
+    _log_signal "SIGTERM"
+    printf '\033[0;33m[spawn/%s] Agent process is being terminated. The droplet is likely still running.\033[0m\n' "$_AGENT_NAME" >&2
+    printf '\033[0;33m[spawn/%s] Check your DigitalOcean dashboard: https://cloud.digitalocean.com/droplets\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -TERM "$_CHILD_PID" 2>/dev/null || true
+    fi
+}
+
+_sighup_handler() {
+    _log_signal "SIGHUP"
+    printf '\033[0;33m[spawn/%s] Terminal connection lost. Agent process will exit.\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -HUP "$_CHILD_PID" 2>/dev/null || true
+    fi
+    exit 129
+}
+
+trap '_sigterm_handler' TERM
+trap '_sighup_handler' HUP
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
@@ -11,19 +44,61 @@ _ensure_bun() {
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 
+_run_with_restart() {
+    local attempt=0
+    local backoff=2
+    while [ "$attempt" -lt "$_MAX_RETRIES" ]; do
+        attempt=$((attempt + 1))
+        _GOT_SIGTERM=0
+
+        "$@" &
+        _CHILD_PID=$!
+        wait "$_CHILD_PID" 2>/dev/null
+        local exit_code=$?
+        _CHILD_PID=""
+
+        # Normal exit — do not restart
+        if [ "$exit_code" -eq 0 ]; then
+            return 0
+        fi
+
+        # If killed by SIGTERM, log and attempt restart (unless max retries reached)
+        if [ "$_GOT_SIGTERM" -eq 1 ]; then
+            if [ "$attempt" -lt "$_MAX_RETRIES" ]; then
+                printf '\033[0;33m[spawn/%s] Restarting after SIGTERM (attempt %s/%s, backoff %ss)...\033[0m\n' \
+                    "$_AGENT_NAME" "$((attempt + 1))" "$_MAX_RETRIES" "$backoff" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2))
+                continue
+            else
+                printf '\033[0;31m[spawn/%s] Max restart attempts reached (%s). Giving up.\033[0m\n' \
+                    "$_AGENT_NAME" "$_MAX_RETRIES" >&2
+                return 143
+            fi
+        fi
+
+        # Non-SIGTERM failure — exit with the original code
+        return "$exit_code"
+    done
+}
+
 _ensure_bun
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 
 # Local checkout — run from source
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" opencode "$@"
+    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
+    exit $?
 fi
 
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
+trap 'rm -f "$DO_JS"; _sigterm_handler' TERM
+trap 'rm -f "$DO_JS"; _sighup_handler' HUP
 trap 'rm -f "$DO_JS"' EXIT
 curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
-exec bun run "$DO_JS" opencode "$@"
+_run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"
+exit $?

--- a/sh/digitalocean/zeroclaw.sh
+++ b/sh/digitalocean/zeroclaw.sh
@@ -2,6 +2,39 @@
 set -eo pipefail
 
 # Thin shim: ensures bun is available, runs bundled digitalocean.js (local or from GitHub release)
+# Includes SIGTERM trapping + restart loop to handle unexpected termination on DigitalOcean
+
+_AGENT_NAME="zeroclaw"
+_GOT_SIGTERM=0
+_MAX_RETRIES=3
+_CHILD_PID=""
+
+_log_signal() {
+    printf '\033[0;33m[spawn/%s] Received %s (pid %s) at %s\033[0m\n' \
+        "$_AGENT_NAME" "$1" "$$" "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)" >&2
+}
+
+_sigterm_handler() {
+    _GOT_SIGTERM=1
+    _log_signal "SIGTERM"
+    printf '\033[0;33m[spawn/%s] Agent process is being terminated. The droplet is likely still running.\033[0m\n' "$_AGENT_NAME" >&2
+    printf '\033[0;33m[spawn/%s] Check your DigitalOcean dashboard: https://cloud.digitalocean.com/droplets\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -TERM "$_CHILD_PID" 2>/dev/null || true
+    fi
+}
+
+_sighup_handler() {
+    _log_signal "SIGHUP"
+    printf '\033[0;33m[spawn/%s] Terminal connection lost. Agent process will exit.\033[0m\n' "$_AGENT_NAME" >&2
+    if [[ -n "$_CHILD_PID" ]]; then
+        kill -HUP "$_CHILD_PID" 2>/dev/null || true
+    fi
+    exit 129
+}
+
+trap '_sigterm_handler' TERM
+trap '_sighup_handler' HUP
 
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
@@ -11,19 +44,61 @@ _ensure_bun() {
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
 
+_run_with_restart() {
+    local attempt=0
+    local backoff=2
+    while [ "$attempt" -lt "$_MAX_RETRIES" ]; do
+        attempt=$((attempt + 1))
+        _GOT_SIGTERM=0
+
+        "$@" &
+        _CHILD_PID=$!
+        wait "$_CHILD_PID" 2>/dev/null
+        local exit_code=$?
+        _CHILD_PID=""
+
+        # Normal exit — do not restart
+        if [ "$exit_code" -eq 0 ]; then
+            return 0
+        fi
+
+        # If killed by SIGTERM, log and attempt restart (unless max retries reached)
+        if [ "$_GOT_SIGTERM" -eq 1 ]; then
+            if [ "$attempt" -lt "$_MAX_RETRIES" ]; then
+                printf '\033[0;33m[spawn/%s] Restarting after SIGTERM (attempt %s/%s, backoff %ss)...\033[0m\n' \
+                    "$_AGENT_NAME" "$((attempt + 1))" "$_MAX_RETRIES" "$backoff" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2))
+                continue
+            else
+                printf '\033[0;31m[spawn/%s] Max restart attempts reached (%s). Giving up.\033[0m\n' \
+                    "$_AGENT_NAME" "$_MAX_RETRIES" >&2
+                return 143
+            fi
+        fi
+
+        # Non-SIGTERM failure — exit with the original code
+        return "$exit_code"
+    done
+}
+
 _ensure_bun
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 
 # Local checkout — run from source
 if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" zeroclaw "$@"
+    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
+    exit $?
 fi
 
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
+trap 'rm -f "$DO_JS"; _sigterm_handler' TERM
+trap 'rm -f "$DO_JS"; _sighup_handler' HUP
 trap 'rm -f "$DO_JS"' EXIT
 curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
-exec bun run "$DO_JS" zeroclaw "$@"
+_run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"
+exit $?


### PR DESCRIPTION
## Why

Agent processes on DigitalOcean droplets receive unexpected SIGTERM signals and die silently — the droplet stays alive in the DO dashboard but the agent process terminates with no error reported to the user and no recovery attempt.

## Summary

- Added `SIGTERM` trap handler to all 6 DigitalOcean agent scripts (`claude.sh`, `codex.sh`, `kilocode.sh`, `openclaw.sh`, `opencode.sh`, `zeroclaw.sh`) that logs the signal name, PID, timestamp, and a link to the DigitalOcean dashboard
- Added `SIGHUP` trap handler for terminal disconnection scenarios
- Replaced bare `exec bun run ...` with a `_run_with_restart` loop that:
  - Runs the bun process in the foreground (backgrounded + `wait`) so the shell can intercept signals
  - On SIGTERM: retries up to 3 times with exponential backoff (2s, 4s, 8s)
  - On normal exit (code 0): exits cleanly without restart
  - On non-SIGTERM failure: exits with the original error code (no retry)
- Child PID tracking ensures signals are forwarded to the bun process
- All scripts pass `bash -n` syntax validation
- Compatible with macOS bash 3.x (no `echo -e`, no `((var++))`, no `set -u`)

Fixes #1859

-- refactor/ux-engineer