### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1132,28 +1132,6 @@ export async function interactiveSession(cmd: string): Promise<number> {
   return exitCode;
 }
 
-// ─── Retry + Wait Helpers ───────────────────────────────────────────────────
-
-export async function runWithRetry(
-  maxAttempts: number,
-  sleepSec: number,
-  timeoutSecs: number,
-  cmd: string,
-): Promise<void> {
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      await runServer(cmd, timeoutSecs);
-      return;
-    } catch {
-      logWarn(`Command failed (attempt ${attempt}/${maxAttempts}): ${cmd.slice(0, 80)}...`);
-      if (attempt < maxAttempts) {
-        await sleep(sleepSec * 1000);
-      }
-    }
-  }
-  throw new Error(`runWithRetry exhausted: ${cmd.slice(0, 80)}...`);
-}
-
 // ─── Server Name ────────────────────────────────────────────────────────────
 
 export async function getServerName(): Promise<string> {

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1095,29 +1095,6 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   return exitCode;
 }
 
-// ─── Retry Helper ────────────────────────────────────────────────────────────
-
-export async function runWithRetry(
-  maxAttempts: number,
-  sleepSec: number,
-  timeoutSecs: number,
-  cmd: string,
-): Promise<void> {
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      await runServer(cmd, timeoutSecs);
-      return;
-    } catch {
-      logWarn(`Command failed (attempt ${attempt}/${maxAttempts}): ${cmd}`);
-      if (attempt < maxAttempts) {
-        await sleep(sleepSec * 1000);
-      }
-    }
-  }
-  logError(`Command failed after ${maxAttempts} attempts: ${cmd}`);
-  throw new Error(`runWithRetry exhausted: ${cmd}`);
-}
-
 // ─── Server Name ─────────────────────────────────────────────────────────────
 
 export async function getServerName(): Promise<string> {

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -948,29 +948,6 @@ export async function interactiveSession(cmd: string): Promise<number> {
   return exitCode;
 }
 
-// ─── Retry Helper ───────────────────────────────────────────────────────────
-
-export async function runWithRetry(
-  maxAttempts: number,
-  sleepSec: number,
-  timeoutSecs: number,
-  cmd: string,
-): Promise<void> {
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      await runServer(cmd, timeoutSecs);
-      return;
-    } catch {
-      logWarn(`Command failed (attempt ${attempt}/${maxAttempts}): ${cmd}`);
-      if (attempt < maxAttempts) {
-        await sleep(sleepSec * 1000);
-      }
-    }
-  }
-  logError(`Command failed after ${maxAttempts} attempts: ${cmd}`);
-  throw new Error(`runWithRetry exhausted: ${cmd}`);
-}
-
 // ─── Lifecycle ──────────────────────────────────────────────────────────────
 
 export async function destroyInstance(name?: string): Promise<void> {

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -662,29 +662,6 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   return exitCode;
 }
 
-// ─── Retry Helper ────────────────────────────────────────────────────────────
-
-export async function runWithRetry(
-  maxAttempts: number,
-  sleepSec: number,
-  timeoutSecs: number,
-  cmd: string,
-): Promise<void> {
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      await runServer(cmd, timeoutSecs);
-      return;
-    } catch {
-      logWarn(`Command failed (attempt ${attempt}/${maxAttempts}): ${cmd}`);
-      if (attempt < maxAttempts) {
-        await sleep(sleepSec * 1000);
-      }
-    }
-  }
-  logError(`Command failed after ${maxAttempts} attempts: ${cmd}`);
-  throw new Error(`runWithRetry exhausted: ${cmd}`);
-}
-
 // ─── Server Name ─────────────────────────────────────────────────────────────
 
 export async function getServerName(): Promise<string> {


### PR DESCRIPTION
## Summary

- Removed `runWithRetry` function from 4 cloud modules (`aws.ts`, `hetzner.ts`, `gcp.ts`, `digitalocean.ts`) that were exported but never called anywhere in the codebase
- Only `fly.ts` uses its own `runWithRetry` internally — that definition is preserved
- Bumped CLI version to `0.10.22` per version policy

## Findings by Category

**a) Dead code**: `runWithRetry` was defined and exported in 5 cloud modules but only called in `fly.ts`. The other 4 modules each exported an identical function that was never imported or invoked anywhere.

**b) Stale references**: None found — all imports resolve to existing files.

**c) Python usage**: None found in shell scripts.

**d) Duplicate utilities**: `runWithRetry` pattern was duplicated across cloud modules (already noted above as dead code). `sleep()` was already centralized in `shared/ssh.ts`.

**e) Stale comments**: None found that require changes.

## Test plan
- [x] `bun test` — 1657 pass, 0 fail
- [x] `biome lint src/` — 0 errors across 91 files
- [x] `bash -n` — N/A (no shell script changes)

-- qa/code-quality