### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,8 @@ spawn/
     cli/
       src/index.ts               # CLI entry point (bun/TypeScript)
       src/manifest.ts            # Manifest fetch + cache logic
-      src/commands.ts            # All subcommands (interactive, list, run, etc.)
+      src/commands/              # Per-command modules (interactive, list, run, etc.)
+      src/commands.ts            # Compatibility shim → re-exports from commands/
       package.json               # npm package (@openrouter/spawn)
     shared/
       src/parse.ts               # parseJsonWith(text, schema) and parseJsonRaw(text)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,10 +28,11 @@ The installer uses bun to build the TypeScript CLI into a standalone JavaScript 
 cli/
 ├── src/
 │   ├── index.ts        # Entry point (routes commands to handlers)
-│   ├── commands.ts     # All command implementations
+│   ├── commands/       # Per-command modules (interactive, list, run, etc.)
+│   │   └── index.ts    # Barrel re-export
+│   ├── commands.ts     # Compatibility shim → re-exports from commands/index.ts
 │   ├── manifest.ts     # Manifest fetching and caching logic
 │   ├── update-check.ts # Auto-update check (once per day)
-│   ├── version.ts      # Version constant
 │   └── __tests__/      # Test suite (Bun test runner)
 ├── ../sh/cli/install.sh # Installer (auto-installs bun if needed, lives in sh/cli/)
 ├── package.json        # Package metadata and dependencies
@@ -195,11 +196,11 @@ bun run dev claude sprite
 - Routes to appropriate command handler
 - Minimal logic (just dispatching)
 
-**`src/commands.ts`**
-- All command implementations
-- Interactive picker UI
-- Script execution logic
-- Help text
+**`src/commands/`**
+- Per-command modules: `interactive.ts`, `list.ts`, `run.ts`, `delete.ts`, `update.ts`, etc.
+- `shared.ts` — helpers, entity resolution, fuzzy matching, credential hints
+- `index.ts` — barrel re-export for backward compat
+- `commands.ts` at root is a thin shim that re-exports from `commands/index.ts`
 
 **`src/manifest.ts`**
 - Manifest fetching from GitHub
@@ -212,7 +213,7 @@ bun run dev claude sprite
 
 ### Adding a New Command
 
-1. Add command handler in `src/commands.ts`:
+1. Add a new file `src/commands/mycommand.ts`:
    ```typescript
    export async function cmdMyCommand() {
      const manifest = await loadManifest();
@@ -220,14 +221,19 @@ bun run dev claude sprite
    }
    ```
 
-2. Add routing in `src/index.ts`:
+2. Re-export from `src/commands/index.ts`:
+   ```typescript
+   export { cmdMyCommand } from "./mycommand.js";
+   ```
+
+3. Add routing in `src/index.ts`:
    ```typescript
    case "mycommand":
      await cmdMyCommand();
      break;
    ```
 
-3. Update help text in `src/commands.ts` → `cmdHelp()`
+4. Update help text in `src/commands/help.ts` → `cmdHelp()`
 
 ## Design Rationale
 

--- a/packages/cli/src/__tests__/check-entity-messages.test.ts
+++ b/packages/cli/src/__tests__/check-entity-messages.test.ts
@@ -3,7 +3,7 @@ import { mockClackPrompts } from "./test-helpers";
 import type { Manifest } from "../manifest";
 
 /**
- * Tests for checkEntity output messages (commands.ts:177-216).
+ * Tests for checkEntity output messages (commands/shared.ts).
  *
  * The existing check-entity.test.ts verifies return values (true/false)
  * but does not capture the messages output via @clack/prompts log calls.

--- a/packages/cli/src/__tests__/check-entity.test.ts
+++ b/packages/cli/src/__tests__/check-entity.test.ts
@@ -3,7 +3,7 @@ import { checkEntity } from "../commands";
 import type { Manifest } from "../manifest";
 
 /**
- * Tests for checkEntity (commands.ts:182-206).
+ * Tests for checkEntity (commands/shared.ts).
  *
  * checkEntity validates that a user-provided value exists in the manifest
  * as the expected entity kind (agent or cloud). It returns true if valid,
@@ -16,7 +16,7 @@ import type { Manifest } from "../manifest";
  *    "Did you mean X?" suggestion.
  * 3. Generic error: no close match found -- returns false with list command hint.
  *
- * This function is called in cmdRun (commands.ts:396-397) for both agent
+ * This function is called in cmdRun (commands/run.ts) for both agent
  * and cloud validation, making it critical for the run pipeline.
  */
 

