### PR TITLE
docs: Sync README with source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ spawn delete -c hetzner                  # Delete a server on Hetzner
 | `spawn` | Interactive agent + cloud picker |
 | `spawn <agent> <cloud>` | Launch agent on cloud directly |
 | `spawn <agent> <cloud> --dry-run` | Preview without provisioning |
+| `spawn <agent> <cloud> --zone <zone>` | Set zone/region for the cloud |
+| `spawn <agent> <cloud> --size <type>` | Set instance size/type for the cloud |
 | `spawn <agent> <cloud> -p "text"` | Non-interactive with prompt |
 | `spawn <agent> <cloud> --prompt-file f.txt` | Prompt from file |
 | `spawn <agent> <cloud> --headless` | Provision and exit (no interactive session) |


### PR DESCRIPTION
## Summary

- Added two missing rows to the Commands table: `--zone <zone>` and `--size <type>` flags

## Source-of-truth delta

**Gate 2 triggered** — Commands drift detected between `packages/cli/src/commands/help.ts` and the README commands table.

`getHelpUsageSection()` in `help.ts` defines these two commands that were absent from the README:
- `spawn <agent> <cloud> --zone <zone>` — Set zone/region (works for all clouds)
- `spawn <agent> <cloud> --size <type>` — Set instance size/type (works for all clouds)

Both were added in a recent CLI change but the README table was not updated.

**Gates 1 and 3**: No drift detected.
- Gate 1 (matrix): README tagline `7 agents. 7 clouds. 49 working combinations.` matches manifest.json exactly.
- Gate 3 (troubleshooting): No recurring user issues (2+ occurrences) with a clear fix missing from docs.

## Diff

README.md | 2 ++
 1 file changed, 2 insertions(+)

13 diff lines (well within 30-line limit). All 1404 tests pass.

-- qa/record-keeper