### PR TITLE
fix: openclaw and zeroclaw reconnect broken by launch command validation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.12.24",
+  "version": "0.12.25",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/security-connection-validation.test.ts
+++ b/packages/cli/src/__tests__/security-connection-validation.test.ts
@@ -210,9 +210,11 @@ describe("validateLaunchCmd", () => {
       ).not.toThrow();
     });
 
-    it("should accept zeroclaw launch command with cargo env", () => {
+    it("should accept zeroclaw launch command with cargo env and PATH", () => {
       expect(() =>
-        validateLaunchCmd("source ~/.cargo/env 2>/dev/null; source ~/.spawnrc 2>/dev/null; zeroclaw agent"),
+        validateLaunchCmd(
+          "export PATH=$HOME/.cargo/bin:$PATH; source ~/.cargo/env 2>/dev/null; source ~/.spawnrc 2>/dev/null; zeroclaw agent",
+        ),
       ).not.toThrow();
     });
 

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -584,13 +584,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       preLaunchMsg:
         "Set up one channel at a time in the OpenClaw TUI. Wait for each channel to fully complete before pasting the next token — concurrent token pastes can cause setup to hang.",
       launchCmd: () =>
-        "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
-        'if command -v systemctl >/dev/null 2>&1; then _sudo=""; [ "$(id -u)" != "0" ] && _sudo="sudo"; $_sudo systemctl start openclaw-gateway 2>/dev/null; fi; ' +
-        "_gw_wait=0; while [ $_gw_wait -lt 15 ]; do " +
-        'if ss -tln 2>/dev/null | grep -q ":18789 " || (echo >/dev/tcp/127.0.0.1/18789) 2>/dev/null || nc -z 127.0.0.1 18789 2>/dev/null; then break; fi; ' +
-        "sleep 1; _gw_wait=$((_gw_wait + 1)); " +
-        "done; " +
-        "openclaw tui",
+        "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; openclaw tui",
     },
 
     opencode: {
@@ -645,7 +639,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       ],
       configure: (apiKey) => setupZeroclawConfig(runner, apiKey),
       launchCmd: () =>
-        'export PATH="$HOME/.cargo/bin:$PATH"; source ~/.cargo/env 2>/dev/null; source ~/.spawnrc 2>/dev/null; zeroclaw agent',
+        "export PATH=$HOME/.cargo/bin:$PATH; source ~/.cargo/env 2>/dev/null; source ~/.spawnrc 2>/dev/null; zeroclaw agent",
     },
 
     hermes: {


### PR DESCRIPTION
**Why:** Users cannot reconnect to openclaw or zeroclaw sessions — `spawn enter` throws a "corrupted history" security error because the stored launch commands fail `validateLaunchCmd()` validation.

## Root Cause

`validateLaunchCmd()` uses an allowlist of three segment patterns (source, export PATH, binary). Two agents produce launch commands that don't match:

1. **openclaw**: `launchCmd()` contained inline `if`/`while`/`$()` shell logic for gateway startup — fails the preamble allowlist
2. **zeroclaw**: `launchCmd()` used `export PATH="$HOME/.cargo/bin:$PATH"` with double quotes — the validation regex doesn't include `"` in its character class

## Fix

- **openclaw**: Remove redundant inline gateway startup from `launchCmd()`. The gateway is already supervised by systemd (`Restart=always`) + cron heartbeat, both set up during `preLaunch`. The inline wait was unnecessary for reconnect.
- **zeroclaw**: Remove quotes from `export PATH=` value — unnecessary since the value has no spaces.
- **tests**: Update zeroclaw test case to match the actual stored command (with `export PATH=` segment).
- **version**: Bump to 0.12.25.

Verified: both commands now pass `validateLaunchCmd()`. All 1408 tests pass, zero lint errors.

-- refactor/code-health