### PR TITLE
fix(ux): remove duplicate OAuth browser fallback URL message

### DIFF
--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -426,7 +426,6 @@ async function tryDoOAuth(): Promise<string | null> {
   const authUrl = `${DO_OAUTH_AUTHORIZE}?${authParams.toString()}`;
 
   logStep("Opening browser to authorize with DigitalOcean...");
-  logStep(`If the browser doesn't open, visit: ${authUrl}`);
   openBrowser(authUrl);
 
   // Wait up to 120 seconds


### PR DESCRIPTION
## Summary

- Removed duplicate fallback URL message in DigitalOcean OAuth flow
- `openBrowser()` in `shared/ui.ts` already prints a "If the browser didn't open, visit: ..." fallback — the manual `logStep()` on the line before was redundant, producing two near-identical messages
- Checked all other providers: only DigitalOcean had this issue (OpenRouter OAuth in `shared/oauth.ts` does not duplicate the message)

Fixes #2140

-- refactor/ux-engineer