### PR TITLE
fix: add missing hermes agent to createAgents() and update sprite agents list

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -503,6 +503,25 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       configure: (apiKey) => setupZeroclawConfig(runner, apiKey),
       launchCmd: () => "source ~/.cargo/env 2>/dev/null; source ~/.spawnrc 2>/dev/null; zeroclaw agent",
     },
+
+    hermes: {
+      name: "Hermes Agent",
+      cloudInitTier: "minimal",
+      preProvision: promptGithubAuth,
+      install: () =>
+        installAgent(
+          runner,
+          "Hermes Agent",
+          "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+          300,
+        ),
+      envVars: (apiKey) => [
+        `OPENROUTER_API_KEY=${apiKey}`,
+        "OPENAI_BASE_URL=https://openrouter.ai/api/v1",
+        `OPENAI_API_KEY=${apiKey}`,
+      ],
+      launchCmd: () => "source ~/.spawnrc 2>/dev/null; hermes",
+    },
   };
 }
 

--- a/packages/cli/src/sprite/main.ts
+++ b/packages/cli/src/sprite/main.ts
@@ -23,7 +23,7 @@ async function main() {
   const agentName = process.argv[2];
   if (!agentName) {
     console.error("Usage: bun run sprite/main.ts <agent>");
-    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw");
+    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw, hermes");
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary

- The hermes agent was added to `manifest.json` and `sh/sprite/hermes.sh` in #2023, but `createAgents()` in `shared/agent-setup.ts` was never updated
- This caused `sh/sprite/hermes.sh` to always throw `Unknown agent: hermes` when launched, making the sprite/hermes combo non-functional despite being marked as `"implemented"` in the matrix
- Updated `sprite/main.ts` usage error message to include `hermes` in the agents list

## Test plan
- [ ] All 1428 unit tests pass (`bun test` — 0 failures)
- [ ] Biome lint clean (`bunx @biomejs/biome lint packages/cli/src/` — 0 errors)
- [ ] `resolveAgent("hermes")` now returns a valid AgentConfig
- [ ] hermes entry includes correct install cmd, envVars (OPENROUTER_API_KEY, OPENAI_BASE_URL, OPENAI_API_KEY), and launchCmd

-- qa/code-quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)