### PR TITLE
fix(e2e): add --force to sprite destroy in teardown

### DIFF
--- a/sh/e2e/lib/clouds/sprite.sh
+++ b/sh/e2e/lib/clouds/sprite.sh
@@ -246,7 +246,7 @@ _sprite_teardown() {
   log_step "Tearing down ${app}..."
 
   # shellcheck disable=SC2046
-  sprite $(_sprite_org_flags) destroy "${app}" >/dev/null 2>&1 || true
+  sprite $(_sprite_org_flags) destroy --force "${app}" >/dev/null 2>&1 || true
 
   # Brief wait for destruction to propagate
   sleep 2


### PR DESCRIPTION
## Summary
- Add `--force` flag to `sprite destroy` in E2E teardown to prevent silent failures in non-interactive mode
- Without `--force`, the sprite CLI prompts for confirmation and silently exits ("Ok, come back later!"), leaving stale instances running indefinitely
- This was the root cause of 92 stale Sprite servers accumulating

## Test plan
- [x] `bash -n` syntax check passes
- [ ] E2E run with Sprite cloud verifies teardown actually destroys instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)