### PR TITLE
fix(security): add --proto '=https' to all curl executable downloads

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/sh/aws/claude.sh
+++ b/sh/aws/claude.sh
@@ -28,6 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
     || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" claude "$@"

--- a/sh/aws/codex.sh
+++ b/sh/aws/codex.sh
@@ -28,6 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
     || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" codex "$@"

--- a/sh/aws/hermes.sh
+++ b/sh/aws/hermes.sh
@@ -28,6 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
     || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" hermes "$@"

--- a/sh/aws/kilocode.sh
+++ b/sh/aws/kilocode.sh
@@ -28,6 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
     || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" kilocode "$@"

--- a/sh/aws/openclaw.sh
+++ b/sh/aws/openclaw.sh
@@ -28,6 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
     || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" openclaw "$@"

--- a/sh/aws/opencode.sh
+++ b/sh/aws/opencode.sh
@@ -28,6 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
     || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" opencode "$@"

--- a/sh/aws/zeroclaw.sh
+++ b/sh/aws/zeroclaw.sh
@@ -28,6 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 AWS_JS=$(mktemp)
 trap 'rm -f "$AWS_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/aws-latest/aws.js" -o "$AWS_JS" \
     || { printf '\033[0;31mFailed to download aws.js\033[0m\n' >&2; exit 1; }
 exec bun run "$AWS_JS" zeroclaw "$@"

--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -198,7 +198,7 @@ build_and_install() {
     trap 'rm -rf "${tmpdir}"' EXIT
 
     log_step "Downloading pre-built CLI binary..."
-    curl -fsSL "https://github.com/${SPAWN_REPO}/releases/download/cli-latest/cli.js" -o "${tmpdir}/cli.js"
+    curl -fsSL --proto '=https' "https://github.com/${SPAWN_REPO}/releases/download/cli-latest/cli.js" -o "${tmpdir}/cli.js"
     if [ ! -s "${tmpdir}/cli.js" ]; then
         log_error "Failed to download pre-built binary"
         exit 1

--- a/sh/daytona/claude.sh
+++ b/sh/daytona/claude.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled daytona.js from GitHub release
 DAYTONA_JS=$(mktemp)
 trap 'rm -f "$DAYTONA_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
     || { printf '\033[0;31mFailed to download daytona.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$DAYTONA_JS" claude "$@"

--- a/sh/daytona/codex.sh
+++ b/sh/daytona/codex.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled daytona.js from GitHub release
 DAYTONA_JS=$(mktemp)
 trap 'rm -f "$DAYTONA_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
     || { printf '\033[0;31mFailed to download daytona.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$DAYTONA_JS" codex "$@"

--- a/sh/daytona/hermes.sh
+++ b/sh/daytona/hermes.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled daytona.js from GitHub release
 DAYTONA_JS=$(mktemp)
 trap 'rm -f "$DAYTONA_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
     || { printf '\033[0;31mFailed to download daytona.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$DAYTONA_JS" hermes "$@"

--- a/sh/daytona/kilocode.sh
+++ b/sh/daytona/kilocode.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled daytona.js from GitHub release
 DAYTONA_JS=$(mktemp)
 trap 'rm -f "$DAYTONA_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
     || { printf '\033[0;31mFailed to download daytona.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$DAYTONA_JS" kilocode "$@"

--- a/sh/daytona/openclaw.sh
+++ b/sh/daytona/openclaw.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled daytona.js from GitHub release
 DAYTONA_JS=$(mktemp)
 trap 'rm -f "$DAYTONA_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
     || { printf '\033[0;31mFailed to download daytona.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$DAYTONA_JS" openclaw "$@"

--- a/sh/daytona/opencode.sh
+++ b/sh/daytona/opencode.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled daytona.js from GitHub release
 DAYTONA_JS=$(mktemp)
 trap 'rm -f "$DAYTONA_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
     || { printf '\033[0;31mFailed to download daytona.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$DAYTONA_JS" opencode "$@"

--- a/sh/daytona/zeroclaw.sh
+++ b/sh/daytona/zeroclaw.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled daytona.js from GitHub release
 DAYTONA_JS=$(mktemp)
 trap 'rm -f "$DAYTONA_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/daytona-latest/daytona.js" -o "$DAYTONA_JS" \
     || { printf '\033[0;31mFailed to download daytona.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$DAYTONA_JS" zeroclaw "$@"

--- a/sh/gcp/claude.sh
+++ b/sh/gcp/claude.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled gcp.js from GitHub release
 GCP_JS=$(mktemp)
 trap 'rm -f "$GCP_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
     || { printf '\033[0;31mFailed to download gcp.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$GCP_JS" claude "$@"

--- a/sh/gcp/codex.sh
+++ b/sh/gcp/codex.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled gcp.js from GitHub release
 GCP_JS=$(mktemp)
 trap 'rm -f "$GCP_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
     || { printf '\033[0;31mFailed to download gcp.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$GCP_JS" codex "$@"

--- a/sh/gcp/hermes.sh
+++ b/sh/gcp/hermes.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled gcp.js from GitHub release
 GCP_JS=$(mktemp)
 trap 'rm -f "$GCP_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
     || { printf '\033[0;31mFailed to download gcp.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$GCP_JS" hermes "$@"

--- a/sh/gcp/kilocode.sh
+++ b/sh/gcp/kilocode.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled gcp.js from GitHub release
 GCP_JS=$(mktemp)
 trap 'rm -f "$GCP_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
     || { printf '\033[0;31mFailed to download gcp.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$GCP_JS" kilocode "$@"

--- a/sh/gcp/openclaw.sh
+++ b/sh/gcp/openclaw.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled gcp.js from GitHub release
 GCP_JS=$(mktemp)
 trap 'rm -f "$GCP_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
     || { printf '\033[0;31mFailed to download gcp.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$GCP_JS" openclaw "$@"

--- a/sh/gcp/opencode.sh
+++ b/sh/gcp/opencode.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled gcp.js from GitHub release
 GCP_JS=$(mktemp)
 trap 'rm -f "$GCP_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
     || { printf '\033[0;31mFailed to download gcp.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$GCP_JS" opencode "$@"

--- a/sh/gcp/zeroclaw.sh
+++ b/sh/gcp/zeroclaw.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled gcp.js from GitHub release
 GCP_JS=$(mktemp)
 trap 'rm -f "$GCP_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/gcp-latest/gcp.js" -o "$GCP_JS" \
     || { printf '\033[0;31mFailed to download gcp.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$GCP_JS" zeroclaw "$@"

--- a/sh/hetzner/claude.sh
+++ b/sh/hetzner/claude.sh
@@ -23,6 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
     || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" claude "$@"

--- a/sh/hetzner/codex.sh
+++ b/sh/hetzner/codex.sh
@@ -23,6 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
     || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" codex "$@"

--- a/sh/hetzner/hermes.sh
+++ b/sh/hetzner/hermes.sh
@@ -28,6 +28,6 @@ fi
 # Remote — download and run compiled TypeScript bundle
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
     || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" hermes "$@"

--- a/sh/hetzner/kilocode.sh
+++ b/sh/hetzner/kilocode.sh
@@ -23,6 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
     || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" kilocode "$@"

--- a/sh/hetzner/openclaw.sh
+++ b/sh/hetzner/openclaw.sh
@@ -23,6 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
     || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" openclaw "$@"

--- a/sh/hetzner/opencode.sh
+++ b/sh/hetzner/opencode.sh
@@ -23,6 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
     || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" opencode "$@"

--- a/sh/hetzner/zeroclaw.sh
+++ b/sh/hetzner/zeroclaw.sh
@@ -23,6 +23,6 @@ fi
 
 HETZNER_JS=$(mktemp)
 trap 'rm -f "$HETZNER_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/hetzner-latest/hetzner.js" -o "$HETZNER_JS" \
     || { printf '\033[0;31mFailed to download hetzner.js\033[0m\n' >&2; exit 1; }
 exec bun run "$HETZNER_JS" zeroclaw "$@"

--- a/sh/local/claude.sh
+++ b/sh/local/claude.sh
@@ -23,7 +23,7 @@ fi
 # Remote — download bundled local.js from GitHub release
 LOCAL_JS=$(mktemp)
 trap 'rm -f "$LOCAL_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
     || { printf '\033[0;31mFailed to download local.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$LOCAL_JS" claude "$@"

--- a/sh/local/codex.sh
+++ b/sh/local/codex.sh
@@ -23,7 +23,7 @@ fi
 # Remote — download bundled local.js from GitHub release
 LOCAL_JS=$(mktemp)
 trap 'rm -f "$LOCAL_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
     || { printf '\033[0;31mFailed to download local.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$LOCAL_JS" codex "$@"

--- a/sh/local/hermes.sh
+++ b/sh/local/hermes.sh
@@ -23,7 +23,7 @@ fi
 # Remote — download bundled local.js from GitHub release
 LOCAL_JS=$(mktemp)
 trap 'rm -f "$LOCAL_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
     || { printf '\033[0;31mFailed to download local.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$LOCAL_JS" hermes "$@"

--- a/sh/local/kilocode.sh
+++ b/sh/local/kilocode.sh
@@ -23,7 +23,7 @@ fi
 # Remote — download bundled local.js from GitHub release
 LOCAL_JS=$(mktemp)
 trap 'rm -f "$LOCAL_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
     || { printf '\033[0;31mFailed to download local.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$LOCAL_JS" kilocode "$@"

--- a/sh/local/openclaw.sh
+++ b/sh/local/openclaw.sh
@@ -23,7 +23,7 @@ fi
 # Remote — download bundled local.js from GitHub release
 LOCAL_JS=$(mktemp)
 trap 'rm -f "$LOCAL_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
     || { printf '\033[0;31mFailed to download local.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$LOCAL_JS" openclaw "$@"

--- a/sh/local/opencode.sh
+++ b/sh/local/opencode.sh
@@ -23,7 +23,7 @@ fi
 # Remote — download bundled local.js from GitHub release
 LOCAL_JS=$(mktemp)
 trap 'rm -f "$LOCAL_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
     || { printf '\033[0;31mFailed to download local.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$LOCAL_JS" opencode "$@"

--- a/sh/local/zeroclaw.sh
+++ b/sh/local/zeroclaw.sh
@@ -23,7 +23,7 @@ fi
 # Remote — download bundled local.js from GitHub release
 LOCAL_JS=$(mktemp)
 trap 'rm -f "$LOCAL_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/local-latest/local.js" -o "$LOCAL_JS" \
     || { printf '\033[0;31mFailed to download local.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$LOCAL_JS" zeroclaw "$@"

--- a/sh/shared/github-auth.sh
+++ b/sh/shared/github-auth.sh
@@ -42,7 +42,7 @@ _install_gh_apt() {
     if [[ "$(id -u)" -ne 0 ]]; then SUDO="sudo"; fi
 
     log_info "Adding GitHub CLI APT repository..."
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    curl -fsSL --proto '=https' https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         | ${SUDO} dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
     ${SUDO} chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
     printf 'deb [arch=%s signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n' \
@@ -130,7 +130,7 @@ _detect_gh_platform() {
 # Fetch the latest gh release version string from GitHub API
 _fetch_gh_latest_version() {
     local latest_version
-    latest_version=$(curl -fsSL "https://api.github.com/repos/cli/cli/releases/latest" \
+    latest_version=$(curl -fsSL --proto '=https' "https://api.github.com/repos/cli/cli/releases/latest" \
         | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/') || {
         log_error "Failed to fetch latest gh release version"
         return 1
@@ -156,7 +156,7 @@ _download_and_install_gh() {
     local tmpdir
     tmpdir=$(mktemp -d)
 
-    curl -fsSL "${url}" -o "${tmpdir}/${tarball}" || {
+    curl -fsSL --proto '=https' "${url}" -o "${tmpdir}/${tarball}" || {
         log_error "Failed to download ${url}"
         rm -rf "${tmpdir}"
         return 1

--- a/sh/sprite/claude.sh
+++ b/sh/sprite/claude.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled sprite.js from GitHub release
 SPRITE_JS=$(mktemp)
 trap 'rm -f "$SPRITE_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
     || { printf '\033[0;31mFailed to download sprite.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$SPRITE_JS" claude "$@"

--- a/sh/sprite/codex.sh
+++ b/sh/sprite/codex.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled sprite.js from GitHub release
 SPRITE_JS=$(mktemp)
 trap 'rm -f "$SPRITE_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
     || { printf '\033[0;31mFailed to download sprite.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$SPRITE_JS" codex "$@"

--- a/sh/sprite/hermes.sh
+++ b/sh/sprite/hermes.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled sprite.js from GitHub release
 SPRITE_JS=$(mktemp)
 trap 'rm -f "$SPRITE_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
     || { printf '\033[0;31mFailed to download sprite.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$SPRITE_JS" hermes "$@"

--- a/sh/sprite/kilocode.sh
+++ b/sh/sprite/kilocode.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled sprite.js from GitHub release
 SPRITE_JS=$(mktemp)
 trap 'rm -f "$SPRITE_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
     || { printf '\033[0;31mFailed to download sprite.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$SPRITE_JS" kilocode "$@"

--- a/sh/sprite/openclaw.sh
+++ b/sh/sprite/openclaw.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled sprite.js from GitHub release
 SPRITE_JS=$(mktemp)
 trap 'rm -f "$SPRITE_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
     || { printf '\033[0;31mFailed to download sprite.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$SPRITE_JS" openclaw "$@"

--- a/sh/sprite/opencode.sh
+++ b/sh/sprite/opencode.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled sprite.js from GitHub release
 SPRITE_JS=$(mktemp)
 trap 'rm -f "$SPRITE_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
     || { printf '\033[0;31mFailed to download sprite.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$SPRITE_JS" opencode "$@"

--- a/sh/sprite/zeroclaw.sh
+++ b/sh/sprite/zeroclaw.sh
@@ -28,7 +28,7 @@ fi
 # Remote — download bundled sprite.js from GitHub release
 SPRITE_JS=$(mktemp)
 trap 'rm -f "$SPRITE_JS"' EXIT
-curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
     || { printf '\033[0;31mFailed to download sprite.js\033[0m\n' >&2; exit 1; }
 
 exec bun run "$SPRITE_JS" zeroclaw "$@"


### PR DESCRIPTION
**Why:** 42 curl calls that download executable code (JS bundles, CLI binaries, gh CLI tarballs) were missing \`--proto '=https'\` protocol enforcement. Without it, curl may follow redirects to non-HTTPS URLs on hostile networks (DNS hijacking, MITM proxy), allowing an attacker to serve malicious code that is immediately executed. PR #2138 fixed bun installer calls; this closes the remaining gap.

## Summary

- Added \`--proto '=https'\` to the JS bundle download curl call in all 42 agent scripts across 6 clouds (sprite, aws, gcp, hetzner, daytona, local)
- Fixed \`sh/cli/install.sh\` — the curl call downloading \`cli.js\` from GitHub releases
- Fixed \`sh/shared/github-auth.sh\` — 3 curl calls: APT keyring download, GitHub API version fetch, and gh CLI tarball download
- Bumped CLI version to 0.12.13 (patch)
- Total: 45 files changed, all 44 curl executable downloads now hardened against protocol downgrade

## Test plan
- [x] \`bash -n\` passes on all 44 modified shell scripts (0 syntax errors)
- [x] Pattern matches digitalocean scripts (already had the fix — used as reference)
- [x] Verified no remaining unprotected \`curl -fsSL "https://github.com/OpenRouterTeam/spawn/releases\` calls in non-digitalocean scripts

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>