### PR TITLE
fix: validate v0 history entries against SpawnRecordSchema

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/history.ts
+++ b/packages/cli/src/history.ts
@@ -268,7 +268,7 @@ export function loadHistory(): SpawnRecord[] {
 
     // v0 format: bare array (pre-versioning; migrated to v1 on next write)
     if (Array.isArray(raw)) {
-      return raw;
+      return raw.filter((el) => v.safeParse(SpawnRecordSchema, el).success);
     }
 
     return [];


### PR DESCRIPTION
**Why:** Fixes silent corruption when loading v0-format history files — corrupted entries bypass schema validation and cause TypeError crashes (e.g., `r.agent.toLowerCase()` on undefined) in getActiveServers, filterHistory, and 5 other callers.

## Changes
- `packages/cli/src/history.ts`: Add `v.safeParse(SpawnRecordSchema, el).success` filter on v0 array path
- Bump patch version (0.15.7 → 0.15.8)

## Test plan
- [x] `bun test` passes (1416 tests)
- [x] `biome check` passes (0 errors)

Fixes #2277

-- refactor/code-health