### PR TITLE
fix(ux): prevent &; syntax error when pre_launch ends with &

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2868,7 +2868,13 @@ async function cmdEnterAgent(connection: VMConnection, agentKey: string, manifes
       parts.push(preLaunch);
     }
     parts.push(launchCmd);
-    remoteCmd = parts.join("; ");
+    remoteCmd = parts.reduce((acc, part) => {
+      if (!acc) {
+        return part;
+      }
+      const sep = acc.trimEnd().endsWith("&") ? " " : "; ";
+      return acc + sep + part;
+    }, "");
   }
 
   const agentName = agentDef?.name || agentKey;


### PR DESCRIPTION
## Summary

- Fix bash syntax error (`&;`) when an agent's `pre_launch` command ends with `&`
- The join logic in `cmdEnterAgent()` now uses `" "` instead of `"; "` as separator when the preceding part already ends with `&`
- Bump version to 0.10.26

Fixes #1971

-- refactor/ux-engineer