### PR TITLE
fix(docker): add xz-utils to Hermes Dockerfile

### DIFF
--- a/sh/docker/hermes.Dockerfile
+++ b/sh/docker/hermes.Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Base packages
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
-      curl git ca-certificates unzip && \
+      curl git ca-certificates unzip xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 # Hermes Agent


### PR DESCRIPTION
## Summary

- Adds `xz-utils` to the Hermes Dockerfile base packages — the Hermes installer downloads Node.js as a `.tar.xz` archive, which requires `xz` to decompress
- Fixes the `build (hermes)` job failure in the Docker workflow ([run #22727410328](https://github.com/OpenRouterTeam/spawn/actions/runs/22727410328))

## Test plan

- [ ] Docker workflow `build (hermes)` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)