### PR TITLE
feat: add local/hermes to complete the 7x7 matrix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -429,7 +429,7 @@
     "sprite/codex": "implemented",
     "sprite/opencode": "implemented",
     "sprite/kilocode": "implemented",
-    "local/hermes": "missing",
+    "local/hermes": "implemented",
     "hetzner/hermes": "implemented",
     "aws/hermes": "implemented",
     "daytona/hermes": "implemented",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.24",
+  "version": "0.11.25",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/sh/local/README.md
+++ b/sh/local/README.md
@@ -14,6 +14,7 @@ spawn openclaw local
 spawn zeroclaw local
 spawn codex local
 spawn kilocode local
+spawn hermes local
 ```
 
 Or run directly without the CLI:
@@ -24,6 +25,7 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/openclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/zeroclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/codex.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/kilocode.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/hermes.sh)
 ```
 
 ## Non-Interactive Mode

--- a/sh/local/hermes.sh
+++ b/sh/local/hermes.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eo pipefail
+
+# Thin shim: ensures bun is available, runs bundled local.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+
+# Local checkout — run from source
+if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" ]]; then
+    exec bun run "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" hermes "$@"
+fi
+
+# Remote — download bundled local.js from GitHub release
+LOCAL_JS=$(mktemp)
+trap 'rm -f "$LOCAL_JS"' EXIT
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
+    || { printf '\033[0;31mFailed to download local.js\033[0m\n' >&2; exit 1; }
+
+exec bun run "$LOCAL_JS" hermes "$@"


### PR DESCRIPTION
## Why

Closes the only remaining gap in the 7x7 cloud x agent matrix -- `local/hermes` was the only missing entry. All 49 entries are now implemented.

Fixes #2079

## Changes

- Add `sh/local/hermes.sh` -- thin bun shim following the existing local agent pattern
- Update `manifest.json` to mark `local/hermes` as `"implemented"`
- Update `sh/local/README.md` with hermes usage instructions
- Bump CLI version to 0.11.25

## Test plan

- [x] `bash -n sh/local/hermes.sh` passes syntax check
- [x] `bun test` -- all 1371 tests pass, 0 failures
- [x] No `"missing"` entries remain in `manifest.json`

-- refactor/ux-engineer