### PR TITLE
fix: pass DO Marketplace img_check validation

### DIFF
--- a/packer/digitalocean.pkr.hcl
+++ b/packer/digitalocean.pkr.hcl
@@ -106,6 +106,19 @@ build {
     ]
   }
 
+  # DO Marketplace: install all security updates and remove DO droplet agent
+  provisioner "shell" {
+    inline = [
+      "apt-get update -y",
+      "apt-get dist-upgrade -y",
+      "apt-get purge -y droplet-agent || true",
+      "rm -rf /opt/digitalocean",
+    ]
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive",
+    ]
+  }
+
   # DO Marketplace cleanup — runs last before snapshot.
   # Based on https://github.com/digitalocean/marketplace-partners/blob/master/scripts/cleanup.sh
   # Clears secrets, history, logs, and machine-id so each launched droplet


### PR DESCRIPTION
## Summary

img_check.sh validation fails on two checks:
- **75 security updates pending** — added `apt-get dist-upgrade` before validation
- **DigitalOcean directory detected** — purge `droplet-agent` and remove `/opt/digitalocean`

## Test plan
- [ ] Trigger workflow dispatch — all 7 agents should pass img_check validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)