### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/manifest-integrity.test.ts
+++ b/packages/cli/src/__tests__/manifest-integrity.test.ts
@@ -176,11 +176,9 @@ describe("Manifest Integrity", () => {
 
       for (const [key] of sample) {
         const scriptPath = join(REPO_ROOT, "sh", key + ".sh");
-        if (existsSync(scriptPath)) {
-          const content = readFileSync(scriptPath, "utf-8");
-          if (!content.trimStart().startsWith("#!")) {
-            badScripts.push(key + ".sh");
-          }
+        const content = readFileSync(scriptPath, "utf-8");
+        if (!content.trimStart().startsWith("#!")) {
+          badScripts.push(key + ".sh");
         }
       }
 
@@ -194,11 +192,9 @@ describe("Manifest Integrity", () => {
 
       for (const [key] of sample) {
         const scriptPath = join(REPO_ROOT, "sh", key + ".sh");
-        if (existsSync(scriptPath)) {
-          const content = readFileSync(scriptPath, "utf-8");
-          if (!content.includes("set -eo pipefail")) {
-            badScripts.push(key + ".sh");
-          }
+        const content = readFileSync(scriptPath, "utf-8");
+        if (!content.includes("set -eo pipefail")) {
+          badScripts.push(key + ".sh");
         }
       }
 


### PR DESCRIPTION
## Summary

- Removed conditional always-pass `existsSync` guards in `manifest-integrity.test.ts` script content validation tests
- The guards `if (existsSync(scriptPath))` silently skipped scripts not found on disk — but a prior test in the same `describe` block already asserts all implemented scripts exist, making these guards dead code that could mask failures
- Without the guards, the tests unconditionally read and validate every sampled script, giving real signal

## Findings

**Scanned all 44 test files** for anti-patterns:
- Duplicate describe blocks: Found only generic names (`edge cases`, `invalid inputs`, etc.) reused across different parent contexts — not true duplicates, each is appropriate in context
- Bash-grep tests (testing existence not behavior): None found — all tests call actual functions
- Always-pass conditionals: Found and fixed in `manifest-integrity.test.ts` (2 guarded loops)
- Excessive subprocess spawning: None — subprocess calls use `spyOn` mocks, not real spawning

## Test plan

- [x] `bun test` passes: 1390 pass, 0 fail
- [x] `biome lint` passes on modified file: no errors