### PR TITLE
fix(daytona): throw on non-2xx responses to prevent silent destroy failures

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/daytona/daytona.ts
+++ b/packages/cli/src/daytona/daytona.ts
@@ -72,6 +72,9 @@ async function daytonaApi(method: string, endpoint: string, body?: string, maxRe
         interval = Math.min(interval * 2, 30);
         continue;
       }
+      if (!resp.ok) {
+        throw new Error(`Daytona API error ${resp.status}: ${extractApiError(text)}`);
+      }
       return text;
     } catch (err) {
       if (attempt >= maxRetries) {
@@ -83,10 +86,6 @@ async function daytonaApi(method: string, endpoint: string, body?: string, maxRe
     }
   }
   throw new Error("daytonaApi: unreachable");
-}
-
-function hasApiError(text: string): boolean {
-  return /"statusCode"\s*:\s*4|"unauthorized"|"forbidden"/i.test(text);
 }
 
 function extractApiError(text: string, fallback = "Unknown error"): string {
@@ -134,10 +133,7 @@ async function testDaytonaToken(): Promise<boolean> {
     return false;
   }
   try {
-    const resp = await daytonaApi("GET", "/sandbox?page=1&limit=1", undefined, 1);
-    if (hasApiError(resp)) {
-      return false;
-    }
+    await daytonaApi("GET", "/sandbox?page=1&limit=1", undefined, 1);
     return true;
   } catch {
     return false;
@@ -648,11 +644,11 @@ export async function destroyServer(id?: string): Promise<void> {
   }
 
   logStep(`Destroying sandbox ${targetId}...`);
-  const response = await daytonaApi("DELETE", `/sandbox/${targetId}`);
-
-  if (response && hasApiError(response)) {
+  try {
+    await daytonaApi("DELETE", `/sandbox/${targetId}`);
+  } catch (err) {
     logError(`Failed to destroy sandbox ${targetId}`);
-    logError(`API Error: ${extractApiError(response)}`);
+    logError(err instanceof Error ? err.message : "Unknown error");
     logWarn("The sandbox may still be running and incurring charges.");
     logWarn(`Delete it manually at: ${DAYTONA_DASHBOARD_URL}`);
     throw new Error("Sandbox deletion failed");


### PR DESCRIPTION
**Why:** `destroyServer()` reported \"Sandbox destroyed\" on persistent 5xx API errors — sandbox kept running and accruing charges with no user warning.

## Root Cause

`daytonaApi()` returned raw response text regardless of HTTP status on the final retry attempt. `destroyServer()` checked `hasApiError()` which only matched a `"statusCode": 4xx` pattern in JSON bodies. A 500/502/503 response body doesn't contain that pattern, so it passed the check silently.

## Fix

1. **`daytonaApi()`**: After retries exhaust, throw `Error` on `!resp.ok` — consistent with `lightsailRest()` (AWS) and GCP equivalents.
2. **`destroyServer()`**: Use `try/catch` instead of `hasApiError()` — catches all failures including 5xx.
3. **`testDaytonaToken()`**: Remove `hasApiError()` check (redundant — already has `try/catch`).
4. **`hasApiError()`**: Removed (no longer used).

## Verification

- `bunx @biomejs/biome lint src/` — 0 errors (99 files)
- `bun test` — 1390/1390 pass

-- refactor/code-health