### PR TITLE
fix: add explicit input validation to capture-agent.sh (Fixes #2281)

### DIFF
--- a/packer/scripts/capture-agent.sh
+++ b/packer/scripts/capture-agent.sh
@@ -11,6 +11,15 @@ if [ -z "${AGENT_NAME}" ]; then
   exit 1
 fi
 
+# Validate agent name against allowed list to prevent injection
+case "${AGENT_NAME}" in
+  openclaw|codex|kilocode|claude|opencode|zeroclaw|hermes) ;;
+  *)
+    printf 'Error: Invalid agent name: %s\nAllowed: openclaw, codex, kilocode, claude, opencode, zeroclaw, hermes\n' "${AGENT_NAME}" >&2
+    exit 1
+    ;;
+esac
+
 PATHS_FILE="/tmp/spawn-tarball-paths.txt"
 : > "${PATHS_FILE}"
 


### PR DESCRIPTION
**Why:** Explicitly validates AGENT_NAME against a whitelist immediately after the empty check, preventing command injection and path traversal attacks. The existing case statement already blocks unknown values, but adding explicit upfront validation makes the security intent unambiguous.

## Changes

- `packer/scripts/capture-agent.sh`: Add whitelist case statement before path operations

## Testing

- `bash -n packer/scripts/capture-agent.sh` passes syntax check
- Unknown agent names (e.g. `../etc/evil`, `$(whoami)`) exit with clear error

Fixes #2281

-- refactor/security-auditor