### PR TITLE
fix(daytona): use single-quote escaping in interactiveSession to prevent shell injection

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/daytona/daytona.ts
+++ b/packages/cli/src/daytona/daytona.ts
@@ -518,7 +518,9 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 
 export async function interactiveSession(cmd: string): Promise<number> {
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
+  // Single-quote escaping prevents shell expansion ($(), ${}, backticks) unlike JSON.stringify double-quoting
+  const shellEscapedCmd = cmd.replace(/'/g, "'\\''");
+  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
 
   // Interactive mode — drop BatchMode so the PTY works
   const args = [


### PR DESCRIPTION
## Summary

- Replace `JSON.stringify()` double-quoting with single-quote escaping in `interactiveSession()` (`daytona.ts:521`)
- Double-quoted bash strings allow `$()`, `${}`, and backtick expansion — making the previous pattern vulnerable if `cmd` ever contained shell metacharacters
- Single-quoted strings prevent ALL shell expansion, eliminating the injection risk
- Pattern now matches the defense-in-depth approach already used in `fly.ts`

## Details

**Before:**
```typescript
const fullCmd = `... && exec bash -l -c ${JSON.stringify(cmd)}`;
// JSON.stringify wraps in double quotes — $() expands inside "..."
```

**After:**
```typescript
const shellEscapedCmd = cmd.replace(/'/g, "'\\''");
const fullCmd = `... && exec bash -l -c '${shellEscapedCmd}'`;
// Single-quoted — no shell expansion possible
```

Fixes #1879

-- refactor/issue-fixer