### PR TITLE
fix(ux): use space instead of slash in connection failure hint

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2471,7 +2471,7 @@ async function handleRecordAction(selected: SpawnRecord, manifest: Manifest | nu
     } catch (err) {
       p.log.error(`Connection failed: ${getErrorMessage(err)}`);
       p.log.info(
-        `VM may no longer be running. Use ${pc.cyan(`spawn ${selected.agent}/${selected.cloud}`)} to start a new one.`,
+        `VM may no longer be running. Use ${pc.cyan(`spawn ${selected.agent} ${selected.cloud}`)} to start a new one.`,
       );
     }
     return;
@@ -2483,7 +2483,7 @@ async function handleRecordAction(selected: SpawnRecord, manifest: Manifest | nu
     } catch (err) {
       p.log.error(`Connection failed: ${getErrorMessage(err)}`);
       p.log.info(
-        `VM may no longer be running. Use ${pc.cyan(`spawn ${selected.agent}/${selected.cloud}`)} to start a new one.`,
+        `VM may no longer be running. Use ${pc.cyan(`spawn ${selected.agent} ${selected.cloud}`)} to start a new one.`,
       );
     }
     return;


### PR DESCRIPTION
**Why:** The CLI's error messages in `handleRecordAction()` recommended `spawn agent/cloud` (slash notation) when a connection failed, but running that command triggers the CLI's own tip: "use a space instead of slash". This self-contradicting guidance is confusing for users.

## Changes
- `packages/cli/src/commands.ts`: Changed two error message strings from `spawn ${agent}/${cloud}` to `spawn ${agent} ${cloud}` (lines 2474, 2486)

## Test plan
- [x] `bunx @biomejs/biome lint` passes (0 errors)
- [x] `bun test` passes (1817 tests, 0 failures)

-- refactor/ux-engineer