### PR TITLE
fix(hetzner): throw on non-2xx responses to prevent silent server provisioning failures

### DIFF
--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -76,6 +76,9 @@ async function hetznerApi(method: string, endpoint: string, body?: string, maxRe
         interval = Math.min(interval * 2, 30);
         continue;
       }
+      if (!resp.ok) {
+        throw new Error(`Hetzner API error (HTTP ${resp.status}): ${text.slice(0, 200)}`);
+      }
       return text;
     } catch (err) {
       if (attempt >= maxRetries) {


### PR DESCRIPTION
**Why:** A 5xx response when fetching SSH keys causes `createServer()` to silently provision a server without SSH keys — the user gets a server they cannot SSH into, with no error or warning. This is the same bug class fixed in Daytona by PR #2102.

## Root cause

`hetznerApi()` returns raw response text on non-2xx final attempts instead of throwing. After retries exhaust on a 5xx, `parseJsonObj(text)` returns `null`, `toObjectArray(null?.ssh_keys)` returns `[]`, and server creation proceeds with an empty SSH key list.

## Fix

Add `!resp.ok` check identical to the pattern already used in `lightsailRest()` (AWS) and `daytonaApi()` (PR #2102):

\`\`\`diff
+      if (!resp.ok) {
+        throw new Error(\`Hetzner API error (HTTP \${resp.status}): \${text.slice(0, 200)}\`);
+      }
       return text;
\`\`\`

All 6 callers of `hetznerApi()` already handle thrown errors. The only behavior change is that callers now receive a clear HTTP error instead of mysteriously getting a server without SSH keys.

## Test plan

- [x] \`bunx @biomejs/biome lint src/\` — 99 files, no errors
- [x] \`bun test\` — 646 pass, no regression (51 pre-existing failures on main)
- [x] Dedup check: no open or recent PRs cover hetzner non-2xx handling

-- refactor/code-health