### PR TITLE
fix: use npm install for OpenClaw to fix Node module resolution

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -54,7 +54,7 @@
       "name": "OpenClaw",
       "description": "Personal AI assistant with multi-channel gateway + TUI",
       "url": "https://github.com/openclaw/openclaw",
-      "install": "bun install -g openclaw",
+      "install": "npm install -g openclaw",
       "launch": "openclaw tui",
       "pre_launch": "nohup openclaw gateway > /tmp/openclaw-gateway.log 2>&1 &",
       "env": {

--- a/packages/cli/src/fly/agents.ts
+++ b/packages/cli/src/fly/agents.ts
@@ -47,7 +47,7 @@ export const agents: Record<string, FlyAgentConfig> = (() => {
         await installAgent(
           runner,
           "openclaw",
-          'export PATH="$HOME/.bun/bin:$HOME/.local/bin:$PATH" && bun install -g openclaw && command -v openclaw',
+          'export PATH="$HOME/.bun/bin:$HOME/.local/bin:$PATH" && npm install -g openclaw && command -v openclaw',
         );
       }
     },

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -332,7 +332,7 @@ export async function setupOpenclawBatched(
     '  echo "    openclaw found at $(command -v openclaw)"',
     "else",
     '  echo "    openclaw not found, installing..."',
-    "  bun install -g openclaw",
+    "  npm install -g openclaw",
     '  command -v openclaw || { echo "ERROR: openclaw install failed"; exit 1; }',
     "fi",
     'echo "==> Writing environment variables..."',
@@ -475,7 +475,7 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       cloudInitTier: "full",
       modelPrompt: true,
       modelDefault: "openrouter/auto",
-      install: () => installAgent(runner, "openclaw", "source ~/.bashrc && bun install -g openclaw"),
+      install: () => installAgent(runner, "openclaw", "source ~/.bashrc && npm install -g openclaw"),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,
         `ANTHROPIC_API_KEY=${apiKey}`,

--- a/sh/fly/docker/openclaw.Dockerfile
+++ b/sh/fly/docker/openclaw.Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update -y && \
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:/root/.local/bin:${PATH}"
 
-# OpenClaw via bun (matches agents.ts install strategy)
-RUN bun install -g openclaw
+# OpenClaw via npm (Node runtime needs standard node_modules layout)
+RUN npm install -g openclaw
 # Ensure tools are on PATH for all shells
 RUN for rc in /root/.bashrc /root/.zshrc; do \
       grep -q '.bun/bin' "$rc" 2>/dev/null || \

--- a/sh/test/fixtures/_shared_agent_assertions.sh
+++ b/sh/test/fixtures/_shared_agent_assertions.sh
@@ -30,8 +30,8 @@ assert_agent_install() {
             # (mock claude binary is pre-installed, so curl installer is skipped)
             _assert_install_pattern "claude.*install" "installs claude code" ;;
         openclaw)
-            # npm install -g openclaw OR bun install -g openclaw (varies by cloud)
-            _assert_install_pattern "install.*openclaw" "installs openclaw via npm/bun" ;;
+            # npm install -g openclaw (Node runtime needs standard node_modules layout)
+            _assert_install_pattern "npm.*install.*openclaw" "installs openclaw via npm" ;;
         codex)
             # npm install -g @openai/codex
             _assert_install_pattern "npm.*install.*codex" "installs codex via npm" ;;


### PR DESCRIPTION
## Summary

OpenClaw runs under Node, but `bun install -g openclaw` produces a flat `node_modules` layout that is incompatible with Node's `require()` resolver. When OpenClaw dynamically loads channel plugins at runtime, it fails silently — users see an empty channels section with zero error messages.

**Fix:** Switch all OpenClaw install commands from `bun install -g` to `npm install -g`, which produces the standard nested `node_modules` layout that Node expects.

### Changed files

- `packages/cli/src/shared/agent-setup.ts` — `setupOpenclawBatched()` and `createAgents()` openclaw install commands
- `packages/cli/src/fly/agents.ts` — Fly-specific openclaw fallback install
- `sh/fly/docker/openclaw.Dockerfile` — Docker image build step
- `manifest.json` — Agent install field
- `sh/test/fixtures/_shared_agent_assertions.sh` — Test assertion pattern (now checks `npm.*install.*openclaw`)

Bun is still used for bootstrapping the Spawn CLI itself (that's unrelated — bun runs the TypeScript shim, not OpenClaw).

Fixes #1875

-- refactor/code-health