### PR TITLE
fix(e2e): add sh/aws/hermes.sh and mark aws/hermes as implemented

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -431,7 +431,7 @@
     "sprite/kilocode": "implemented",
     "local/hermes": "missing",
     "hetzner/hermes": "missing",
-    "aws/hermes": "missing",
+    "aws/hermes": "implemented",
     "daytona/hermes": "missing",
     "digitalocean/hermes": "missing",
     "gcp/hermes": "missing",

--- a/sh/aws/README.md
+++ b/sh/aws/README.md
@@ -48,6 +48,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/kilocode.sh)
 ```
 
+#### Hermes Agent
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/hermes.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/sh/aws/hermes.sh
+++ b/sh/aws/hermes.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -eo pipefail
+
+# Thin shim: ensures bun is available, runs bundled aws.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" hermes "$@"
+fi
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" hermes "$@"
+fi
+
+# Remote — download and run compiled TypeScript bundle
+AWS_JS=$(mktemp)
+trap 'rm -f "$AWS_JS"' EXIT
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS"
+exec bun run "$AWS_JS" hermes "$@"


### PR DESCRIPTION
## Summary

- Add missing `sh/aws/hermes.sh` script (thin shim matching all other AWS agent scripts)
- Update `manifest.json`: `"aws/hermes"` from `"missing"` → `"implemented"`
- Update `sh/aws/README.md` with Hermes Agent install command

## Background

During QA E2E sweep, found that the Hermes agent was fully implemented in `packages/cli/src/shared/agent-setup.ts` (inside `createAgents()`) — with install script, `envVars`, and `launchCmd` — but the convenience shell script `sh/aws/hermes.sh` was missing and the matrix showed `"missing"`.

The E2E suite lists `hermes` in `ALL_AGENTS` (in `sh/e2e/lib/common.sh`) and will attempt to provision it on AWS. The TypeScript CLI already supports it; the shell wrapper was the only missing piece.

## Test plan

- [x] `bash -n sh/aws/hermes.sh` — syntax check passes
- [x] `bunx @biomejs/biome lint src/` — zero errors
- [x] `bun test` — 1410 pass, 0 fail
- [x] E2E live test blocked by missing credentials in CI environment (requires AWS + OPENROUTER_API_KEY configured)

-- qa/e2e-tester