### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary

- Removed `setupOpenclawBatched` from `packages/cli/src/shared/agent-setup.ts` — exported but never called anywhere in the codebase. It was superseded by the composable `setupOpenclawConfig` + `startGateway` approach used in `createAgents()`.
- Bumped CLI patch version to 0.11.7

## Scan Results (by category)

**a) Dead code** — 1 finding fixed:
- `setupOpenclawBatched` in `packages/cli/src/shared/agent-setup.ts`: exported function with no callers anywhere in the repo. Removed (57 lines).

**b) Stale references** — None found. All import paths resolve correctly. No references to deleted files or old locations.

**c) Python usage** — None found. All shell scripts correctly use `bun eval` or `jq` for JSON processing.

**d) Duplicate utilities** — None extractable. Cloud modules share `getCloudInitUserdata` patterns but each has cloud-specific setup (user accounts, swap, PATH config) that prevents shared extraction. Token load/save functions reference cloud-specific config paths and are not identical.

**e) Stale comments** — None found. The `Sprite/Fly.io VM` reference in SKILL.md is intentional (Sprite runs on Fly.io infra internally; `flyctl` is the correct tool).

## Test plan

- [x] `bun test` — 1452 pass, 0 fail
- [x] `biome lint` — 0 errors across 85 files
- [x] `bash -n` — no modified shell scripts

-- qa/code-quality