### PR TITLE
fix(security): base64-encode INPUT_TEST_PROMPT in E2E verify.sh

### DIFF
--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -91,11 +91,15 @@ input_test_claude() {
   local app="$1"
 
   log_step "Running input test for claude..."
+  # Base64-encode prompt to prevent shell injection from special characters.
+  # -w 0 is GNU coreutils (Linux); falls back to plain base64 (macOS/BSD).
+  local encoded_prompt
+  encoded_prompt=$(printf '%s' "${INPUT_TEST_PROMPT}" | base64 -w 0 2>/dev/null || printf '%s' "${INPUT_TEST_PROMPT}" | base64)
   local remote_cmd
   remote_cmd="source ~/.spawnrc 2>/dev/null; \
     export PATH=\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH; \
     rm -rf /tmp/e2e-test && mkdir -p /tmp/e2e-test && cd /tmp/e2e-test && git init -q; \
-    claude -p '${INPUT_TEST_PROMPT}' 2>/dev/null"
+    PROMPT=\$(echo '${encoded_prompt}' | base64 -d); claude -p \"\$PROMPT\" 2>/dev/null"
 
   local output
   output=$(fly_ssh_long "${app}" "${remote_cmd}" "${INPUT_TEST_TIMEOUT}" 2>&1) || true
@@ -115,11 +119,14 @@ input_test_codex() {
   local app="$1"
 
   log_step "Running input test for codex..."
+  # Base64-encode prompt to prevent shell injection from special characters.
+  local encoded_prompt
+  encoded_prompt=$(printf '%s' "${INPUT_TEST_PROMPT}" | base64 -w 0 2>/dev/null || printf '%s' "${INPUT_TEST_PROMPT}" | base64)
   local remote_cmd
   remote_cmd="source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; \
     export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH; \
     rm -rf /tmp/e2e-test && mkdir -p /tmp/e2e-test && cd /tmp/e2e-test && git init -q; \
-    codex -q '${INPUT_TEST_PROMPT}' 2>/dev/null"
+    PROMPT=\$(echo '${encoded_prompt}' | base64 -d); codex -q \"\$PROMPT\" 2>/dev/null"
 
   local output
   output=$(fly_ssh_long "${app}" "${remote_cmd}" "${INPUT_TEST_TIMEOUT}" 2>&1) || true
@@ -146,11 +153,14 @@ input_test_openclaw() {
     log_warn "openclaw gateway not detected on :18789 — attempting test anyway"
   fi
 
+  # Base64-encode prompt to prevent shell injection from special characters.
+  local encoded_prompt
+  encoded_prompt=$(printf '%s' "${INPUT_TEST_PROMPT}" | base64 -w 0 2>/dev/null || printf '%s' "${INPUT_TEST_PROMPT}" | base64)
   local remote_cmd
   remote_cmd="source ~/.spawnrc 2>/dev/null; \
     export PATH=\$HOME/.bun/bin:\$HOME/.local/bin:\$PATH; \
     rm -rf /tmp/e2e-test && mkdir -p /tmp/e2e-test && cd /tmp/e2e-test && git init -q; \
-    openclaw -p '${INPUT_TEST_PROMPT}' 2>/dev/null"
+    PROMPT=\$(echo '${encoded_prompt}' | base64 -d); openclaw -p \"\$PROMPT\" 2>/dev/null"
 
   local output
   output=$(fly_ssh_long "${app}" "${remote_cmd}" "${INPUT_TEST_TIMEOUT}" 2>&1) || true
@@ -170,10 +180,13 @@ input_test_zeroclaw() {
   local app="$1"
 
   log_step "Running input test for zeroclaw..."
+  # Base64-encode prompt to prevent shell injection from special characters.
+  local encoded_prompt
+  encoded_prompt=$(printf '%s' "${INPUT_TEST_PROMPT}" | base64 -w 0 2>/dev/null || printf '%s' "${INPUT_TEST_PROMPT}" | base64)
   local remote_cmd
   remote_cmd="source ~/.spawnrc 2>/dev/null; source ~/.cargo/env 2>/dev/null; \
     rm -rf /tmp/e2e-test && mkdir -p /tmp/e2e-test && cd /tmp/e2e-test && git init -q; \
-    zeroclaw agent -p '${INPUT_TEST_PROMPT}' 2>/dev/null"
+    PROMPT=\$(echo '${encoded_prompt}' | base64 -d); zeroclaw agent -p \"\$PROMPT\" 2>/dev/null"
 
   local output
   output=$(fly_ssh_long "${app}" "${remote_cmd}" "${INPUT_TEST_TIMEOUT}" 2>&1) || true


### PR DESCRIPTION
**Why:** Prevents shell injection if `INPUT_TEST_PROMPT` is ever modified to contain single quotes or other shell metacharacters. Follows the base64 encoding pattern already established in `fly_ssh()` and `fly_ssh_long()` in the same file.

Fixes #1921

## Changes

- Base64-encode `INPUT_TEST_PROMPT` before interpolating it into remote command strings in all four input test functions:
  - `input_test_claude()`
  - `input_test_codex()`
  - `input_test_openclaw()`
  - `input_test_zeroclaw()`
- Decode on the remote side with `base64 -d` into a `$PROMPT` variable before passing to the agent CLI
- Uses the same `-w 0` with macOS fallback pattern as `fly_ssh()`

## Test plan

- [x] `bash -n` syntax check passes
- [ ] E2E tests still pass with the encoded/decoded prompt flow

-- refactor/security-auditor