### PR TITLE
fix(security): shell script hardening (issue #1913)

### DIFF
--- a/.claude/skills/setup-agent-team/qa.sh
+++ b/.claude/skills/setup-agent-team/qa.sh
@@ -197,8 +197,9 @@ if [[ "${RUN_MODE}" == "quality" ]]; then
     fi
     cat "$PROMPT_TEMPLATE" > "${PROMPT_FILE}"
 
-    sed -i "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
-    sed -i "s|REPO_ROOT_PLACEHOLDER|${REPO_ROOT}|g" "${PROMPT_FILE}"
+    sed -i.bak "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
+    sed -i.bak "s|REPO_ROOT_PLACEHOLDER|${REPO_ROOT}|g" "${PROMPT_FILE}"
+    rm -f "${PROMPT_FILE}.bak"
 
 elif [[ "${RUN_MODE}" == "fixtures" ]]; then
     PROMPT_TEMPLATE="${SCRIPT_DIR}/qa-fixtures-prompt.md"
@@ -208,8 +209,9 @@ elif [[ "${RUN_MODE}" == "fixtures" ]]; then
     fi
     cat "$PROMPT_TEMPLATE" > "${PROMPT_FILE}"
 
-    sed -i "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
-    sed -i "s|REPO_ROOT_PLACEHOLDER|${REPO_ROOT}|g" "${PROMPT_FILE}"
+    sed -i.bak "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
+    sed -i.bak "s|REPO_ROOT_PLACEHOLDER|${REPO_ROOT}|g" "${PROMPT_FILE}"
+    rm -f "${PROMPT_FILE}.bak"
 
 elif [[ "${RUN_MODE}" == "issue" ]]; then
     PROMPT_TEMPLATE="${SCRIPT_DIR}/qa-issue-prompt.md"
@@ -219,9 +221,10 @@ elif [[ "${RUN_MODE}" == "issue" ]]; then
     fi
     cat "$PROMPT_TEMPLATE" > "${PROMPT_FILE}"
 
-    sed -i "s|ISSUE_NUM_PLACEHOLDER|${ISSUE_NUM}|g" "${PROMPT_FILE}"
-    sed -i "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
-    sed -i "s|REPO_ROOT_PLACEHOLDER|${REPO_ROOT}|g" "${PROMPT_FILE}"
+    sed -i.bak "s|ISSUE_NUM_PLACEHOLDER|${ISSUE_NUM}|g" "${PROMPT_FILE}"
+    sed -i.bak "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
+    sed -i.bak "s|REPO_ROOT_PLACEHOLDER|${REPO_ROOT}|g" "${PROMPT_FILE}"
+    rm -f "${PROMPT_FILE}.bak"
 
 elif [[ "${RUN_MODE}" == "e2e" ]]; then
     PROMPT_TEMPLATE="${SCRIPT_DIR}/qa-e2e-prompt.md"
@@ -231,8 +234,9 @@ elif [[ "${RUN_MODE}" == "e2e" ]]; then
     fi
     cat "$PROMPT_TEMPLATE" > "${PROMPT_FILE}"
 
-    sed -i "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
-    sed -i "s|REPO_ROOT_PLACEHOLDER|${REPO_ROOT}|g" "${PROMPT_FILE}"
+    sed -i.bak "s|WORKTREE_BASE_PLACEHOLDER|${WORKTREE_BASE}|g" "${PROMPT_FILE}"
+    sed -i.bak "s|REPO_ROOT_PLACEHOLDER|${REPO_ROOT}|g" "${PROMPT_FILE}"
+    rm -f "${PROMPT_FILE}.bak"
 
 fi
 

--- a/sh/digitalocean/claude.sh
+++ b/sh/digitalocean/claude.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
@@ -71,7 +71,7 @@ fi
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
 trap 'rm -f "$DO_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
 _run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"

--- a/sh/digitalocean/codex.sh
+++ b/sh/digitalocean/codex.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
@@ -71,7 +71,7 @@ fi
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
 trap 'rm -f "$DO_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
 _run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"

--- a/sh/digitalocean/kilocode.sh
+++ b/sh/digitalocean/kilocode.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
@@ -71,7 +71,7 @@ fi
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
 trap 'rm -f "$DO_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
 _run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"

--- a/sh/digitalocean/openclaw.sh
+++ b/sh/digitalocean/openclaw.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
@@ -71,7 +71,7 @@ fi
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
 trap 'rm -f "$DO_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
 _run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"

--- a/sh/digitalocean/opencode.sh
+++ b/sh/digitalocean/opencode.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
@@ -71,7 +71,7 @@ fi
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
 trap 'rm -f "$DO_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
 _run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"

--- a/sh/digitalocean/zeroclaw.sh
+++ b/sh/digitalocean/zeroclaw.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }
@@ -71,7 +71,7 @@ fi
 # Remote — download bundled digitalocean.js from GitHub release
 DO_JS=$(mktemp)
 trap 'rm -f "$DO_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
     || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
 
 _run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"

