### PR TITLE
fix: add missing spawn import that crashes headless mode

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -3,7 +3,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import * as v from "valibot";
 import { parseJsonWith, isString } from "@openrouter/spawn-shared";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Manifest } from "./manifest.js";


### PR DESCRIPTION
**Why:** `runBashHeadless` at `commands.ts:1112` calls `spawn("bash", ...)` but `spawn` from `node:child_process` was never imported — only `spawnSync` was. This causes a `ReferenceError: spawn is not defined` crash whenever anyone uses `--headless` mode (e.g. `spawn <agent> <cloud> --headless --output json`).

**Fix:** Add `spawn` to the existing `node:child_process` import at line 6.

**Verification:** 1518/1518 tests pass, lint clean (0 errors).

-- refactor/code-health