### PR TITLE
fix(security): add --proto '=https' to update-check and update command curl calls

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,10 +1,12 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
+import { execFileSync } from "node:child_process";
 import { parseJsonWith } from "../shared/parse.js";
 import { SPAWN_CDN, VERSION_URL, RAW_BASE } from "../manifest.js";
 import { VERSION, PkgVersionSchema, getErrorMessage } from "./shared.js";
 
-const INSTALL_CMD = `curl -fsSL ${SPAWN_CDN}/cli/install.sh | bash`;
+const INSTALL_URL = `${SPAWN_CDN}/cli/install.sh`;
+const INSTALL_CMD = `curl --proto '=https' -fsSL ${INSTALL_URL} | bash`;
 
 async function fetchRemoteVersion(): Promise<string> {
   // Primary: plain-text version file from GitHub release artifact (static URL)
@@ -37,12 +39,36 @@ async function fetchRemoteVersion(): Promise<string> {
 }
 
 async function performUpdate(_remoteVersion: string): Promise<void> {
-  const { execSync } = await import("node:child_process");
   try {
-    execSync(INSTALL_CMD, {
-      stdio: "inherit",
-      shell: "/bin/bash",
-    });
+    // Two-step: fetch with --proto '=https', then execute via bash -c
+    // Prevents protocol downgrade on hostile networks (matches update-check.ts pattern)
+    const scriptContent = execFileSync(
+      "curl",
+      [
+        "--proto",
+        "=https",
+        "-fsSL",
+        INSTALL_URL,
+      ],
+      {
+        encoding: "utf8",
+        stdio: [
+          "pipe",
+          "pipe",
+          "inherit",
+        ],
+      },
+    );
+    execFileSync(
+      "bash",
+      [
+        "-c",
+        scriptContent ?? "",
+      ],
+      {
+        stdio: "inherit",
+      },
+    );
     console.log();
     p.log.success("Updated successfully!");
     p.log.info("Run spawn again to use the new version.");

--- a/packages/cli/src/update-check.ts
+++ b/packages/cli/src/update-check.ts
@@ -218,6 +218,8 @@ function performAutoUpdate(latestVersion: string): void {
     const scriptBytes = executor.execFileSync(
       "curl",
       [
+        "--proto",
+        "=https",
         "-fsSL",
         installUrl,
       ],


### PR DESCRIPTION
**Why:** The auto-update path in \`update-check.ts\` and the manual \`spawn update\` command in \`commands/update.ts\` were downloading and executing the install script via curl without \`--proto '=https'\`. On a hostile network (DNS hijacking, MITM), curl can follow a redirect from HTTPS to HTTP, allowing an attacker to serve malicious code that gets immediately executed. Same vulnerability class as PR #2172 (fixed 5 other TypeScript files) and PR #2160 (fixed 44 shell scripts) — these two code paths were missed.

## Summary

- **\`update-check.ts\`**: Added \`--proto\` / \`=https\` to the \`execFileSync("curl", [...])\` args in \`performAutoUpdate\`
- **\`commands/update.ts\`**: Replaced \`execSync(INSTALL_CMD, { shell: "/bin/bash" })\` (shell pipe, no protocol enforcement) with the safe two-step \`execFileSync\` pattern: fetch with \`curl --proto =https -fsSL\`, then execute via \`execFileSync("bash", ["-c", scriptContent])\`
- **\`package.json\`**: Bumped patch 0.12.15 → 0.12.16

## Verification
- Biome check: 0 errors
- All 1401 tests pass

-- refactor/security-auditor