### PR TITLE
refactor: remove duplicate sleep() definitions in fly and daytona modules

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/daytona/daytona.ts
+++ b/packages/cli/src/daytona/daytona.ts
@@ -20,7 +20,7 @@ import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../sh
 import { parseJsonWith, parseJsonRaw, isString, toObjectArray, toRecord } from "@openrouter/spawn-shared";
 import * as v from "valibot";
 import { saveVmConnection } from "../history.js";
-import { spawnInteractive } from "../shared/ssh";
+import { sleep, spawnInteractive } from "../shared/ssh";
 
 const DAYTONA_API_BASE = "https://app.daytona.io/api";
 const DAYTONA_DASHBOARD_URL = "https://app.daytona.io/";
@@ -44,10 +44,6 @@ export function getState() {
 }
 
 // ─── API Client ──────────────────────────────────────────────────────────────
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
 
 const LooseObject = v.record(v.string(), v.unknown());
 

--- a/packages/cli/src/fly/fly.ts
+++ b/packages/cli/src/fly/fly.ts
@@ -20,7 +20,7 @@ import type { CloudInitTier } from "../shared/agents";
 import { getPackagesForTier, needsNode, needsBun, NODE_INSTALL_CMD } from "../shared/cloud-init";
 import * as v from "valibot";
 import { parseJsonWith, parseJsonRaw, isString, isNumber, toObjectArray } from "@openrouter/spawn-shared";
-import { killWithTimeout, spawnInteractive } from "../shared/ssh";
+import { killWithTimeout, sleep, spawnInteractive } from "../shared/ssh";
 import { saveVmConnection } from "../history.js";
 
 const FLY_API_BASE = "https://api.machines.dev/v1";
@@ -158,10 +158,6 @@ async function flyApi(method: string, endpoint: string, body?: string, maxRetrie
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
 
 const LooseObject = v.record(v.string(), v.unknown());
 


### PR DESCRIPTION
## Summary
- Both `fly.ts` and `daytona.ts` defined a local `sleep(ms)` helper function identical to `sleep` already exported from `packages/cli/src/shared/ssh.ts`
- Removed the 4-line local duplicate from each file and added `sleep` to their existing `../shared/ssh` import
- All other cloud modules (`aws`, `gcp`, `hetzner`, `digitalocean`, `sprite`) already imported `sleep` from `shared/ssh` — this change makes `fly` and `daytona` consistent

## Findings Summary (qa/code-quality scan)
- **No python3 usage** found in shell scripts (compliant with CLAUDE.md)
- **No stale references** to deleted files found
- **No banned `as` type assertions** found in TypeScript
- **No `require()` CJS calls** found
- **Duplicate `sleep` function** in `fly.ts` and `daytona.ts` — fixed (removed, import from shared)
- Other `parseJson` local wrappers across clouds are private, module-scoped delegation helpers — left as-is since they serve internal use within each module

## Test plan
- [x] `bun x @biomejs/biome lint packages/cli/src/` — 0 errors (96 files)
- [x] `bun test` — 1817 pass, 0 fail
- [x] Version bumped: `0.10.19` → `0.10.20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)