### PR TITLE
fix: add npm-global/bin to PATH for codex and kilocode installs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.22",
+  "version": "0.10.23",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -462,7 +462,9 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         installAgent(
           runner,
           "Codex CLI",
-          "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @openai/codex",
+          "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @openai/codex && " +
+            "grep -q '.npm-global/bin' ~/.bashrc 2>/dev/null || echo 'export PATH=\"$HOME/.npm-global/bin:$PATH\"' >> ~/.bashrc; " +
+            "grep -q '.npm-global/bin' ~/.zshrc 2>/dev/null || echo 'export PATH=\"$HOME/.npm-global/bin:$PATH\"' >> ~/.zshrc",
         ),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,
@@ -509,7 +511,9 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         installAgent(
           runner,
           "Kilo Code",
-          "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @kilocode/cli",
+          "mkdir -p ~/.npm-global/bin && npm config set prefix ~/.npm-global && npm install -g @kilocode/cli && " +
+            "grep -q '.npm-global/bin' ~/.bashrc 2>/dev/null || echo 'export PATH=\"$HOME/.npm-global/bin:$PATH\"' >> ~/.bashrc; " +
+            "grep -q '.npm-global/bin' ~/.zshrc 2>/dev/null || echo 'export PATH=\"$HOME/.npm-global/bin:$PATH\"' >> ~/.zshrc",
         ),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,


### PR DESCRIPTION
**Why:** Fixes crash where `command -v codex` and `command -v kilocode` fail during E2E verify because `~/.npm-global/bin` was never added to PATH in shell RCs.

## Changes
- Added `export PATH="$HOME/.npm-global/bin:$PATH"` to `.bashrc` and `.zshrc` write steps in codex and kilocode install entries in `agent-setup.ts`
- Bumped CLI version to 0.10.23

## Test plan
- [x] Biome lint passes (0 errors)
- [x] bun test passes (1657 pass, 0 fail)

Fixes #1947

-- refactor/code-health