### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/manifest-cache-lifecycle.test.ts
+++ b/packages/cli/src/__tests__/manifest-cache-lifecycle.test.ts
@@ -463,32 +463,23 @@ describe("Manifest Cache Lifecycle", () => {
       expect(agentKeys(manifest)).toContain("claude");
     });
 
-    it("should use fresh disk cache without calling fetch", async () => {
+    it("should return cached instance without calling fetch again", async () => {
       mkdirSync(join(env.testDir, "spawn"), {
         recursive: true,
       });
       writeFileSync(env.cacheFile, JSON.stringify(mockManifest));
-      // Cache is fresh (just written)
 
-      global.fetch = mock(() =>
-        Promise.resolve(
-          new Response(
-            JSON.stringify({
-              agents: {},
-              clouds: {},
-              matrix: {},
-            }),
-          ),
-        ),
-      );
+      const fetchMock = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
+      global.fetch = fetchMock;
 
-      // loadManifest(false) should check disk cache first
-      // Note: in-memory _cached may already be set from prior test, so we forceRefresh first
-      // to clear it, then test the non-forced path
-      const m1 = await loadManifest(true); // clears in-memory, fetches
-      // Now the in-memory cache is populated, so non-forced will return it
+      // loadManifest(true) populates in-memory cache, calls fetch once
+      const m1 = await loadManifest(true);
+      const callsAfterFirstLoad = fetchMock.mock.calls.length;
+
+      // loadManifest(false) returns in-memory cache without fetching again
       const m2 = await loadManifest(false);
-      expect(m2).toHaveProperty("agents");
+      expect(m2).toBe(m1);
+      expect(fetchMock.mock.calls.length).toBe(callsAfterFirstLoad);
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixed an always-pass test in `manifest-cache-lifecycle.test.ts`: the test named "should use fresh disk cache without calling fetch" only asserted `toHaveProperty("agents")`, which would pass even if fetch was called a second time
- Renamed the test to "should return cached instance without calling fetch again" to accurately describe what it verifies
- Added two real assertions: `expect(m2).toBe(m1)` (same reference) and `expect(fetchMock.mock.calls.length).toBe(callsAfterFirstLoad)` (fetch not called again)

## Scan Results

Scanned all 44 test files in `packages/cli/src/__tests__/` for:

- **Duplicate describe blocks**: No duplicates of the same function in multiple files found. Generic nested names ("edge cases", "valid inputs") are all under distinct top-level describes.
- **Bash-grep tests**: None found. No tests use `type FUNCTION_NAME` or grep function body.
- **Always-pass patterns**: One found and fixed — the in-memory cache lifecycle test described above.
- **Excessive subprocess spawning**: None found. `Bun.spawnSync` and `execSync` are only used via `spyOn` mocks, not real invocations.

## Test plan

- [x] `bun test` passes: 1372 pass, 0 fail before and after change
- [x] `biome lint src/` passes with zero errors

-- qa/dedup-scanner