### PR TITLE
fix(security): quote timeout var and validate numeric in sprite.sh

### DIFF
--- a/sh/e2e/lib/clouds/sprite.sh
+++ b/sh/e2e/lib/clouds/sprite.sh
@@ -205,6 +205,13 @@ _sprite_exec_long() {
   local app="$1"
   local cmd="$2"
   local timeout="${3:-120}"
+
+  # Validate timeout is numeric to prevent command injection
+  if ! printf '%s' "${timeout}" | grep -qE '^[0-9]+$'; then
+    printf 'ERROR: timeout must be numeric, got: %s\n' "${timeout}" >&2
+    return 1
+  fi
+
   local _attempt=0
   local _max=3
   local _stderr_tmp="/tmp/sprite-execl-err.$$"
@@ -216,7 +223,7 @@ _sprite_exec_long() {
   while [ "${_attempt}" -lt "${_max}" ]; do
     _sprite_fix_config
     # shellcheck disable=SC2046
-    sprite $(_sprite_org_flags) exec -s "${app}" -- bash -c "timeout ${timeout} bash -c \"\$(printf '%s' '${encoded_cmd}' | base64 -d)\"" 2>"${_stderr_tmp}"
+    sprite $(_sprite_org_flags) exec -s "${app}" -- bash -c "timeout '${timeout}' bash -c \"\$(printf '%s' '${encoded_cmd}' | base64 -d)\"" 2>"${_stderr_tmp}"
     local _rc=$?
     if [ "${_rc}" -eq 0 ]; then
       rm -f "${_stderr_tmp}"


### PR DESCRIPTION
## Summary

- **Validate `timeout` is numeric** at the start of `_sprite_exec_long` — rejects non-numeric values immediately with an error
- **Quote `${timeout}`** as `'${timeout}'` in the nested `bash -c` command string to prevent shell interpretation

## Why

Unquoted `${timeout}` in `_sprite_exec_long` (line 219) allows command injection if timeout contains shell metacharacters (e.g., `120; malicious-command #`). The variable is interpolated inside a double-quoted string passed to `bash -c`, so metacharacters would be executed on the remote host.

Fixes #2117

-- refactor/security-auditor