--- a/sh/e2e/lib/common.sh
+++ b/sh/e2e/lib/common.sh
@@ -83,7 +83,7 @@ require_env() {
   # Check / generate FLY_API_TOKEN
   if [ -z "${FLY_API_TOKEN:-}" ]; then
     log_info "FLY_API_TOKEN not set, generating via flyctl..."
-    FLY_API_TOKEN=$(flyctl tokens create org personal --expiry 2h 2>/dev/null || true)
+    FLY_API_TOKEN=$(flyctl tokens create org personal --expiry 8h 2>/dev/null || true)
     if [ -z "${FLY_API_TOKEN:-}" ]; then
       log_warn "Could not generate token. Falling back to flyctl stored credentials."
       # Validate flyctl is authenticated
@@ -93,7 +93,7 @@ require_env() {
       fi
     else
       export FLY_API_TOKEN
-      log_ok "Generated FLY_API_TOKEN (expires in 2h)"
+      log_ok "Generated FLY_API_TOKEN (expires in 8h)"
     fi
   fi
 

--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -36,6 +36,14 @@ provision_agent() {
   # Environment for headless provisioning
   # FLY_API_TOKEN="" forces spawn to use flyctl stored credentials (see plan section 6)
   # MODEL_ID bypasses the interactive model selection prompt (required by openclaw)
+  #
+  # Validate flyctl is authenticated before proceeding with empty token fallback
+  if [ -z "${FLY_API_TOKEN:-}" ]; then
+    if ! flyctl auth whoami >/dev/null 2>&1; then
+      log_err "FLY_API_TOKEN is empty and flyctl is not authenticated. Run: flyctl auth login"
+      return 1
+    fi
+  fi
   (
     SPAWN_NON_INTERACTIVE=1 \
     SPAWN_SKIP_GITHUB_AUTH=1 \


### PR DESCRIPTION
**Why:** Prevents silent auth failures, fixes macOS sed incompatibility, reduces token refresh churn, and blocks HTTP downgrade attacks on curl redirects.

## Changes

### MEDIUM - FLY_API_TOKEN empty fallback validation (`sh/e2e/lib/provision.sh`)
- Added `flyctl auth whoami` validation before proceeding with empty token fallback
- Fails fast with clear error instead of silently falling through to unauthenticated flyctl

### LOW - sed -i portability (`.claude/skills/setup-agent-team/qa.sh`)
- Changed all `sed -i` calls to `sed -i.bak` with cleanup (`rm -f *.bak`)
- macOS requires an extension argument for in-place editing; Linux accepts both forms

### LOW - Token expiry increased (`sh/e2e/lib/common.sh`)
- Changed `--expiry 2h` to `--expiry 8h` for generated FLY_API_TOKEN
- 2h was too short for long-running E2E suites; 8h covers a full workday

### LOW - curl HTTPS enforcement (`sh/digitalocean/*.sh`, 6 files)
- Added `--proto '=https'` to all `curl -fsSL` calls
- Prevents HTTP downgrade if a redirect points to an HTTP URL

## Skipped
- **MEDIUM - curl|bash Bun install signature verification**: Skipped because adding checksum validation for bun's installer script is complex (checksums change per release, bun doesn't publish detached signatures) and a wrong implementation would be worse than the status quo.

Fixes #1913

-- refactor/code-health