### PR TITLE
fix(ux): stop spinner before credential prompts during delete

### DIFF
--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -19,6 +19,55 @@ import { destroyServer as spriteDestroyServer, ensureSpriteCli, ensureSpriteAuth
 import { getErrorMessage, isInteractiveTTY } from "./shared.js";
 import { resolveListFilters, activeServerPicker } from "./list.js";
 
+/**
+ * Ensure credentials are available for a record's cloud provider.
+ * This may prompt the user interactively and must be called BEFORE
+ * starting any spinner to avoid overlapping UI elements.
+ */
+export async function ensureDeleteCredentials(record: SpawnRecord): Promise<void> {
+  const conn = record.connection;
+  if (!conn?.cloud || conn.cloud === "local") {
+    return;
+  }
+
+  switch (conn.cloud) {
+    case "hetzner":
+      await ensureHcloudToken();
+      break;
+    case "digitalocean":
+      await ensureDoToken();
+      break;
+    case "gcp": {
+      const zone = conn.metadata?.zone || "us-central1-a";
+      const project = conn.metadata?.project || "";
+      validateMetadataValue(zone, "GCP zone");
+      if (project) {
+        validateMetadataValue(project, "GCP project");
+      }
+      process.env.GCP_ZONE = zone;
+      if (project) {
+        process.env.GCP_PROJECT = project;
+      }
+      await gcpEnsureGcloudCli();
+      await gcpAuthenticate();
+      break;
+    }
+    case "aws":
+      await ensureAwsCli();
+      await awsAuthenticate();
+      break;
+    case "daytona":
+      await ensureDaytonaToken();
+      break;
+    case "sprite":
+      await ensureSpriteCli();
+      await ensureSpriteAuthenticated();
+      break;
+    default:
+      break;
+  }
+}
+
 /** Execute server deletion for a given record using TypeScript cloud modules */
 export async function execDeleteServer(record: SpawnRecord): Promise<boolean> {
   const conn = record.connection;
@@ -147,6 +196,10 @@ export async function confirmAndDelete(record: SpawnRecord, manifest: Manifest |
     p.log.info("Delete cancelled.");
     return false;
   }
+
+  // Ensure credentials before starting the spinner so interactive
+  // prompts (e.g. expired API key entry) don't overlap with it.
+  await ensureDeleteCredentials(record);
 
   const s = p.spinner();
   s.start(`Deleting ${label}...`);


### PR DESCRIPTION
## Summary

When credentials expire during server deletion, the spinner/working indicator was running simultaneously with interactive credential prompts, creating a confusing UI where both a prompt and a spinner were shown at the same time.

**Root cause:** `confirmAndDelete()` started the spinner before calling `execDeleteServer()`, which internally calls credential-ensuring functions (`ensureAwsCli`, `awsAuthenticate`, `ensureHcloudToken`, etc.) that may interactively prompt the user.

**Fix:** Extract `ensureDeleteCredentials()` that runs all credential checks (which may prompt) before starting the spinner. The credential functions are idempotent, so when `execDeleteServer()` calls them again inside the spinner, they return immediately since credentials are already validated.

All 6 cloud providers are covered: AWS, Hetzner, DigitalOcean, GCP, Daytona, and Sprite.

Fixes #2141

-- refactor/code-health