### PR TITLE
refactor: Remove stale comment listing untested functions in run-path test

### DIFF
--- a/packages/cli/src/__tests__/run-path-credential-display.test.ts
+++ b/packages/cli/src/__tests__/run-path-credential-display.test.ts
@@ -3,18 +3,11 @@ import { mockClackPrompts } from "./test-helpers";
 import type { Manifest } from "../manifest";
 
 /**
- * Tests for critical-path functions in the `spawn <agent> <cloud>` run flow
- * that had ZERO test coverage:
+ * Tests for critical-path functions in the `spawn <agent> <cloud>` run flow:
  *
  * - prioritizeCloudsByCredentials: sorts clouds by credential availability,
  *   builds hint overrides, counts clouds with credentials
- * - buildCredentialStatusLines: builds credential status lines for dry-run preview
- * - formatAuthVarLine: formats individual auth env var display lines
- * - validateRunSecurity: validates agent/cloud/prompt before execution
- * - validateEntities: validates agent + cloud exist in manifest before execution
- *
- * These functions are all in the hot path of cmdRun (the primary CLI flow).
- * A bug in any of them breaks the user experience for every spawn invocation.
+ * - isRetryableExitCode: identifies exit codes that warrant a retry suggestion
  */
 
 // ── Test manifest ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Removed stale block comment in `run-path-credential-display.test.ts` that listed four functions (`buildCredentialStatusLines`, `formatAuthVarLine`, `validateRunSecurity`, `validateEntities`) not actually imported or tested in the file
- Updated comment to accurately reflect the two functions that are tested: `prioritizeCloudsByCredentials` and `isRetryableExitCode`

## Findings
- Dead code removed: 0 items (no executable dead code found)
- Stale references fixed: 1 (misleading test file comment)
- Python replaced with bun/jq: 0 (none found)
- Duplicate utils consolidated: 0 (intentional local copies in packages/cli/src/shared vs packages/shared/src)

## Notes
Full scan performed across:
- All 64 shell scripts in `sh/` — no python usage, no banned patterns, no stale file references
- All TypeScript in `packages/cli/src/` — biome lint clean (0 errors), all 1393 tests passing
- All exported functions verified to have callers or be intentionally exported as library API

-- qa/code-quality