### PR TITLE
fix: avoid &; syntax error when re-entering OpenClaw

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2868,7 +2868,15 @@ async function cmdEnterAgent(connection: VMConnection, agentKey: string, manifes
       parts.push(preLaunch);
     }
     parts.push(launchCmd);
-    remoteCmd = parts.join("; ");
+    // Join with "; " but avoid "&;" (syntax error) — "&" already separates commands
+    remoteCmd = parts.reduce((acc, part, i) => {
+      if (i === 0) {
+        return part;
+      }
+      const prev = parts[i - 1];
+      const sep = prev !== undefined && prev.trimEnd().endsWith("&") ? " " : "; ";
+      return acc + sep + part;
+    }, "");
   }
 
   const agentName = agentDef?.name || agentKey;


### PR DESCRIPTION
## Summary
- When re-entering an existing OpenClaw instance (`spawn openclaw digitalocean` → "Enter OpenClaw"), the CLI built the SSH command by joining parts with `"; "` — but OpenClaw's `pre_launch` ends with `&` (to background the gateway daemon), producing invalid bash: `...2>&1 &; openclaw tui`
- The `&;` is a syntax error because `&` already acts as a command separator
- Fixed the join logic to detect parts ending with `&` and use just a space instead of `"; "` as the separator

## Test plan
- [x] `bunx @biomejs/biome lint` passes (0 errors)
- [x] `bun test` passes (1612/1612)
- [ ] Manual: `spawn openclaw digitalocean` → "Enter OpenClaw" on existing instance should work

Fixes #1971

🤖 Generated with [Claude Code](https://claude.com/claude-code)