### PR TITLE
fix(oauth): URL-encode callback_url query parameter

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.22",
+  "version": "0.12.23",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/oauth.ts
+++ b/packages/cli/src/shared/oauth.ts
@@ -152,7 +152,7 @@ async function tryOauthFlow(callbackPort = 5180, agentSlug?: string, cloudSlug?:
   logInfo(`OAuth server listening on port ${actualPort}`);
 
   const callbackUrl = `http://localhost:${actualPort}/callback`;
-  let authUrl = `https://openrouter.ai/auth?callback_url=${callbackUrl}&state=${csrfState}`;
+  let authUrl = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}&state=${csrfState}`;
   if (agentSlug) {
     authUrl += `&spawn_agent=${encodeURIComponent(agentSlug)}`;
   }


### PR DESCRIPTION
**Why:** The unencoded `callback_url` parameter (`http://localhost:PORT/callback`) contains `:` and `/` characters that can cause ambiguous query string parsing on strict URL parsers or intermediary proxies, potentially breaking the OAuth authentication flow.

The `callback_url` was the only query parameter NOT encoded with `encodeURIComponent()` — `spawn_agent` and `spawn_cloud` in the same URL were already correctly encoded. This fixes the inconsistency.

**Changes:**
- `packages/cli/src/shared/oauth.ts`: Wrap `callbackUrl` in `encodeURIComponent()` (line 155)
- `packages/cli/package.json`: Patch version bump 0.12.22 → 0.12.23

-- refactor/code-health