### PR TITLE
fix: remove BASH_SOURCE usage from all cloud agent scripts

### DIFF
--- a/sh/aws/claude.sh
+++ b/sh/aws/claude.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" claude "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" claude "$@"
 fi
 
 # Remote — download and run compiled TypeScript bundle

--- a/sh/aws/codex.sh
+++ b/sh/aws/codex.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" codex "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" codex "$@"
 fi
 
 # Remote — download and run compiled TypeScript bundle

--- a/sh/aws/hermes.sh
+++ b/sh/aws/hermes.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" hermes "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" hermes "$@"
 fi
 
 # Remote — download and run compiled TypeScript bundle

--- a/sh/aws/kilocode.sh
+++ b/sh/aws/kilocode.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" kilocode "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" kilocode "$@"
 fi
 
 # Remote — download and run compiled TypeScript bundle

--- a/sh/aws/openclaw.sh
+++ b/sh/aws/openclaw.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" openclaw "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" openclaw "$@"
 fi
 
 # Remote — download and run compiled TypeScript bundle

--- a/sh/aws/opencode.sh
+++ b/sh/aws/opencode.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" opencode "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" opencode "$@"
 fi
 
 # Remote — download and run compiled TypeScript bundle

--- a/sh/aws/zeroclaw.sh
+++ b/sh/aws/zeroclaw.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/aws/main.ts" zeroclaw "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/aws/main.ts" zeroclaw "$@"
 fi
 
 # Remote — download and run compiled TypeScript bundle

--- a/sh/digitalocean/claude.sh
+++ b/sh/digitalocean/claude.sh
@@ -60,17 +60,9 @@ _run_with_restart() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" ]]; then
     _run_with_restart bun run "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
-    exit $?
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
     exit $?
 fi
 

--- a/sh/digitalocean/codex.sh
+++ b/sh/digitalocean/codex.sh
@@ -60,17 +60,9 @@ _run_with_restart() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" ]]; then
     _run_with_restart bun run "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
-    exit $?
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
     exit $?
 fi
 

--- a/sh/digitalocean/hermes.sh
+++ b/sh/digitalocean/hermes.sh
@@ -60,17 +60,9 @@ _run_with_restart() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" ]]; then
     _run_with_restart bun run "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
-    exit $?
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
     exit $?
 fi
 

--- a/sh/digitalocean/kilocode.sh
+++ b/sh/digitalocean/kilocode.sh
@@ -60,17 +60,9 @@ _run_with_restart() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" ]]; then
     _run_with_restart bun run "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
-    exit $?
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
     exit $?
 fi
 

--- a/sh/digitalocean/openclaw.sh
+++ b/sh/digitalocean/openclaw.sh
@@ -60,17 +60,9 @@ _run_with_restart() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" ]]; then
     _run_with_restart bun run "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
-    exit $?
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
     exit $?
 fi
 

--- a/sh/digitalocean/opencode.sh
+++ b/sh/digitalocean/opencode.sh
@@ -60,17 +60,9 @@ _run_with_restart() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" ]]; then
     _run_with_restart bun run "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
-    exit $?
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
     exit $?
 fi
 

--- a/sh/digitalocean/zeroclaw.sh
+++ b/sh/digitalocean/zeroclaw.sh
@@ -60,17 +60,9 @@ _run_with_restart() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" ]]; then
     _run_with_restart bun run "$SPAWN_CLI_DIR/packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
-    exit $?
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" ]]; then
-    _run_with_restart bun run "$SCRIPT_DIR/../../packages/cli/src/digitalocean/main.ts" "$_AGENT_NAME" "$@"
     exit $?
 fi
 

--- a/sh/gcp/claude.sh
+++ b/sh/gcp/claude.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" claude "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" claude "$@"
 fi
 
 # Remote — download bundled gcp.js from GitHub release

