### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/.claude/rules/type-safety.md
+++ b/.claude/rules/type-safety.md
@@ -64,7 +64,7 @@ If multiple modules validate the same shape, extract the schema to a shared file
 
 Shared schema locations:
 - `.claude/scripts/schemas.ts` — hook stdin payload schemas
-- `packages/shared/src/parse.ts` — `parseJsonWith(text, schema)` and `parseJsonRaw(text)`
+- `packages/shared/src/parse.ts` — `parseJsonWith(text, schema)` and `parseJsonObj(text)`
 
 ### For test mocks — use proper Response objects instead of `as any`:
 ```typescript
@@ -83,5 +83,5 @@ global.fetch = mock(() => Promise.resolve(new Response("Error", { status: 500 })
 ```
 
 ### Shared utilities
-- `packages/shared/src/parse.ts` — `parseJsonWith(text, schema)` and `parseJsonRaw(text)`
+- `packages/shared/src/parse.ts` — `parseJsonWith(text, schema)` and `parseJsonObj(text)`
 - `packages/shared/src/type-guards.ts` — `isString`, `isNumber`, `hasStatus`, `hasMessage`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ spawn/
       src/commands.ts            # Compatibility shim → re-exports from commands/
       package.json               # npm package (@openrouter/spawn)
     shared/
-      src/parse.ts               # parseJsonWith(text, schema) and parseJsonRaw(text)
+      src/parse.ts               # parseJsonWith(text, schema) and parseJsonObj(text)
       src/type-guards.ts         # isString, isNumber, hasStatus, hasMessage
       package.json               # npm package (@openrouter/spawn-shared)
   sh/


### PR DESCRIPTION
## Summary
- Fixed stale `parseJsonRaw` references in `CLAUDE.md` and `.claude/rules/type-safety.md` — the function was removed in 8b99fe0a but documentation still referenced it. Updated to `parseJsonObj` which is the current function name.

## Scan results (no action needed)
- **Dead code**: No unused functions found in `sh/shared/*.sh` or `packages/cli/src/`
- **Python usage**: None found
- **Duplicate utilities**: `packages/cli/src/shared/{parse,type-guards}.ts` duplicate `packages/shared/src/{parse,type-guards}.ts` but the CLI package doesn't depend on `@openrouter/spawn-shared` — consolidation would require adding a workspace dependency (tracked separately)
- **Shell compatibility**: No `echo -e`, `source <(...)`, or other bash 3.x incompatibilities found

## Validation
- `bun test`: 1415 tests pass (0 failures)
- `biome check`: 0 errors
- No `.sh` files were modified

-- qa/code-quality