### PR TITLE
fix: revert Bun.spawn for interactive sessions — breaks TTY forwarding

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1,6 +1,7 @@
 // aws/aws.ts — Core AWS Lightsail provider: auth, provisioning, SSH execution
 
 import { existsSync, readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 
 import { createHash, createHmac } from "node:crypto";
 import {
@@ -1099,22 +1100,20 @@ export async function interactiveSession(cmd: string): Promise<number> {
   const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
   const escapedCmd = fullCmd.replace(/'/g, "'\\''");
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
-  const exitCode = await Bun.spawn(
-    [
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn(
       "ssh",
-      ...SSH_INTERACTIVE_OPTS,
-      ...keyOpts,
-      `${SSH_USER}@${instanceIp}`,
-      `bash -c '${escapedCmd}'`,
-    ],
-    {
-      stdio: [
-        "inherit",
-        "inherit",
-        "inherit",
+      [
+        ...SSH_INTERACTIVE_OPTS,
+        ...keyOpts,
+        `${SSH_USER}@${instanceIp}`,
+        `bash -c '${escapedCmd}'`,
       ],
-    },
-  ).exited;
+      { stdio: "inherit" },
+    );
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 
   // Post-session summary
   process.stderr.write("\n");

--- a/packages/cli/src/daytona/daytona.ts
+++ b/packages/cli/src/daytona/daytona.ts
@@ -1,6 +1,7 @@
 // daytona/daytona.ts — Core Daytona provider: API, SSH, provisioning, execution
 
 import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 
 import {
   logInfo,
@@ -531,13 +532,11 @@ export async function interactiveSession(cmd: string): Promise<number> {
     fullCmd,
   ];
 
-  const exitCode = await Bun.spawn(args, {
-    stdio: [
-      "inherit",
-      "inherit",
-      "inherit",
-    ],
-  }).exited;
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn(args[0], args.slice(1), { stdio: "inherit" });
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 
   // Post-session summary
   process.stderr.write("\n");

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1,6 +1,7 @@
 // digitalocean/digitalocean.ts — Core DigitalOcean provider: API, auth, SSH, provisioning
 
 import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 
 import * as v from "valibot";
 import {
@@ -1064,22 +1065,20 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
-  const exitCode = await Bun.spawn(
-    [
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn(
       "ssh",
-      ...SSH_INTERACTIVE_OPTS,
-      ...keyOpts,
-      `root@${serverIp}`,
-      fullCmd,
-    ],
-    {
-      stdio: [
-        "inherit",
-        "inherit",
-        "inherit",
+      [
+        ...SSH_INTERACTIVE_OPTS,
+        ...keyOpts,
+        `root@${serverIp}`,
+        fullCmd,
       ],
-    },
-  ).exited;
+      { stdio: "inherit" },
+    );
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 
   // Post-session summary
   process.stderr.write("\n");

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -1,6 +1,7 @@
 // gcp/gcp.ts — Core GCP Compute Engine provider: gcloud CLI wrapper, auth, provisioning, SSH
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 
 import {
   logInfo,
@@ -918,23 +919,20 @@ export async function interactiveSession(cmd: string): Promise<number> {
   const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
-  const exitCode = await Bun.spawn(
-    [
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn(
       "ssh",
-      ...SSH_INTERACTIVE_OPTS,
-      ...keyOpts,
-      `${username}@${gcpServerIp}`,
-      `bash -c ${shellQuote(fullCmd)}`,
-    ],
-    {
-      stdio: [
-        "inherit",
-        "inherit",
-        "inherit",
+      [
+        ...SSH_INTERACTIVE_OPTS,
+        ...keyOpts,
+        `${username}@${gcpServerIp}`,
+        `bash -c ${shellQuote(fullCmd)}`,
       ],
-      env: process.env,
-    },
-  ).exited;
+      { stdio: "inherit", env: process.env },
+    );
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 
   // Post-session summary
   process.stderr.write("\n");

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -1,6 +1,7 @@
 // hetzner/hetzner.ts — Core Hetzner Cloud provider: API, auth, SSH, provisioning
 
 import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 
 import {
   logInfo,
@@ -631,22 +632,20 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
 
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
-  const exitCode = await Bun.spawn(
-    [
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn(
       "ssh",
-      ...SSH_INTERACTIVE_OPTS,
-      ...keyOpts,
-      `root@${serverIp}`,
-      fullCmd,
-    ],
-    {
-      stdio: [
-        "inherit",
-        "inherit",
-        "inherit",
+      [
+        ...SSH_INTERACTIVE_OPTS,
+        ...keyOpts,
+        `root@${serverIp}`,
+        fullCmd,
       ],
-    },
-  ).exited;
+      { stdio: "inherit" },
+    );
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 
   // Post-session summary
   process.stderr.write("\n");

--- a/packages/cli/src/local/local.ts
+++ b/packages/cli/src/local/local.ts
@@ -2,6 +2,7 @@
 
 import { copyFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { spawn } from "node:child_process";
 
 import { getSpawnDir } from "../history.js";
 
@@ -70,21 +71,11 @@ export function uploadFile(localPath: string, remotePath: string): void {
 
 /** Launch an interactive shell session locally. */
 export async function interactiveSession(cmd: string): Promise<number> {
-  return Bun.spawn(
-    [
-      "bash",
-      "-c",
-      cmd,
-    ],
-    {
-      stdio: [
-        "inherit",
-        "inherit",
-        "inherit",
-      ],
-      env: process.env,
-    },
-  ).exited;
+  return new Promise<number>((resolve, reject) => {
+    const child = spawn("bash", ["-c", cmd], { stdio: "inherit", env: process.env });
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 }
 
 // ─── Connection Tracking ─────────────────────────────────────────────────────

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -1,6 +1,7 @@
 // sprite/sprite.ts — Core Sprite provider: CLI installation, auth, provisioning, execution
 
 import { existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { spawn } from "node:child_process";
 
 import {
   logInfo,
@@ -584,13 +585,11 @@ export async function interactiveSession(cmd: string): Promise<number> {
         cmd,
       ];
 
-  const exitCode = await Bun.spawn(args, {
-    stdio: [
-      "inherit",
-      "inherit",
-      "inherit",
-    ],
-  }).exited;
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn(args[0], args.slice(1), { stdio: "inherit" });
+    child.on("close", (code) => resolve(code ?? 0));
+    child.on("error", reject);
+  });
 
   // Post-session summary
   process.stderr.write("\n");


### PR DESCRIPTION
**Why:** Bun.spawn with \`stdio: \"inherit\"\` creates pipe-based inheritance that loses TTY properties — SSH detects no terminal, Claude Code enters \`--print\` mode, and agents crash in a restart loop. child_process.spawn passes actual TTY file descriptors.

## Summary

- Reverts \`interactiveSession()\` in all 8 cloud modules (hetzner, aws, daytona, digitalocean, fly, gcp, local, sprite) from \`Bun.spawn\` back to \`child_process.spawn\` with \`stdio: \"inherit\"\`
- Reverts \`runInteractiveCommand()\` in \`commands.ts\` from \`Bun.spawn\` to \`child_process.spawn\`
- Bumps CLI version 0.10.8 → 0.10.9

## Context

Supersedes #1899 which had complex merge conflicts with intervening commits (#1891 pickToTTY refactor, #1893 single-quote escaping, #1896 biome config fix). Applied the same change cleanly to current main.

Supersedes #1899

## Test Plan

- [x] \`bunx @biomejs/biome lint src/\` — 0 errors (97 files)
- [x] \`bun test\` — 1906 pass, 0 fail

-- refactor/team-lead