### PR TITLE
fix: Exclude Daytona from key-request emails

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -271,6 +271,7 @@
       "url": "https://www.daytona.io/",
       "type": "sandbox",
       "auth": "DAYTONA_API_KEY",
+      "key_request": false,
       "provision_method": "daytona create",
       "exec_method": "daytona exec",
       "interactive_method": "daytona ssh",

--- a/sh/shared/key-request.sh
+++ b/sh/shared/key-request.sh
@@ -22,13 +22,14 @@ fi
 _parse_cloud_auths() {
     local manifest_path="${1}"
     if command -v jq &>/dev/null; then
-        jq -r '.clouds | to_entries[] | select(.value.auth != null and .value.auth != "") | select(.value.auth | test("\\b(login|configure|setup)\\b"; "i") | not) | "\(.key)|\(.value.auth)"' "${manifest_path}" 2>/dev/null
+        jq -r '.clouds | to_entries[] | select(.value.auth != null and .value.auth != "") | select(.value.key_request != false) | select(.value.auth | test("\\b(login|configure|setup)\\b"; "i") | not) | "\(.key)|\(.value.auth)"' "${manifest_path}" 2>/dev/null
     else
         _MANIFEST="${manifest_path}" bun -e "
 import fs from 'fs';
 const m = JSON.parse(fs.readFileSync(process.env._MANIFEST, 'utf8'));
 for (const [key, cloud] of Object.entries(m.clouds || {})) {
   const auth = cloud.auth || '';
+  if (cloud.key_request === false) continue;
   if (/\b(login|configure|setup)\b/i.test(auth)) continue;
   if (!auth.trim()) continue;
   process.stdout.write(key + '|' + auth + '\n');


### PR DESCRIPTION
## Summary
- Adds `key_request: false` to the Daytona cloud entry in `manifest.json`
- Updates `_parse_cloud_auths()` in `sh/shared/key-request.sh` to skip clouds with that flag

## Test plan
- [ ] `bash -n sh/shared/key-request.sh` passes
- [ ] Running `load_cloud_keys_from_config` no longer lists daytona in missing providers

-- qa/e2e-tester