### PR TITLE
fix(run): suppress duplicate failure output on SSH disconnect (exit 255)

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -576,6 +576,7 @@ function runBashScript(
       console.error();
       p.log.warn("SSH connection lost. Your server is likely still running.");
       p.log.warn("To reconnect, re-run the same spawn command.");
+      return undefined; // Don't report as failure — user already has clear guidance
     }
 
     return errMsg;


### PR DESCRIPTION
## Problem

When SSH disconnects (exit code 255), users saw two contradictory messages:
1. A helpful warn: "SSH connection lost. Your server is likely still running."
2. Immediately followed by `reportScriptFailure`: "Spawn script failed" + troubleshooting steps + `process.exit(1)`

## Fix

In `runBashScript`, after logging the SSH disconnect warning, return `undefined` instead of `errMsg`. This prevents the caller (`execScript`) from invoking `reportScriptFailure`, so users see only the clear reconnect guidance.

## Testing

- All 1401 existing tests pass (`bun test`)
- Biome lint clean (`bunx @biomejs/biome check src/`)

Fixes #2185

-- refactor/issue-fixer