### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/sh/shared/key-request.sh
+++ b/sh/shared/key-request.sh
@@ -90,7 +90,7 @@ process.stdout.write(d[process.env._VAR] || d.api_key || d.token || '');
             #   - _ . / @  (standard API key chars)
             #   : + =      (base64 segments, URL-safe and base64 formats)
             #   space       (prefixed token formats, e.g., "Bearer <token>")
-            # Must match CLI's loadTokenFromConfig regex in cli/src/digitalocean/digitalocean.ts
+            # Keep in sync with loadTokenFromConfig regex in packages/cli/src/digitalocean/digitalocean.ts
             if [[ ! "${val}" =~ ^[a-zA-Z0-9._/@:+=\ -]+$ ]]; then
                 log "SECURITY: Invalid characters in config value for ${var_name}"
                 return 1


### PR DESCRIPTION
## Summary

- Fixed stale path comment in `sh/shared/key-request.sh` that incorrectly referenced `cli/src/digitalocean/digitalocean.ts` instead of the correct `packages/cli/src/digitalocean/digitalocean.ts`
- Also updated the comment wording from "Must match" to "Keep in sync with" to more accurately reflect the relationship

## Full scan results

**a) Dead code** — None found. All functions in `sh/shared/*.sh` and `packages/cli/src/` are referenced by callers.

**b) Stale references** — One stale path comment in `sh/shared/key-request.sh` (fixed above). All shell script source references and TypeScript imports point to existing files.

**c) Python usage** — None found. No `python3 -c` or `python -c` calls anywhere in `sh/`.

**d) Duplicate utilities** — No true duplicates requiring extraction. Cloud modules (`hetzner`, `digitalocean`, `daytona`) share a similar `getConfigPath`/`loadTokenFromConfig` pattern but each reads from a distinct config path (`~/.config/spawn/{cloud}.json`) so consolidation is not appropriate.

**e) Stale comments** — One fixed (see above). No other stale comments referencing removed infrastructure or deleted functions were found.

## Test plan

- [x] `bash -n sh/shared/key-request.sh` — passes
- [x] `bun test` in `packages/cli/` — 1419 pass, 0 fail

-- qa/code-quality