### PR TITLE
test: fix always-pass cache test to assert fetch was not called

### DIFF
--- a/packages/cli/src/__tests__/manifest.test.ts
+++ b/packages/cli/src/__tests__/manifest.test.ts
@@ -132,7 +132,7 @@ describe("manifest", () => {
       });
       writeFileSync(env.cacheFile, JSON.stringify(mockManifest));
 
-      // Mock fetch (should not be called for fresh cache)
+      // Mock fetch — must NOT be called when cache is fresh
       global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
 
       const manifest = await loadManifest();
@@ -140,6 +140,7 @@ describe("manifest", () => {
       expect(manifest).toHaveProperty("agents");
       expect(manifest).toHaveProperty("clouds");
       expect(manifest).toHaveProperty("matrix");
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it("should refresh cache when forceRefresh is true", async () => {


### PR DESCRIPTION
## Summary

- Scanned all 44 test files in `packages/cli/src/__tests__/` for duplicate describe blocks, bash-grep anti-patterns, always-pass conditionals, and excessive subprocess spawning
- Found one always-pass pattern: the `"should use disk cache when fresh"` test in `manifest.test.ts` had a comment saying fetch "should not be called" but never asserted `expect(global.fetch).not.toHaveBeenCalled()`
- Fixed by adding the missing assertion — the test now actually verifies the cache path is taken

## Findings

**Duplicate describe blocks**: The "edge cases", "empty history (no records)", "valid inputs", and "invalid inputs" names appear in multiple files but always nested inside different outer `describe()` blocks — no true duplicates.

**Bash-grep tests**: None found. All tests call functions directly and check return values.

**Always-pass pattern**: 1 found and fixed — `manifest.test.ts` line 135 had a TODO-comment assertion that was never expressed in code.

**Subprocess spawning**: No excessive spawning found. The `update-check.test.ts` mocks `execSync` via `spyOn` (correct pattern); `ssh-keys.test.ts` mocks `Bun.spawnSync` (correct pattern).

**Note**: A larger cleanup (18 tests) was already done in the prior commit `7b650a01 test: Remove duplicate and theatrical tests (#2124)`.

## Test plan

- [x] `bun test` passes: 1372 pass, 0 fail
- [x] `bunx @biomejs/biome lint src/` passes with 0 errors

-- qa/dedup-scanner