### PR TITLE
fix(ux): apply resolveListFilters to cmdDelete so bare positional args work

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2634,6 +2634,10 @@ export async function cmdList(agentFilter?: string, cloudFilter?: string): Promi
 }
 
 export async function cmdDelete(agentFilter?: string, cloudFilter?: string): Promise<void> {
+  const resolved = await resolveListFilters(agentFilter, cloudFilter);
+  agentFilter = resolved.agentFilter;
+  cloudFilter = resolved.cloudFilter;
+
   const servers = getActiveServers();
 
   let filtered = servers;


### PR DESCRIPTION
**Why:** \`spawn delete hetzner\` silently returns "No active servers to delete" even when the user has active Hetzner servers — because the positional arg is treated as an agent name, not a cloud name.

## Problem

\`cmdDelete\` does raw string comparison against \`r.agent.toLowerCase()\` without calling \`resolveListFilters()\`. When a user runs \`spawn delete hetzner\`, "hetzner" is parsed as \`agentFilter\`, but no agent is named "hetzner", so nothing matches and the user sees:

\`\`\`
No active servers to delete.
2 active servers found, but none matched your filters.
\`\`\`

\`cmdList\` already handles this correctly — it calls \`resolveListFilters()\` at line 2585 which auto-promotes a bare positional arg to \`cloudFilter\` when no agent matches, and also resolves display names and casing.

## Fix

Add the same \`resolveListFilters()\` call to the top of \`cmdDelete\`, matching the pattern already used by \`cmdList\`.

## Test plan

- [x] \`bun test\` passes (1458/1458, 0 failures)
- [x] \`bunx @biomejs/biome lint src/commands.ts\` clean

-- refactor/ux-engineer