### PR TITLE
fix: make macOS compat linter blocking and add missing rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,6 +66,5 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Warn-only for initial rollout — switch to blocking after burn-in
       - name: Run macOS compat linter
-        run: bash sh/test/macos-compat.sh --warn-only
+        run: bash sh/test/macos-compat.sh

--- a/sh/test/macos-compat.sh
+++ b/sh/test/macos-compat.sh
@@ -34,6 +34,7 @@ TARGETS="$(printf '%s' "$TARGETS" | sed 's/^ //')"
 is_excluded() {
     case "$1" in
         */.claude/skills/*) return 0 ;;
+        */.claude/worktrees/*) return 0 ;;
         */.git/*) return 0 ;;
         */node_modules/*) return 0 ;;
         */packages/cli/*) return 0 ;;
@@ -150,6 +151,30 @@ while IFS= read -r _f; do
     # MC013: printf -v (variable assignment via printf)
     grep_rule "error" "MC013" "'printf -v' requires bash 4.0+ — use eval or stdout capture" \
         "$_f" "$_r" 'printf[[:space:]]+-v[[:space:]]'
+
+    # MC014: readarray / mapfile (bash 4.0+)
+    grep_rule "error" "MC014" "'readarray'/'mapfile' requires bash 4.0+ — use while read loop" \
+        "$_f" "$_r" '\b(readarray|mapfile)\b'
+
+    # MC015: coproc (bash 4.0+)
+    grep_rule "error" "MC015" "'coproc' requires bash 4.0+" \
+        "$_f" "$_r" '\bcoproc\b'
+
+    # MC016: &>> (append redirect stderr+stdout, bash 4.0+)
+    grep_rule "error" "MC016" "'&>>' requires bash 4.0+ — use >> file 2>&1 instead" \
+        "$_f" "$_r" '&>>'
+
+    # MC017: relative source paths (breaks bash <(curl ...) execution)
+    grep_rule "error" "MC017" "relative source path breaks bash <(curl...) — use absolute path or eval" \
+        "$_f" "$_r" '(source|\.)[[:space:]]+\.\.?/'
+
+    # MC018: wait -n (bash 4.3+)
+    grep_rule "error" "MC018" "'wait -n' requires bash 4.3+ — use wait with specific PID" \
+        "$_f" "$_r" 'wait[[:space:]]+-n\b'
+
+    # MC019: declare -g (bash 4.2+)
+    grep_rule "error" "MC019" "'declare -g' requires bash 4.2+ — use global assignment instead" \
+        "$_f" "$_r" 'declare[[:space:]]+-[a-zA-Z]*g'
 
 done <<FILELIST
 $_all_files


### PR DESCRIPTION
## Summary
- **Removes `--warn-only`** from CI workflow so the macOS compat linter actually blocks PRs with violations (it was vaporware — never failed a build)
- **Adds 6 new lint rules** for bash 4.0+ features documented in CLAUDE.md but never enforced: `readarray`/`mapfile` (MC014), `coproc` (MC015), `&>>` redirect (MC016), relative source paths (MC017), `wait -n` (MC018), `declare -g` (MC019)
- **Excludes `.claude/worktrees/`** from scanning — these are temporary copies of the repo, not committed code (was inflating file count from 64 to 139)

## Test plan
- [x] `bash -n sh/test/macos-compat.sh` syntax check passes
- [x] Linter runs clean on current codebase: 0 errors, 0 warnings, 64 files
- [x] All 6 new rules verified against synthetic test file — each fires correctly
- [x] Existing 13 rules (MC001-MC013) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)