--- a/sh/gcp/codex.sh
+++ b/sh/gcp/codex.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" codex "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" codex "$@"
 fi
 
 # Remote — download bundled gcp.js from GitHub release

--- a/sh/gcp/hermes.sh
+++ b/sh/gcp/hermes.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" hermes "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" hermes "$@"
 fi
 
 # Remote — download bundled gcp.js from GitHub release

--- a/sh/gcp/kilocode.sh
+++ b/sh/gcp/kilocode.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" kilocode "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" kilocode "$@"
 fi
 
 # Remote — download bundled gcp.js from GitHub release

--- a/sh/gcp/openclaw.sh
+++ b/sh/gcp/openclaw.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" openclaw "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" openclaw "$@"
 fi
 
 # Remote — download bundled gcp.js from GitHub release

--- a/sh/gcp/opencode.sh
+++ b/sh/gcp/opencode.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" opencode "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" opencode "$@"
 fi
 
 # Remote — download bundled gcp.js from GitHub release

--- a/sh/gcp/zeroclaw.sh
+++ b/sh/gcp/zeroclaw.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/gcp/main.ts" zeroclaw "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/gcp/main.ts" zeroclaw "$@"
 fi
 
 # Remote — download bundled gcp.js from GitHub release

--- a/sh/hetzner/claude.sh
+++ b/sh/hetzner/claude.sh
@@ -10,15 +10,9 @@ _ensure_bun() {
 }
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" claude "$@"
-fi
-
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" claude "$@"
 fi
 
 HETZNER_JS=$(mktemp)

--- a/sh/hetzner/codex.sh
+++ b/sh/hetzner/codex.sh
@@ -10,15 +10,9 @@ _ensure_bun() {
 }
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" codex "$@"
-fi
-
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" codex "$@"
 fi
 
 HETZNER_JS=$(mktemp)

--- a/sh/hetzner/hermes.sh
+++ b/sh/hetzner/hermes.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" hermes "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" hermes "$@"
 fi
 
 # Remote — download and run compiled TypeScript bundle

--- a/sh/hetzner/kilocode.sh
+++ b/sh/hetzner/kilocode.sh
@@ -10,15 +10,9 @@ _ensure_bun() {
 }
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" kilocode "$@"
-fi
-
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" kilocode "$@"
 fi
 
 HETZNER_JS=$(mktemp)

--- a/sh/hetzner/openclaw.sh
+++ b/sh/hetzner/openclaw.sh
@@ -10,15 +10,9 @@ _ensure_bun() {
 }
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" openclaw "$@"
-fi
-
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" openclaw "$@"
 fi
 
 HETZNER_JS=$(mktemp)

--- a/sh/hetzner/opencode.sh
+++ b/sh/hetzner/opencode.sh
@@ -10,15 +10,9 @@ _ensure_bun() {
 }
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" opencode "$@"
-fi
-
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" opencode "$@"
 fi
 
 HETZNER_JS=$(mktemp)

--- a/sh/hetzner/zeroclaw.sh
+++ b/sh/hetzner/zeroclaw.sh
@@ -10,15 +10,9 @@ _ensure_bun() {
 }
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/hetzner/main.ts" zeroclaw "$@"
-fi
-
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/hetzner/main.ts" zeroclaw "$@"
 fi
 
 HETZNER_JS=$(mktemp)

--- a/sh/local/claude.sh
+++ b/sh/local/claude.sh
@@ -13,11 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" claude "$@"
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" claude "$@"
 fi
 
 # Remote — download bundled local.js from GitHub release

--- a/sh/local/codex.sh
+++ b/sh/local/codex.sh
@@ -13,11 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" codex "$@"
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" codex "$@"
 fi
 
 # Remote — download bundled local.js from GitHub release

--- a/sh/local/hermes.sh
+++ b/sh/local/hermes.sh
@@ -13,11 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" hermes "$@"
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" hermes "$@"
 fi
 
 # Remote — download bundled local.js from GitHub release

