### PR TITLE
test: Remove duplicate boundary tests in history-trimming

### DIFF
--- a/packages/cli/src/__tests__/history-trimming.test.ts
+++ b/packages/cli/src/__tests__/history-trimming.test.ts
@@ -885,52 +885,9 @@ describe("History Trimming and Boundaries", () => {
   // ── Race-like sequential saves near the boundary ────────────────────────
 
   describe("sequential saves at the boundary", () => {
-    it("should correctly handle saving from exactly 99 to 100 entries", () => {
-      const records: SpawnRecord[] = [];
-      for (let i = 0; i < 99; i++) {
-        records.push({
-          agent: `agent-${i}`,
-          cloud: "cloud",
-          timestamp: "2026-01-01T00:00:00.000Z",
-        });
-      }
-      writeFileSync(join(testDir, "history.json"), JSON.stringify(records));
-
-      saveSpawnRecord({
-        agent: "agent-99",
-        cloud: "cloud",
-        timestamp: "2026-01-01T00:00:00.000Z",
-      });
-
-      const loaded = loadHistory();
-      expect(loaded).toHaveLength(100);
-      // No trimming should have happened
-      expect(loaded[0].agent).toBe("agent-0");
-    });
-
-    it("should correctly handle saving from exactly 100 to 101 entries (trim boundary)", () => {
-      const records: SpawnRecord[] = [];
-      for (let i = 0; i < 100; i++) {
-        records.push({
-          agent: `agent-${i}`,
-          cloud: "cloud",
-          timestamp: "2026-01-01T00:00:00.000Z",
-        });
-      }
-      writeFileSync(join(testDir, "history.json"), JSON.stringify(records));
-
-      saveSpawnRecord({
-        agent: "agent-100",
-        cloud: "cloud",
-        timestamp: "2026-01-01T00:00:00.000Z",
-      });
-
-      const loaded = loadHistory();
-      expect(loaded).toHaveLength(100);
-      // Oldest entry should be trimmed
-      expect(loaded[0].agent).toBe("agent-1");
-      expect(loaded[99].agent).toBe("agent-100");
-    });
+    // NOTE: "99 to 100" and "100 to 101" boundary tests were removed as duplicates
+    // of "should keep all entries when at exactly 100" and "should trim to 100 when
+    // adding entry that exceeds the limit" in the MAX_HISTORY_ENTRIES section above.
 
     it("should handle rapid sequential saves that build up from zero", () => {
       for (let i = 0; i < 105; i++) {


### PR DESCRIPTION
## Summary

- Removed 2 duplicate tests from `history-trimming.test.ts` in the "sequential saves at the boundary" section that were exact copies of tests already in the "MAX_HISTORY_ENTRIES trimming" section:
  - "99 to 100 entries" == "should keep all entries when at exactly 100" (both: pre-populate 99 records, save 1 more, verify no trim)
  - "100 to 101 entries" == "should trim to 100 when adding entry that exceeds the limit" (both: pre-populate 100 records, save 1 more, verify trim)
- Kept the unique "rapid sequential saves that build up from zero" test in the boundary section

## Scan results

Scanned all 50 test files in `packages/cli/src/__tests__/` for:
- **Duplicate describe blocks**: No top-level describe names appear in multiple files. Files that test the same functions (e.g., security.test.ts, security-edge-cases.test.ts, security-encoding.test.ts) are intentionally split by scope (core, edge cases, encoding attacks).
- **Bash-grep tests**: None found. All tests call actual functions with inputs and check outputs.
- **Always-pass patterns**: No conditional expects that silently skip.
- **Excessive subprocess spawning**: ssh-keys.test.ts uses `spyOn(Bun, "spawnSync")` (mocked, not real subprocesses). commands-update-download.test.ts mocks `execSync`/`spawnSync`. No actual subprocess spawning in tests.

## Test plan

- [x] `bun test` passes (1415 tests, 0 failures)
- [x] `biome check` passes (0 errors)

-- qa/dedup-scanner