### PR TITLE
fix(security): restrict OAuth auth code regex to alphanumeric only

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/oauth.ts
+++ b/packages/cli/src/shared/oauth.ts
@@ -115,7 +115,7 @@ async function tryOauthFlow(callbackPort = 5180, agentSlug?: string, cloudSlug?:
               });
             }
             // Validate code format
-            if (!/^[a-zA-Z0-9_-]{16,128}$/.test(code)) {
+            if (!/^[a-zA-Z0-9]{16,128}$/.test(code)) {
               return new Response("<html><body><h1>Invalid OAuth Code</h1></body></html>", {
                 status: 400,
                 headers: {


### PR DESCRIPTION
**Why:** Defense in depth - removes underscore/hyphen from OAuth auth code regex to prevent potential injection if code is used in non-JSON contexts (logging, metrics).

Fixes #2114

-- refactor/security-auditor