### PR TITLE
feat(spa): deduplicate issues before creating new ones

### DIFF
--- a/.claude/skills/setup-spa/main.ts
+++ b/.claude/skills/setup-spa/main.ts
@@ -82,6 +82,17 @@ Your primary job is to help manage GitHub issues based on Slack conversations:
 
 Always use the \`gh\` CLI for GitHub operations. You are already authenticated.
 
+**Duplicate check — MANDATORY before creating any issue.** Before filing a new issue, you MUST:
+1. Extract 3-5 keywords from the proposed issue (e.g. "delete", "cloud", "hetzner", "script missing").
+2. Search BOTH open AND closed issues for matches:
+   \`gh issue list --repo ${GITHUB_REPO} --state all --search "KEYWORDS" --limit 20\`
+3. If a matching closed issue exists, check whether the fix is still present in the codebase:
+   - Use Grep/Read to verify the relevant code — was it reverted, removed, or is it still there?
+   - If the fix is still in place → the issue is already resolved. Tell the Slack thread "This was already fixed in #N" and do NOT create a duplicate.
+   - If the fix was reverted or the problem recurred → reopen the existing issue with \`gh issue reopen N --comment "Regression: ..."\` instead of creating a new one.
+4. If a matching open issue exists → do NOT create a duplicate. Instead comment on the existing issue if the Slack thread adds new context, and link it in Slack.
+5. Only create a new issue if no existing issue (open or closed) covers the same problem.
+
 **Issue title format — MANDATORY.** Before creating an issue, read the issue templates in \`.github/ISSUE_TEMPLATE/\` to determine the correct title prefix, labels, and required fields. Each template specifies a bracket prefix (e.g. \`[Bug]:\`, \`[CLI]:\`) — always use the matching one. Apply the labels defined in the template's \`labels:\` field.
 
 When creating issues, include a footer: "_Filed from Slack by SPA_"


### PR DESCRIPTION
## Summary
- SPA's system prompt now includes a **mandatory duplicate check** before creating any GitHub issue
- Searches both open AND closed issues using extracted keywords (`gh issue list --state all --search ...`)
- For closed matches: verifies the fix is still in the codebase via Grep/Read before skipping
- For regressions: reopens the existing issue instead of creating a duplicate
- For open matches: comments on the existing issue instead of filing a new one

## Test plan
- [x] All 1915 existing tests pass (0 failures)
- [ ] Verify SPA in Slack: mention a known-fixed issue topic → should respond "already fixed in #N"
- [ ] Verify SPA in Slack: mention a new bug → should still create an issue normally
- [ ] Verify SPA in Slack: mention a regressed issue → should reopen with regression comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)