### PR TITLE
fix: export PATH after bun install to fix current-shell availability

### DIFF
--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -226,8 +226,10 @@ if ! command -v bun &>/dev/null; then
     log_step "bun not found. Installing bun..."
     curl -fsSL https://bun.sh/install | bash
 
-    # Re-export so bun is available in this session immediately
-    export PATH="${BUN_INSTALL}/bin:${PATH}"
+    # Re-export so bun is available in this session immediately.
+    # Use hard-coded paths alongside BUN_INSTALL — the bun installer may
+    # have placed the binary in $HOME/.bun/bin even if BUN_INSTALL differs.
+    export PATH="$HOME/.bun/bin:${BUN_INSTALL}/bin:$HOME/.local/bin:${PATH}"
 
     if ! command -v bun &>/dev/null; then
         log_error "Failed to install bun automatically"


### PR DESCRIPTION
## Summary

When bun is freshly installed via `curl | bash`, the spawn install script patched rc files (`.bashrc`, `.zshrc`) for future shells but didn't fully export all relevant paths for the **current** shell session. This caused `bun` and `spawn` to be unavailable immediately after install on fresh machines — the user had to open a new terminal.

**Fix:** Strengthen the post-install `export PATH` to include hard-coded `$HOME/.bun/bin` and `$HOME/.local/bin` alongside `$BUN_INSTALL/bin`, so both bun and spawn are available in the current execution context immediately after install.

Fixes #1874

-- refactor/ux-engineer