### PR TITLE
fix(interactive): honour --dry-run flag in single-agent interactive path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.16",
+  "version": "0.12.17",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -15,7 +15,7 @@ import {
   preflightCredentialCheck,
   getAuthHint,
 } from "./shared.js";
-import { execScript } from "./run.js";
+import { execScript, showDryRunPreview } from "./run.js";
 
 // Prompt user to select an agent with hints and type-ahead filtering
 async function selectAgent(manifest: Manifest): Promise<string> {
@@ -170,6 +170,11 @@ export async function cmdAgentInteractive(agent: string, prompt?: string, dryRun
   const { clouds, hintOverrides } = getAndValidateCloudChoices(manifest, resolvedAgent);
   const cloudChoice = await selectCloud(manifest, clouds, hintOverrides);
 
+  if (dryRun) {
+    showDryRunPreview(manifest, resolvedAgent, cloudChoice, prompt);
+    return;
+  }
+
   await preflightCredentialCheck(manifest, cloudChoice);
 
   const spawnName = await promptSpawnName();
@@ -186,7 +191,7 @@ export async function cmdAgentInteractive(agent: string, prompt?: string, dryRun
     prompt,
     getAuthHint(manifest, cloudChoice),
     manifest.clouds[cloudChoice].url,
-    dryRun,
+    undefined,
     spawnName,
   );
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -170,7 +170,7 @@ function buildPromptLines(prompt: string): string[] {
   return lines;
 }
 
-function showDryRunPreview(manifest: Manifest, agent: string, cloud: string, prompt?: string): void {
+export function showDryRunPreview(manifest: Manifest, agent: string, cloud: string, prompt?: string): void {
   p.log.info(pc.bold("Dry run -- no resources will be provisioned\n"));
 
   printDryRunSection("Agent", buildAgentLines(manifest.agents[agent]));


### PR DESCRIPTION
**Why:** Billing bug — `spawn claude --dry-run` silently provisions a real cloud server instead of showing a preview. `dryRun` was passed in the `debug` parameter position of `execScript`, so the flag was never checked and `SPAWN_DEBUG=1` was set instead.

## Root cause

`cmdAgentInteractive` calls `execScript(cloud, agent, prompt, authHint, dashboardUrl, dryRun, spawnName)` — passing `dryRun` as the 6th argument (`debug`). The `cmdRun` two-arg path correctly checks `if (dryRun)` before calling `execScript`; the single-agent interactive path did not.

## Fix

- Export `showDryRunPreview` from `run.ts`
- In `cmdAgentInteractive`: check `dryRun` after cloud selection, call `showDryRunPreview`, and return early
- Pass `undefined` for the `debug` argument (the interactive path has no `--debug` flag)

## Verification

- `bunx @biomejs/biome check src/` — 0 errors
- `bun test` — 1401 pass, 0 fail

-- refactor/code-health