### PR TITLE
feat: add hermes agent to 4 clouds, fix zeroclaw install timeout

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -430,11 +430,11 @@
     "sprite/opencode": "implemented",
     "sprite/kilocode": "implemented",
     "local/hermes": "missing",
-    "hetzner/hermes": "missing",
+    "hetzner/hermes": "implemented",
     "aws/hermes": "implemented",
-    "daytona/hermes": "missing",
-    "digitalocean/hermes": "missing",
-    "gcp/hermes": "missing",
+    "daytona/hermes": "implemented",
+    "digitalocean/hermes": "implemented",
+    "gcp/hermes": "implemented",
     "sprite/hermes": "implemented"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.22",
+  "version": "0.11.23",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/sh/daytona/README.md
+++ b/sh/daytona/README.md
@@ -42,6 +42,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/kilocode.sh)
 ```
 
+#### Hermes
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/daytona/hermes.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/sh/daytona/hermes.sh
+++ b/sh/daytona/hermes.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eo pipefail
+
+# Thin shim: ensures bun is available, runs bundled daytona TypeScript (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/daytona/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/daytona/main.ts" hermes "$@"
+fi
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/daytona/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../../packages/cli/src/daytona/main.ts" hermes "$@"
+fi
+
+# Remote — download bundled daytona.js from GitHub release
+DAYTONA_JS=$(mktemp)
+trap 'rm -f "$DAYTONA_JS"' EXIT
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
+    || { printf '\033[0;31mFailed to download daytona.js\033[0m\n' >&2; exit 1; }
+
+exec bun run "$DAYTONA_JS" hermes "$@"

--- a/sh/digitalocean/README.md
+++ b/sh/digitalocean/README.md
@@ -40,6 +40,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/kilocode.sh)
 ```
 
+#### Hermes
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/hermes.sh)
+```
+
 ## Environment Variables
 
 | Variable | Description | Default |

--- a/sh/digitalocean/hermes.sh
+++ b/sh/digitalocean/hermes.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -eo pipefail
+
+# Thin shim: ensures bun is available, runs bundled digitalocean.js (local or from GitHub release)
+# Includes restart loop for SIGTERM recovery on DigitalOcean
+
+_AGENT_NAME="hermes"
+_MAX_RETRIES=3
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_run_with_restart() {
+    local attempt=0
+    local backoff=2
+    while [ "$attempt" -lt "$_MAX_RETRIES" ]; do
+        attempt=$((attempt + 1))
+
+        "$@"
+        local exit_code=$?
+
+        if [ "$exit_code" -eq 0 ]; then
+            return 0
+        fi
+
+        if [ "$exit_code" -eq 143 ] || [ "$exit_code" -eq 137 ]; then
+            printf '\033[0;33m[spawn/%s] Agent process terminated (exit %s). The droplet is likely still running.\033[0m\n' \
+                "$_AGENT_NAME" "$exit_code" >&2
+            printf '\033[0;33m[spawn/%s] Check your DigitalOcean dashboard: https://cloud.digitalocean.com/droplets\033[0m\n' \
+                "$_AGENT_NAME" >&2
+            if [ "$attempt" -lt "$_MAX_RETRIES" ]; then
+                printf '\033[0;33m[spawn/%s] Restarting (attempt %s/%s, backoff %ss)...\033[0m\n' \
+                    "$_AGENT_NAME" "$((attempt + 1))" "$_MAX_RETRIES" "$backoff" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2))
+                continue
+            else
+                printf '\033[0;31m[spawn/%s] Max restart attempts reached (%s). Giving up.\033[0m\n' \
+                    "$_AGENT_NAME" "$_MAX_RETRIES" >&2
+                return "$exit_code"
+            fi
+        fi
+
+        return "$exit_code"
+    done
+}
+
+_ensure_bun
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" ]]; then
+    _run_with_restart bun run "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
+    exit $?
+fi
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
+    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
+    exit $?
+fi
+
+# Remote — download bundled digitalocean.js from GitHub release
+DO_JS=$(mktemp)
+trap 'rm -f "$DO_JS"' EXIT
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/digitalocean-latest/digitalocean.js" -o "$DO_JS" \
+    || { printf '\033[0;31mFailed to download digitalocean.js\033[0m\n' >&2; exit 1; }
+
+_run_with_restart bun run "$DO_JS" "$_AGENT_NAME" "$@"
+exit $?

--- a/sh/e2e/lib/common.sh
+++ b/sh/e2e/lib/common.sh
@@ -7,7 +7,7 @@ set -eo pipefail
 # ---------------------------------------------------------------------------
 ALL_AGENTS="claude openclaw zeroclaw codex opencode kilocode hermes"
 PROVISION_TIMEOUT="${PROVISION_TIMEOUT:-480}"
-INSTALL_WAIT="${INSTALL_WAIT:-300}"
+INSTALL_WAIT="${INSTALL_WAIT:-600}"
 INPUT_TEST_TIMEOUT="${INPUT_TEST_TIMEOUT:-120}"
 
 # Active cloud (set by load_cloud_driver)

--- a/sh/gcp/README.md
+++ b/sh/gcp/README.md
@@ -42,6 +42,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/kilocode.sh)
 ```
 
+#### Hermes
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/hermes.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/sh/gcp/hermes.sh
+++ b/sh/gcp/hermes.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eo pipefail
+
+# Thin shim: ensures bun is available, runs bundled gcp.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" hermes "$@"
+fi
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" hermes "$@"
+fi
+
+# Remote — download bundled gcp.js from GitHub release
+GCP_JS=$(mktemp)
+trap 'rm -f "$GCP_JS"' EXIT
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
+    || { printf '\033[0;31mFailed to download gcp.js\033[0m\n' >&2; exit 1; }
+
+exec bun run "$GCP_JS" hermes "$@"

--- a/sh/hetzner/README.md
+++ b/sh/hetzner/README.md
@@ -40,6 +40,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/kilocode.sh)
 ```
 
+#### Hermes
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/hermes.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/sh/hetzner/hermes.sh
+++ b/sh/hetzner/hermes.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eo pipefail
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+_ensure_bun
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" hermes "$@"
+fi
+
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" hermes "$@"
+fi
+
+HETZNER_JS=$(mktemp)
+trap 'rm -f "$HETZNER_JS"' EXIT
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS"
+exec bun run "$HETZNER_JS" hermes "$@"


### PR DESCRIPTION
**Why:** hermes was only available on 2/7 clouds (AWS, Sprite); this extends coverage to GCP, Hetzner, DigitalOcean, Daytona. zeroclaw was timing out on Rust compilation at 300s; 600s fixes observed 8-12 min build times.

Rebased version of #2075 (approved, but had merge conflict on version bump — resolved by advancing to 0.11.23).

## Changes
- Add hermes agent shim scripts for GCP, Hetzner, DigitalOcean, and Daytona
- Bump default E2E `INSTALL_WAIT` from 300s to 600s to fix zeroclaw timeout failures
- Update manifest.json matrix entries to `"implemented"` for hermes on 4 clouds
- Update cloud READMEs with hermes usage docs
- Bump CLI version to 0.11.23 (rebased from 0.11.18, resolving conflict with 0.11.22)

## Test plan
- [x] `bash -n` passes on all 4 new hermes scripts
- [x] `biome lint` clean (0 errors)
- [x] `bun test` passes

-- refactor/pr-maintainer