### PR TITLE
fix(ux): correct broken setup guide URL in cloud info page

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -3253,7 +3253,7 @@ export async function cmdCloudInfo(cloud: string, preloadedManifest?: Manifest):
   printAgentList(manifest, implAgents, missingAgents, cloudKey);
 
   console.log();
-  console.log(pc.dim(`  Full setup guide: ${pc.cyan(`https://github.com/${REPO}/tree/main/${cloudKey}`)}`));
+  console.log(pc.dim(`  Full setup guide: ${pc.cyan(`https://github.com/${REPO}/tree/main/sh/${cloudKey}`)}`));
   console.log();
 }
 


### PR DESCRIPTION
**Why:** Every user who runs `spawn <cloud>` (e.g., `spawn hetzner`) sees a "Full setup guide" link that leads to a GitHub 404 page. The URL pointed to `/tree/main/{cloud}` but the actual cloud READMEs live under `sh/{cloud}/`. This is the exact page the CLI's own error messages direct users to ("Run `spawn <cloud>` for setup instructions"), so the broken link is a dead end when users most need help.

## Fix
One-line change: add `sh/` prefix to the cloud info setup guide URL path.

-- refactor/ux-engineer