### PR TITLE
fix(security): remove space from token validation charset

### DIFF
--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -202,7 +202,7 @@ function loadTokenFromConfig(): string | null {
   if (!token) {
     return null;
   }
-  if (!/^[a-zA-Z0-9._/@:+=, -]+$/.test(token)) {
+  if (!/^[a-zA-Z0-9._/@:+=-]+$/.test(token)) {
     return null;
   }
   return token;
@@ -217,7 +217,7 @@ function loadRefreshToken(): string | null {
   if (!refreshToken) {
     return null;
   }
-  if (!/^[a-zA-Z0-9._/@:+=, -]+$/.test(refreshToken)) {
+  if (!/^[a-zA-Z0-9._/@:+=-]+$/.test(refreshToken)) {
     return null;
   }
   return refreshToken;

--- a/sh/shared/key-request.sh
+++ b/sh/shared/key-request.sh
@@ -89,13 +89,12 @@ process.stdout.write(d[process.env._VAR] || d.api_key || d.token || '');
             # Allow alphanumeric plus safe chars needed by real tokens:
             #   - _ . / @  (standard API key chars)
             #   : + =      (base64 segments, URL-safe and base64 formats)
-            #   space       (prefixed token formats, e.g., "Bearer <token>")
             # Keep in sync with loadTokenFromConfig regex in packages/cli/src/digitalocean/digitalocean.ts
-            if [[ ! "${val}" =~ ^[a-zA-Z0-9._/@:+=\ -]+$ ]]; then
+            if [[ ! "${val}" =~ ^[a-zA-Z0-9._/@:+=-]+$ ]]; then
                 log "SECURITY: Invalid characters in config value for ${var_name}"
                 return 1
             fi
-            # SECURITY: val is already validated against ^[a-zA-Z0-9._/@:+=\ -]+$ above,
+            # SECURITY: val is already validated against ^[a-zA-Z0-9._/@:+=-]+$ above,
             # and var_name is validated against ^[A-Z_][A-Z0-9_]*$ by the caller.
             # Use export NAME=VALUE (bash 3.2 compatible; printf -v requires bash 4.0+).
             export "${var_name}=${val}"


### PR DESCRIPTION
**Why:** API tokens never legitimately contain spaces; allowing them risks word-splitting in downstream unquoted env var uses, weakening defense-in-depth.

Fixes #2072

## Summary
- Removed space character from the allowed charset in `_try_load_env_var` regex validation in `sh/shared/key-request.sh`
- Updated corresponding TypeScript regexes in `packages/cli/src/digitalocean/digitalocean.ts` (`loadTokenFromConfig` and `loadRefreshToken`) to stay in sync (also removed space and comma)
- Hyphen kept at end of character class to avoid range interpretation
- All 1385 tests pass, lint clean, `bash -n` syntax check passes

-- refactor/code-health