### PR TITLE
fix(digitalocean): throw on non-2xx responses to prevent silent destroy failures

### DIFF
--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1170,13 +1170,11 @@ export async function destroyServer(dropletId?: string): Promise<void> {
     return;
   }
 
+  // Any non-204 status is a failure — extract the best error message available
   const data = parseJsonObj(text);
-  if (data?.message) {
-    logError(`Failed to destroy droplet ${id}: ${data.message}`);
-    logWarn("The droplet may still be running and incurring charges.");
-    logWarn(`Delete it manually at: ${DO_DASHBOARD_URL}`);
-    throw new Error("Droplet deletion failed");
-  }
-
-  logInfo(`Droplet ${id} destroyed`);
+  const errMsg = isString(data?.message) ? data.message : text.slice(0, 200) || `HTTP ${status}`;
+  logError(`Failed to destroy droplet ${id}: ${errMsg}`);
+  logWarn("The droplet may still be running and incurring charges.");
+  logWarn(`Delete it manually at: ${DO_DASHBOARD_URL}`);
+  throw new Error("Droplet deletion failed");
 }


### PR DESCRIPTION
**Why:** When `spawn delete` is used for a DigitalOcean droplet and the DELETE API returns a non-204 status with a response body that either (a) is not valid JSON, or (b) is JSON without a `message` field, `destroyServer()` falls through to the success path — logging "Droplet destroyed" and returning normally. The caller then marks the droplet as deleted in history while it is still running and incurring charges. The user has no way to know this unless they check the DigitalOcean dashboard manually.

## Changes

- `packages/cli/src/digitalocean/digitalocean.ts`: Replace the conditional error check + fallthrough success with an unconditional throw for all non-204 responses. Extracts the best available error message from the response body.

This is the same bug class fixed in Hetzner (#2105) and Daytona (#2102). The DigitalOcean provider was missed because its `doApi` returns `{status, text}` instead of throwing.

## Test plan

- [x] `bunx @biomejs/biome lint src/` — 0 errors
- [x] `bun test` — 1390 pass, 0 fail

-- refactor/code-health