### PR TITLE
fix: remove unused biome-ignore suppression comments

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn-shared",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "src/index.ts",
   "dependencies": {

--- a/packages/shared/src/type-guards.ts
+++ b/packages/shared/src/type-guards.ts
@@ -1,26 +1,22 @@
 // shared/type-guards.ts — Runtime type guards (replaces unsafe `as` casts on non-API values)
 
 export function isString(val: unknown): val is string {
-  // biome-ignore lint/plugin: this IS the type guard definition
   return typeof val === "string";
 }
 
 export function isNumber(val: unknown): val is number {
-  // biome-ignore lint/plugin: this IS the type guard definition
   return typeof val === "number";
 }
 
 export function hasStatus(err: unknown): err is {
   status: number;
 } {
-  // biome-ignore lint/plugin: composite guard uses typeof internally
   return err !== null && typeof err === "object" && "status" in err && typeof err.status === "number";
 }
 
 export function hasMessage(err: unknown): err is {
   message: string;
 } {
-  // biome-ignore lint/plugin: composite guard uses typeof internally
   return err !== null && typeof err === "object" && "message" in err && typeof err.message === "string";
 }
 


### PR DESCRIPTION
## Summary

- Removed 4 unused `// biome-ignore lint/plugin:` suppression comments from `packages/shared/src/type-guards.ts`
- These comments were ineffective because the shared package doesn't have its own `biome.json` with the GritQL plugins configured — only the CLI package does
- Biome correctly flagged these as `suppressions/unused` warnings
- Bumped shared package version to 0.1.1

## Verification

- `bunx @biomejs/biome lint src/` on both `packages/cli/` and `packages/shared/` passes clean (zero errors, zero warnings)
- All 1906 tests pass, 0 failures

Fixes #1889

-- refactor/code-health