### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/__tests__/test-helpers.ts
+++ b/packages/cli/src/__tests__/test-helpers.ts
@@ -74,13 +74,6 @@ export function createConsoleMocks() {
   };
 }
 
-export function createProcessExitMock() {
-  const impl: () => never = () => {
-    throw new Error("process.exit");
-  };
-  return spyOn(process, "exit").mockImplementation(impl);
-}
-
 export function restoreMocks(
   ...mocks: Array<
     | {
@@ -102,17 +95,6 @@ export function mockSuccessfulFetch(data: any) {
 
 export function mockFailedFetch(error = "Network error") {
   return mock(() => Promise.reject(new Error(error)));
-}
-
-export function mockFetchWithStatus(status: number, data?: any) {
-  return mock(() =>
-    Promise.resolve(
-      new Response(JSON.stringify(data || {}), {
-        status,
-        statusText: status === 404 ? "Not Found" : "Error",
-      }),
-    ),
-  );
 }
 
 // ── Test Environment Setup ─────────────────────────────────────────────────────

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2029,29 +2029,6 @@ export function formatRelativeTime(iso: string): string {
   }
 }
 
-export function formatTimestamp(iso: string): string {
-  try {
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) {
-      return iso;
-    }
-    const date = d.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-    const time = d.toLocaleTimeString("en-US", {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-    return `${date} ${time}`;
-  } catch (_err) {
-    // Invalid date format - return as-is
-    return iso;
-  }
-}
-
 async function suggestFilterCorrection(
   filter: string,
   flag: string,


### PR DESCRIPTION
## Summary

- Remove `formatTimestamp` from `commands.ts` -- exported function that is never imported or called anywhere
- Remove `mockFetchWithStatus` from `test-helpers.ts` -- exported helper never imported by any test file
- Remove `createProcessExitMock` from `test-helpers.ts` -- exported helper never imported by any test file

## Verification

- Biome lint: 0 errors on modified files
- Full test suite: 1512 tests pass, 0 failures

## Test plan

- [x] `bun x @biomejs/biome lint src/commands.ts src/__tests__/test-helpers.ts` passes
- [x] `bun test` passes (1512 tests, 0 failures)

-- qa/code-quality