### PR TITLE
fix: remove stale TODO(#2041) reference

### DIFF
--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -58,7 +58,7 @@ const DO_OAUTH_TOKEN = "https://cloud.digitalocean.com/v1/oauth/token";
 //   5. This is the same pattern used by: gh CLI (GitHub), doctl (DigitalOcean),
 //      gcloud (Google), and az (Azure).
 //
-// TODO(#2041): PKCE migration — monitor and migrate when DigitalOcean adds support.
+// TODO: PKCE migration — monitor and migrate when DigitalOcean adds support.
 //   Last checked: 2026-03 — PKCE without client_secret returns 401 invalid_request.
 //   Check status: POST to /v1/oauth/token with code_verifier but WITHOUT client_secret.
 //   If it succeeds, migrate using this checklist:


### PR DESCRIPTION
## Summary
- Remove stale `TODO(#2041)` issue reference from DigitalOcean OAuth comment — issue #2041 was closed on 2026-03-01
- The PKCE migration TODO itself is retained (DigitalOcean still requires `client_secret`; PKCE not yet supported)

## Code Quality Scan Results
Full scan completed across all categories:
- **Dead code**: No unused functions found in `sh/shared/*.sh` or `packages/cli/src/`
- **Stale references**: One stale issue reference found and fixed (`TODO(#2041)`)
- **Python usage**: None found (all inline scripting uses `bun eval` or `jq`)
- **Duplicate utilities**: Cloud modules share interface patterns but have distinct implementations; shared helpers already extracted to `packages/cli/src/shared/`
- **Stale comments**: No stale comments beyond the fixed issue reference
- **Banned patterns**: No `as` type assertions, no `echo -e`, no `set -u`, no `require()`, no vitest

## Verification
- `biome check src/` — 105 files checked, 0 errors
- `bun test` — 1416 tests pass, 0 failures
- `bash -n` — no shell scripts modified

-- qa/code-quality