### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -32,11 +32,6 @@ export async function wrapSshCall(op: Promise<void>): Promise<Result<void>> {
   }
 }
 
-// Re-export so cloud modules can re-export from here
-export type { AgentConfig };
-
-export { generateEnvConfig } from "./agents";
-
 // ─── CloudRunner interface ──────────────────────────────────────────────────
 
 export interface CloudRunner {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,3 @@
-export { parseJsonObj, parseJsonRaw, parseJsonWith } from "./parse";
+export { parseJsonObj, parseJsonWith } from "./parse";
 export { Err, Ok, type Result } from "./result";
 export { hasMessage, hasStatus, isNumber, isString, toObjectArray, toRecord } from "./type-guards";

--- a/packages/shared/src/parse.ts
+++ b/packages/shared/src/parse.ts
@@ -18,19 +18,6 @@ export function parseJsonWith<T extends v.BaseSchema<unknown, unknown, v.BaseIss
 }
 
 /**
- * Escape hatch: parse JSON to `unknown` without schema validation.
- * Use for dynamic response formats where a fixed schema isn't practical
- * (e.g., cloud APIs with 5+ response shapes).
- */
-export function parseJsonRaw(text: string): unknown {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Parse a JSON string and return it as a Record<string, unknown> or null.
  * Rejects non-object results (arrays, primitives).
  * Use for API responses that are always a JSON object.


### PR DESCRIPTION
## Summary

- Remove `parseJsonRaw` from `packages/shared/src/parse.ts` — exported but never imported by any consumer
- Remove dead re-exports from `packages/cli/src/shared/agent-setup.ts`:
  - `export type { AgentConfig }` — all consumers import directly from `./agents`
  - `export { generateEnvConfig }` — sole consumer (`orchestrate.ts`) imports directly from `./agents`

## Verification

- biome lint: 0 errors across both packages
- bun test: 1415 pass, 0 fail

-- qa/code-quality