### PR TITLE
fix(security): escape cmd args in _exec_long to prevent shell injection

### DIFF
--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -179,10 +179,14 @@ _digitalocean_exec_long() {
     return 1
   fi
 
+  # Base64-encode the command to avoid shell injection via single-quote breakout
+  local encoded_cmd
+  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
+
   ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
       -o "ServerAliveInterval=15" -o "ServerAliveCountMax=$((timeout_secs / 15 + 1))" \
-      "root@${ip}" "timeout ${timeout_secs} bash -c '${cmd}'"
+      "root@${ip}" "timeout ${timeout_secs} bash -c \"\$(printf '%s' '${encoded_cmd}' | base64 -d)\""
 }
 
 # ---------------------------------------------------------------------------

--- a/sh/e2e/lib/clouds/sprite.sh
+++ b/sh/e2e/lib/clouds/sprite.sh
@@ -209,10 +209,14 @@ _sprite_exec_long() {
   local _max=3
   local _stderr_tmp="/tmp/sprite-execl-err.$$"
 
+  # Base64-encode the command to avoid shell injection via single-quote breakout
+  local encoded_cmd
+  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
+
   while [ "${_attempt}" -lt "${_max}" ]; do
     _sprite_fix_config
     # shellcheck disable=SC2046
-    sprite $(_sprite_org_flags) exec -s "${app}" -- bash -c "timeout ${timeout} bash -c '${cmd}'" 2>"${_stderr_tmp}"
+    sprite $(_sprite_org_flags) exec -s "${app}" -- bash -c "timeout ${timeout} bash -c \"\$(printf '%s' '${encoded_cmd}' | base64 -d)\"" 2>"${_stderr_tmp}"
     local _rc=$?
     if [ "${_rc}" -eq 0 ]; then
       rm -f "${_stderr_tmp}"


### PR DESCRIPTION
**Why:** Command injection via unquoted single-quote in `_sprite_exec_long` and `_digitalocean_exec_long` — a `cmd` value containing `'` breaks out of the bash -c quoted context, enabling arbitrary code execution.

## Changes

- `sh/e2e/lib/clouds/sprite.sh`: Base64-encode `cmd` before embedding in shell string; decode on the remote side via `printf '%s' | base64 -d`
- `sh/e2e/lib/clouds/digitalocean.sh`: Same fix

## Security Impact

Prevents CWE-78 (OS Command Injection) via malicious single-quote in cmd argument.

Fixes #2063

-- refactor/security-auditor