### PR TITLE
fix: drain piped stderr in Fly/Daytona runServerCapture to prevent deadlock

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/daytona/daytona.ts
+++ b/packages/cli/src/daytona/daytona.ts
@@ -456,7 +456,11 @@ export async function runServerCapture(cmd: string): Promise<string> {
   } catch {
     /* already closed */
   }
-  const stdout = await new Response(proc.stdout).text();
+  // Drain both pipes before awaiting exit to prevent pipe buffer deadlock
+  const [stdout] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
   const exitCode = await proc.exited;
 
   await sleep(1000);

--- a/packages/cli/src/fly/fly.ts
+++ b/packages/cli/src/fly/fly.ts
@@ -955,7 +955,11 @@ export async function runServerCapture(cmd: string, timeoutSecs?: number): Promi
     } catch {}
   }, timeout);
 
-  const stdout = await new Response(proc.stdout).text();
+  // Drain both pipes before awaiting exit to prevent pipe buffer deadlock
+  const [stdout] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
   const exitCode = await proc.exited;
   try {
     proc.stdin!.end();


### PR DESCRIPTION
## Summary

**Why:** Prevents process deadlock when remote commands produce >64KB of stderr output (e.g., verbose npm install, compilation warnings).

- Fix pipe buffer deadlock in `fly/fly.ts:runServerCapture` — stderr was not being drained concurrently with stdout
- Fix same deadlock in `daytona/daytona.ts:runServerCapture`
- Apply the same `Promise.all` drain pattern already used in Hetzner, DigitalOcean, AWS, GCP, and `shared/ssh.ts`

This bug was introduced when commit `2e79d71b` fixed the deadlock in other providers but missed Fly and Daytona.

## Test plan

- [x] `bunx @biomejs/biome lint src/` — 0 errors
- [x] `bun test` — 1817 pass, 0 fail

-- refactor/code-health