--- a/packages/cli/src/__tests__/clear-history.test.ts
+++ b/packages/cli/src/__tests__/clear-history.test.ts
@@ -7,7 +7,7 @@ import type { SpawnRecord } from "../history.js";
 import { clearHistory, loadHistory, saveSpawnRecord, filterHistory, getHistoryPath } from "../history.js";
 
 /**
- * Tests for clearHistory (history.ts) and cmdListClear (commands.ts).
+ * Tests for clearHistory (history.ts) and cmdListClear (commands/list.ts).
  *
  * clearHistory is invoked via `spawn list --clear` and performs a destructive
  * operation (deleting the history file). It has zero existing test coverage.

--- a/packages/cli/src/__tests__/cmd-interactive.test.ts
+++ b/packages/cli/src/__tests__/cmd-interactive.test.ts
@@ -4,7 +4,7 @@ import { loadManifest } from "../manifest";
 import { isString } from "../shared/type-guards";
 
 /**
- * Tests for cmdInteractive() in commands.ts.
+ * Tests for cmdInteractive() in commands/interactive.ts.
  *
  * cmdInteractive is the primary user entry point (invoked with bare `spawn`).
  * It has zero test coverage for:

--- a/packages/cli/src/__tests__/commands-cloud-info.test.ts
+++ b/packages/cli/src/__tests__/commands-cloud-info.test.ts
@@ -3,7 +3,7 @@ import { createMockManifest, createConsoleMocks, restoreMocks, mockClackPrompts 
 import { loadManifest } from "../manifest";
 
 /**
- * Tests for cmdCloudInfo and related cloud validation paths in commands.ts.
+ * Tests for cmdCloudInfo and related cloud validation paths in commands/info.ts.
  *
  * cmdCloudInfo had zero test coverage despite being a user-facing command.
  * These tests exercise the actual exported function with:

--- a/packages/cli/src/__tests__/commands-error-paths.test.ts
+++ b/packages/cli/src/__tests__/commands-error-paths.test.ts
@@ -4,7 +4,7 @@ import { loadManifest } from "../manifest";
 import { isString } from "../shared/type-guards";
 
 /**
- * Tests for commands.ts error/validation paths that call process.exit(1).
+ * Tests for commands/ error/validation paths that call process.exit(1).
  *
  * - cmdRun with invalid identifiers (injection characters, path traversal)
  * - cmdRun with unknown agent or cloud names

--- a/packages/cli/src/__tests__/commands-exported-utils.test.ts
+++ b/packages/cli/src/__tests__/commands-exported-utils.test.ts
@@ -13,7 +13,7 @@ import {
 import { createMockManifest, createEmptyManifest } from "./test-helpers";
 
 /**
- * Tests for exported utility functions in commands.ts that lacked
+ * Tests for exported utility functions in commands/ that lacked
  * direct unit test coverage.
  *
  * Previously tested functions like levenshtein, findClosestMatch,
@@ -374,7 +374,7 @@ describe("calculateColumnWidth (actual export)", () => {
   });
 
   it("should expand beyond minimum for long items", () => {
-    // COL_PADDING is 2 in commands.ts
+    // COL_PADDING is 2 in commands/info.ts
     const result = calculateColumnWidth(
       [
         "long-item-name",
@@ -429,7 +429,7 @@ describe("getTerminalWidth", () => {
   });
 });
 
-// ── getImplementedClouds (actual export from commands.ts) ─────────────────────
+// ── getImplementedClouds (actual export from commands/shared.ts) ───────────────
 
 describe("getImplementedClouds (actual export)", () => {
   it("should return implemented clouds for a given agent", () => {

--- a/packages/cli/src/__tests__/commands-name-suggestions.test.ts
+++ b/packages/cli/src/__tests__/commands-name-suggestions.test.ts
@@ -4,7 +4,7 @@ import { loadManifest } from "../manifest";
 
 /**
  * Tests for the display-name suggestion branches in validateAgent and
- * validateCloud (commands.ts lines 145-199).
+ * validateCloud (commands/shared.ts).
  *
  * When a user types an unknown agent or cloud, validateAgent/validateCloud:
  *   1. Try findClosestMatch on keys (e.g. "claud" -> "claude")

--- a/packages/cli/src/__tests__/commands-resolve-run.test.ts
+++ b/packages/cli/src/__tests__/commands-resolve-run.test.ts
@@ -5,7 +5,7 @@ import { isString } from "../shared/type-guards";
 
 /**
  * Tests for cmdRun display-name resolution and validateImplementation
- * suggestion paths in commands.ts.
+ * suggestion paths in commands/run.ts.
  *
  * - cmdRun resolving case-insensitive display names and logging "Resolved" messages
  * - cmdRun resolving case-insensitive keys (e.g. "Claude" -> "claude")

--- a/packages/cli/src/__tests__/commands-swap-resolve.test.ts
+++ b/packages/cli/src/__tests__/commands-swap-resolve.test.ts
@@ -4,7 +4,7 @@ import { loadManifest } from "../manifest";
 import { isString } from "../shared/type-guards";
 
 /**
- * Tests for detectAndFixSwappedArgs and resolveAndLog logic in commands.ts.
+ * Tests for detectAndFixSwappedArgs and resolveAndLog logic in commands/run.ts.
  *
  * These functions handle two important CLI UX features:
  * - Swapped argument detection: "spawn sprite claude" -> "spawn claude sprite"

--- a/packages/cli/src/__tests__/commands-update-download.test.ts
+++ b/packages/cli/src/__tests__/commands-update-download.test.ts
@@ -6,7 +6,7 @@ import pkg from "../../package.json" with { type: "json" };
 const VERSION = pkg.version;
 
 /**
- * Tests for cmdUpdate and script download/execution paths in commands.ts.
+ * Tests for cmdUpdate and script download/execution paths in commands/update.ts and commands/run.ts.
  *
  * These functions have zero test coverage in the existing test suite:
  * - cmdUpdate: checks for CLI updates by fetching remote package.json

--- a/packages/cli/src/__tests__/download-and-failure.test.ts
+++ b/packages/cli/src/__tests__/download-and-failure.test.ts
@@ -5,7 +5,7 @@ import { isString } from "../shared/type-guards";
 
 /**
  * Tests for the download fallback pipeline and script failure reporting
- * through real exported code paths in commands.ts.
+ * through real exported code paths in commands/run.ts.
  *
  * - downloadScriptWithFallback: primary URL succeeds (real code path through cmdRun)
  * - downloadScriptWithFallback: primary fails, fallback succeeds (real cmdRun)

--- a/packages/cli/src/__tests__/fuzzy-key-matching.test.ts
+++ b/packages/cli/src/__tests__/fuzzy-key-matching.test.ts
@@ -13,9 +13,8 @@ import { createMockManifest } from "./test-helpers";
  * checks both keys AND display names to find the best match for a typo.
  *
  * This function was added in PR #414 and is used in:
- * - validateAgent (commands.ts:177) — error suggestions for unknown agents
- * - validateCloud (commands.ts:206) — error suggestions for unknown clouds
- * - showInfoOrError (index.ts:112-113) — fallback suggestions for unknown commands
+ * - checkEntity (commands/shared.ts) — error suggestions for unknown agents/clouds
+ * - showInfoOrError (index.ts) — fallback suggestions for unknown commands
  *
  * It has a nuanced priority system:
  * 1. Check Levenshtein distance to each key

--- a/packages/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/packages/cli/src/__tests__/script-failure-guidance.test.ts
@@ -21,7 +21,7 @@ function getSignalGuidance(...args: Parameters<typeof _getSignalGuidance>): stri
 }
 
 /**
- * Tests for getScriptFailureGuidance() in commands.ts.
+ * Tests for getScriptFailureGuidance() in commands/run.ts.
  *
  * This function maps exit codes from failed spawn scripts to user-facing
  * guidance strings. It was recently modified (PRs #450, #449) but has

--- a/packages/cli/src/guidance-data.ts
+++ b/packages/cli/src/guidance-data.ts
@@ -1,6 +1,6 @@
 /**
  * Guidance data structures for error and signal reporting.
- * Extracted from commands.ts to improve maintainability and reduce cognitive complexity.
+ * Used by getScriptFailureGuidance in commands/run.ts.
  */
 
 import pc from "picocolors";
