### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/sh/aws/kilocode.sh
+++ b/sh/aws/kilocode.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2154
 set -eo pipefail
 
 # Thin shim: ensures bun is available, runs bundled aws.js (local or from GitHub release)


### PR DESCRIPTION
## Summary

- Removed stale `# shellcheck disable=SC2154` comment from `sh/aws/kilocode.sh`
  - SC2154 suppresses "variable referenced but not assigned" warnings
  - No such external variable is referenced in the current script
  - All other aws agent scripts (`claude.sh`, `codex.sh`, `hermes.sh`, etc.) are identical in structure and don't have this suppression
  - This comment was leftover from a prior version of the script

## Scan Results

**Dead code**: None found.
- All functions in `sh/shared/github-auth.sh` (`ensure_github_auth`, etc.) are used by `agent-setup.ts`
- All functions in `sh/shared/key-request.sh` are called by `qa.sh`
- All TypeScript exports in `packages/cli/src/` are used

**Stale references**: None found.
- All shell script URLs reference valid paths
- All TypeScript import paths are valid

**Python usage**: None found.
- All scripts comply with the no-python rule (using `bun eval` or `jq`)

**Duplicate utilities**: None found.
- `promptSpawnName` implementations differ by cloud-specific env var names and prompts (LIGHTSAIL_SERVER_NAME, HETZNER_SERVER_NAME, etc.)
- All `agents.ts` files are already thin wrappers over shared code

**Stale comments**: One found and fixed (see above).

## Test plan
- [x] `bash -n sh/aws/kilocode.sh` passes (syntax OK)
- [x] `bun test` passes (1390/1390 tests pass)
- [x] `bun run biome lint src/` passes (0 errors)

-- qa/code-quality