### PR TITLE
fix(hetzner): add SPAWN_CUSTOM guard to promptServerType

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.18",
+  "version": "0.11.19",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/custom-flag.test.ts
+++ b/packages/cli/src/__tests__/custom-flag.test.ts
@@ -124,10 +124,9 @@ describe("Hetzner --custom prompts", () => {
     restoreEnv("HETZNER_LOCATION", savedLocation);
   });
 
-  it("promptServerType should return default in non-interactive mode", async () => {
+  it("promptServerType should return default without --custom", async () => {
     delete process.env.HETZNER_SERVER_TYPE;
     delete process.env.SPAWN_CUSTOM;
-    process.env.SPAWN_NON_INTERACTIVE = "1";
     const { promptServerType, DEFAULT_SERVER_TYPE } = await import("../hetzner/hetzner");
     const result = await promptServerType();
     expect(result).toBe(DEFAULT_SERVER_TYPE);

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -347,6 +347,10 @@ export async function promptServerType(): Promise<string> {
     return process.env.HETZNER_SERVER_TYPE;
   }
 
+  if (process.env.SPAWN_CUSTOM !== "1") {
+    return DEFAULT_SERVER_TYPE;
+  }
+
   if (process.env.SPAWN_NON_INTERACTIVE === "1") {
     return DEFAULT_SERVER_TYPE;
   }


### PR DESCRIPTION
**Why:** Hetzner's \`promptServerType()\` was missing the \`SPAWN_CUSTOM !== "1"\` guard that every other cloud (GCP, DigitalOcean, Daytona) uses to skip interactive pickers on default launch. Users running \`spawn claude hetzner\` without \`--custom\` got an unexpected server type picker that no other cloud shows. Hetzner is the cheapest cloud and likely the most-used.

## Changes

- \`packages/cli/src/hetzner/hetzner.ts\`: Add \`SPAWN_CUSTOM\` guard to \`promptServerType()\`, matching the existing guard already in \`promptLocation()\` on line 365
- \`packages/cli/src/__tests__/custom-flag.test.ts\`: Update Hetzner server type test to validate the \`SPAWN_CUSTOM\` guard (consistent with \`promptLocation\` test pattern)
- \`packages/cli/package.json\`: Bump to 0.11.19

## Before / After

Before: `spawn claude hetzner` (no --custom) → unexpected interactive server type picker
After: `spawn claude hetzner` (no --custom) → picks CX22 default immediately, consistent with all other clouds

## Verification

- Biome lint: 0 errors on modified files
- Failure count unchanged: 59 pre-existing failures (all from missing module deps unrelated to this change)

-- refactor/team-lead