### PR TITLE
fix: pause stdin before interactive handoff to stop keystroke loss

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Replaces `process.stdin.resume()` with `process.stdin.pause()` in `prepareStdinForHandoff()`
- The parent process was put into flowing mode by `resume()`, causing it to race with the child SSH process for bytes on fd 0 — keystrokes were randomly swallowed by the parent
- With `pause()`, the parent stops reading from fd 0, giving the child (SSH) exclusive access via `dup2()`

## Root cause
When the CLI hands off to an interactive SSH session via `Bun.spawn(stdio: "inherit")`, both the parent and child process share fd 0. Calling `resume()` made the parent actively call `read()` on that fd, so the kernel arbitrarily split input bytes between the two processes. Direct `ssh root@ip` worked fine because there was no competing parent process.

## Test plan
- [x] `bun test` passes (1815/1817, 2 pre-existing failures unrelated to this change)
- [x] `biome lint` passes with zero errors
- [ ] Manual test: `spawn` → pick any cloud/agent → verify no keystroke loss in interactive session

🤖 Generated with [Claude Code](https://claude.com/claude-code)