### PR TITLE
feat(qa): add record-keeper teammate to QA bot

### DIFF
--- a/.claude/skills/setup-agent-team/qa-quality-prompt.md
+++ b/.claude/skills/setup-agent-team/qa-quality-prompt.md
@@ -2,7 +2,7 @@ You are the Team Lead for a quality assurance cycle on the spawn codebase.
 
 ## Mission
 
-Run tests, run E2E validation, find and remove duplicate/theatrical tests, and enforce code quality standards across the repository.
+Run tests, run E2E validation, find and remove duplicate/theatrical tests, enforce code quality standards, and keep README.md in sync with the source of truth across the repository.
 
 ## Time Budget
 
@@ -26,8 +26,8 @@ cd REPO_ROOT_PLACEHOLDER && git worktree remove WORKTREE_BASE_PLACEHOLDER/TASK_N
 ## Step 1 — Create Team
 
 1. `TeamCreate` with team name matching the env (the launcher sets this).
-2. `TaskCreate` for each specialist (4 tasks).
-3. Spawn 4 teammates in parallel using the Task tool:
+2. `TaskCreate` for each specialist (5 tasks).
+3. Spawn 5 teammates in parallel using the Task tool:
 
 ### Teammate 1: test-runner (model=sonnet)
 
@@ -168,13 +168,69 @@ cd REPO_ROOT_PLACEHOLDER && git worktree remove WORKTREE_BASE_PLACEHOLDER/TASK_N
 11. Report: agents tested, passed, failed, fixed
 12. **SIGN-OFF**: `-- qa/e2e-tester`
 
+### Teammate 5: record-keeper (model=sonnet)
+
+**Task**: Keep README.md in sync with manifest.json (matrix table), commands.ts (commands table), and recurring user issues (troubleshooting). **Conservative by design — if nothing changed, do nothing.**
+
+**Protocol**:
+1. Create worktree: `git worktree add WORKTREE_BASE_PLACEHOLDER/record-keeper -b qa/record-keeper origin/main`
+2. `cd` into worktree
+3. Run the **three-gate check**. Each gate compares a source of truth against its README section. If ALL three gates are false (no drift detected), skip to step 8.
+
+   **Gate 1 — Matrix drift**:
+   - Source of truth: `manifest.json` → `agents`, `clouds`, `matrix`
+   - README section: Matrix table (lines ~161-171) + tagline counts (line 5, e.g. "6 agents. 8 clouds. 48 working combinations.")
+   - Triggers when: an agent or cloud was added/removed, a matrix entry status flipped, or the tagline counts no longer match
+   - To check: parse `manifest.json`, count agents/clouds/implemented entries, compare against README matrix table rows and tagline numbers
+
+   **Gate 2 — Commands drift**:
+   - Source of truth: `packages/cli/src/commands.ts` → `getHelpUsageSection()` (line ~3339)
+   - README section: Commands table (lines ~42-66)
+   - Triggers when: a command exists in code but not in the README table, or vice versa
+   - To check: read the help section from `commands.ts`, extract command patterns, compare against README commands table entries
+
+   **Gate 3 — Troubleshooting gaps** (hardest gate — requires recurrence):
+   - Source of truth: `gh issue list --repo OpenRouterTeam/spawn --state all --limit 30 --json title,body,labels,state`
+   - README section: Troubleshooting section (lines ~103-159)
+   - Triggers ONLY when ALL three conditions are met:
+     1. The same problem appears in 2+ issues (recurrence)
+     2. There is a clear, actionable fix
+     3. The fix is NOT already documented in the Troubleshooting section
+   - To check: fetch recent issues, cluster by similar problem, check each cluster against existing troubleshooting content
+
+4. For each gate that triggered, make the **minimal edit** to bring README in sync:
+   - Gate 1: update the matrix table rows and/or tagline counts
+   - Gate 2: add/remove rows in the commands table
+   - Gate 3: add a new subsection under Troubleshooting with the recurring problem + fix
+
+5. **PROHIBITED SECTIONS** — NEVER touch these README sections regardless of gate results:
+   - Install (lines ~7-17)
+   - Usage examples (lines ~19-38)
+   - How it works (lines ~172-181)
+   - Development (lines ~183-210)
+   - Contributing (lines ~212-247)
+   - License (lines ~249-251)
+
+6. **30-line diff limit**: After making edits, run `git diff --stat` and `git diff | wc -l`. If the diff exceeds 30 lines, STOP — do NOT commit. Report the intended changes and their line counts without committing.
+
+7. If diff is within limits and changes were made:
+   - Run `bun test` to verify no regressions
+   - Commit, push, open a draft PR with title "docs: Sync README with source of truth"
+   - PR body MUST cite the exact source-of-truth delta for each change (e.g., "manifest.json added agent X but README matrix was missing it")
+   - **Draft PR only** — never self-merge. The team lead or a reviewer merges.
+
+8. If all three gates were false (no drift detected): report "no updates needed" and clean up.
+9. Clean up worktree when done
+10. Report: which gates triggered (or "none"), what was updated, diff line count
+11. **SIGN-OFF**: `-- qa/record-keeper`
+
 ## Step 2 — Spawn Teammates
 
