### PR TITLE
feat(agent): add Hermes Agent (Nous Research)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -241,6 +241,42 @@
         "agentic",
         "engineering"
       ]
+    },
+    "hermes": {
+      "name": "Hermes Agent",
+      "description": "Persistent AI agent with multi-platform messaging, memory across sessions, and tool use",
+      "url": "https://github.com/NousResearch/hermes-agent",
+      "install": "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+      "launch": "hermes",
+      "env": {
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
+        "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
+        "OPENAI_API_KEY": "${OPENROUTER_API_KEY}"
+      },
+      "notes": "Natively supports OpenRouter via OPENROUTER_API_KEY. Also works via OPENAI_BASE_URL + OPENAI_API_KEY for OpenAI-compatible mode. Installs Python 3.11 via uv.",
+      "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/hermes.png",
+      "featured_cloud": [
+        "sprite",
+        "hetzner",
+        "gcp"
+      ],
+      "creator": "Nous Research",
+      "repo": "NousResearch/hermes-agent",
+      "license": "MIT",
+      "created": "2025-06",
+      "added": "2026-02",
+      "github_stars": 1016,
+      "stars_updated": "2026-02-28",
+      "language": "Python",
+      "runtime": "python",
+      "category": "cli",
+      "tagline": "Persistent AI agent with memory, tools, and multi-platform messaging",
+      "tags": [
+        "agent",
+        "messaging",
+        "memory",
+        "tools"
+      ]
     }
   },
   "clouds": {
@@ -392,6 +428,13 @@
     "sprite/zeroclaw": "implemented",
     "sprite/codex": "implemented",
     "sprite/opencode": "implemented",
-    "sprite/kilocode": "implemented"
+    "sprite/kilocode": "implemented",
+    "local/hermes": "missing",
+    "hetzner/hermes": "missing",
+    "aws/hermes": "missing",
+    "daytona/hermes": "missing",
+    "digitalocean/hermes": "missing",
+    "gcp/hermes": "missing",
+    "sprite/hermes": "implemented"
   }
 }

--- a/sh/sprite/hermes.sh
+++ b/sh/sprite/hermes.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eo pipefail
+
+# Thin shim: ensures bun is available, runs bundled sprite.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" hermes "$@"
+fi
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" hermes "$@"
+fi
+
+# Remote — download bundled sprite.js from GitHub release
+SPRITE_JS=$(mktemp)
+trap 'rm -f "$SPRITE_JS"' EXIT
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
+    || { printf '\033[0;31mFailed to download sprite.js\033[0m\n' >&2; exit 1; }
+
+exec bun run "$SPRITE_JS" hermes "$@"


### PR DESCRIPTION
## Summary

- Add Hermes Agent (Nous Research) to the spawn agent matrix
- Implement on Sprite cloud with thin bash shim (`sh/sprite/hermes.sh`)
- Add matrix entries for all 7 clouds (`sprite/hermes` = implemented, rest = missing)

**Why:** Hermes Agent has crossed the 1,000-star threshold (now 1,016 stars) and has a direct user request in #1952 — both community demand signals met. All technical requirements confirmed (single-command install via curl, native `OPENROUTER_API_KEY` support, Python-based with uv/Python 3.11 auto-install).

**Agent details:**
- **Install:** `curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`
- **Launch:** `hermes`
- **Env:** `OPENROUTER_API_KEY` (native), `OPENAI_BASE_URL` + `OPENAI_API_KEY` (OpenAI-compatible mode)
- **Features:** Persistent memory, multi-platform messaging (Telegram, Discord, Slack, CLI), tool use

Closes #1952

## Test plan

- [x] `bash -n sh/sprite/hermes.sh` — syntax check passes
- [x] `manifest.json` — valid JSON, hermes agent entry present, all 7 matrix entries present
- [x] `bun test --filter manifest` — all 323 manifest tests pass (0 failures)
- [ ] Manual: `bash sh/sprite/hermes.sh` on a Sprite VM with OPENROUTER_API_KEY set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- refactor/ux-engineer