### PR TITLE
fix: extend HOME hardening to local.ts and commands.ts (missed by #2026/#2036)

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -5,6 +5,7 @@ import * as v from "valibot";
 import { parseJsonWith, isString } from "@openrouter/spawn-shared";
 import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
+import { homedir } from "node:os";
 import * as path from "node:path";
 import type { Manifest } from "./manifest.js";
 import {
@@ -895,7 +896,7 @@ function getAuthHint(manifest: Manifest, cloud: string): string | undefined {
 /** Check if credentials are saved in ~/.config/spawn/{cloud}.json */
 function hasCloudConfigCredentials(cloud: string): boolean {
   try {
-    const configPath = path.join(process.env.HOME || "", ".config/spawn", `${cloud}.json`);
+    const configPath = path.join(process.env.HOME || homedir(), ".config/spawn", `${cloud}.json`);
     if (!fs.existsSync(configPath)) {
       return false;
     }

--- a/packages/cli/src/local/local.ts
+++ b/packages/cli/src/local/local.ts
@@ -1,6 +1,7 @@
 // local/local.ts — Core local provider: runs commands on the user's machine
 
 import { copyFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname } from "node:path";
 
 import { getSpawnDir } from "../history.js";
@@ -35,7 +36,7 @@ export async function runLocal(cmd: string): Promise<void> {
 
 /** Copy a file locally, expanding ~ in the destination path. */
 export function uploadFile(localPath: string, remotePath: string): void {
-  const expanded = remotePath.replace(/^~/, process.env.HOME || "");
+  const expanded = remotePath.replace(/^~/, process.env.HOME || homedir());
   mkdirSync(dirname(expanded), {
     recursive: true,
   });


### PR DESCRIPTION
**Why:** When HOME is unset (Docker containers without HOME env, systemd services, cron jobs, some CI runners), two files still used \`process.env.HOME || ""\` — producing broken paths and silently failing credential detection. Completing the hardening series from #2026 (4 cloud config files) and #2036 (ssh-keys, sprite, gcp) which both missed these two occurrences.

## Changes

- **\`local/local.ts:38\`** — \`uploadFile()\` expands \`~\` using \`process.env.HOME || ""\`. When HOME is unset, \`~/\` expands to \`""\`, writing config files relative to CWD instead of the user's home directory, breaking local agent setup.
- **\`commands.ts:898\`** — \`hasCloudConfigCredentials()\` builds the credential path with \`process.env.HOME || ""\`. When HOME is unset, this resolves to a relative path, so \`fs.existsSync\` never finds saved credentials, causing false "Missing credentials" warnings on every run.

## Fix

Add \`import { homedir } from "node:os"\` to both files and change \`process.env.HOME || ""\` to \`process.env.HOME || homedir()\`.

## Test results

- 1410 pass, 0 fail, 3147 expect() calls
- Lint: 0 errors (biome)

-- refactor/team-lead