### PR TITLE
fix: use single-quote escaping for restart loop in interactiveSession

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1094,7 +1094,9 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 
 export async function interactiveSession(cmd: string): Promise<number> {
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
+  // Single-quote escaping prevents premature shell expansion of $variables in cmd
+  const shellEscapedCmd = cmd.replace(/'/g, "'\\''");
+  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
   const escapedCmd = fullCmd.replace(/'/g, "'\\''");
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
   const exitCode = await Bun.spawn(

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1059,7 +1059,9 @@ export async function uploadFile(localPath: string, remotePath: string, ip?: str
 export async function interactiveSession(cmd: string, ip?: string): Promise<number> {
   const serverIp = ip || doServerIp;
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
+  // Single-quote escaping prevents premature shell expansion of $variables in cmd
+  const shellEscapedCmd = cmd.replace(/'/g, "'\\''");
+  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const exitCode = await Bun.spawn(

--- a/packages/cli/src/fly/fly.ts
+++ b/packages/cli/src/fly/fly.ts
@@ -1010,7 +1010,10 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 
 export async function interactiveSession(cmd: string): Promise<number> {
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
+  // Single-quote escaping prevents premature shell expansion of $variables in cmd
+  // (JSON.stringify double-quoting lets the shell expand $vars before the script runs)
+  const shellEscapedCmd = cmd.replace(/'/g, "'\\''");
+  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
   // Shell-quote the command for -C
   const escapedCmd = fullCmd.replace(/'/g, "'\\''");
   const flyCmd = getCmd()!;

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -913,7 +913,9 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 export async function interactiveSession(cmd: string): Promise<number> {
   const username = resolveUsername();
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
+  // Single-quote escaping prevents premature shell expansion of $variables in cmd
+  const shellEscapedCmd = cmd.replace(/'/g, "'\\''");
+  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const exitCode = await Bun.spawn(

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -625,7 +625,9 @@ export async function uploadFile(localPath: string, remotePath: string, ip?: str
 export async function interactiveSession(cmd: string, ip?: string): Promise<number> {
   const serverIp = ip || hetznerServerIp;
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${JSON.stringify(cmd)}`;
+  // Single-quote escaping prevents premature shell expansion of $variables in cmd
+  const shellEscapedCmd = cmd.replace(/'/g, "'\\''");
+  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
 
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 


### PR DESCRIPTION
## Summary

- **Fixed restart loop crash** on fly, gcp, hetzner, digitalocean, and aws clouds
- `JSON.stringify(cmd)` double-quoting caused two bugs in the restart wrapper sent via SSH:
  1. Literal `\n` instead of actual newlines — bash doesn't interpret `\n` in double-quoted strings, so the entire multi-line restart script became one line, causing `syntax error near unexpected token 'then'`
  2. Shell variables (`$_spawn_restarts`, `$_spawn_max`, `$_spawn_exit`) were expanded to empty strings by the outer shell *before* the script ran, causing `[ "" -lt "" ]` failures
- Replaced `JSON.stringify(cmd)` with single-quote escaping (`cmd.replace(/'/g, "'\\''")`) which prevents premature variable expansion and preserves newlines
- Daytona already had the correct approach (with a comment explaining why) — aligned all other clouds to match

## Test plan

- [x] `bunx @biomejs/biome lint` passes on all 5 changed files (0 errors)
- [x] `bun test` — 1904 pass, 2 pre-existing failures (unrelated to this change)
- [ ] Manual verification: `spawn openclaw fly` should launch without `syntax error near unexpected token 'then'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)