### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/__tests__/cmdlist-integration.test.ts
+++ b/packages/cli/src/__tests__/cmdlist-integration.test.ts
@@ -10,11 +10,6 @@ import type { SpawnRecord } from "../history";
  *
  * Existing tests cover:
  * - history.test.ts: data layer (loadHistory, saveSpawnRecord, filterHistory)
- * - list-display.test.ts: formatTimestamp and parseListFilters replicas
- * - list-table-rendering.test.ts: resolveDisplayName unit tests and table rendering
- * - list-empty-footer.test.ts: showEmptyListMessage and showListFooter replicas
- * - list-filter-suggestions.test.ts: suggestFilterCorrection replicas
- * - list-prompt-display.test.ts: prompt preview rendering
  *
  * This file covers the UNTESTED integration path: calling the real cmdList
  * exported function with mock.module for @clack/prompts and a controlled

--- a/packages/cli/src/__tests__/history.test.ts
+++ b/packages/cli/src/__tests__/history.test.ts
@@ -419,11 +419,8 @@ describe("history", () => {
     });
   });
 
-  // ── formatTimestamp (imported via commands.ts, tested inline) ──────────
-
-  describe("formatTimestamp edge cases (via cmdList integration)", () => {
-    // formatTimestamp is not exported from history.ts, but we test the
-    // timestamp handling indirectly through loadHistory round-trip
+  describe("timestamp round-trip", () => {
+    // timestamp handling tested indirectly through loadHistory round-trip
     it("preserves ISO timestamp strings through save/load cycle", () => {
       const ts = "2026-02-11T14:30:00.000Z";
       saveSpawnRecord({


### PR DESCRIPTION
## Summary

- **Stale comments (category e)**: Removed references to 5 non-existent test files in `cmdlist-integration.test.ts` (`list-display.test.ts`, `list-table-rendering.test.ts`, `list-empty-footer.test.ts`, `list-filter-suggestions.test.ts`, `list-prompt-display.test.ts`). These files were never created.
- **Stale comments (category e)**: Fixed misleading `describe` block name in `history.test.ts` that referenced `formatTimestamp`, a function removed from production code in a prior cleanup.

## Scan results by category

**a) Dead code** — No dead functions found in `sh/shared/*.sh` or `packages/cli/src/`. All exported functions confirmed to have callers.

**b) Stale references** — Found and fixed stale references to non-existent test files in JSDoc comments. No shell scripts referencing deleted files.

**c) Python usage** — No `python3 -c` or `python -c` calls found in any shell scripts.

**d) Duplicate utilities** — No identical helper functions duplicated across cloud modules. Each cloud imports from `packages/shared/src/` as designed.

**e) Stale comments** — Fixed 2 files:
  - `packages/cli/src/__tests__/cmdlist-integration.test.ts`: removed 5 references to non-existent test files
  - `packages/cli/src/__tests__/history.test.ts`: updated stale `formatTimestamp` describe block name

## Verification

- `bun test`: 1458 pass, 0 fail
- `biome lint src/`: 0 errors, 85 files checked

-- qa/code-quality