### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/sh/shared/github-auth.sh
+++ b/sh/shared/github-auth.sh
@@ -39,7 +39,7 @@ _install_gh_brew() {
 
 # Install gh via APT with GitHub's official repository (Debian/Ubuntu)
 _install_gh_apt() {
-    # Use sudo only when not already root (Fly.io containers run as root)
+    # Use sudo only when not already root (some cloud containers run as root)
     local SUDO=""
     if [[ "$(id -u)" -ne 0 ]]; then SUDO="sudo"; fi
 

--- a/sh/shared/key-request.sh
+++ b/sh/shared/key-request.sh
@@ -121,8 +121,8 @@ process.stdout.write(d[process.env._VAR] || d.api_key || d.token || '');
             # downstream in unquoted expansions, eval contexts, or logging
             # Allow alphanumeric plus safe chars needed by real tokens:
             #   - _ . / @  (standard API key chars)
-            #   : + =      (base64 segments, URL-style formats)
-            #   space       (Fly.io "FlyV1 <macaroon>" prefixed tokens)
+            #   : + =      (base64 segments, URL-safe and base64 formats)
+            #   space       (prefixed token formats, e.g., "Bearer <token>")
             # Must match CLI's loadTokenFromConfig regex in cli/src/digitalocean/digitalocean.ts
             if [[ ! "${val}" =~ ^[a-zA-Z0-9._/@:+=\ -]+$ ]]; then
                 log "SECURITY: Invalid characters in config value for ${var_name}"


### PR DESCRIPTION
## Summary

- Removes stale Fly.io references from `sh/shared/key-request.sh` and `sh/shared/github-auth.sh`
- Fly.io was removed as a cloud provider in #1979, but two comments referencing its specific behavior remained
- `key-request.sh` line 125: updated comment about space-allowing token regex (was "Fly.io FlyV1 <macaroon> prefixed tokens", now generic "prefixed token formats, e.g., Bearer <token>")
- `github-auth.sh` line 42: updated sudo comment (was "Fly.io containers run as root", now "some cloud containers run as root")

## QA Sweep Findings Summary

**Scan categories checked:**

| Category | Findings |
|---|---|
| Dead code (sh/shared, packages/cli/src) | None found |
| Stale references to non-existent files | None found |
| Python usage in shell scripts | None found |
| Duplicate utilities across TS cloud modules | None found (agents.ts files are thin wrappers by design) |
| Stale comments | 2 Fly.io references removed |

**No regressions:** All 1518 tests pass after changes.

## Test plan

- [x] `bash -n sh/shared/key-request.sh` passes
- [x] `bash -n sh/shared/github-auth.sh` passes
- [x] `bun test` passes (1518/1518)
- [x] Biome lint passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)