### PR TITLE
fix(security): escape single quotes in standard SSH enter-agent path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2925,16 +2925,17 @@ async function cmdEnterAgent(connection: VMConnection, agentKey: string, manifes
 
   // Standard SSH connection with agent launch
   p.log.step(`Entering ${pc.bold(agentName)} on ${pc.bold(connection.ip)}...`);
+  const escapedRemoteCmd = remoteCmd.replace(/'/g, "'\\''");
   return runInteractiveCommand(
     "ssh",
     [
       ...SSH_INTERACTIVE_OPTS,
       `${connection.user}@${connection.ip}`,
       "--",
-      `bash -lc '${remoteCmd}'`,
+      `bash -lc '${escapedRemoteCmd}'`,
     ],
     `Failed to enter ${agentName}`,
-    `ssh -t ${connection.user}@${connection.ip} -- bash -lc '${remoteCmd}'`,
+    `ssh -t ${connection.user}@${connection.ip} -- bash -lc '${escapedRemoteCmd}'`,
   );
 }
 


### PR DESCRIPTION
**Why:** Unescaped `launch_cmd` in SSH path allows single-quote injection on non-Fly clouds; exploitable if `~/.spawn/history.json` is tampered with or manifest is compromised.

## Summary

- The standard SSH path in `cmdEnterAgent()` (`commands.ts:2917`) interpolated `remoteCmd` directly into a `bash -lc '...'` wrapper without escaping single quotes
- The Fly.io path (line 2874) already had the correct `replace(/'/g, "'\\''")` escaping from PRs #1880 and #1893, but the generic SSH fallback did not
- A `remoteCmd` containing a single quote would break the shell quoting, allowing unintended command execution on the remote server
- This adds the same single-quote escaping pattern used throughout the codebase (`sanitizeTermValue`, `interactiveSession` in all cloud modules)

## Changes

- `packages/cli/src/commands.ts`: Add `escapedRemoteCmd` variable with single-quote escaping on the standard SSH path, used in both the command args and the display string
- `packages/cli/package.json`: Bump version 0.10.8 -> 0.10.9

## Test plan

- [x] `bunx @biomejs/biome lint src/` passes with 0 errors
- [x] `bun test` passes (1906 tests, 0 failures)
- [x] Pattern matches established escaping in Fly.io path and all `interactiveSession()` implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)