### PR TITLE
fix(reliability): add curl download error handling to AWS and Hetzner shims

### DIFF
--- a/sh/aws/claude.sh
+++ b/sh/aws/claude.sh
@@ -28,5 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+    || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" claude "$@"

--- a/sh/aws/codex.sh
+++ b/sh/aws/codex.sh
@@ -28,5 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+    || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" codex "$@"

--- a/sh/aws/hermes.sh
+++ b/sh/aws/hermes.sh
@@ -28,5 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+    || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" hermes "$@"

--- a/sh/aws/kilocode.sh
+++ b/sh/aws/kilocode.sh
@@ -29,5 +29,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+    || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" kilocode "$@"

--- a/sh/aws/openclaw.sh
+++ b/sh/aws/openclaw.sh
@@ -28,5 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+    || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" openclaw "$@"

--- a/sh/aws/opencode.sh
+++ b/sh/aws/opencode.sh
@@ -28,5 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+    || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" opencode "$@"

--- a/sh/aws/zeroclaw.sh
+++ b/sh/aws/zeroclaw.sh
@@ -28,5 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+    || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" zeroclaw "$@"

--- a/sh/hetzner/claude.sh
+++ b/sh/hetzner/claude.sh
@@ -23,5 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+    || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" claude "$@"

--- a/sh/hetzner/codex.sh
+++ b/sh/hetzner/codex.sh
@@ -23,5 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+    || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" codex "$@"

--- a/sh/hetzner/hermes.sh
+++ b/sh/hetzner/hermes.sh
@@ -28,5 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+    || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" hermes "$@"

--- a/sh/hetzner/kilocode.sh
+++ b/sh/hetzner/kilocode.sh
@@ -23,5 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+    || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" kilocode "$@"

--- a/sh/hetzner/openclaw.sh
+++ b/sh/hetzner/openclaw.sh
@@ -23,5 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+    || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" openclaw "$@"

--- a/sh/hetzner/opencode.sh
+++ b/sh/hetzner/opencode.sh
@@ -23,5 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+    || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" opencode "$@"

--- a/sh/hetzner/zeroclaw.sh
+++ b/sh/hetzner/zeroclaw.sh
@@ -23,5 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS"
+curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+    || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" zeroclaw "$@"


### PR DESCRIPTION
## Summary

- Add missing `|| { printf '...Failed to download...' >&2; exit 1; }` error handlers to 14 agent shim scripts across `sh/aws/` (7 files) and `sh/hetzner/` (7 files)
- Without this fix, a failed curl download (network issue, 404, etc.) silently proceeds to `exec bun run` on an empty/corrupt file, producing confusing errors
- All other clouds (GCP, Daytona, DigitalOcean, Sprite) already had this pattern -- this brings AWS and Hetzner into consistency

## Files changed

**sh/aws/**: claude.sh, codex.sh, hermes.sh, kilocode.sh, opencode.sh, openclaw.sh, zeroclaw.sh
**sh/hetzner/**: claude.sh, codex.sh, hermes.sh, kilocode.sh, opencode.sh, openclaw.sh, zeroclaw.sh

## Test plan

- [x] `bash -n` syntax check passes on all 14 modified scripts
- [x] Pattern matches existing error handling in GCP/Daytona/DigitalOcean/Sprite shims
- [x] No TypeScript changes, so `bun test` and `biome lint` are unaffected

Agent: code-health