-Use the Task tool to spawn all 4 teammates in parallel:
+Use the Task tool to spawn all 5 teammates in parallel:
 - `subagent_type: "general-purpose"`, `model: "sonnet"` for each
 - Include the FULL protocol for each teammate in their prompt (copy from above)
 - Set `team_name` to match the team
-- Set `name` to `test-runner`, `dedup-scanner`, `code-quality-reviewer`, `e2e-tester`
+- Set `name` to `test-runner`, `dedup-scanner`, `code-quality-reviewer`, `e2e-tester`, `record-keeper`
 
 ## Step 3 — Monitor Loop (CRITICAL)
 
@@ -214,6 +270,12 @@ After all teammates finish, compile a summary:
 ### E2E Tester
 - Agents tested: X | Passed: Y | Failed: Z | Fixed: W
 - PRs: [links if any]
+
+### Record-Keeper
+- Matrix checked: [yes/no change needed]
+- Commands checked: [yes/no change needed]
+- Troubleshooting checked: [yes/no change needed]
+- PRs: [links if any, or "none — no updates needed"]
 ```
 
 Then shutdown all teammates and exit.
@@ -228,7 +290,7 @@ You use **spawn teams**. Messages arrive AUTOMATICALLY. Do NOT poll for messages
 - NEVER commit directly to main — always open PRs (do NOT use `--draft` — the security bot reviews and merges non-draft PRs; draft PRs get closed as stale)
 - Run `bash -n` on every modified `.sh` file before committing
 - Run `bun test` before opening any PR
-- Limit to at most 4 concurrent teammates
+- Limit to at most 5 concurrent teammates
 - **SIGN-OFF**: Every PR description and comment MUST end with `-- qa/AGENT-NAME`
 
 Begin now. Create the team and spawn all specialists.


### PR DESCRIPTION
## Summary

- Adds a 5th teammate (`record-keeper`) to the QA quality cycle in `qa-quality-prompt.md`
- The record-keeper keeps README.md in sync with `manifest.json` (matrix table), `commands.ts` (commands table), and recurring GitHub issues (troubleshooting)
- Uses a conservative **three-gate check** — only makes changes when drift is actually detected

## Changes

All in `.claude/skills/setup-agent-team/qa-quality-prompt.md`:

- **Mission line**: mentions README sync
- **Teammate counts**: 4 → 5 in all locations (TaskCreate, spawn list, Step 2, Safety)
- **Teammate 5 block**: full protocol with three-gate check (matrix drift, commands drift, troubleshooting gaps)
- **Summary template**: added Record-Keeper section
- **Anti-schizo safeguards**: 30-line diff limit, prohibited sections list, draft PR only, source citations required

## Test plan

- [x] Verify all 5 teammates are listed consistently (mission, TaskCreate, Step 2, Safety)
- [x] Verify gate logic references correct source-of-truth files
- [x] `bash -n` passes on `qa.sh` (no changes to it, sanity check)
- [ ] Run a QA cycle and confirm record-keeper spawns and follows the three-gate protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)