@@ -24,7 +24,7 @@ export function buildDashboardHint(dashboardUrl?: string): string {
     : "  - Check your cloud provider dashboard to stop or delete any unused servers";
 }
 
-// Note: Exit code 1 uses specialHandling because it needs credentialHints from commands.ts to avoid circular deps
+// Note: Exit code 1 uses specialHandling because it needs credentialHints from commands/run.ts to avoid circular deps
 export const EXIT_CODE_GUIDANCE: Record<number, ExitCodeEntry> = {
   130: {
     header: "Script was interrupted (Ctrl+C).",
@@ -80,7 +80,7 @@ export const EXIT_CODE_GUIDANCE: Record<number, ExitCodeEntry> = {
     header: "Common causes:",
     lines: [],
     includeDashboard: true,
-    // specialHandling is set in getScriptFailureGuidance in commands.ts
+    // specialHandling is set in getScriptFailureGuidance in commands/run.ts
     // to avoid circular dependency with credentialHints
     specialHandling: () => [],
   },


### PR DESCRIPTION
## Summary

- Update stale `commands.ts` references in 10 test files to point to the actual modules under `commands/` (introduced in PR #2095 which split the monolith into per-command files)
- Fix `guidance-data.ts` comments: update extraction note and circular-dep annotation to reference `commands/run.ts` instead of the now-thin `commands.ts` shim
- Update `CLAUDE.md` file structure diagram to show `commands/` directory and note `commands.ts` is a compatibility shim
- Update `packages/cli/README.md`: directory structure diagram and "Adding a New Command" guide now reflect the per-module layout

## Test plan

- [x] `bun test` — 646 pass / 51 fail / 26 errors (no regression; failures are pre-existing on main)
- [x] `bun x @biomejs/biome lint src/` — zero errors
- [x] No shell scripts modified (no `bash -n` needed)
- [x] All changes are comment/documentation only — no logic affected

-- qa/code-quality