### PR TITLE
fix: use spawnSync for script execution to eliminate remaining keystroke loss

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/cmdrun-happy-path.test.ts
+++ b/packages/cli/src/__tests__/cmdrun-happy-path.test.ts
@@ -68,13 +68,6 @@ const { cmdRun } = await import("../commands.js");
 
 const VALID_SCRIPT = "#!/bin/bash\nset -eo pipefail\nexit 0";
 
-/** Track child_process.spawn calls to verify env vars passed to bash */
-let spawnCalls: Array<{
-  command: string;
-  args: string[];
-  options: any;
-}> = [];
-
 /** Track all fetch calls to verify download behavior */
 let fetchCalls: Array<{
   url: string;
@@ -156,7 +149,6 @@ describe("cmdRun happy-path pipeline", () => {
     mockSpinnerStop.mockClear();
     mockSpinnerMessage.mockClear();
     fetchCalls = [];
-    spawnCalls = [];
 
     processExitSpy = spyOn(process, "exit").mockImplementation((_code?: number): never => {
       throw new Error("process.exit");

--- a/packages/cli/src/__tests__/commands-update-download.test.ts
+++ b/packages/cli/src/__tests__/commands-update-download.test.ts
@@ -56,29 +56,16 @@ mock.module("@clack/prompts", () => ({
 // - execSync: used by performUpdate() to run curl|bash install — without this mock,
 //   "should handle update failure gracefully" downloads the real install script from
 //   the network, causing a 58s timeout under full-suite concurrency (CLAUDE.md violation).
-// - spawn: used by spawnBash() to run downloaded scripts — mock must fire the "close"
-//   event immediately (code 0) so Promise-based callers resolve rather than hanging.
+// - spawnSync: used by spawnBash() to run downloaded scripts — returns exit code 0
+//   so callers see a successful execution.
 mock.module("node:child_process", () => ({
   execSync: mock(() => {}),
   execFileSync: mock(() => {}),
-  spawn: mock(() => {
-    type Handler = (...args: unknown[]) => void;
-    const child = {
-      on: mock((event: string, cb: Handler) => {
-        if (event === "close") {
-          queueMicrotask(() => cb(0, null));
-        }
-        return child;
-      }),
-      stdout: {
-        on: mock(() => {}),
-      },
-      stderr: {
-        on: mock(() => {}),
-      },
-    };
-    return child;
-  }),
+  spawnSync: mock(() => ({
+    status: 0,
+    signal: null,
+    error: null,
+  })),
 }));
 
 // Import commands after mock setup


### PR DESCRIPTION
## Summary

- **Root cause**: PR #1939 fixed `runInteractiveCommand` (used by `cmdInteractive`) but the main user path — `cmdRun` → `execScript` → `spawnBash` — still used async `child_process.spawn` with `stdio: "inherit"`. This left Bun's event loop alive and competing with SSH (a grandchild process inside the bash script) for fd 0 input bytes, causing intermittent keystroke loss.
- **Fix**: Switch `spawnBash` from async `spawn` to blocking `spawnSync`, matching what `spawnInteractive` already does. The event loop is now fully blocked during script execution, giving the child process exclusive terminal access.
- Removes dead `spawnCalls` tracking code from `cmdrun-happy-path` test
- Updates `commands-update-download` test mock from `spawn` to `spawnSync`

## Test plan

- [x] `bunx @biomejs/biome format packages/cli/src/` — 0 errors
- [x] `bunx @biomejs/biome lint packages/cli/src/` — 0 errors
- [x] `bun test` — 1815 pass, 2 pre-existing failures (unrelated `prioritizeCloudsByCredentials`)
- [ ] Manual test: `spawn` → pick agent/cloud → verify no keystroke loss during SSH session

🤖 Generated with [Claude Code](https://claude.com/claude-code)