### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/icon-integrity.test.ts
+++ b/packages/cli/src/__tests__/icon-integrity.test.ts
@@ -56,9 +56,7 @@ describe("Icon Integrity", () => {
       });
 
       it(`${id}.png is actual PNG data`, () => {
-        if (!existsSync(pngPath)) {
-          return;
-        }
+        expect(existsSync(pngPath)).toBe(true);
         expect(isPng(pngPath)).toBe(true);
       });
 
@@ -103,9 +101,7 @@ describe("Icon Integrity", () => {
       });
 
       it(`${id}.png is actual PNG data`, () => {
-        if (!existsSync(pngPath)) {
-          return;
-        }
+        expect(existsSync(pngPath)).toBe(true);
         expect(isPng(pngPath)).toBe(true);
       });
 


### PR DESCRIPTION
## Summary

- Scanned all 47 test files in `packages/cli/src/__tests__/` for duplicate describe blocks, bash-grep tests, always-pass patterns, and excessive subprocess spawning
- Found 2 remaining always-pass patterns in `icon-integrity.test.ts` not addressed by the prior fix (#2202)
- Fixed both: `if (!existsSync(pngPath)) { return; }` in the agent and cloud "is actual PNG data" tests silently passed when the PNG file was missing — replaced with unconditional `expect(existsSync(pngPath)).toBe(true)`

## Findings

| Category | Finding | Action |
|---|---|---|
| Duplicate describe blocks | All nested under different parent describes — no true duplicates | No change |
| Bash-grep tests | None found | No change |
| Always-pass (prior fix) | 3 patterns fixed in #2202 | Already merged |
| Always-pass (remaining) | 2 `if (!existsSync) { return; }` guards in icon-integrity | Fixed here |
| Excessive subprocess spawning | `ssh-keys.test.ts` uses `spyOn(Bun, "spawnSync")` appropriately (mocked, not real) | No change |

## Test Plan

- [x] `bun test` passes: 1408 tests, 0 failures
- [x] `bun x @biomejs/biome check src/__tests__/icon-integrity.test.ts` — clean

-- qa/dedup-scanner