### PR TITLE
fix: spawn last reconnects to existing VM instead of always reprovisioning

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/cmdlast.test.ts
+++ b/packages/cli/src/__tests__/cmdlast.test.ts
@@ -195,7 +195,7 @@ describe("cmdLast", () => {
       },
     ];
 
-    it("should show 'Rerunning last spawn' when history exists", async () => {
+    it("should show 'Last spawn' when history exists", async () => {
       writeHistory(sampleRecords);
 
       global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
@@ -209,7 +209,7 @@ describe("cmdLast", () => {
       }
 
       const step = logStepOutput();
-      expect(step).toContain("Rerunning last spawn");
+      expect(step).toContain("Last spawn");
     });
 
     it("should select the most recent record (newest first)", async () => {
@@ -442,7 +442,7 @@ describe("cmdLast", () => {
 
       const step = logStepOutput();
       // Should handle old dates gracefully
-      expect(step).toContain("Rerunning");
+      expect(step).toContain("Last spawn");
     });
 
     it("should handle records with all metadata fields", async () => {
@@ -464,7 +464,7 @@ describe("cmdLast", () => {
       }
 
       const step = logStepOutput();
-      expect(step).toContain("Rerunning");
+      expect(step).toContain("Last spawn");
       expect(step).toContain("Claude Code");
     });
 

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -2732,12 +2732,13 @@ export async function cmdLast(): Promise<void> {
 
   const label = buildRecordLabel(latest, manifest);
   const subtitle = buildRecordSubtitle(latest, manifest);
-  p.log.step(`Rerunning last spawn: ${pc.bold(label)} ${pc.dim(`(${subtitle})`)}`);
+  p.log.step(`Last spawn: ${pc.bold(label)} ${pc.dim(`(${subtitle})`)}`);
 
-  if (latest.name) {
-    process.env.SPAWN_NAME = latest.name;
-  }
-  await cmdRun(latest.agent, latest.cloud, latest.prompt);
+  // If the latest record has connection info (IP/server), let the user
+  // reconnect to the existing VM instead of blindly provisioning a new one.
+  // handleRecordAction already offers enter/reconnect/rerun/delete options
+  // and falls back to cmdRun when there's no connection.
+  await handleRecordAction(latest, manifest);
 }
 
 // ── Connect ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `cmdLast()` was always calling `cmdRun()`, which provisions a **brand-new VM** every time — even when the previous session's VM is still running
- Fix wires `cmdLast()` into the existing `handleRecordAction()` function, which already contains the correct reconnect-vs-rerun logic used by `spawn list`
- When the latest history record has a live connection (IP + server ID), the user is presented with reconnect options (enter agent, SSH into VM, or spawn new VM)
- Only falls back to `cmdRun()` when no connection info is stored in the record

## Test plan

- [x] All 21 existing `cmdlast.test.ts` tests pass (updated message assertions from "Rerunning last spawn" → "Last spawn")
- [x] `bunx @biomejs/biome lint src/` — zero errors
- [x] No `as` type assertions introduced
- [x] CLI version bumped `0.11.13` → `0.11.14`

Fixes #2050

-- refactor/issue-fixer