### PR TITLE
docs: Sync README with source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Launch any AI agent on any cloud with a single command. Coding agents, research agents, self-hosted AI tools — Spawn deploys them all. All models powered by [OpenRouter](https://openrouter.ai). (ALPHA software, use at your own risk!)
 
-**6 agents. 7 clouds. 42 working combinations. Zero config.**
+**7 agents. 7 clouds. 49 working combinations. Zero config.**
 
 ## Install
 
@@ -47,6 +47,9 @@ spawn delete -c hetzner                  # Delete a server on Hetzner
 | `spawn <agent> <cloud> -p "text"` | Non-interactive with prompt |
 | `spawn <agent> <cloud> --prompt-file f.txt` | Prompt from file |
 | `spawn <agent> <cloud> --debug` | Show all commands being executed |
+| `spawn <agent> <cloud> --headless` | Provision and exit (no interactive session) |
+| `spawn <agent> <cloud> --output json` | Headless mode with structured JSON on stdout |
+| `spawn <agent> <cloud> --custom` | Show interactive size/region pickers |
 | `spawn <agent>` | Show available clouds for an agent |
 | `spawn <cloud>` | Show available agents for a cloud |
 | `spawn matrix` | Full agent x cloud matrix |
@@ -168,6 +171,7 @@ If an agent fails to install or launch on a cloud:
 | [**Codex CLI**](https://github.com/openai/codex) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [**OpenCode**](https://github.com/sst/opencode) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [**Kilo Code**](https://github.com/Kilo-Org/kilocode) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**Hermes Agent**](https://github.com/NousResearch/hermes-agent) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ### How it works
 


### PR DESCRIPTION
## Summary

- **Gate 1 (Matrix drift)**: `manifest.json` has 7 agents (hermes was added) and 49 implemented combinations. README tagline read "6 agents. 7 clouds. 42 working combinations." and the matrix table was missing the Hermes Agent row entirely. Updated tagline to "7 agents. 7 clouds. 49 working combinations." and added the missing row.
- **Gate 2 (Commands drift)**: Three flags exist in `packages/cli/src/commands/help.ts` → `getHelpUsageSection()` but were absent from the README commands table: `--headless`, `--output json`, `--custom`. Added all three rows.
- **Gate 3 (Troubleshooting)**: Not triggered — no recurring user-reported problem without an existing fix found in the last 30 issues.

## Source-of-truth delta

- `manifest.json` agents: 7 (includes `hermes`) vs README showing 6
- `manifest.json` matrix implemented entries: 49 vs README tagline showing 42
- `help.ts` commands: `--headless`, `--output json`, `--custom` vs README table (missing all three)

## Test plan

- [x] `bun test` — 1401 pass, 0 fail
- [x] No prohibited sections touched (Install, Usage examples, How it works, Development, Contributing, License untouched)
- [x] Diff: 31 lines (+5 content lines, -1 content line)

-- qa/record-keeper