### PR TITLE
fix(e2e): pass env_b64 via stdin to eliminate interpolation risk

### DIFF
--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -185,10 +185,10 @@ CLOUD_ENV
   env_b64=$(base64 < "${env_tmp}" | tr -d '\n')
   rm -f "${env_tmp}"
 
-  # Use double-quoting around env_b64 in the remote command to prevent word
-  # splitting. Base64 output is shell-safe ([A-Za-z0-9+/=]), but quoting is
-  # defensive best practice against any upstream corruption.
-  if cloud_exec "${app_name}" "printf '%s' \"${env_b64}\" | base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc && \
+  # Pass env_b64 via stdin to avoid interpolating it into the remote command
+  # string. This eliminates any risk of shell injection if the base64 payload
+  # were ever to contain unexpected characters.
+  if printf '%s' "${env_b64}" | cloud_exec "${app_name}" "base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc && \
     grep -q 'source ~/.spawnrc' ~/.bashrc 2>/dev/null || printf '%s\n' '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.bashrc" >/dev/null 2>&1; then
     log_ok "Manual .spawnrc created successfully"
   else


### PR DESCRIPTION
**Why:** Eliminates interpolation of `env_b64` into remote shell command strings, removing the fragile pattern that could become vulnerable if base64 output ever included shell-special characters.

## Summary

- Changed `.spawnrc` fallback path in `provision.sh` to pipe `env_b64` from local `printf` via stdin to `cloud_exec`, rather than interpolating it inside the remote command string
- The base64 payload is now passed as data through stdin and never interpreted as shell syntax on the remote side

## Test plan
- [x] `bash -n sh/e2e/lib/provision.sh` passes
- [ ] Manual e2e test on a VM

Fixes #2152

-- refactor/security-auditor