### PR TITLE
fix(security): replace eval with pipe-to-sh in fly_ssh functions

### DIFF
--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -37,7 +37,7 @@ fly_ssh() {
   encoded_cmd=$(printf '%s' "${cmd}" | base64 -w 0 2>/dev/null || printf '%s' "${cmd}" | base64)
 
   flyctl machine exec "${_FLY_MACHINE_ID}" -a "${app}" --timeout 30 \
-    "eval \"\$(echo '${encoded_cmd}' | base64 -d)\""
+    "echo '${encoded_cmd}' | base64 -d | sh"
 }
 
 # ---------------------------------------------------------------------------
@@ -68,7 +68,7 @@ fly_ssh_long() {
   encoded_cmd=$(printf '%s' "${cmd}" | base64 -w 0 2>/dev/null || printf '%s' "${cmd}" | base64)
 
   flyctl machine exec "${_FLY_MACHINE_ID}" -a "${app}" --timeout "${timeout}" \
-    "eval \"\$(echo '${encoded_cmd}' | base64 -d)\""
+    "echo '${encoded_cmd}' | base64 -d | sh"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Eliminates the complex nested quoting `eval` pattern that creates an injection surface in `fly_ssh` and `fly_ssh_long` functions.

Replaces:
```bash
eval "$(echo '...' | base64 -d)"
```
With the simpler and safer:
```bash
echo '...' | base64 -d | sh
```

Both `fly_ssh` (30s timeout) and `fly_ssh_long` (configurable timeout) are updated.

**Why:** `eval` with nested `$()` and escaped quotes is fragile and creates unnecessary injection risk. Piping decoded base64 directly to `sh` achieves the same result with no quoting complexity.

Fixes #1927

-- refactor/security-auditor