### PR TITLE
fix: derive agent lists dynamically in usage messages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.25",
+  "version": "0.11.26",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/main.ts
+++ b/packages/cli/src/aws/main.ts
@@ -16,7 +16,7 @@ import {
   uploadFile,
   interactiveSession,
 } from "./aws";
-import { resolveAgent } from "./agents";
+import { agents, resolveAgent } from "./agents";
 import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
@@ -25,7 +25,7 @@ async function main() {
   const agentName = process.argv[2];
   if (!agentName) {
     console.error("Usage: bun run aws/main.ts <agent>");
-    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw");
+    console.error(`Agents: ${Object.keys(agents).join(", ")}`);
     process.exit(1);
   }
 

--- a/packages/cli/src/daytona/main.ts
+++ b/packages/cli/src/daytona/main.ts
@@ -13,7 +13,7 @@ import {
   interactiveSession,
 } from "./daytona";
 import type { SandboxSize } from "./daytona";
-import { resolveAgent } from "./agents";
+import { agents, resolveAgent } from "./agents";
 import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
@@ -22,7 +22,7 @@ async function main() {
   const agentName = process.argv[2];
   if (!agentName) {
     console.error("Usage: bun run daytona/main.ts <agent>");
-    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw");
+    console.error(`Agents: ${Object.keys(agents).join(", ")}`);
     process.exit(1);
   }
 

--- a/packages/cli/src/digitalocean/main.ts
+++ b/packages/cli/src/digitalocean/main.ts
@@ -14,7 +14,7 @@ import {
   uploadFile,
   interactiveSession,
 } from "./digitalocean";
-import { resolveAgent } from "./agents";
+import { agents, resolveAgent } from "./agents";
 import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
@@ -24,7 +24,7 @@ async function main() {
   const agentName = process.argv[2];
   if (!agentName) {
     console.error("Usage: bun run digitalocean/main.ts <agent>");
-    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw");
+    console.error(`Agents: ${Object.keys(agents).join(", ")}`);
     process.exit(1);
   }
 

--- a/packages/cli/src/gcp/main.ts
+++ b/packages/cli/src/gcp/main.ts
@@ -15,7 +15,7 @@ import {
   uploadFile,
   interactiveSession,
 } from "./gcp";
-import { resolveAgent } from "./agents";
+import { agents, resolveAgent } from "./agents";
 import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
@@ -24,7 +24,7 @@ async function main() {
   const agentName = process.argv[2];
   if (!agentName) {
     console.error("Usage: bun run gcp/main.ts <agent>");
-    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw");
+    console.error(`Agents: ${Object.keys(agents).join(", ")}`);
     process.exit(1);
   }
 

--- a/packages/cli/src/hetzner/main.ts
+++ b/packages/cli/src/hetzner/main.ts
@@ -14,7 +14,7 @@ import {
   uploadFile,
   interactiveSession,
 } from "./hetzner";
-import { resolveAgent } from "./agents";
+import { agents, resolveAgent } from "./agents";
 import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
@@ -23,7 +23,7 @@ async function main() {
   const agentName = process.argv[2];
   if (!agentName) {
     console.error("Usage: bun run hetzner/main.ts <agent>");
-    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw");
+    console.error(`Agents: ${Object.keys(agents).join(", ")}`);
     process.exit(1);
   }
 

--- a/packages/cli/src/local/main.ts
+++ b/packages/cli/src/local/main.ts
@@ -2,7 +2,7 @@
 // local/main.ts — Orchestrator: deploys an agent on the local machine
 
 import { runLocal, uploadFile, interactiveSession, saveLocalConnection } from "./local";
-import { resolveAgent } from "./agents";
+import { agents, resolveAgent } from "./agents";
 import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
@@ -11,7 +11,7 @@ async function main() {
   const agentName = process.argv[2];
   if (!agentName) {
     console.error("Usage: bun run local/main.ts <agent>");
-    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw");
+    console.error(`Agents: ${Object.keys(agents).join(", ")}`);
     process.exit(1);
   }
 

--- a/packages/cli/src/sprite/main.ts
+++ b/packages/cli/src/sprite/main.ts
@@ -14,7 +14,7 @@ import {
   uploadFileSprite,
   interactiveSession,
 } from "./sprite";
-import { resolveAgent } from "./agents";
+import { agents, resolveAgent } from "./agents";
 import { saveLaunchCmd } from "../history.js";
 import { runOrchestration } from "../shared/orchestrate";
 import type { CloudOrchestrator } from "../shared/orchestrate";
@@ -23,7 +23,7 @@ async function main() {
   const agentName = process.argv[2];
   if (!agentName) {
     console.error("Usage: bun run sprite/main.ts <agent>");
-    console.error("Agents: claude, codex, openclaw, opencode, kilocode, zeroclaw, hermes");
+    console.error(`Agents: ${Object.keys(agents).join(", ")}`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary

- Replace hardcoded agent name lists in all 7 cloud `main.ts` usage error messages with `Object.keys(agents).join(", ")`
- Six of seven clouds were stale (missing `hermes` after #2084); only `sprite/main.ts` was updated
- Prevents recurrence: new agents added to `createAgents()` will automatically appear in usage messages

## Files changed

- `packages/cli/src/aws/main.ts`
- `packages/cli/src/hetzner/main.ts`
- `packages/cli/src/digitalocean/main.ts`
- `packages/cli/src/gcp/main.ts`
- `packages/cli/src/daytona/main.ts`
- `packages/cli/src/local/main.ts`
- `packages/cli/src/sprite/main.ts`
- `packages/cli/package.json` (version bump 0.11.23 -> 0.11.24)

## Test plan

- [x] `bunx @biomejs/biome lint` passes on all 7 files (0 errors)
- [x] `bun test` passes (1385 tests, 0 failures)

-- refactor/code-health