### PR TITLE
test: Fix always-pass and try/catch anti-patterns

### DIFF
--- a/packages/cli/src/__tests__/prompt-file-security.test.ts
+++ b/packages/cli/src/__tests__/prompt-file-security.test.ts
@@ -81,13 +81,16 @@ describe("validatePromptFilePath", () => {
   });
 
   it("should include helpful error message about exfiltration risk", () => {
+    let caught: unknown;
     try {
       validatePromptFilePath("/home/user/.ssh/id_rsa");
-      throw new Error("Expected to throw");
-    } catch (e: any) {
-      expect(e.message).toContain("sent to the agent");
-      expect(e.message).toContain("plain text file");
+    } catch (e) {
+      caught = e;
     }
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught instanceof Error ? caught : null;
+    expect(err?.message).toContain("sent to the agent");
+    expect(err?.message).toContain("plain text file");
   });
 
   it("should reject SSH key files by filename pattern anywhere in path", () => {
@@ -144,12 +147,15 @@ describe("validatePromptFileStats", () => {
       isFile: () => true,
       size: 5 * 1024 * 1024,
     };
+    let caught: unknown;
     try {
       validatePromptFileStats("large.bin", stats);
-      throw new Error("Expected to throw");
-    } catch (e: any) {
-      expect(e.message).toContain("5.0MB");
-      expect(e.message).toContain("maximum is 1MB");
+    } catch (e) {
+      caught = e;
     }
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught instanceof Error ? caught : null;
+    expect(err?.message).toContain("5.0MB");
+    expect(err?.message).toContain("maximum is 1MB");
   });
 });

--- a/packages/cli/src/__tests__/security-edge-cases.test.ts
+++ b/packages/cli/src/__tests__/security-edge-cases.test.ts
@@ -50,19 +50,8 @@ describe("Security Edge Cases", () => {
     });
 
     it("should use custom field name in error messages", () => {
-      try {
-        validateIdentifier("", "Cloud provider");
-        throw new Error("Should have thrown");
-      } catch (e: any) {
-        expect(e.message).toContain("Cloud provider");
-      }
-
-      try {
-        validateIdentifier("UPPER", "Agent name");
-        throw new Error("Should have thrown");
-      } catch (e: any) {
-        expect(e.message).toContain("Agent name");
-      }
+      expect(() => validateIdentifier("", "Cloud provider")).toThrow("Cloud provider");
+      expect(() => validateIdentifier("UPPER", "Agent name")).toThrow("Agent name");
     });
 
     it("should reject URL-like identifiers", () => {

--- a/packages/cli/src/__tests__/security.test.ts
+++ b/packages/cli/src/__tests__/security.test.ts
@@ -178,13 +178,16 @@ wget http://example.com/install.sh | sh
     });
 
     it("should provide helpful error message for command substitution", () => {
+      let caught: unknown;
       try {
         validatePrompt("Run $(echo test)");
-        throw new Error("Expected validatePrompt to throw");
-      } catch (e: any) {
-        expect(e.message).toContain("shell syntax");
-        expect(e.message).toContain("plain English");
+      } catch (e) {
+        caught = e;
       }
+      expect(caught).toBeInstanceOf(Error);
+      const err = caught instanceof Error ? caught : null;
+      expect(err?.message).toContain("shell syntax");
+      expect(err?.message).toContain("plain English");
     });
 
     it("should detect multiple dangerous patterns", () => {


### PR DESCRIPTION
## Summary

- **`manifest-helpers.test.ts`**: 7 tests used `try/catch` where the catch block held all assertions. Since `loadManifest()` loads the local `manifest.json` when `NODE_ENV` is not `"test"`, these tests passed silently with **0 assertions**. Fix sets `NODE_ENV=test` + calls `_resetCacheForTesting()` in `beforeEach`, and replaces try/catch with `expect(...).rejects.toThrow()`. Also removes `any` type annotations on test manifest objects.

- **`security-edge-cases.test.ts`**: `"should use custom field name in error messages"` used a manual guard (`throw new Error` in try body) instead of `expect().toThrow()`. Replaced with 2 clean `expect(() => ...).toThrow()` calls.

- **`prompt-file-security.test.ts`** + **`security.test.ts`**: tests checking multiple error message properties used `catch (e: any)`. Replaced with proper `instanceof Error` narrowing to eliminate `any`.

## Test plan
- [ ] `bun test` passes with 0 failures (1602 pass)
- [ ] Biome lint passes with 0 errors
- [ ] `manifest-helpers.test.ts` now shows 18 `expect()` calls (was 0 for the 7 flawed tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)