### PR TITLE
fix: stdin dies after SSH key multiselect — model prompt silently exits

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- `@clack/prompts` multiselect (SSH key selection) creates/destroys its own readline on stdin
- Due to Bun #1707, subsequent `readline.createInterface()` calls get an immediate "close" event
- The model selection prompt (`Enter model ID [openrouter/auto]:`) silently exits the process
- **Fix**: Replace readline-based `prompt()` with `p.text()` from `@clack/prompts` so all stdin interactions use one library

## Test plan
- [x] `bun test` passes (1904/1904, same 2 pre-existing failures)
- [x] `biome lint` clean
- [ ] Manual: run `spawn` with OpenClaw on AWS, verify model prompt appears and accepts input after SSH key selection + OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)