### PR TITLE
fix: tarball workflow failures (root ownership, swapfile, hermes TTY)

### DIFF
--- a/.github/workflows/agent-tarballs.yml
+++ b/.github/workflows/agent-tarballs.yml
@@ -113,7 +113,7 @@ jobs:
             fi
 
             echo "==> Running: ${cmd}"
-            sudo HOME=/root bash -c "${cmd}"
+            sudo HOME=/root bash -c "${cmd}" < /dev/null
             i=$((i + 1))
           done
 
@@ -134,8 +134,9 @@ jobs:
           DATE=$(date -u +%Y%m%d)
           TARBALL="spawn-agent-${AGENT_NAME}-x86_64-${DATE}.tar.gz"
 
-          # Move tarball to expected name
-          mv "/tmp/spawn-agent-${AGENT_NAME}.tar.gz" "${TARBALL}"
+          # Move tarball to expected name (tarball is owned by root from sudo capture)
+          sudo mv "/tmp/spawn-agent-${AGENT_NAME}.tar.gz" "${TARBALL}"
+          sudo chown "$(id -u):$(id -g)" "${TARBALL}"
 
           # Delete existing release if present (rolling release)
           gh release delete "${TAG}" --yes 2>/dev/null || true

--- a/packer/agents.json
+++ b/packer/agents.json
@@ -32,14 +32,14 @@
   "zeroclaw": {
     "tier": "minimal",
     "install": [
-      "fallocate -l 4G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile",
+      "if [ ! -f /swapfile ]; then fallocate -l 4G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile; fi",
       "curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/a117be64fdaa31779204beadf2942c8aef57d0e5/scripts/bootstrap.sh | bash -s -- --install-rust --install-system-deps --prefer-prebuilt"
     ]
   },
   "hermes": {
     "tier": "minimal",
     "install": [
-      "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
+      "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash || [ -f ~/.local/bin/hermes ]"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- **Release step**: `mv` fails because tarball is owned by root (created via `sudo` capture). Fixed with `sudo mv` + `chown`.
- **Zeroclaw**: `fallocate` fails on GitHub Actions runners because `/swapfile` already exists. Added existence check.
- **Hermes**: Install script setup wizard tries `/dev/tty` which doesn't exist in CI. Fall back to binary existence check.

## Test plan
- [ ] Re-trigger `agent-tarballs.yml` workflow after merge
- [ ] Verify all 7 agent builds succeed
- [ ] Verify releases exist: `gh release view agent-{name}-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)