### PR TITLE
feat: propagate host git identity to remote VMs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.18",
+  "version": "0.12.19",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -163,6 +163,35 @@ async function setupClaudeCodeConfig(runner: CloudRunner, apiKey: string): Promi
 
 let githubAuthRequested = false;
 let githubToken = "";
+let hostGitName = "";
+let hostGitEmail = "";
+
+/** Read a git config value from the host machine, returning "" on failure. */
+function readHostGitConfig(key: string): string {
+  try {
+    const result = Bun.spawnSync(
+      [
+        "git",
+        "config",
+        "--global",
+        key,
+      ],
+      {
+        stdio: [
+          "ignore",
+          "pipe",
+          "ignore",
+        ],
+      },
+    );
+    if (result.exitCode === 0) {
+      return new TextDecoder().decode(result.stdout).trim();
+    }
+  } catch {
+    /* ignore — git may not be installed on host */
+  }
+  return "";
+}
 
 async function promptGithubAuth(): Promise<void> {
   if (process.env.SPAWN_SKIP_GITHUB_AUTH) {
@@ -197,6 +226,10 @@ async function promptGithubAuth(): Promise<void> {
         /* ignore */
       }
     }
+
+    // Capture host git identity to propagate to the remote VM
+    hostGitName = readHostGitConfig("user.name");
+    hostGitEmail = readHostGitConfig("user.email");
   }
 }
 
@@ -242,6 +275,26 @@ export async function offerGithubAuth(runner: CloudRunner): Promise<void> {
       } catch {
         /* ignore */
       }
+    }
+  }
+
+  // Propagate host git identity to the remote VM
+  if (hostGitName || hostGitEmail) {
+    logStep("Configuring git identity...");
+    const cmds: string[] = [];
+    if (hostGitName) {
+      const escaped = hostGitName.replace(/'/g, "'\\''");
+      cmds.push(`git config --global user.name '${escaped}'`);
+    }
+    if (hostGitEmail) {
+      const escaped = hostGitEmail.replace(/'/g, "'\\''");
+      cmds.push(`git config --global user.email '${escaped}'`);
+    }
+    try {
+      await runner.runServer(cmds.join(" && "));
+      logInfo("Git identity configured from host");
+    } catch {
+      logWarn("Git identity setup failed (non-fatal, continuing)");
     }
   }
 }


### PR DESCRIPTION
## Summary
- When users say "yes" to GitHub CLI setup, we now also read their local `git config --global user.name` and `user.email`
- Those values are applied on the remote VM via `git config --global`, so commits made on spawn machines use the correct identity
- Non-fatal: if git isn't installed on the host or values are unset, we silently skip

## Test plan
- [x] Biome lint passes (0 errors)
- [x] All 1411 tests pass
- [ ] Manual: spawn a VM with GitHub setup enabled, verify `git config user.name` and `user.email` match host

🤖 Generated with [Claude Code](https://claude.com/claude-code)