### PR TITLE
fix: resolve biome nested root configuration conflict

### DIFF
--- a/.claude/skills/setup-spa/biome.json
+++ b/.claude/skills/setup-spa/biome.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.3/schema.json",
-  "extends": ["../../../lint/biome.json"],
+  "root": false,
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "extends": ["../../../biome.json"],
   "vcs": {
     "enabled": false
   },

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/packages/cli/biome.json
+++ b/packages/cli/biome.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.3/schema.json",
-  "extends": ["../../lint/biome.json"],
+  "root": false,
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "extends": ["../../biome.json"],
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary
- Moved shared `lint/biome.json` to repo root `biome.json` so it's the single root config
- Added `"root": false` to nested configs (`packages/cli/biome.json`, `.claude/skills/setup-spa/biome.json`) via `biome migrate`
- Bumped biome schema from 2.4.3 → 2.4.4
- Fixes `bunx @biomejs/biome lint packages/cli/src/` failing when run from the repo root with "Found a nested root configuration" error

## Test plan
- [x] `bunx @biomejs/biome lint packages/cli/src/` passes from repo root (was failing before)
- [x] `cd packages/cli && bunx @biomejs/biome lint src/` still passes
- [x] `bun test` passes (1905/1906, 1 pre-existing failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)