### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/packages/cli/src/__tests__/script-failure-guidance.test.ts
@@ -299,45 +299,6 @@ describe("getScriptFailureGuidance", () => {
   // ── Return type and structure ─────────────────────────────────────────────
 
   describe("return type and structure", () => {
-    it("should always return an array of strings", () => {
-      const codes: (number | null)[] = [
-        0,
-        1,
-        2,
-        126,
-        127,
-        130,
-        137,
-        255,
-        null,
-      ];
-      for (const code of codes) {
-        const lines = getScriptFailureGuidance(code, "sprite");
-        expect(Array.isArray(lines)).toBe(true);
-        for (const line of lines) {
-          expect(typeof line).toBe("string");
-        }
-      }
-    });
-
-    it("should never return an empty array", () => {
-      const codes: (number | null)[] = [
-        0,
-        1,
-        2,
-        126,
-        127,
-        130,
-        255,
-        null,
-        -1,
-      ];
-      for (const code of codes) {
-        const lines = getScriptFailureGuidance(code, "sprite");
-        expect(lines.length).toBeGreaterThan(0);
-      }
-    });
-
     it("should produce different output for each handled exit code", () => {
       const result130 = getScriptFailureGuidance(130, "sprite");
       const result137 = getScriptFailureGuidance(137, "sprite");


### PR DESCRIPTION
## Summary

- Removed two redundant structural tests from `getScriptFailureGuidance` in `script-failure-guidance.test.ts`
- **"should always return an array of strings"** — already implicitly proven by every content-checking test in the file (e.g. `expect(joined).toContain(...)`, `expect(lines).toHaveLength(...)` all require the function to return a non-empty `string[]`)
- **"should never return an empty array"** — same: every `toContain` / `toHaveLength` assertion already implies a non-empty result
- Kept the useful **"should produce different output for each handled exit code"** uniqueness assertion

No functional changes. Test count: **1411 → 1409** (2 removed, 0 failures, 0 lint errors).

## Scan Summary

Scanned all 47 test files across `packages/cli/src/__tests__/` for:
- Duplicate top-level `describe` blocks (same function tested in 2+ files)
- Bash-grep / existence tests that don't call the function
- Always-pass conditional `expect` patterns
- Excessive subprocess spawning

**Findings:**
- No duplicate top-level `describe` blocks covering the same module
- No bash-grep / `type FUNCTION_NAME` patterns
- Conditional `if/else` in tests only appears in `afterEach` teardown (env var restore)
- Subprocess spawning only appears via `spyOn` mocks, never real subprocess execution
- **2 theatrical structural tests found and removed**

## Test plan
- [x] `bun test` passes: 1409/1409
- [x] `biome check src/`: 0 errors

-- qa/dedup-scanner