### PR TITLE
fix(security): use explicit exports in provision.sh subshell

### DIFF
--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -45,15 +45,16 @@ provision_agent() {
     fi
   fi
   (
-    SPAWN_NON_INTERACTIVE=1 \
-    SPAWN_SKIP_GITHUB_AUTH=1 \
-    SPAWN_SKIP_API_VALIDATION=1 \
-    MODEL_ID="${MODEL_ID:-openrouter/auto}" \
-    FLY_APP_NAME="${app_name}" \
-    FLY_REGION="${FLY_REGION}" \
-    FLY_VM_MEMORY="${FLY_VM_MEMORY}" \
-    FLY_API_TOKEN="" \
-    OPENROUTER_API_KEY="${OPENROUTER_API_KEY}" \
+    export SPAWN_NON_INTERACTIVE=1
+    export SPAWN_SKIP_GITHUB_AUTH=1
+    export SPAWN_SKIP_API_VALIDATION=1
+    export MODEL_ID="${MODEL_ID:-openrouter/auto}"
+    export FLY_APP_NAME="${app_name}"
+    export FLY_REGION="${FLY_REGION}"
+    export FLY_VM_MEMORY="${FLY_VM_MEMORY}"
+    export FLY_API_TOKEN=""
+    export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
+
     bun run "${cli_entry}" "${agent}" fly --headless --output json \
       > "${stdout_file}" 2> "${stderr_file}"
     printf '%s' "$?" > "${exit_file}"


### PR DESCRIPTION
**Why:** The inline env-var prefix pattern (`VAR=value command`) uses a fragile backslash-continuation chain and could invite unsafe copy-paste into contexts where values aren't properly quoted. Explicit `export` statements inside the subshell make intent unambiguous, improve readability for security reviewers, and follow the defensive coding convention used elsewhere in the codebase.

**What changed:**
- Replaced inline `VAR=value \` continuation pattern (lines 47-58) with explicit `export VAR=value` statements inside the `( ... ) &` subshell
- Separated env setup from command execution with a blank line for clarity
- No behavioral change: the subshell still scopes all exports, and `bun run` receives the same environment

**Risk:** None — the subshell `( ... )` isolates all exports, and the values/quoting are unchanged.

Fixes #1924

-- refactor/security-auditor