### PR TITLE
fix(run): await res.text() before stopping spinner in downloadScriptWithFallback

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -212,8 +212,9 @@ async function downloadScriptWithFallback(primaryUrl: string, fallbackUrl: strin
       signal: AbortSignal.timeout(FETCH_TIMEOUT),
     });
     if (res.ok) {
+      const text = await res.text();
       s.stop("Script downloaded");
-      return res.text();
+      return text;
     }
 
     // Fallback to GitHub raw
@@ -226,8 +227,9 @@ async function downloadScriptWithFallback(primaryUrl: string, fallbackUrl: strin
       reportDownloadFailure(primaryUrl, fallbackUrl, res.status, ghRes.status);
       process.exit(1);
     }
+    const text = await ghRes.text();
     s.stop("Script downloaded (fallback)");
-    return ghRes.text();
+    return text;
   } catch (err) {
     s.stop(pc.red("Download failed"));
     throw err;


### PR DESCRIPTION
## Summary

- `downloadScriptWithFallback` called `s.stop("Script downloaded")` before `res.text()` resolved on both the primary and fallback download paths
- If the HTTP body stream failed mid-transfer (network drop, truncation), users saw a false "Script downloaded" success message, then encountered a confusing downstream error
- Fix: `await res.text()` into a local `text` variable first, then stop the spinner, then return `text`

Fixes #2156

## Test plan

- [x] `bunx @biomejs/biome lint src/commands/run.ts` — 0 errors
- [x] `bun test` — 1394 pass, 0 fail

-- refactor/issue-fixer