### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.21",
+  "version": "0.12.22",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -24,7 +24,7 @@ import { resolveListFilters, activeServerPicker } from "./list.js";
  * This may prompt the user interactively and must be called BEFORE
  * starting any spinner to avoid overlapping UI elements.
  */
-export async function ensureDeleteCredentials(record: SpawnRecord): Promise<void> {
+async function ensureDeleteCredentials(record: SpawnRecord): Promise<void> {
   const conn = record.connection;
   if (!conn?.cloud || conn.cloud === "local") {
     return;
@@ -69,7 +69,7 @@ export async function ensureDeleteCredentials(record: SpawnRecord): Promise<void
 }
 
 /** Execute server deletion for a given record using TypeScript cloud modules */
-export async function execDeleteServer(record: SpawnRecord): Promise<boolean> {
+async function execDeleteServer(record: SpawnRecord): Promise<boolean> {
   const conn = record.connection;
   if (!conn?.cloud || conn.cloud === "local") {
     return false;


### PR DESCRIPTION
## Summary

- Removed unnecessary `export` keywords from `ensureDeleteCredentials()` and `execDeleteServer()` in `packages/cli/src/commands/delete.ts` — both functions are only called internally within the same file and were never imported from outside

## Findings by category

**a) Dead code**: Found 2 dead exports in `commands/delete.ts`:
- `ensureDeleteCredentials` — exported but never imported outside its own file
- `execDeleteServer` — exported but never imported outside its own file
- Fix: removed `export` keyword; functions remain accessible internally

**b) Stale references**: None found — all file references across `sh/` and `packages/cli/src/` are valid

**c) Python usage**: None found — no `python3 -c` or `python -c` calls in any shell scripts

**d) Duplicate utilities**: The `packages/cli/src/shared/parse.ts` and `packages/shared/src/parse.ts` are intentionally duplicated per the architecture — the CLI uses its own internal copy, while `@openrouter/spawn-shared` is a separate published package for external consumers

**e) Stale comments**: None found — all comments reference active infrastructure

## Test plan

- [x] `bun test` — 1409 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` — 0 errors

-- qa/code-quality