### PR TITLE
refactor: Remove unnecessary exports from cloud modules

### DIFF
--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -126,18 +126,18 @@ export const BUNDLES: Bundle[] = [
 export const DEFAULT_BUNDLE = BUNDLES[0]; // nano_3_0
 
 /** Per-agent default bundles — heavier agents need more RAM. */
-export const AGENT_BUNDLE_DEFAULTS: Record<string, string> = {
+const AGENT_BUNDLE_DEFAULTS: Record<string, string> = {
   openclaw: "medium_3_0", // OpenClaw gateway + 713 npm packages needs >=4 GB
 };
 
 // ─── Lightsail Regions ────────────────────────────────────────────────────────
 
-export interface Region {
+interface Region {
   id: string;
   label: string;
 }
 
-export const REGIONS: Region[] = [
+const REGIONS: Region[] = [
   {
     id: "us-east-1",
     label: "us-east-1 (N. Virginia)",
@@ -166,7 +166,7 @@ export const REGIONS: Region[] = [
 
 // ─── State ──────────────────────────────────────────────────────────────────
 
-export interface AwsState {
+interface AwsState {
   accessKeyId: string;
   secretAccessKey: string;
   sessionToken: string;

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -90,7 +90,7 @@ const DO_OAUTH_CALLBACK_PORT = 5190;
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
-export interface DigitalOceanState {
+interface DigitalOceanState {
   token: string;
   dropletId: string;
   serverIp: string;
@@ -621,12 +621,12 @@ export async function ensureSshKey(): Promise<void> {
 
 // ─── Droplet Size Options ────────────────────────────────────────────────────
 
-export interface DropletSize {
+interface DropletSize {
   id: string;
   label: string;
 }
 
-export const DROPLET_SIZES: DropletSize[] = [
+const DROPLET_SIZES: DropletSize[] = [
   {
     id: "s-1vcpu-1gb",
     label: "1 vCPU \u00b7 1 GB RAM \u00b7 $6/mo",
@@ -657,12 +657,12 @@ export const DEFAULT_DROPLET_SIZE = "s-2vcpu-4gb";
 
 // ─── Region Options ──────────────────────────────────────────────────────────
 
-export interface DoRegion {
+interface DoRegion {
   id: string;
   label: string;
 }
 
-export const DO_REGIONS: DoRegion[] = [
+const DO_REGIONS: DoRegion[] = [
   {
     id: "nyc1",
     label: "New York 1",

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -35,12 +35,12 @@ const DASHBOARD_URL = "https://console.cloud.google.com/compute/instances";
 
 // ─── Machine Type Tiers ─────────────────────────────────────────────────────
 
-export interface MachineTypeTier {
+interface MachineTypeTier {
   id: string;
   label: string;
 }
 
-export const MACHINE_TYPES: MachineTypeTier[] = [
+const MACHINE_TYPES: MachineTypeTier[] = [
   {
     id: "e2-micro",
     label: "Shared CPU \u00b7 2 vCPU \u00b7 1 GB RAM (~$7/mo)",
@@ -79,12 +79,12 @@ export const DEFAULT_MACHINE_TYPE = "e2-medium";
 
 // ─── Zone Options ────────────────────────────────────────────────────────────
 
-export interface ZoneOption {
+interface ZoneOption {
   id: string;
   label: string;
 }
 
-export const ZONES: ZoneOption[] = [
+const ZONES: ZoneOption[] = [
   {
     id: "us-central1-a",
     label: "Iowa, US",
@@ -139,7 +139,7 @@ export const DEFAULT_ZONE = "us-central1-a";
 
 // ─── State ──────────────────────────────────────────────────────────────────
 
-export interface GcpState {
+interface GcpState {
   project: string;
   zone: string;
   instanceName: string;

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -40,7 +40,7 @@ const HETZNER_DASHBOARD_URL = "https://console.hetzner.cloud/";
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
-export interface HetznerState {
+interface HetznerState {
   hcloudToken: string;
   serverId: string;
   serverIp: string;
@@ -262,12 +262,12 @@ function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
 
 // ─── Server Type Options ─────────────────────────────────────────────────────
 
-export interface ServerTypeTier {
+interface ServerTypeTier {
   id: string;
   label: string;
 }
 
-export const SERVER_TYPES: ServerTypeTier[] = [
+const SERVER_TYPES: ServerTypeTier[] = [
   {
     id: "cx23",
     label: "cx23 \u00b7 2 vCPU \u00b7 4 GB \u00b7 40 GB (~\u20AC3.49/mo, EU only)",
@@ -298,12 +298,12 @@ export const DEFAULT_SERVER_TYPE = "cx23";
 
 // ─── Location Options ────────────────────────────────────────────────────────
 
-export interface LocationOption {
+interface LocationOption {
   id: string;
   label: string;
 }
 
-export const LOCATIONS: LocationOption[] = [
+const LOCATIONS: LocationOption[] = [
   {
     id: "fsn1",
     label: "Falkenstein, Germany",

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -25,7 +25,7 @@ const CONNECTIVITY_POLL_DELAY = Number.parseInt(process.env.SPRITE_CONNECTIVITY_
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
-export interface SpriteState {
+interface SpriteState {
   name: string;
   org: string;
 }


### PR DESCRIPTION
## Summary

- De-export 17 interfaces, types, and constants across 5 cloud modules that were exported but never imported externally
- These symbols are only used within their own module files — removing `export` narrows the public API surface without any behavior change

**Affected modules:**
- `aws/aws.ts`: `AwsState`, `Region`, `REGIONS`, `AGENT_BUNDLE_DEFAULTS`
- `digitalocean/digitalocean.ts`: `DigitalOceanState`, `DropletSize`, `DROPLET_SIZES`, `DoRegion`, `DO_REGIONS`
- `gcp/gcp.ts`: `GcpState`, `MachineTypeTier`, `MACHINE_TYPES`, `ZoneOption`, `ZONES`
- `hetzner/hetzner.ts`: `HetznerState`, `ServerTypeTier`, `SERVER_TYPES`, `LocationOption`, `LOCATIONS`
- `sprite/sprite.ts`: `SpriteState`

## Test plan

- [x] `bunx @biomejs/biome check src/` — zero errors
- [x] `bun test` — all 1416 tests pass
- [x] Verified no external imports of any de-exported symbols (including tests)

-- qa/code-quality