### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/check-entity-messages.test.ts
+++ b/packages/cli/src/__tests__/check-entity-messages.test.ts
@@ -12,8 +12,6 @@ import type { Manifest } from "../manifest";
  * 2. Cross-kind fuzzy match: "looks like {kind} X" + swap warning (PR #510)
  * 3. Exact wrong-type detection: "X is a cloud, not an agent" (existing)
  * 4. No match at all: just the listCmd hint (existing)
- *
- * Agent: test-engineer
  */
 
 // ── Mock @clack/prompts ─────────────────────────────────────────────────────

--- a/packages/cli/src/__tests__/check-entity.test.ts
+++ b/packages/cli/src/__tests__/check-entity.test.ts
@@ -18,8 +18,6 @@ import type { Manifest } from "../manifest";
  *
  * This function is called in cmdRun (commands.ts:396-397) for both agent
  * and cloud validation, making it critical for the run pipeline.
- *
- * Agent: test-engineer
  */
 
 // ── Test Fixtures ──────────────────────────────────────────────────────────

--- a/packages/cli/src/__tests__/clear-history.test.ts
+++ b/packages/cli/src/__tests__/clear-history.test.ts
@@ -12,8 +12,6 @@ import { clearHistory, loadHistory, saveSpawnRecord, filterHistory, getHistoryPa
  * operation (deleting the history file). It has zero existing test coverage.
  * cmdListClear wraps clearHistory with user-facing output and also has
  * zero existing test coverage.
- *
- * Agent: test-engineer
  */
 
 describe("clearHistory", () => {

--- a/packages/cli/src/__tests__/cmd-interactive.test.ts
+++ b/packages/cli/src/__tests__/cmd-interactive.test.ts
@@ -14,8 +14,6 @@ import { isString } from "@openrouter/spawn-shared";
  * - Happy path: agent selected, cloud selected, execScript called
  * - Intro banner and outro messaging
  * - "Next time, run directly" hint after selection
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/cmd-listing-output.test.ts
+++ b/packages/cli/src/__tests__/cmd-listing-output.test.ts
@@ -25,8 +25,6 @@ import { createConsoleMocks, restoreMocks } from "./test-helpers";
  * - cmdAgents: agent keys, display names, implementation counts, footer hint
  * - cmdClouds: cloud keys, display names, type grouping, auth hints, footer
  * - Edge cases: empty manifest, single entry, all implemented, none implemented
- *
- * Agent: test-engineer
  */
 
 // ── Mock manifests ──────────────────────────────────────────────────────────

--- a/packages/cli/src/__tests__/cmdlast.test.ts
+++ b/packages/cli/src/__tests__/cmdlast.test.ts
@@ -16,8 +16,6 @@ import type { SpawnRecord } from "../history";
  * - Manifest unavailable (falls back to raw keys)
  * - Records with/without prompts
  * - Integration with cmdRun (mocked)
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/cmdlist-integration.test.ts
+++ b/packages/cli/src/__tests__/cmdlist-integration.test.ts
@@ -23,8 +23,6 @@ import type { SpawnRecord } from "../history";
  * - cmdList with filters that match nothing (empty + suggestion flow)
  * - cmdList when manifest is unavailable (falls back to raw keys)
  * - cmdList footer: rerun hint with/without prompt, filter count text
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/cmdrun-happy-path.test.ts
+++ b/packages/cli/src/__tests__/cmdrun-happy-path.test.ts
@@ -25,8 +25,6 @@ import { isString } from "@openrouter/spawn-shared";
  * - SPAWN_PROMPT and SPAWN_MODE are NOT set when no prompt is provided
  * - saveSpawnRecord failure is non-fatal (script still runs)
  * - Dry-run mode skips script download entirely
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/commands-cloud-info.test.ts
+++ b/packages/cli/src/__tests__/commands-cloud-info.test.ts
@@ -13,8 +13,6 @@ import { loadManifest } from "../manifest";
  * - Invalid/unknown cloud error paths
  * - Typo suggestion via findClosestMatch integration
  * - validateAndGetCloud identifier + empty string rejection
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/commands-error-paths.test.ts
+++ b/packages/cli/src/__tests__/commands-error-paths.test.ts
@@ -6,10 +6,6 @@ import { isString } from "@openrouter/spawn-shared";
 /**
  * Tests for commands.ts error/validation paths that call process.exit(1).
  *
- * These test the ACTUAL exported functions from commands.ts (not inline replicas).
- * Previous tests in commands-helpers.test.ts and commands-untested.test.ts used
- * re-implemented copies of the logic. This file tests the real code paths:
- *
  * - cmdRun with invalid identifiers (injection characters, path traversal)
  * - cmdRun with unknown agent or cloud names
  * - cmdRun with unimplemented agent/cloud combinations
@@ -18,8 +14,6 @@ import { isString } from "@openrouter/spawn-shared";
  * - cmdAgentInfo with invalid identifier
  * - validateNonEmptyString triggering process.exit for empty inputs
  * - validateImplementation showing available clouds when combination is missing
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/commands-exported-utils.test.ts
+++ b/packages/cli/src/__tests__/commands-exported-utils.test.ts
@@ -30,8 +30,6 @@ import { createMockManifest, createEmptyManifest } from "./test-helpers";
  * - getStatusDescription: HTTP status to human-readable string
  * - calculateColumnWidth: matrix display column sizing
  * - getTerminalWidth: terminal width with fallback
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/commands-name-suggestions.test.ts
+++ b/packages/cli/src/__tests__/commands-name-suggestions.test.ts
@@ -19,8 +19,6 @@ import { loadManifest } from "../manifest";
  * - validateCloud: display name suggestion when key suggestion fails
  * - Both key AND display name suggestions returning null (very different input)
  * - findClosestMatch with display names via the full cmdRun / cmdAgentInfo paths
- *
- * Agent: test-engineer
  */
 
 // Manifest with names very different from keys so key-based suggestion fails

--- a/packages/cli/src/__tests__/commands-resolve-run.test.ts
+++ b/packages/cli/src/__tests__/commands-resolve-run.test.ts
@@ -7,19 +7,11 @@ import { isString } from "@openrouter/spawn-shared";
  * Tests for cmdRun display-name resolution and validateImplementation
  * suggestion paths in commands.ts.
  *
- * Existing tests cover:
- * - resolveAgentKey/resolveCloudKey as isolated functions (commands-helpers.test.ts)
- * - cmdRun error paths: invalid identifiers, unknown agents/clouds (commands-error-paths.test.ts)
- * - cmdRun swapped argument detection (commands-error-paths.test.ts)
- *
- * This file covers the UNTESTED integration paths:
  * - cmdRun resolving case-insensitive display names and logging "Resolved" messages
  * - cmdRun resolving case-insensitive keys (e.g. "Claude" -> "claude")
  * - validateImplementation showing "see all N options" hint when > 3 clouds available
  * - validateImplementation showing "no implemented cloud providers" message
  * - cmdRun proceeding correctly after resolution (step log with agent/cloud names)
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/commands-swap-resolve.test.ts
+++ b/packages/cli/src/__tests__/commands-swap-resolve.test.ts
@@ -19,8 +19,6 @@ import { isString } from "@openrouter/spawn-shared";
  * - resolveAndLog: no resolution needed, agent resolved, cloud resolved, both resolved
  * - Edge case: swapped args after display name resolution
  * - Edge case: resolution to a key that then fails validation
- *
- * Agent: test-engineer
  */
 
 // Mock @clack/prompts

--- a/packages/cli/src/__tests__/commands-update-download.test.ts
+++ b/packages/cli/src/__tests__/commands-update-download.test.ts
@@ -17,8 +17,6 @@ const VERSION = pkg.version;
  *
  * The tests mock @clack/prompts, global.fetch, and process.exit to
  * exercise the actual exported functions without side effects.
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/credential-hints.test.ts
+++ b/packages/cli/src/__tests__/credential-hints.test.ts
@@ -6,8 +6,6 @@ import { credentialHints } from "../commands";
  *
  * credentialHints now checks which required env vars are actually set
  * and gives specific feedback about which are missing vs present.
- *
- * Agent: ux-engineer
  */
 
 describe("credentialHints", () => {

--- a/packages/cli/src/__tests__/download-and-failure.test.ts
+++ b/packages/cli/src/__tests__/download-and-failure.test.ts
@@ -7,14 +7,6 @@ import { isString } from "@openrouter/spawn-shared";
  * Tests for the download fallback pipeline and script failure reporting
  * through real exported code paths in commands.ts.
  *
- * Existing tests cover:
- * - getScriptFailureGuidance in isolation (script-failure-guidance.test.ts)
- * - getStatusDescription as a reimplemented copy (commands-untested.test.ts)
- * - downloadScriptWithFallback logic as a reimplemented copy (commands-untested.test.ts)
- * - cmdRun validation paths (commands-error-paths.test.ts)
- * - cmdRun resolution and swap (commands-resolve-run.test.ts, commands-swap-resolve.test.ts)
- *
- * This file covers the UNTESTED real code paths:
  * - downloadScriptWithFallback: primary URL succeeds (real code path through cmdRun)
  * - downloadScriptWithFallback: primary fails, fallback succeeds (real cmdRun)
  * - downloadScriptWithFallback: both fail with 404 (reportDownloadFailure 404+404 path)
@@ -26,8 +18,6 @@ import { isString } from "@openrouter/spawn-shared";
  * - reportScriptFailure: unknown exit code (default guidance)
  * - execScript: validateScriptContent rejection of bad scripts
  * - execScript: interrupted script (code 130) handling
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/fuzzy-key-matching.test.ts
+++ b/packages/cli/src/__tests__/fuzzy-key-matching.test.ts
@@ -23,8 +23,6 @@ import { createMockManifest } from "./test-helpers";
  * 3. Return the key with the smallest distance (key or name), if <= 3
  *
  * This is distinct from findClosestMatch which only checks one list.
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/history-trimming.test.ts
+++ b/packages/cli/src/__tests__/history-trimming.test.ts
@@ -14,8 +14,6 @@ import { loadHistory, saveSpawnRecord, filterHistory } from "../history.js";
  * recent entries and not lose data prematurely.
  *
  * Also tests filterHistory ordering guarantees (reverse chronological).
- *
- * Agent: test-engineer
  */
 
 describe("History Trimming and Boundaries", () => {

--- a/packages/cli/src/__tests__/manifest-cache-lifecycle.test.ts
+++ b/packages/cli/src/__tests__/manifest-cache-lifecycle.test.ts
@@ -20,8 +20,6 @@ import { createMockManifest, setupTestEnvironment, teardownTestEnvironment } fro
  * - agentKeys/cloudKeys insertion order preservation
  * - In-memory cache forceRefresh bypass
  * - Fallback chain: invalid fetch data + stale cache
- *
- * Agent: test-engineer
  */
 
 const mockManifest = createMockManifest();

--- a/packages/cli/src/__tests__/manifest-integrity.test.ts
+++ b/packages/cli/src/__tests__/manifest-integrity.test.ts
@@ -14,8 +14,6 @@ import type { Manifest } from "../manifest";
  * These tests catch configuration drift — when someone adds a script
  * without updating the manifest, or marks an entry "implemented" without
  * creating the script.
- *
- * Agent: test-engineer
  */
 
 const REPO_ROOT = resolve(import.meta.dir, "../../../..");

--- a/packages/cli/src/__tests__/manifest-type-contracts.test.ts
+++ b/packages/cli/src/__tests__/manifest-type-contracts.test.ts
@@ -23,8 +23,6 @@ import type { Manifest } from "../manifest";
  *
  * Unlike manifest-integrity.test.ts which checks truthiness, these tests
  * verify exact types to prevent subtle runtime bugs from type mismatches.
- *
- * Agent: test-engineer
  */
 
 const REPO_ROOT = resolve(import.meta.dir, "../../../..");

--- a/packages/cli/src/__tests__/run-path-credential-display.test.ts
+++ b/packages/cli/src/__tests__/run-path-credential-display.test.ts
@@ -14,8 +14,6 @@ import type { Manifest } from "../manifest";
  *
  * These functions are all in the hot path of cmdRun (the primary CLI flow).
  * A bug in any of them breaks the user experience for every spawn invocation.
- *
- * Agent: test-engineer
  */
 
 // ── Test manifest ───────────────────────────────────────────────────────

--- a/packages/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/packages/cli/src/__tests__/script-failure-guidance.test.ts
@@ -26,8 +26,6 @@ function getSignalGuidance(...args: Parameters<typeof _getSignalGuidance>): stri
  * This function maps exit codes from failed spawn scripts to user-facing
  * guidance strings. It was recently modified (PRs #450, #449) but has
  * zero direct test coverage.
- *
- * Agent: test-engineer
  */
 
 describe("getScriptFailureGuidance", () => {

--- a/packages/cli/src/__tests__/security-encoding.test.ts
+++ b/packages/cli/src/__tests__/security-encoding.test.ts
@@ -11,8 +11,6 @@ import { validateIdentifier, validateScriptContent, validatePrompt } from "../se
  * - Script content with various line endings
  * - Prompt validation with embedded control characters
  * - Regex boundary conditions in dangerous pattern detection
- *
- * Agent: test-engineer
  */
 
 describe("Security Encoding Edge Cases", () => {


### PR DESCRIPTION
## Summary

- Removed stale comments in 3 test files referencing deleted test files (`commands-untested.test.ts`, `commands-helpers.test.ts`)
- Removed `Agent: X` metadata annotations from 22 test files — these are leftover from an earlier automated agent workflow and provide no value
- Bumped CLI version from 0.11.8 → 0.11.9

## Categories scanned

**a) Dead code** — No unused unexported functions found in `sh/shared/*.sh` or `packages/cli/src/`

**b) Stale references** — Found and removed references to deleted test files in JSDoc comments in:
- `commands-error-paths.test.ts`
- `download-and-failure.test.ts`
- `commands-resolve-run.test.ts`

**c) Python usage** — None found (all scripts use `bun eval` or `jq` per CLAUDE.md)

**d) Duplicate utilities** — `getCloudInitUserdata` and `saveTokenToConfig` appear in multiple cloud modules but are NOT identical (cloud-specific path constants and user configuration differ); no shared extraction warranted

**e) Stale comments** — 22 `Agent: test-engineer` metadata annotations removed from test file JSDoc blocks

## Test plan

- [x] \`bun test\` — 1424 pass, 0 fail
- [x] \`biome lint src/\` — no errors

-- qa/code-quality