### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/check-entity.test.ts
+++ b/packages/cli/src/__tests__/check-entity.test.ts
@@ -109,66 +109,6 @@ describe("checkEntity", () => {
     manifest = createTestManifest();
   });
 
-  // ── Happy path: valid entities ──────────────────────────────────────────
-
-  describe("valid entities", () => {
-    it("should return true for agent key 'claude'", () => {
-      expect(checkEntity(manifest, "claude", "agent")).toBe(true);
-    });
-
-    it("should return true for agent key 'codex'", () => {
-      expect(checkEntity(manifest, "codex", "agent")).toBe(true);
-    });
-
-    it("should return true for agent key 'cline'", () => {
-      expect(checkEntity(manifest, "cline", "agent")).toBe(true);
-    });
-
-    it("should return true for cloud key 'sprite'", () => {
-      expect(checkEntity(manifest, "sprite", "cloud")).toBe(true);
-    });
-
-    it("should return true for cloud key 'hetzner'", () => {
-      expect(checkEntity(manifest, "hetzner", "cloud")).toBe(true);
-    });
-
-    it("should return true for cloud key 'vultr'", () => {
-      expect(checkEntity(manifest, "vultr", "cloud")).toBe(true);
-    });
-  });
-
-  // ── Wrong-type detection: cloud given as agent ──────────────────────────
-
-  describe("wrong-type detection: cloud given as agent", () => {
-    it("should return false when 'sprite' is checked as agent", () => {
-      expect(checkEntity(manifest, "sprite", "agent")).toBe(false);
-    });
-
-    it("should return false when 'hetzner' is checked as agent", () => {
-      expect(checkEntity(manifest, "hetzner", "agent")).toBe(false);
-    });
-
-    it("should return false when 'vultr' is checked as agent", () => {
-      expect(checkEntity(manifest, "vultr", "agent")).toBe(false);
-    });
-  });
-
-  // ── Wrong-type detection: agent given as cloud ──────────────────────────
-
-  describe("wrong-type detection: agent given as cloud", () => {
-    it("should return false when 'claude' is checked as cloud", () => {
-      expect(checkEntity(manifest, "claude", "cloud")).toBe(false);
-    });
-
-    it("should return false when 'codex' is checked as cloud", () => {
-      expect(checkEntity(manifest, "codex", "cloud")).toBe(false);
-    });
-
-    it("should return false when 'cline' is checked as cloud", () => {
-      expect(checkEntity(manifest, "cline", "cloud")).toBe(false);
-    });
-  });
-
   // ── Non-existent entities: no close match (distance > 3) ───────────────
 
   describe("non-existent entities with no close match", () => {

--- a/packages/cli/src/__tests__/cloud-init.test.ts
+++ b/packages/cli/src/__tests__/cloud-init.test.ts
@@ -91,16 +91,8 @@ describe("needsBun", () => {
 });
 
 describe("NODE_INSTALL_CMD", () => {
-  it("is a non-empty string", () => {
-    expect(typeof NODE_INSTALL_CMD).toBe("string");
-    expect(NODE_INSTALL_CMD.length).toBeGreaterThan(0);
-  });
-
-  it("installs Node 22", () => {
-    expect(NODE_INSTALL_CMD).toContain("22");
-  });
-
-  it("downloads and runs an install script", () => {
+  it("is a curl-based install command targeting Node 22", () => {
     expect(NODE_INSTALL_CMD).toContain("curl");
+    expect(NODE_INSTALL_CMD).toContain("22");
   });
 });


### PR DESCRIPTION
## Summary

- **check-entity.test.ts**: Remove 12 individual tests made redundant by existing loop-based exhaustive tests:
  - 6 "valid entities" individual tests (claude/codex/cline as agents, sprite/hetzner/vultr as clouds) — fully covered by `all manifest agents/clouds validate correctly` describe blocks
  - 6 "wrong-type detection" individual tests (3 clouds-as-agents, 3 agents-as-clouds) — covered by `should reject every agent key when checked as cloud` and `should reject every cloud key when checked as agent`

- **cloud-init.test.ts**: Consolidate 3 `NODE_INSTALL_CMD` tests into 1. The `"is a non-empty string"` test was theatrical (testing the constant exists rather than what it does). Merged with the two content-checking tests into a single meaningful assertion.

## Test plan
- [x] `bun test` passes: 1371 tests, 0 failures (was 1385 before)
- [x] `bun run biome lint src/` passes: 0 errors across 84 files
- [x] All removed tests were provably covered by existing broader tests

-- qa/dedup-scanner