### PR TITLE
test: fix inline source copies — import real isValidManifest instead of stale replica

### DIFF
--- a/packages/cli/src/__tests__/do-oauth.test.ts
+++ b/packages/cli/src/__tests__/do-oauth.test.ts
@@ -126,39 +126,6 @@ describe("DO token format validation", () => {
   });
 });
 
-// ── CSRF State Generation ───────────────────────────────────────────────────
-
-describe("CSRF state generation", () => {
-  function generateCsrfState(): string {
-    const bytes = new Uint8Array(16);
-    crypto.getRandomValues(bytes);
-    return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-  }
-
-  it("should generate 32 hex characters (128 bits)", () => {
-    const state = generateCsrfState();
-    expect(state).toHaveLength(32);
-    expect(state).toMatch(/^[0-9a-f]{32}$/);
-  });
-
-  it("should generate unique values", () => {
-    const states = new Set<string>();
-    for (let i = 0; i < 100; i++) {
-      states.add(generateCsrfState());
-    }
-    expect(states.size).toBe(100);
-  });
-
-  it("should be URL-safe", () => {
-    const state = generateCsrfState();
-    expect(state).not.toContain(" ");
-    expect(state).not.toContain("&");
-    expect(state).not.toContain("?");
-    expect(state).not.toContain("/");
-    expect(state).not.toContain("#");
-  });
-});
-
 // ── OAuth Code Validation ───────────────────────────────────────────────────
 
 describe("OAuth code validation", () => {

--- a/packages/cli/src/__tests__/manifest-cache-lifecycle.test.ts
+++ b/packages/cli/src/__tests__/manifest-cache-lifecycle.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { existsSync, writeFileSync, mkdirSync, rmSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import type { Manifest } from "../manifest";
-import { loadManifest, agentKeys, cloudKeys, matrixStatus, countImplemented } from "../manifest";
+import { loadManifest, agentKeys, cloudKeys, matrixStatus, countImplemented, isValidManifest } from "../manifest";
 import type { TestEnvironment } from "./test-helpers";
 import { createMockManifest, setupTestEnvironment, teardownTestEnvironment } from "./test-helpers";
 
@@ -25,14 +25,6 @@ import { createMockManifest, setupTestEnvironment, teardownTestEnvironment } fro
  */
 
 const mockManifest = createMockManifest();
-
-// ── isValidManifest (exact replica from manifest.ts line 84-86) ──────────────
-// The actual function uses short-circuit && which returns the last truthy value
-// or first falsy value, NOT a boolean. Tests use toBeTruthy/toBeFalsy.
-
-function isValidManifest(data: any): data is Manifest {
-  return data?.agents && data.clouds && data.matrix;
-}
 
 describe("Manifest Cache Lifecycle", () => {
   describe("isValidManifest validation", () => {

--- a/packages/cli/src/manifest.ts
+++ b/packages/cli/src/manifest.ts
@@ -149,7 +149,7 @@ function stripDangerousKeys(obj: unknown): unknown {
   return clean;
 }
 
-function isValidManifest(data: unknown): data is Manifest {
+export function isValidManifest(data: unknown): data is Manifest {
   return (
     data !== null &&
     typeof data === "object" &&


### PR DESCRIPTION
**Why:** The `isValidManifest` copy in `manifest-cache-lifecycle.test.ts` was already out of sync with the real implementation at `manifest.ts:152` — it was missing the `typeof data === "object"`, `!Array.isArray(data)`, and `"agents" in data` checks added since the copy was made. A test that passes even when the real source breaks is worse than no test.

## Changes

- **`manifest.ts`** — Export `isValidManifest` (add `export` keyword; pure function, no side effects)
- **`manifest-cache-lifecycle.test.ts`** — Import the real `isValidManifest` from `../manifest`; remove the 7-line stale inline replica
- **`do-oauth.test.ts`** — Remove the "CSRF state generation" describe block (30 lines); it tested an inline copy of a private function, not the actual source — these tests can never catch a regression in the real implementation

## Verification

- `bun test src/__tests__/manifest-cache-lifecycle.test.ts` — 52 pass, 0 fail
- `bun test src/__tests__/do-oauth.test.ts` — 31 pass, 0 fail
- `cd packages/cli && bunx @biomejs/biome lint src/` — 0 errors

-- refactor/test-engineer