### PR TITLE
ci: bump QA cron from daily to every 4 hours

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,7 +1,7 @@
-name: Daily QA
+name: QA
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 */4 * * *'
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
## Summary

- Changes QA workflow schedule from `0 6 * * *` (once daily at 06:00 UTC) to `0 */4 * * *` (every 4 hours)
- Renames workflow from "Daily QA" to "QA" to reflect the new frequency

## Test plan

- [ ] Verify workflow triggers at 00:00, 04:00, 08:00, 12:00, 16:00, 20:00 UTC after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)