### PR TITLE
fix(security): prevent command injection in branch deletion loops

### DIFF
--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -103,6 +103,13 @@ safe_substitute() {
     rm -f "${file}.bak"
 }
 
+# --- Validate branch name against safe pattern (defense-in-depth) ---
+# Prevents command injection via shell metacharacters in branch names
+is_safe_branch_name() {
+    local name="${1:-}"
+    [[ -n "${name}" ]] && [[ "${name}" =~ ^[a-zA-Z0-9._/-]+$ ]]
+}
+
 # --- Safe rm -rf for worktree paths (defense-in-depth) ---
 safe_rm_worktree() {
     local target="${1:-}"
@@ -180,16 +187,20 @@ fi
 # Delete merged security-related remote branches (team-building/*, review-pr-*)
 MERGED_BRANCHES=$(git branch -r --merged origin/main | grep -E 'origin/(team-building/|review-pr-)' | sed 's|origin/||' | tr -d ' ') || true
 for branch in $MERGED_BRANCHES; do
-    if [[ -n "$branch" ]]; then
-        git push origin --delete "$branch" 2>&1 | tee -a "${LOG_FILE}" && log "Deleted merged branch: $branch" || true
+    if is_safe_branch_name "$branch"; then
+        git push origin --delete -- "$branch" 2>&1 | tee -a "${LOG_FILE}" && log "Deleted merged branch: $branch" || true
+    else
+        log "WARNING: Skipping branch with unsafe name: ${branch}"
     fi
 done
 
 # Delete stale local security-related branches
 LOCAL_BRANCHES=$(git branch --list 'team-building/*' --list 'review-pr-*' | tr -d ' *') || true
 for branch in $LOCAL_BRANCHES; do
-    if [[ -n "$branch" ]]; then
-        git branch -D "$branch" 2>&1 | tee -a "${LOG_FILE}" || true
+    if is_safe_branch_name "$branch"; then
+        git branch -D -- "$branch" 2>&1 | tee -a "${LOG_FILE}" || true
+    else
+        log "WARNING: Skipping local branch with unsafe name: ${branch}"
     fi
 done
 


### PR DESCRIPTION
**Why:** The cycle scripts (discovery.sh, refactor.sh, qa.sh, security.sh) pass unvalidated branch names directly to `git push origin --delete` and `git branch -D`, allowing potential shell metacharacter injection. This is labeled HIGH severity in issue #1960.

## Changes

- Add `is_safe_branch_name()` function to all four cycle scripts, validating branch names against `^[a-zA-Z0-9._/-]+$`
- Replace bare `-n` checks with `is_safe_branch_name` validation in all branch deletion loops
- Add `--` end-of-options separator to all `git push --delete` and `git branch -D` commands to prevent flag injection
- Log warnings when unsafe branch names are skipped (instead of silently ignoring)
- Fix `xargs`-based local branch cleanup in discovery.sh to use validated loop instead

## Files changed

- `.claude/skills/setup-agent-team/discovery.sh` — 2 vulnerable patterns fixed (remote + local branch cleanup)
- `.claude/skills/setup-agent-team/refactor.sh` — 2 vulnerable patterns fixed (remote + local)
- `.claude/skills/setup-agent-team/qa.sh` — 2 vulnerable patterns fixed (remote + local)
- `.claude/skills/setup-agent-team/security.sh` — 2 vulnerable patterns fixed (remote + local)

All files pass `bash -n` syntax checks.

Fixes #1960

-- refactor/security-auditor