### PR TITLE
feat(qa): add e2e-tester as subagent in scheduled quality sweep

### DIFF
--- a/.claude/skills/setup-agent-team/qa.sh
+++ b/.claude/skills/setup-agent-team/qa.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 # QA Service — Single Cycle (Quad-Mode)
 # Triggered by trigger-server.ts via GitHub Actions
 #
-# RUN_MODE=quality  — agent team: test-runner + dedup-scanner + code-quality-reviewer (reason=schedule/workflow_dispatch, 35 min)
+# RUN_MODE=quality  — agent team: test-runner + dedup-scanner + code-quality-reviewer + e2e-tester (reason=schedule/workflow_dispatch, 40 min)
 # RUN_MODE=fixtures — single agent: collect API fixtures from cloud providers (reason=fixtures, 20 min)
 # RUN_MODE=issue    — single agent: investigate and fix a specific issue (reason=issues, 15 min)
 # RUN_MODE=e2e      — single agent: run Fly.io E2E tests, investigate failures (reason=e2e, 20 min)
@@ -43,12 +43,12 @@ elif [[ "${SPAWN_REASON}" == "schedule" ]] || [[ "${SPAWN_REASON}" == "workflow_
     RUN_MODE="quality"
     WORKTREE_BASE="/tmp/spawn-worktrees/qa-quality"
     TEAM_NAME="spawn-qa-quality"
-    CYCLE_TIMEOUT=2100  # 35 min for quality sweep
+    CYCLE_TIMEOUT=2400  # 40 min for quality sweep (includes E2E)
 else
     RUN_MODE="quality"
     WORKTREE_BASE="/tmp/spawn-worktrees/qa-quality"
     TEAM_NAME="spawn-qa-quality"
-    CYCLE_TIMEOUT=2100  # 35 min for quality sweep
+    CYCLE_TIMEOUT=2400  # 40 min for quality sweep (includes E2E)
 fi
 
 LOG_FILE="${REPO_ROOT}/.docs/${TEAM_NAME}.log"

--- a/.claude/skills/setup-agent-team/trigger-server.ts
+++ b/.claude/skills/setup-agent-team/trigger-server.ts
@@ -102,6 +102,7 @@ const VALID_REASONS = new Set([
   "review_all",
   "hygiene",
   "fixtures",
+  "e2e",
 ]);
 
 /** Check if a process is still alive via kill(0) */

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,20 +1,17 @@
 name: Daily QA
-# Disabled until QA VM is fixed
-# on:
-#   schedule:
-#     - cron: '0 6 * * *'
-#   workflow_dispatch:
 on:
+  schedule:
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       reason:
         description: 'QA mode to trigger'
         required: false
-        default: 'e2e'
+        default: 'schedule'
         type: choice
         options:
-          - e2e
           - schedule
+          - e2e
           - fixtures
 jobs:
   trigger:
@@ -26,7 +23,7 @@ jobs:
           SPRITE_URL: ${{ secrets.QA_SPRITE_URL }}
           TRIGGER_SECRET: ${{ secrets.QA_TRIGGER_SECRET }}
         run: |
-          REASON="${{ github.event.inputs.reason || 'e2e' }}"
+          REASON="${{ github.event.inputs.reason || 'schedule' }}"
           curl -sS --fail-with-body -X POST \
             "${SPRITE_URL}/trigger?reason=${REASON}" \
             -H "Authorization: Bearer ${TRIGGER_SECRET}"


### PR DESCRIPTION
## Summary
- E2E tests now run as a 4th teammate (`e2e-tester`) alongside `test-runner`, `dedup-scanner`, and `code-quality-reviewer` during schedule-triggered QA cycles
- Standalone `reason=e2e` mode preserved for on-demand use
- Re-enabled daily schedule cron in qa.yml (defaults to `schedule` which now includes E2E)

## Changes
- **qa-quality-prompt.md**: Added `e2e-tester` teammate (Teammate 4) with full protocol for running `fly-e2e.sh`, investigating failures, and opening fix PRs
- **qa.sh**: Increased quality mode timeout from 35 min to 40 min to accommodate E2E runs
- **trigger-server.ts**: Added `"e2e"` to `VALID_REASONS` set
- **qa.yml**: Re-enabled `schedule` cron trigger, changed default from `e2e` to `schedule`

## Test plan
- [ ] Trigger QA cycle with `reason=schedule` and verify e2e-tester spawns as teammate
- [ ] Trigger QA cycle with `reason=e2e` and verify standalone mode still works
- [ ] Verify trigger-server accepts `reason=e2e` without 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)