### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -177,7 +177,7 @@ export interface AwsState {
   selectedBundle: string;
 }
 
-let _state: AwsState = {
+const _state: AwsState = {
   accessKeyId: "",
   secretAccessKey: "",
   sessionToken: "",
@@ -187,20 +187,6 @@ let _state: AwsState = {
   instanceIp: "",
   selectedBundle: DEFAULT_BUNDLE.id,
 };
-
-/** Reset session state — used in tests for isolation. */
-export function resetAwsState(): void {
-  _state = {
-    accessKeyId: "",
-    secretAccessKey: "",
-    sessionToken: "",
-    region: "us-east-1",
-    lightsailMode: "cli",
-    instanceName: "",
-    instanceIp: "",
-    selectedBundle: DEFAULT_BUNDLE.id,
-  };
-}
 
 export function getState() {
   return {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -131,7 +131,7 @@ async function checkServerStatus(record: SpawnRecord): Promise<LiveState> {
     }
 
     default:
-      // Other clouds (aws, gcp, sprite, daytona) require CLI or complex auth;
+      // Other clouds (aws, gcp, sprite) require CLI or complex auth;
       // report "unknown" rather than attempting a potentially interactive flow.
       return "unknown";
   }
@@ -159,7 +159,7 @@ function fmtIp(conn: SpawnRecord["connection"]): string {
   if (conn.cloud === "local") {
     return "localhost";
   }
-  if (!conn.ip || conn.ip === "sprite-console" || conn.ip === "daytona-sandbox") {
+  if (!conn.ip || conn.ip === "sprite-console") {
     return "—";
   }
   return conn.ip;

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -96,20 +96,11 @@ export interface DigitalOceanState {
   serverIp: string;
 }
 
-let _state: DigitalOceanState = {
+const _state: DigitalOceanState = {
   token: "",
   dropletId: "",
   serverIp: "",
 };
-
-/** Reset session state — used in tests for isolation. */
-export function resetDigitalOceanState(): void {
-  _state = {
-    token: "",
-    dropletId: "",
-    serverIp: "",
-  };
-}
 
 // ─── API Client ──────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -147,24 +147,13 @@ export interface GcpState {
   username: string;
 }
 
-let _state: GcpState = {
+const _state: GcpState = {
   project: "",
   zone: "",
   instanceName: "",
   serverIp: "",
   username: "",
 };
-
-/** Reset session state — used in tests for isolation. */
-export function resetGcpState(): void {
-  _state = {
-    project: "",
-    zone: "",
-    instanceName: "",
-    serverIp: "",
-    username: "",
-  };
-}
 
 // ─── gcloud CLI Wrapper ─────────────────────────────────────────────────────
 

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -46,20 +46,11 @@ export interface HetznerState {
   serverIp: string;
 }
 
-let _state: HetznerState = {
+const _state: HetznerState = {
   hcloudToken: "",
   serverId: "",
   serverIp: "",
 };
-
-/** Reset session state — used in tests for isolation. */
-export function resetHetznerState(): void {
-  _state = {
-    hcloudToken: "",
-    serverId: "",
-    serverIp: "",
-  };
-}
 
 // ─── API Client ──────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -30,18 +30,10 @@ export interface SpriteState {
   org: string;
 }
 
-let _state: SpriteState = {
+const _state: SpriteState = {
   name: "",
   org: "",
 };
-
-/** Reset session state — used in tests for isolation. */
-export function resetSpriteState(): void {
-  _state = {
-    name: "",
-    org: "",
-  };
-}
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Remove 5 unused `reset*State()` exports from cloud modules (aws, hetzner, gcp, digitalocean, sprite) -- defined but never called anywhere in the codebase
- Convert associated `_state` variables from `let` to `const` since they are no longer reassigned (fixes biome lint errors)
- Remove stale Daytona references in `status.ts` left over after Daytona cloud provider removal in #2261

## Validation

- `bun test`: 1414 pass, 0 fail
- `biome check`: 0 errors
- No shell files modified (no `bash -n` needed)

-- qa/code-quality