### PR TITLE
fix: use user-local npm prefix for openclaw install

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -327,12 +327,13 @@ export async function setupOpenclawBatched(
 
   const script = [
     'echo "==> Checking openclaw..."',
-    'export PATH="$HOME/.bun/bin:$HOME/.local/bin:$PATH"',
+    'export PATH="$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH"',
     "if command -v openclaw >/dev/null 2>&1; then",
     '  echo "    openclaw found at $(command -v openclaw)"',
     "else",
     '  echo "    openclaw not found, installing..."',
-    "  npm install -g openclaw",
+    "  mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g openclaw",
+    '  export PATH="$HOME/.npm-global/bin:$PATH"',
     '  command -v openclaw || { echo "ERROR: openclaw install failed"; exit 1; }',
     "fi",
     'echo "==> Writing environment variables..."',
@@ -475,7 +476,12 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       cloudInitTier: "full",
       modelPrompt: true,
       modelDefault: "openrouter/auto",
-      install: () => installAgent(runner, "openclaw", "source ~/.bashrc && npm install -g openclaw"),
+      install: () =>
+        installAgent(
+          runner,
+          "openclaw",
+          "source ~/.bashrc && mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g openclaw",
+        ),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,
         `ANTHROPIC_API_KEY=${apiKey}`,


### PR DESCRIPTION
## Summary
- OpenClaw's `npm install -g openclaw` fails with `EACCES: permission denied` on non-root users (e.g., `ubuntu` on AWS Lightsail) because `/usr/local/lib/node_modules` isn't writable
- Fixed by using the `~/.npm-global` prefix pattern already used by the codex and kilocode agents
- Fixed both the standard `installAgent` path (used by AWS, Hetzner, GCP, etc.) and the batched `setupOpenclawBatched` path (used by Fly)

## Test plan
- [x] Lint passes (0 errors)
- [x] Test suite passes (pre-existing failures only)
- [ ] Manual test: `bash sh/aws/openclaw.sh` should install openclaw without EACCES errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)