### PR TITLE
fix: add --prune and --json to KNOWN_FLAGS for spawn status

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/unknown-flags.test.ts
+++ b/packages/cli/src/__tests__/unknown-flags.test.ts
@@ -10,13 +10,13 @@ import { expandEqualsFlags, findUnknownFlag, KNOWN_FLAGS } from "../flags";
 
 describe("Unknown Flag Detection", () => {
   describe("detects unknown flags", () => {
-    it("should detect --json as unknown", () => {
+    it("should detect --foo as unknown", () => {
       expect(
         findUnknownFlag([
           "list",
-          "--json",
+          "--foo",
         ]),
-      ).toBe("--json");
+      ).toBe("--foo");
     });
 
     it("should detect --verbose as unknown (middle position)", () => {
@@ -50,20 +50,20 @@ describe("Unknown Flag Detection", () => {
     it("should detect unknown flag at the beginning", () => {
       expect(
         findUnknownFlag([
-          "--json",
+          "--foo",
           "list",
         ]),
-      ).toBe("--json");
+      ).toBe("--foo");
     });
 
     it("should return first unknown when multiple unknown flags", () => {
       expect(
         findUnknownFlag([
-          "--json",
+          "--foo",
           "--verbose",
           "list",
         ]),
-      ).toBe("--json");
+      ).toBe("--foo");
     });
   });
 
@@ -87,6 +87,8 @@ describe("Unknown Flag Detection", () => {
         "--debug",
         "--name",
         "--reauth",
+        "--prune",
+        "--json",
       ];
       for (const flag of knownFlagsToTest) {
         expect(
@@ -211,6 +213,8 @@ describe("KNOWN_FLAGS completeness", () => {
       "--clear",
       "--custom",
       "--reauth",
+      "--prune",
+      "--json",
     ];
     for (const flag of expected) {
       expect(KNOWN_FLAGS.has(flag)).toBe(true);

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -28,6 +28,8 @@ export const KNOWN_FLAGS = new Set([
   "--region",
   "--machine-type",
   "--size",
+  "--prune",
+  "--json",
 ]);
 
 /** Return the first unknown flag in args, or null if all are known/positional */


### PR DESCRIPTION
**Why:** `spawn status --prune` and `spawn status --json` are completely broken -- the CLI rejects them with "Unknown flag" before the command even dispatches. Users cannot use either documented feature of the status command.

## Summary

- Add `--prune` and `--json` to `KNOWN_FLAGS` in `flags.ts` so the unknown-flag checker allows them
- Fix tests in `unknown-flags.test.ts` that used `--json` as an example of an unknown flag (now it's known)
- Add `--prune` and `--json` to the KNOWN_FLAGS completeness test
- Bump CLI version 0.15.4 -> 0.15.5

## Root cause

PR #2254 added the `spawn status` command with `--prune` and `--json` flags, but did not register these flags in the `KNOWN_FLAGS` set in `flags.ts`. The CLI runs `checkUnknownFlags()` at `index.ts:874` **before** command dispatch, so any unregistered flag is rejected immediately.

## Test plan

- [x] `bunx @biomejs/biome check packages/cli/src/` -- 0 errors
- [x] `bun test` -- 1409/1409 tests pass
- [x] Verified `--prune` and `--json` are now in KNOWN_FLAGS
- [x] Verified completeness test includes both new flags

-- refactor/ux-engineer