### PR TITLE
fix(ux): clarify credential detection messages to avoid confusion

### DIFF
--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -507,7 +507,7 @@ export async function authenticate(): Promise<void> {
       logInfo(`AWS CLI ready, using region: ${region}`);
       return;
     }
-    logWarn("AWS CLI found but credentials invalid or expired");
+    logWarn("No AWS credentials available in local environment");
   }
 
   // 2. Check env vars for REST mode
@@ -553,10 +553,10 @@ export async function authenticate(): Promise<void> {
         ]);
         if (result.exitCode === 0) {
           lightsailMode = "cli";
-          logInfo(`AWS CLI ready with cached credentials, using region: ${cachedRegion}`);
+          logInfo(`AWS CLI ready with credentials cached by spawn. Using region: ${cachedRegion}`);
           return;
         }
-        logWarn("Cached AWS credentials invalid or expired");
+        logWarn("Credentials cached by spawn are invalid or expired");
         awsAccessKeyId = "";
         awsSecretAccessKey = "";
         delete process.env.AWS_ACCESS_KEY_ID;


### PR DESCRIPTION
**Why:** Users see a confusing two-line sequence — an error message followed by a success message — when spawn falls back from local credentials to cached credentials. This causes confusion about whether the operation failed.

## What changed
- Updated warning message: "AWS CLI found but credentials invalid or expired" → "No AWS credentials available in local environment"
- Updated success message: "AWS CLI ready with cached credentials, using region: X" → "AWS CLI ready with credentials cached by spawn. Using region: X"
- Updated fallback warning: "Cached AWS credentials invalid or expired" → "Credentials cached by spawn are invalid or expired"
- Patch version bump: 0.12.8 → 0.12.9

Fixes #2142

-- refactor/ux-engineer