### PR TITLE
fix(e2e): use explicit PATH for hermes, codex, and kilocode binary checks

### DIFF
--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -55,8 +55,8 @@ input_test_codex() {
   local encoded_prompt
   encoded_prompt=$(printf '%s' "${INPUT_TEST_PROMPT}" | base64 -w 0 2>/dev/null || printf '%s' "${INPUT_TEST_PROMPT}" | base64)
   local remote_cmd
-  remote_cmd="source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; \
-    export PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH; \
+  remote_cmd="source ~/.spawnrc 2>/dev/null; \
+    export PATH=\$HOME/.npm-global/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH; \
     rm -rf /tmp/e2e-test && mkdir -p /tmp/e2e-test && cd /tmp/e2e-test && git init -q; \
     PROMPT=\$(printf '%s' '${encoded_prompt}' | base64 -d); codex exec \"\$PROMPT\""
 
@@ -337,7 +337,7 @@ verify_codex() {
 
   # Binary check
   log_step "Checking codex binary..."
-  if cloud_exec "${app}" "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; command -v codex" >/dev/null 2>&1; then
+  if cloud_exec "${app}" "PATH=\$HOME/.npm-global/bin:\$HOME/.bun/bin:\$HOME/.local/bin:\$PATH command -v codex" >/dev/null 2>&1; then
     log_ok "codex binary found"
   else
     log_err "codex binary not found"
@@ -396,7 +396,7 @@ verify_kilocode() {
 
   # Binary check
   log_step "Checking kilocode binary..."
-  if cloud_exec "${app}" "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; command -v kilocode" >/dev/null 2>&1; then
+  if cloud_exec "${app}" "PATH=\$HOME/.npm-global/bin:\$HOME/.bun/bin:\$HOME/.local/bin:\$PATH command -v kilocode" >/dev/null 2>&1; then
     log_ok "kilocode binary found"
   else
     log_err "kilocode binary not found"
@@ -430,7 +430,7 @@ verify_hermes() {
 
   # Binary check
   log_step "Checking hermes binary..."
-  if cloud_exec "${app}" "source ~/.spawnrc 2>/dev/null; command -v hermes" >/dev/null 2>&1; then
+  if cloud_exec "${app}" "PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH command -v hermes" >/dev/null 2>&1; then
     log_ok "hermes binary found"
   else
     log_err "hermes binary not found"


### PR DESCRIPTION
## Summary

- **hermes**: Installed via `uv tool install` to `~/.local/bin/hermes`. Verify only sourced `.spawnrc` which doesn't include `~/.local/bin` in PATH. Fixed with explicit `PATH=$HOME/.local/bin:...`.
- **codex/kilocode**: Installed via `npm install -g` to `~/.npm-global/bin/`. Verify sourced `.spawnrc` and `.zshrc`, but non-interactive SSH doesn't run `.bashrc` (where npm PATH is added). Fixed with explicit `PATH=$HOME/.npm-global/bin:...`.
- **codex input test**: Same PATH fix applied to `input_test_codex`.

This matches the pattern already used by `verify_openclaw` and `verify_claude`.

## Test Results (5-cloud run)

| Cloud | Result | Notes |
|-------|--------|-------|
| AWS | **7/7 PASS** | hermes now passes |
| Hetzner | **6/6 implemented PASS** | hermes not implemented |
| GCP | **6/6 implemented PASS** | codex+kilocode now pass, hermes not implemented |
| DigitalOcean | blocked | Account billing issue |
| Sprite | blocked | Auth token expired |

## Test plan

- [x] AWS 7/7 all agents pass (including hermes)
- [x] GCP 6/6 implemented agents pass (codex and kilocode were failing before)
- [x] Hetzner 6/6 implemented agents pass
- [x] `bash -n sh/e2e/lib/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)