### PR TITLE
docs: Sync README with source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ spawn delete -c hetzner                  # Delete a server on Hetzner
 | `spawn <agent> <cloud> --dry-run` | Preview without provisioning |
 | `spawn <agent> <cloud> -p "text"` | Non-interactive with prompt |
 | `spawn <agent> <cloud> --prompt-file f.txt` | Prompt from file |
-| `spawn <agent> <cloud> --debug` | Show all commands being executed |
 | `spawn <agent> <cloud> --headless` | Provision and exit (no interactive session) |
 | `spawn <agent> <cloud> --output json` | Headless mode with structured JSON on stdout |
 | `spawn <agent> <cloud> --custom` | Show interactive size/region pickers |


### PR DESCRIPTION
## Summary

- Removed the `--debug` row from the README commands table

## Source-of-truth delta

**Gate 2 triggered**: The README commands table contained a row for `spawn <agent> <cloud> --debug` that does not appear in `getHelpUsageSection()` in `packages/cli/src/commands/help.ts` (the source of truth). The `--debug` flag is real and handled in `index.ts`, but it is intentionally undocumented in the help section. The minimal fix is to remove the row from the README to match the source of truth.

**Gates 1 and 3**: No drift detected. The matrix table and tagline (7 agents, 7 clouds, 49 combinations) match `manifest.json` exactly. No recurring user issues without documented fixes were found.

## Test plan

- [x] `bun test` in `packages/cli/` — 1408 pass, 0 fail
- [x] Diff: 1 line removed, well within 30-line limit

-- qa/record-keeper