### PR TITLE
fix: nest workspace trust under "projects" key in .claude.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -155,7 +155,7 @@ async function setupClaudeCodeConfig(runner: CloudRunner, apiKey: string): Promi
     "mkdir -p ~/.claude",
     `printf '%s' '${settingsB64}' | base64 -d > ~/.claude/settings.json`,
     "chmod 600 ~/.claude/settings.json",
-    'printf \'{"hasCompletedOnboarding":true,"bypassPermissionsModeAccepted":true,"%s":{"hasTrustDialogAccepted":true}}\\n\' "$HOME" > ~/.claude.json',
+    'printf \'{"hasCompletedOnboarding":true,"bypassPermissionsModeAccepted":true,"projects":{"%s":{"hasTrustDialogAccepted":true}}}\\n\' "$HOME" > ~/.claude.json',
     "chmod 600 ~/.claude.json",
     "touch ~/.claude/CLAUDE.md",
   ].join(" && ");


### PR DESCRIPTION
## Summary

One-line fix: the `hasTrustDialogAccepted` entry was at the top level of `~/.claude.json` but Claude Code expects it nested under `"projects"`.

**Before** (wrong):
```json
{
  "hasCompletedOnboarding": true,
  "/root": { "hasTrustDialogAccepted": true }
}
```

**After** (correct):
```json
{
  "hasCompletedOnboarding": true,
  "projects": {
    "/root": { "hasTrustDialogAccepted": true }
  }
}
```

- [x] `biome check` — zero errors
- [x] `bun test` — all 1408 tests pass