### PR TITLE
fix(e2e): correct provision.sh fallback .spawnrc env vars for zeroclaw, hermes, kilocode

### DIFF
--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -160,8 +160,18 @@ CLOUD_ENV
     zeroclaw)
       {
         printf 'export ZEROCLAW_PROVIDER=%q\n' "openrouter"
-        printf 'export OPENAI_API_KEY=%q\n' "${api_key}"
+      } >> "${env_tmp}"
+      ;;
+    hermes)
+      {
         printf 'export OPENAI_BASE_URL=%q\n' "https://openrouter.ai/api/v1"
+        printf 'export OPENAI_API_KEY=%q\n' "${api_key}"
+      } >> "${env_tmp}"
+      ;;
+    kilocode)
+      {
+        printf 'export KILO_PROVIDER_TYPE=%q\n' "openrouter"
+        printf 'export KILO_OPEN_ROUTER_API_KEY=%q\n' "${api_key}"
       } >> "${env_tmp}"
       ;;
   esac


### PR DESCRIPTION
## Summary

- Fixed `zeroclaw` case in provision.sh fallback: removed wrongly-included `OPENAI_API_KEY` and `OPENAI_BASE_URL` (these are hermes env vars, not zeroclaw's)
- Added missing `hermes` case: sets `OPENAI_BASE_URL=https://openrouter.ai/api/v1` and `OPENAI_API_KEY` — required for `verify_hermes` to pass the `OPENAI_BASE_URL` check
- Added missing `kilocode` case: sets `KILO_PROVIDER_TYPE=openrouter` and `KILO_OPEN_ROUTER_API_KEY` — required for `verify_kilocode` to pass the `KILO_PROVIDER_TYPE` check

## Context

The fallback `.spawnrc` construction in `provision.sh` is used when provisioning times out before the CLI writes `.spawnrc` normally. The fallback must match each agent's `envVars()` output from `agent-setup.ts`. The `zeroclaw` case contained env vars that belong to `hermes`, and `hermes`/`kilocode` were absent entirely.

## Test plan

- [ ] Verify `bash -n sh/e2e/lib/provision.sh` passes (syntax check)
- [ ] Cross-check each agent's case against `envVars()` in `packages/cli/src/shared/agent-setup.ts`
- [ ] Run full AWS E2E suite when credentials are available: `./sh/e2e/aws-e2e.sh --parallel 6`

-- qa/e2e-tester