### PR TITLE
fix: Add SSH key identity opts to reconnect path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -5,6 +5,7 @@ import type { VMConnection } from "../history.js";
 import { getHistoryPath } from "../history.js";
 import { validateConnectionIP, validateUsername, validateServerIdentifier, validateLaunchCmd } from "../security.js";
 import { SSH_INTERACTIVE_OPTS, spawnInteractive } from "../shared/ssh.js";
+import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys.js";
 import { getErrorMessage } from "./shared.js";
 
 /** Execute a shell command and resolve/reject on process close/error */
@@ -83,11 +84,13 @@ export async function cmdConnect(connection: VMConnection): Promise<void> {
   // Handle SSH connections
   p.log.step(`Connecting to ${pc.bold(connection.ip)}...`);
   const sshCmd = `ssh ${connection.user}@${connection.ip}`;
+  const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   return runInteractiveCommand(
     "ssh",
     [
       ...SSH_INTERACTIVE_OPTS,
+      ...keyOpts,
       `${connection.user}@${connection.ip}`,
     ],
     "SSH connection failed",
@@ -192,10 +195,12 @@ export async function cmdEnterAgent(
   // Standard SSH connection with agent launch
   p.log.step(`Entering ${pc.bold(agentName)} on ${pc.bold(connection.ip)}...`);
   const escapedRemoteCmd = remoteCmd.replace(/'/g, "'\\''");
+  const keyOpts = getSshKeyOpts(await ensureSshKeys());
   return runInteractiveCommand(
     "ssh",
     [
       ...SSH_INTERACTIVE_OPTS,
+      ...keyOpts,
       `${connection.user}@${connection.ip}`,
       "--",
       `bash -lc '${escapedRemoteCmd}'`,


### PR DESCRIPTION
## Summary

- The reconnect path in `connect.ts` (`cmdConnect` and `cmdEnterAgent`) was missing SSH key identity file opts (`-i` flags)
- Every cloud provider's `interactiveSession` includes `getSshKeyOpts(await ensureSshKeys())` but the reconnect path (used by `spawn list` -> reconnect/enter) omitted them
- Users with non-default SSH key paths got "Permission denied (publickey)" when reconnecting, while initial connections worked fine

## Test plan

- [x] All 1396 tests pass
- [x] `biome check` clean (0 errors)
- [ ] Manual: reconnect to a server with non-default SSH key via `spawn list`

Agent: code-health
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>