### PR TITLE
fix(e2e): correct env var names passed to AWS CLI in provision.sh

### DIFF
--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -40,9 +40,12 @@ provision_agent() {
     export SPAWN_SKIP_GITHUB_AUTH=1
     export SPAWN_SKIP_API_VALIDATION=1
     export MODEL_ID="${MODEL_ID:-openrouter/auto}"
-    export AWS_LIGHTSAIL_INSTANCE_NAME="${app_name}"
-    export AWS_REGION="${AWS_REGION}"
-    export AWS_BUNDLE="${AWS_BUNDLE}"
+    # LIGHTSAIL_SERVER_NAME is the env var read by aws.ts:getServerName()
+    export LIGHTSAIL_SERVER_NAME="${app_name}"
+    # AWS_DEFAULT_REGION is the env var read by aws.ts:authenticate() and promptRegion()
+    export AWS_DEFAULT_REGION="${AWS_REGION}"
+    # LIGHTSAIL_BUNDLE is the env var read by aws.ts:promptBundle()
+    export LIGHTSAIL_BUNDLE="${AWS_BUNDLE:-nano_3_0}"
     export OPENROUTER_API_KEY="${OPENROUTER_API_KEY}"
 
     bun run "${cli_entry}" "${agent}" aws --headless --output json \


### PR DESCRIPTION
## Summary

- `provision.sh` was exporting wrong env var names that `aws.ts` never reads
- `AWS_LIGHTSAIL_INSTANCE_NAME` → `LIGHTSAIL_SERVER_NAME` (read by `aws.ts:getServerName()`)
- `AWS_REGION` → `AWS_DEFAULT_REGION` (read by `aws.ts:authenticate()` and `promptRegion()`)
- `AWS_BUNDLE` → `LIGHTSAIL_BUNDLE` (read by `aws.ts:promptBundle()`)

Without the correct names, each E2E provisioning run would:
1. Ignore the specified instance name and generate a random one
2. Use the wrong region (falling back to `us-east-1` default instead of `${AWS_REGION}`)
3. Use the wrong bundle size
4. The post-provision `aws lightsail get-instance --instance-name "${app_name}"` check would fail because the instance was created under a different random name

## Test plan

- [x] `bash -n sh/e2e/lib/provision.sh` passes syntax check
- [ ] Run `./sh/e2e/aws-e2e.sh claude` with valid AWS credentials to confirm instance is now created with the expected name

🤖 Generated with [Claude Code](https://claude.com/claude-code)