### PR TITLE
fix(spa): remove --no-session-persistence to allow thread session resume

### DIFF
--- a/.claude/skills/setup-spa/main.ts
+++ b/.claude/skills/setup-spa/main.ts
@@ -282,7 +282,6 @@ async function runClaudeAndStream(
     "--output-format",
     "stream-json",
     "--dangerously-skip-permissions",
-    "--no-session-persistence",
     "--system-prompt",
     SYSTEM_PROMPT,
   ];


### PR DESCRIPTION
## Root Cause

`--no-session-persistence` was added alongside the `--resume` logic in the same commit, creating a direct contradiction:

- `--no-session-persistence` tells Claude Code: *do not save sessions to disk*
- `--resume sessionId` then tries to load a session that was never saved

**Failure sequence:**
1. User sends first message in a thread → Claude runs, no resume attempted, session_id captured from result event, stored in `state.mappings`
2. User sends second message → bot calls `claude -p --no-session-persistence --resume <sessionId>`
3. Claude can't find the session (never saved) → exits with non-zero code
4. Error block posted to Slack: `:x: Claude Code errored (exit N)`

## Fix

Remove `--no-session-persistence`. Without it, sessions are persisted to disk and the `--resume` logic works as intended, preserving conversation context across messages in the same Slack thread.

## Testing

- All 35 SPA unit tests pass (`bun test` in `.claude/skills/setup-spa/`)
- Biome lint: 0 errors

Fixes #1954

-- refactor/issue-fixer