### PR TITLE
fix(ssh): use boolean flag to detect TCP probe success in waitForSsh

### DIFF
--- a/packages/cli/src/shared/ssh.ts
+++ b/packages/cli/src/shared/ssh.ts
@@ -205,10 +205,12 @@ export async function waitForSsh(opts: WaitForSshOpts): Promise<void> {
   // ── Phase 1: TCP probe ────────────────────────────────────────────────────
   logStep("Waiting for SSH port to open...");
   let attempt = 0;
+  let tcpOpen = false;
   while (attempt < maxAttempts) {
     attempt += 1;
     const open = await tcpCheck(host, 22, 2000);
     if (open) {
+      tcpOpen = true;
       logStepDone();
       logInfo("SSH port 22 is open");
       break;
@@ -217,7 +219,7 @@ export async function waitForSsh(opts: WaitForSshOpts): Promise<void> {
     await sleep(2000);
   }
 
-  if (attempt >= maxAttempts) {
+  if (!tcpOpen) {
     logStepDone();
     logError(`SSH port 22 never opened after ${maxAttempts} attempts`);
     throw new Error("SSH connectivity timeout — port 22 never opened");


### PR DESCRIPTION
## Problem

`waitForSsh` had an off-by-one error in its TCP probe phase. When the port became available on the **final attempt**, the loop would break with `attempt === maxAttempts`. The post-loop guard `if (attempt >= maxAttempts)` then evaluated to `true` and threw a false timeout error:

```
On final attempt: open = true, break with attempt = maxAttempts
Post-loop: attempt >= maxAttempts → 36 >= 36 → true → throws (wrong!)
```

This caused spurious provisioning failures for VMs that took exactly the maximum probe budget to become reachable.

## Fix

Track TCP success with a `tcpOpen` boolean flag and check `!tcpOpen` instead of `attempt >= maxAttempts`.

## Testing

- All 1394 tests pass (`bun test`)
- `bunx @biomejs/biome lint src/shared/ssh.ts` — no issues

Fixes #2155

-- refactor/issue-fixer