--- a/sh/local/kilocode.sh
+++ b/sh/local/kilocode.sh
@@ -13,11 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" kilocode "$@"
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" kilocode "$@"
 fi
 
 # Remote — download bundled local.js from GitHub release

--- a/sh/local/openclaw.sh
+++ b/sh/local/openclaw.sh
@@ -13,11 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" openclaw "$@"
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" openclaw "$@"
 fi
 
 # Remote — download bundled local.js from GitHub release

--- a/sh/local/opencode.sh
+++ b/sh/local/opencode.sh
@@ -13,11 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" opencode "$@"
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" opencode "$@"
 fi
 
 # Remote — download bundled local.js from GitHub release

--- a/sh/local/zeroclaw.sh
+++ b/sh/local/zeroclaw.sh
@@ -13,11 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/local/main.ts" zeroclaw "$@"
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/local/main.ts" zeroclaw "$@"
 fi
 
 # Remote — download bundled local.js from GitHub release

--- a/sh/sprite/claude.sh
+++ b/sh/sprite/claude.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" claude "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" claude "$@"
 fi
 
 # Remote — download bundled sprite.js from GitHub release

--- a/sh/sprite/codex.sh
+++ b/sh/sprite/codex.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" codex "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" codex "$@"
 fi
 
 # Remote — download bundled sprite.js from GitHub release

--- a/sh/sprite/hermes.sh
+++ b/sh/sprite/hermes.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" hermes "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" hermes "$@"
 fi
 
 # Remote — download bundled sprite.js from GitHub release

--- a/sh/sprite/kilocode.sh
+++ b/sh/sprite/kilocode.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" kilocode "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" kilocode "$@"
 fi
 
 # Remote — download bundled sprite.js from GitHub release

--- a/sh/sprite/openclaw.sh
+++ b/sh/sprite/openclaw.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" openclaw "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" openclaw "$@"
 fi
 
 # Remote — download bundled sprite.js from GitHub release

--- a/sh/sprite/opencode.sh
+++ b/sh/sprite/opencode.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" opencode "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" opencode "$@"
 fi
 
 # Remote — download bundled sprite.js from GitHub release

--- a/sh/sprite/zeroclaw.sh
+++ b/sh/sprite/zeroclaw.sh
@@ -13,16 +13,9 @@ _ensure_bun() {
 
 _ensure_bun
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-
 # SPAWN_CLI_DIR override — force local source (used by e2e tests)
 if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" ]]; then
     exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" zeroclaw "$@"
-fi
-
-# Local checkout — run from source
-if [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" ]]; then
-    exec bun run "$SCRIPT_DIR/../../packages/cli/src/sprite/main.ts" zeroclaw "$@"
 fi
 
 # Remote — download bundled sprite.js from GitHub release


### PR DESCRIPTION
Why: Fixes curl|bash safety violation — BASH_SOURCE breaks when piped through bash <(curl ...)

Fixes #2285

## Summary

- Removed `BASH_SOURCE[0]` / `SCRIPT_DIR` usage from all 42 cloud agent scripts across 6 clouds (sprite, aws, gcp, hetzner, local, digitalocean) x 7 agents (claude, codex, hermes, kilocode, openclaw, opencode, zeroclaw)
- The "Local checkout — run from source" code path relied on `BASH_SOURCE[0]` resolving to a real filesystem path, which fails when scripts are executed via `bash <(curl -fsSL URL)` (resolves to `/dev/fd/XX`)
- Retained the `SPAWN_CLI_DIR` env var override for e2e test support — this is the correct mechanism for running from source
- Added `SPAWN_CLI_DIR` support to the 7 `local/` scripts that previously lacked it (they only had BASH_SOURCE-based detection)

## Verification

- `bash -n` passes on all 42 modified scripts
- No remaining `BASH_SOURCE` or `SCRIPT_DIR` references in any cloud agent script

-- refactor/security-auditor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openrouterteam/spawn/pull/2289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
