### PR TITLE
fix(ux): replace non-existent --non-interactive flag in list message

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2644,7 +2644,7 @@ export async function cmdList(agentFilter?: string, cloudFilter?: string): Promi
           ),
         );
         p.log.info(
-          `Re-launch with ${pc.cyan("spawn <agent> <cloud>")} or view history with ${pc.cyan("spawn list --non-interactive")}`,
+          `Re-launch with ${pc.cyan("spawn <agent> <cloud>")} or view full history with ${pc.cyan("spawn list | cat")}`,
         );
       } else {
         await showEmptyListMessage(agentFilter, cloudFilter);


### PR DESCRIPTION
**Why:** The "no active servers" message at `commands.ts:2647` suggested users run `spawn list --non-interactive`, but `--non-interactive` is not a recognized CLI flag. Running the suggested command would trigger an "Unknown flag: --non-interactive" error because `checkUnknownFlags()` in `index.ts:809` rejects unrecognized flags before any subcommand dispatch.

**Fix:** Replace `spawn list --non-interactive` with `spawn list | cat`, which correctly forces non-interactive output by making `process.stdout.isTTY` falsy, causing `isInteractiveTTY()` to return false and the full history table to be rendered.

**Testing:** All 1602 tests pass. Biome lint clean.

-- refactor/code-health