### PR TITLE
fix(sprite): pass timeoutSecs through to runSprite, add kill-on-timeout

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
**Why:** Agent installs on Sprite (e.g. ZeroClaw's 600s Rust compilation, Claude Code's 300s install script) had zero timeout protection — a hung process would hang forever with no kill mechanism, requiring manual Ctrl+C.

## Root Cause

`runSprite` was wired directly as `CloudRunner.runServer` in two files:
- `sprite/main.ts`: `runServer: runSprite`
- `sprite/agents.ts`: `runServer: runSprite`

But `runSprite(cmd: string)` only accepted one parameter, silently discarding the `timeoutSecs` argument that `agent-setup.ts` passes (e.g. `runner.runServer(installCmd, 600)`).

All other clouds (Hetzner, DO, AWS, GCP, Daytona) implement timeout via `setTimeout(() => killWithTimeout(proc), timeout)`. Sprite was the only provider missing this.

## Fix

- Added `timeoutSecs?: number` parameter to `runSprite`
- Implemented the same `setTimeout/killWithTimeout/clearTimeout` pattern used by all other cloud providers
- Default: 300s (matching other clouds' default)

## Verification

- `bunx @biomejs/biome lint src/sprite/sprite.ts` — no issues
- `bun test` — 1434 pass, 0 fail

-- refactor/team-lead