### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/cmdlast.test.ts
+++ b/packages/cli/src/__tests__/cmdlast.test.ts
@@ -113,14 +113,6 @@ describe("cmdLast", () => {
       expect(info).toMatch(/<cloud>/);
     });
 
-    it("should not call cmdRun when no history exists", async () => {
-      await cmdLast();
-
-      // cmdRunMock should not have been called (would need to be spied on in actual code)
-      const info = logInfoOutput();
-      expect(info).toContain("No spawn history found");
-    });
-
     it("should handle corrupted history file gracefully", async () => {
       writeFileSync(join(testDir, "history.json"), "not valid json{{{");
 

--- a/packages/cli/src/__tests__/manifest-type-contracts.test.ts
+++ b/packages/cli/src/__tests__/manifest-type-contracts.test.ts
@@ -293,11 +293,10 @@ describe("Agent launch command consistency", () => {
 
 describe("Interactive prompts structure", () => {
   it("all interactive_prompts entries should have non-empty prompt text and string defaults", () => {
-    for (const [, agent] of allAgents) {
-      if (agent.interactive_prompts === undefined) {
-        continue;
-      }
-      for (const [, entry] of Object.entries(agent.interactive_prompts)) {
+    const agentsWithInteractivePrompts = allAgents.filter(([, agent]) => agent.interactive_prompts !== undefined);
+    expect(agentsWithInteractivePrompts.length).toBeGreaterThan(0);
+    for (const [, agent] of agentsWithInteractivePrompts) {
+      for (const [, entry] of Object.entries(agent.interactive_prompts!)) {
         expect(entry.prompt.trim().length).toBeGreaterThan(0);
         expect(entry.default).toBeDefined();
         expect(typeof entry.default).toBe("string");
@@ -387,11 +386,10 @@ describe("Agent metadata field types", () => {
 
 describe("Config files structure", () => {
   it("config file paths should look like file paths and values should be objects", () => {
-    for (const [, agent] of allAgents) {
-      if (agent.config_files === undefined) {
-        continue;
-      }
-      for (const [filePath, content] of Object.entries(agent.config_files)) {
+    const agentsWithConfigFiles = allAgents.filter(([, agent]) => agent.config_files !== undefined);
+    expect(agentsWithConfigFiles.length).toBeGreaterThan(0);
+    for (const [, agent] of agentsWithConfigFiles) {
+      for (const [filePath, content] of Object.entries(agent.config_files!)) {
         // Should contain / or ~ or . indicating a path
         expect(filePath).toMatch(/[/~.]/);
         expect(typeof content).toBe("object");


### PR DESCRIPTION
## Summary

- **Removes** one theatrical test in `cmdlast.test.ts`: "should not call cmdRun when no history exists" — its own comment admitted it could not actually verify whether `cmdRun` was called, and its only assertion (`expect(info).toContain("No spawn history found")`) was identical to the preceding test in the same describe block. Zero additional signal.

- **Fixes** two always-pass risks in `manifest-type-contracts.test.ts`: "Interactive prompts structure" and "Config files structure" both iterated over optional agent fields with `continue` when the field was absent. If no agents in the manifest had those fields, both tests would pass vacuously. Added `expect(agentsWithX.length).toBeGreaterThan(0)` guards — matching the exact pattern already used by sibling tests (`agentsWithPreLaunch`, `agentsWithNotes`, etc.) in the same file.

## Test plan

- [x] `bun test` passes with same 646/51 pass/fail split as baseline (pre-existing failures unrelated to this PR)
- [x] Net change: 1 test removed (theatrical duplicate), 2 expect() calls added (guard assertions)
- [x] `bun x @biomejs/biome lint` passes on changed files with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)