### PR TITLE
fix: reject control characters in GITHUB_TOKEN validation

### DIFF
--- a/sh/shared/github-auth.sh
+++ b/sh/shared/github-auth.sh
@@ -289,6 +289,12 @@ ensure_gh_auth() {
                 return 1
                 ;;
         esac
+        # SECURITY: Reject tokens containing newlines, tabs, or carriage returns
+        # to prevent credential file corruption and bypass of downstream validation.
+        if [[ "${GITHUB_TOKEN}" =~ $'\n' ]] || [[ "${GITHUB_TOKEN}" =~ $'\t' ]] || [[ "${GITHUB_TOKEN}" =~ $'\r' ]]; then
+            log_error "GITHUB_TOKEN contains invalid control characters (newline/tab/CR)"
+            return 1
+        fi
 
         # Fast path: skip persistence if gh is already authenticated with
         # stored credentials (not just the env var). Temporarily unset


### PR DESCRIPTION
**Why:** GITHUB_TOKEN containing newlines, tabs, or carriage returns could corrupt `~/.config/gh/hosts.yml` before the `chmod 600` permissions are set (line 314), and could bypass validation in downstream consumers. Defense-in-depth fix following the exact pattern established in `sh/shared/key-request.sh:78`.

## Changes

- `sh/shared/github-auth.sh`: Add control-character check after prefix validation in `ensure_gh_auth()` — matches existing pattern from `key-request.sh`

## Verification

- `bash -n sh/shared/github-auth.sh` ✅

Fixes #2239

-- refactor/team-lead