### PR TITLE
fix(openclaw): add pre-launch tip for sequential channel setup

### DIFF
--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -446,6 +446,8 @@ export function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       ],
       configure: (apiKey, modelId) => setupOpenclawConfig(runner, apiKey, modelId || "openrouter/auto"),
       preLaunch: () => startGateway(runner),
+      preLaunchMsg:
+        "Set up one channel at a time in the OpenClaw TUI. Wait for each channel to fully complete before pasting the next token — concurrent token pastes can cause setup to hang.",
       launchCmd: () =>
         "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; openclaw tui",
     },

--- a/packages/cli/src/shared/agents.ts
+++ b/packages/cli/src/shared/agents.ts
@@ -28,6 +28,8 @@ export interface AgentConfig {
   setup?: (envContent: string, apiKey: string, modelId?: string) => Promise<void>;
   /** Pre-launch hook (e.g., start gateway daemon). */
   preLaunch?: () => Promise<void>;
+  /** Optional tip or warning shown to the user just before the agent launches. */
+  preLaunchMsg?: string;
   /** Shell command to launch the agent interactively. */
   launchCmd: () => string;
   /** Cloud-init dependency tier. Defaults to "full" if unset. */

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -130,6 +130,12 @@ export async function runOrchestration(cloud: CloudOrchestrator, agent: AgentCon
     await agent.preLaunch();
   }
 
+  // 11b. Agent-specific pre-launch tip (e.g. channel setup ordering hint)
+  if (agent.preLaunchMsg) {
+    process.stderr.write("\n");
+    logInfo(`Tip: ${agent.preLaunchMsg}`);
+  }
+
   // 12. Launch interactive session
   logInfo(`${agent.name} is ready`);
   process.stderr.write("\n");


### PR DESCRIPTION
## Summary

- Adds an optional `preLaunchMsg` field to the `AgentConfig` interface in `shared/agents.ts`
- Displays the message in `shared/orchestrate.ts` between the pre-launch hook and the interactive session start
- Sets `preLaunchMsg` for the OpenClaw agent to warn users to set up channels one at a time

## Root Cause

The race condition lives inside OpenClaw's own TUI (upstream). Spawn's only direct lever is to inform users *before* they enter the TUI that concurrent token pastes cause setup to hang.

## Fix

```
Tip: Set up one channel at a time in the OpenClaw TUI. Wait for each channel to
fully complete before pasting the next token — concurrent token pastes can cause
setup to hang.
```

This tip is printed to stderr between the gateway-start step and the `openclaw tui` launch, giving users the guidance they need before they have a chance to trigger the race.

The `preLaunchMsg` field is generic — any future agent can use it to show a similar pre-launch tip.

Fixes #2030

-- refactor/issue-fixer