### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/agents.ts
+++ b/packages/cli/src/aws/agents.ts
@@ -3,10 +3,6 @@
 import { runServer, uploadFile } from "./aws";
 import { createAgents, resolveAgent as _resolveAgent } from "../shared/agent-setup";
 import type { AgentConfig } from "../shared/agents";
-import { generateEnvConfig } from "../shared/agents";
-
-export type { AgentConfig };
-export { generateEnvConfig };
 
 const runner = {
   runServer,

--- a/packages/cli/src/daytona/agents.ts
+++ b/packages/cli/src/daytona/agents.ts
@@ -3,10 +3,6 @@
 import { runServer, uploadFile } from "./daytona";
 import { createAgents, resolveAgent as _resolveAgent } from "../shared/agent-setup";
 import type { AgentConfig } from "../shared/agents";
-import { generateEnvConfig } from "../shared/agents";
-
-export type { AgentConfig };
-export { generateEnvConfig };
 
 const runner = {
   runServer,

--- a/packages/cli/src/digitalocean/agents.ts
+++ b/packages/cli/src/digitalocean/agents.ts
@@ -3,10 +3,6 @@
 import { runServer, uploadFile } from "./digitalocean";
 import { createAgents, resolveAgent as _resolveAgent } from "../shared/agent-setup";
 import type { AgentConfig } from "../shared/agents";
-import { generateEnvConfig } from "../shared/agents";
-
-export type { AgentConfig };
-export { generateEnvConfig };
 
 const runner = {
   runServer,

--- a/packages/cli/src/gcp/agents.ts
+++ b/packages/cli/src/gcp/agents.ts
@@ -3,10 +3,6 @@
 import { runServer, uploadFile } from "./gcp";
 import { createAgents, resolveAgent as _resolveAgent } from "../shared/agent-setup";
 import type { AgentConfig } from "../shared/agents";
-import { generateEnvConfig } from "../shared/agents";
-
-export type { AgentConfig };
-export { generateEnvConfig };
 
 const runner = {
   runServer,

--- a/packages/cli/src/hetzner/agents.ts
+++ b/packages/cli/src/hetzner/agents.ts
@@ -3,10 +3,6 @@
 import { runServer, uploadFile } from "./hetzner";
 import { createAgents, resolveAgent as _resolveAgent } from "../shared/agent-setup";
 import type { AgentConfig } from "../shared/agents";
-import { generateEnvConfig } from "../shared/agents";
-
-export type { AgentConfig };
-export { generateEnvConfig };
 
 const runner = {
   runServer,

--- a/packages/cli/src/local/agents.ts
+++ b/packages/cli/src/local/agents.ts
@@ -3,10 +3,6 @@
 import { runLocal, uploadFile } from "./local";
 import { createAgents, resolveAgent as _resolveAgent } from "../shared/agent-setup";
 import type { AgentConfig } from "../shared/agents";
-import { generateEnvConfig } from "../shared/agents";
-
-export type { AgentConfig };
-export { generateEnvConfig };
 
 const runner = {
   runServer: runLocal,

--- a/packages/cli/src/sprite/agents.ts
+++ b/packages/cli/src/sprite/agents.ts
@@ -3,10 +3,6 @@
 import { runSprite, uploadFileSprite } from "./sprite";
 import { createAgents, resolveAgent as _resolveAgent } from "../shared/agent-setup";
 import type { AgentConfig } from "../shared/agents";
-import { generateEnvConfig } from "../shared/agents";
-
-export type { AgentConfig };
-export { generateEnvConfig };
 
 const runner = {
   runServer: runSprite,

--- a/sh/e2e/lib/cleanup.sh
+++ b/sh/e2e/lib/cleanup.sh
@@ -1,13 +1,3 @@
 #!/bin/bash
 # e2e/lib/cleanup.sh — Find and destroy stale e2e-* instances (cloud-agnostic)
 set -eo pipefail
-
-# ---------------------------------------------------------------------------
-# cleanup_stale_apps
-#
-# Delegates to the active cloud driver's stale cleanup function.
-# ---------------------------------------------------------------------------
-cleanup_stale_apps() {
-  log_header "Cleaning up stale e2e instances (${ACTIVE_CLOUD})"
-  cloud_cleanup_stale
-}


### PR DESCRIPTION
## Summary

- **Dead `cleanup_stale_apps` shell function** (`sh/e2e/lib/cleanup.sh`): Defined but never called anywhere. The `e2e.sh` orchestrator calls `cloud_cleanup_stale` directly, making this wrapper dead code. Removed the function; the file now just declares the module header.

- **Dead `generateEnvConfig` + `AgentConfig` re-exports** (all 7 cloud `agents.ts` modules): `aws`, `hetzner`, `gcp`, `digitalocean`, `daytona`, `local`, and `sprite` each re-exported `generateEnvConfig` and `AgentConfig` from `../shared/agents`. Nothing imported these symbols from the cloud-specific modules — callers that need them import directly from `@openrouter/spawn-shared` or `../shared/agents`. Removed the unused imports and re-exports from all 7 files.

- Bumped CLI version `0.11.7` → `0.11.8` (patch bump for this refactor).

## Verification

- `bash -n` passes on all modified `.sh` files
- `bunx @biomejs/biome lint src/` — 0 errors
- `bun test` — **1435 pass, 0 fail**

-- qa/code-quality