### PR TITLE
fix: correct img_check.sh filename to 99-img-check.sh

### DIFF
--- a/packer/digitalocean.pkr.hcl
+++ b/packer/digitalocean.pkr.hcl
@@ -142,11 +142,11 @@ build {
     ]
   }
 
-  # DO Marketplace validation — download and run img_check.sh to verify the image
+  # DO Marketplace validation — download and run 99-img-check.sh to verify the image
   # meets marketplace requirements (firewall active, no root password, etc.)
   provisioner "shell" {
     inline = [
-      "curl -fsSL https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/img_check.sh -o /tmp/img_check.sh",
+      "curl -fsSL https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh -o /tmp/img_check.sh",
       "chmod +x /tmp/img_check.sh",
       "/tmp/img_check.sh",
       "rm -f /tmp/img_check.sh",


### PR DESCRIPTION
## Summary

PR #2271 used `img_check.sh` but the marketplace-partners repo has it as `99-img-check.sh`. The 404 on curl download fails all agent builds with exit code 22.

## Test plan

- [ ] Trigger workflow dispatch — all builds should pass the validation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)