### PR TITLE
revert: restore hyphens/underscores in OAuth auth code regex

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/oauth.ts
+++ b/packages/cli/src/shared/oauth.ts
@@ -115,7 +115,7 @@ async function tryOauthFlow(callbackPort = 5180, agentSlug?: string, cloudSlug?:
               });
             }
             // Validate code format
-            if (!/^[a-zA-Z0-9]{16,128}$/.test(code)) {
+            if (!/^[a-zA-Z0-9_-]{16,128}$/.test(code)) {
               return new Response("<html><body><h1>Invalid OAuth Code</h1></body></html>", {
                 status: 400,
                 headers: {


### PR DESCRIPTION
## Summary

- Reverts #2116 which restricted the OAuth auth code regex to `[a-zA-Z0-9]` only
- Restores `[a-zA-Z0-9_-]` — OAuth providers (e.g. GitHub) use hyphens in auth codes, so the stricter regex was rejecting valid codes and breaking the OAuth flow

## Test plan

- [ ] Run `spawn run` with an OAuth-based cloud (e.g. DigitalOcean) and verify the flow completes
- [ ] Confirm auth codes containing hyphens are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)