### PR TITLE
fix: update stale paths in QA quality prompt

### DIFF
--- a/.claude/skills/setup-agent-team/qa-quality-prompt.md
+++ b/.claude/skills/setup-agent-team/qa-quality-prompt.md
@@ -94,14 +94,14 @@ cd REPO_ROOT_PLACEHOLDER && git worktree remove WORKTREE_BASE_PLACEHOLDER/TASK_N
 2. `cd` into worktree
 3. Scan for these issues:
 
-   **a) Dead code**: Functions in `shared/*.sh` or `packages/cli/src/` that are never called
+   **a) Dead code**: Functions in `sh/shared/*.sh` or `packages/cli/src/` that are never called
    - Grep for the function name across all source files
    - If only the definition exists (no callers), remove the function
 
-   **b) Stale references**: Scripts or code referencing deleted files:
-   - `test/record.sh`, `test/mock.sh`, `test/e2e.sh`, `test/run.sh`
-   - Any file in `test/` that no longer exists
-   - Remove or update these references
+   **b) Stale references**: Scripts or code referencing files that no longer exist
+   - Shell scripts are under `sh/` (e.g., `sh/shared/`, `sh/e2e/`, `sh/test/`, `sh/{cloud}/`)
+   - TypeScript is under `packages/cli/src/` and `packages/shared/src/`
+   - Grep for paths that reference old locations or deleted files and fix them
 
    **c) Python usage**: Any `python3 -c` or `python -c` calls in shell scripts
    - Replace with `bun eval` or `jq` as appropriate per CLAUDE.md rules


### PR DESCRIPTION
## Summary
- Fixes `shared/*.sh` → `sh/shared/*.sh` (shell scripts were moved to `sh/` in a prior refactor)
- Removes hardcoded references to `test/record.sh`, `test/mock.sh`, `test/e2e.sh`, `test/run.sh` — the old `test/` directory at repo root no longer exists
- Replaces with general guidance pointing to the actual current file structure (`sh/`, `packages/cli/src/`, `packages/shared/src/`)

The other three QA prompts (e2e, fixtures, issue) were verified correct — no changes needed.

## Test plan
- [x] Verified `sh/test/fixtures/{cloud}/_env.sh` files exist (fixtures prompt is correct)
- [x] Verified `packages/cli/src/fly/agents.ts` and `packages/cli/src/shared/agent-setup.ts` exist (e2e prompt is correct)
- [x] Confirmed `test/` directory does not exist at repo root (stale reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)