### PR TITLE
fix: use ignore stdin for SSH commands to prevent deadlock on Hetzner/DigitalOcean

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.19",
+  "version": "0.11.20",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -995,7 +995,7 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
     ],
     {
       stdio: [
-        "pipe",
+        "ignore",
         "inherit",
         "inherit",
       ],
@@ -1005,11 +1005,6 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
   const timeout = (timeoutSecs || 300) * 1000;
   const timer = setTimeout(() => killWithTimeout(proc), timeout);
   const exitCode = await proc.exited;
-  try {
-    proc.stdin!.end();
-  } catch {
-    /* already closed */
-  }
   clearTimeout(timer);
 
   if (exitCode !== 0) {
@@ -1032,7 +1027,7 @@ export async function runServerCapture(cmd: string, timeoutSecs?: number, ip?: s
     ],
     {
       stdio: [
-        "pipe",
+        "ignore",
         "pipe",
         "pipe",
       ],
@@ -1047,11 +1042,6 @@ export async function runServerCapture(cmd: string, timeoutSecs?: number, ip?: s
     new Response(proc.stderr).text(),
   ]);
   const exitCode = await proc.exited;
-  try {
-    proc.stdin!.end();
-  } catch {
-    /* already closed */
-  }
   clearTimeout(timer);
 
   if (exitCode !== 0) {

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -520,7 +520,7 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
     ],
     {
       stdio: [
-        "pipe",
+        "ignore",
         "inherit",
         "inherit",
       ],
@@ -530,11 +530,6 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
   const timeout = (timeoutSecs || 300) * 1000;
   const timer = setTimeout(() => killWithTimeout(proc), timeout);
   const exitCode = await proc.exited;
-  try {
-    proc.stdin!.end();
-  } catch {
-    /* already closed */
-  }
   clearTimeout(timer);
 
   if (exitCode !== 0) {
@@ -557,7 +552,7 @@ export async function runServerCapture(cmd: string, timeoutSecs?: number, ip?: s
     ],
     {
       stdio: [
-        "pipe",
+        "ignore",
         "pipe",
         "pipe",
       ],
@@ -572,11 +567,6 @@ export async function runServerCapture(cmd: string, timeoutSecs?: number, ip?: s
     new Response(proc.stderr).text(),
   ]);
   const exitCode = await proc.exited;
-  try {
-    proc.stdin!.end();
-  } catch {
-    /* already closed */
-  }
   clearTimeout(timer);
 
   if (exitCode !== 0) {


### PR DESCRIPTION
**Why:** Hetzner and DigitalOcean \`runServer\`/\`runServerCapture\` use \`stdio:["pipe",...]\` for stdin but call \`proc.stdin!.end()\` AFTER \`await proc.exited\`. If a remote SSH command reads from stdin (apt prompts, \`read\` calls in install scripts), the process deadlocks until the 5-minute timeout fires — wasting user time on the two most popular cloud providers.

AWS and GCP correctly use \`stdio:["ignore",...]\` for stdin. Daytona calls \`stdin.end()\` before \`await proc.exited\`. Only Hetzner and DigitalOcean had the wrong pattern.

## Changes

- \`packages/cli/src/hetzner/hetzner.ts\`: Change stdin from \`"pipe"\` to \`"ignore"\` in \`runServer\` and \`runServerCapture\`, remove dead \`proc.stdin!.end()\` calls
- \`packages/cli/src/digitalocean/digitalocean.ts\`: Same fix
- \`packages/cli/package.json\`: Bump version 0.11.19 → 0.11.20

## Verification

- 1389 tests pass, 0 failures
- \`bunx @biomejs/biome lint src/\` — 0 errors across 84 files

-- refactor/code-health