### PR TITLE
fix: replace non-null assertions with proper null guards

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/fly/fly.ts
+++ b/packages/cli/src/fly/fly.ts
@@ -214,7 +214,7 @@ export function sanitizeFlyToken(raw: string): string {
   let t = raw.replace(/[\n\r]/g, "").trim();
   if (t.includes("FlyV1 ")) {
     // Already prefixed — extract everything after "FlyV1 "
-    t = "FlyV1 " + t.split("FlyV1 ").pop()!;
+    t = "FlyV1 " + (t.split("FlyV1 ").pop() || "");
   } else if (t.includes("fm2_")) {
     // Macaroon token — may have comma-separated discharge tokens (fm2_xxx,fm2_yyy,fo1_zzz).
     // Extract from the first fm2_ to end-of-string, preserving all segments.
@@ -870,7 +870,10 @@ export async function createServer(name: string, opts: ServerOptions, image?: st
 
 export async function runServer(cmd: string, timeoutSecs?: number): Promise<void> {
   const fullCmd = `export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
-  const flyCmd = getCmd()!;
+  const flyCmd = getCmd();
+  if (!flyCmd) {
+    throw new Error("flyctl not found in PATH — run `spawn fly` to reinstall");
+  }
 
   // Wrap command with a background keepalive that sends a space to stderr every
   // 10s. Without this, flyctl tears down silent SSH sessions ("session forcibly
@@ -920,7 +923,10 @@ export async function runServer(cmd: string, timeoutSecs?: number): Promise<void
 /** Run a command and capture stdout. */
 export async function runServerCapture(cmd: string, timeoutSecs?: number): Promise<string> {
   const fullCmd = `export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
-  const flyCmd = getCmd()!;
+  const flyCmd = getCmd();
+  if (!flyCmd) {
+    throw new Error("flyctl not found in PATH — run `spawn fly` to reinstall");
+  }
 
   const escapedCmd = fullCmd.replace(/'/g, "'\\''");
   const args = [
@@ -968,7 +974,10 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
     logError(`Invalid remote path: ${remotePath}`);
     throw new Error("Invalid remote path");
   }
-  const flyCmd = getCmd()!;
+  const flyCmd = getCmd();
+  if (!flyCmd) {
+    throw new Error("flyctl not found in PATH — run `spawn fly` to reinstall");
+  }
   const content: Buffer = readFileSync(localPath);
   const b64 = content.toString("base64");
   const proc = Bun.spawn(
@@ -1009,7 +1018,10 @@ export async function interactiveSession(cmd: string): Promise<number> {
   const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
   // Shell-quote the command for -C
   const escapedCmd = fullCmd.replace(/'/g, "'\\''");
-  const flyCmd = getCmd()!;
+  const flyCmd = getCmd();
+  if (!flyCmd) {
+    throw new Error("flyctl not found in PATH — run `spawn fly` to reinstall");
+  }
 
   const exitCode = spawnInteractive([
     flyCmd,

--- a/packages/cli/src/shared/oauth.ts
+++ b/packages/cli/src/shared/oauth.ts
@@ -83,7 +83,8 @@ async function tryOauthFlow(callbackPort = 5180, agentSlug?: string, cloudSlug?:
         hostname: "127.0.0.1",
         fetch(req) {
           const url = new URL(req.url);
-          if (url.pathname === "/callback" && url.searchParams.get("code")) {
+          const code = url.searchParams.get("code");
+          if (url.pathname === "/callback" && code) {
             // CSRF check
             if (url.searchParams.get("state") !== csrfState) {
               return new Response(ERROR_HTML, {
@@ -94,7 +95,6 @@ async function tryOauthFlow(callbackPort = 5180, agentSlug?: string, cloudSlug?:
                 },
               });
             }
-            const code = url.searchParams.get("code")!;
             // Validate code format
             if (!/^[a-zA-Z0-9_-]{16,128}$/.test(code)) {
               return new Response("<html><body><h1>Invalid OAuth Code</h1></body></html>", {


### PR DESCRIPTION
**Why:** 4 call sites in `fly.ts` use `getCmd()!` which silences the TypeScript compiler but passes `null` to `Bun.spawn()` if flyctl is missing at runtime, causing a cryptic "Expected string, received null" crash instead of a clear "flyctl not found" error. Also removes 2 additional `!` assertions in `sanitizeFlyToken` and `oauth.ts` that circumvent null safety.

## Changes

- `packages/cli/src/fly/fly.ts`: Replace 4x `getCmd()!` with null guard + descriptive throw. Replace 1x `.pop()!` with safe `|| ""` fallback.
- `packages/cli/src/shared/oauth.ts`: Hoist `url.searchParams.get("code")` into a const before the `if` block instead of re-calling with `!`.
- `packages/cli/package.json`: Version bump 0.10.20 -> 0.10.21.

## Verification

- Lint: 0 errors (91 files checked)
- Tests: 1657 pass, 0 fail
- Build: not affected (no new exports)

-- refactor/code-health