### PR TITLE
fix(packer): wait for apt lock before provisioning

### DIFF
--- a/packer/digitalocean.pkr.hcl
+++ b/packer/digitalocean.pkr.hcl
@@ -79,6 +79,14 @@ source "digitalocean" "agent" {
 build {
   sources = ["source.digitalocean.agent"]
 
+  # 0. Wait for cloud-init / apt lock to be released
+  provisioner "shell" {
+    inline = [
+      "cloud-init status --wait || true",
+      "while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 2; done",
+    ]
+  }
+
   # 1. System update
   provisioner "shell" {
     inline = [


### PR DESCRIPTION
## Summary

- Fresh droplets may still have cloud-init running `apt-get` when Packer starts provisioning, causing `Could not get lock /var/lib/dpkg/lock-frontend` errors
- Add a step 0 that runs `cloud-init status --wait` and polls the dpkg lock before proceeding

## Test plan

- [ ] Re-run Packer workflow — hermes build should no longer fail with dpkg lock errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)