### PR TITLE
fix(security): add path traversal defense-in-depth to uploadFile

### DIFF
--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1086,7 +1086,7 @@ export async function runServerCapture(cmd: string, timeoutSecs?: number): Promi
 }
 
 export async function uploadFile(localPath: string, remotePath: string): Promise<void> {
-  if (!/^[a-zA-Z0-9/_.~-]+$/.test(remotePath)) {
+  if (!/^[a-zA-Z0-9/_.~-]+$/.test(remotePath) || remotePath.includes("..")) {
     throw new Error(`Invalid remote path: ${remotePath}`);
   }
   const keyOpts = getSshKeyOpts(await ensureSshKeys());

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1040,7 +1040,7 @@ export async function runServerCapture(cmd: string, timeoutSecs?: number, ip?: s
 
 export async function uploadFile(localPath: string, remotePath: string, ip?: string): Promise<void> {
   const serverIp = ip || doServerIp;
-  if (!/^[a-zA-Z0-9/_.~-]+$/.test(remotePath)) {
+  if (!/^[a-zA-Z0-9/_.~-]+$/.test(remotePath) || remotePath.includes("..")) {
     logError(`Invalid remote path: ${remotePath}`);
     throw new Error("Invalid remote path");
   }

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -579,7 +579,7 @@ export async function runServerCapture(cmd: string, timeoutSecs?: number, ip?: s
 
 export async function uploadFile(localPath: string, remotePath: string, ip?: string): Promise<void> {
   const serverIp = ip || hetznerServerIp;
-  if (!/^[a-zA-Z0-9/_.~-]+$/.test(remotePath)) {
+  if (!/^[a-zA-Z0-9/_.~-]+$/.test(remotePath) || remotePath.includes("..")) {
     logError(`Invalid remote path: ${remotePath}`);
     throw new Error("Invalid remote path");
   }


### PR DESCRIPTION
**Why:** The regex `/^[a-zA-Z0-9/_.~-]+$/` allows `.` characters, so paths like `../../etc/passwd` pass validation in hetzner, digitalocean, and aws `uploadFile`. The gcp, daytona, and sprite providers already include an explicit `remotePath.includes("..")` check as defense-in-depth. This inconsistency means an attacker-controlled remotePath on those 3 clouds could write files outside the intended directory on the remote server via SCP. PR #1964 fixed this same issue for the now-removed fly.ts.

## Changes

- `packages/cli/src/hetzner/hetzner.ts` — add `|| remotePath.includes("..")` to `uploadFile` validation
- `packages/cli/src/digitalocean/digitalocean.ts` — same fix
- `packages/cli/src/aws/aws.ts` — same fix

All providers now consistently block `..` segments in remote paths.

## Test plan
- [x] `bun test` — 1518 pass, 0 fail
- [x] `biome lint` on changed files — 0 errors

-- refactor/code-health