### PR TITLE
fix: suppress Claude Code workspace trust prompt on provisioned VMs

### DIFF
--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -145,17 +145,22 @@ async function setupClaudeCodeConfig(runner: CloudRunner, apiKey: string): Promi
     "dangerouslySkipPermissions": true
   }
 }`;
-  const globalState = `{
-  "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
-}`;
 
   const settingsB64 = Buffer.from(settingsJson).toString("base64");
-  const stateB64 = Buffer.from(globalState).toString("base64");
 
-  await runner.runServer(
-    `mkdir -p ~/.claude && printf '%s' '${settingsB64}' | base64 -d > ~/.claude/settings.json && chmod 600 ~/.claude/settings.json && printf '%s' '${stateB64}' | base64 -d > ~/.claude.json && chmod 600 ~/.claude.json && touch ~/.claude/CLAUDE.md`,
-  );
+  // Build ~/.claude.json on the remote using $HOME so the workspace trust
+  // entry uses the actual home directory path (e.g. /root, /home/user).
+  // This pre-accepts the "Quick safety check" trust dialog for the home dir.
+  const stateScript = [
+    "mkdir -p ~/.claude",
+    `printf '%s' '${settingsB64}' | base64 -d > ~/.claude/settings.json`,
+    "chmod 600 ~/.claude/settings.json",
+    'printf \'{"hasCompletedOnboarding":true,"bypassPermissionsModeAccepted":true,"%s":{"hasTrustDialogAccepted":true}}\\n\' "$HOME" > ~/.claude.json',
+    "chmod 600 ~/.claude.json",
+    "touch ~/.claude/CLAUDE.md",
+  ].join(" && ");
+
+  await runner.runServer(stateScript);
   logInfo("Claude Code configured");
 }
 


### PR DESCRIPTION
## Summary

- Pre-accept the Claude Code "Quick safety check" workspace trust dialog by injecting `hasTrustDialogAccepted: true` under the `$HOME` key in `~/.claude.json`
- JSON is now constructed on the remote side so `$HOME` resolves to the actual path (`/root`, `/home/user`, etc.)

## Why

The workspace trust prompt ("Is this a project you created or one you trust?") is separate from onboarding and is **not suppressed** by `hasCompletedOnboarding`, `bypassPermissions`, or `--dangerously-skip-permissions` ([anthropics/claude-code#28506](https://github.com/anthropics/claude-code/issues/28506)). It fires per-directory when there's no prior trust entry in `~/.claude.json`.

## Before/after

**Before** (`~/.claude.json`):
```json
{
  "hasCompletedOnboarding": true,
  "bypassPermissionsModeAccepted": true
}
```
→ Trust prompt appears on every spawn

**After** (`~/.claude.json`):
```json
{
  "hasCompletedOnboarding": true,
  "bypassPermissionsModeAccepted": true,
  "/root": {
    "hasTrustDialogAccepted": true
  }
}
```
→ No trust prompt

## Test plan

- [x] `biome check` — zero errors
- [x] `bun test` — all 1411 tests pass
- [ ] `spawn claude digitalocean` — verify no trust prompt on fresh VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)