### PR TITLE
fix: replace base64 interpolation with stdin piping in cloud exec_long functions

### DIFF
--- a/sh/e2e/lib/clouds/aws.sh
+++ b/sh/e2e/lib/clouds/aws.sh
@@ -174,14 +174,12 @@ _aws_exec_long() {
 
   local alive_count=$((timeout / 15 + 1))
 
-  # Base64-encode the command to avoid shell injection via single-quote breakout
-  local encoded_cmd
-  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
-
-  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  # Pipe the command via stdin to avoid interpolating it into the remote
+  # command string — eliminates shell injection risk from base64 encoding.
+  printf '%s' "${cmd}" | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
       -o "ServerAliveInterval=15" -o "ServerAliveCountMax=${alive_count}" \
-      "ubuntu@${_AWS_INSTANCE_IP}" "timeout ${timeout} bash -c \"\$(printf '%s' '${encoded_cmd}' | base64 -d)\""
+      "ubuntu@${_AWS_INSTANCE_IP}" "timeout ${timeout} bash"
 }
 
 # ---------------------------------------------------------------------------

--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -179,14 +179,12 @@ _digitalocean_exec_long() {
     return 1
   fi
 
-  # Base64-encode the command to avoid shell injection via single-quote breakout
-  local encoded_cmd
-  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
-
-  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  # Pipe the command via stdin to avoid interpolating it into the remote
+  # command string — eliminates shell injection risk from base64 encoding.
+  printf '%s' "${cmd}" | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
       -o "ServerAliveInterval=15" -o "ServerAliveCountMax=$((timeout_secs / 15 + 1))" \
-      "root@${ip}" "timeout ${timeout_secs} bash -c \"\$(printf '%s' '${encoded_cmd}' | base64 -d)\""
+      "root@${ip}" "timeout ${timeout_secs} bash"
 }
 
 # ---------------------------------------------------------------------------

--- a/sh/e2e/lib/clouds/gcp.sh
+++ b/sh/e2e/lib/clouds/gcp.sh
@@ -182,14 +182,12 @@ _gcp_exec_long() {
 
   local alive_count=$((timeout / 15 + 1))
 
-  # Base64-encode the command to avoid shell injection via single-quote breakout
-  local encoded_cmd
-  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
-
-  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  # Pipe the command via stdin to avoid interpolating it into the remote
+  # command string — eliminates shell injection risk from base64 encoding.
+  printf '%s' "${cmd}" | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
       -o "ServerAliveInterval=15" -o "ServerAliveCountMax=${alive_count}" \
-      "${ssh_user}@${_GCP_INSTANCE_IP}" "timeout ${timeout} bash -c \"\$(printf '%s' '${encoded_cmd}' | base64 -d)\""
+      "${ssh_user}@${_GCP_INSTANCE_IP}" "timeout ${timeout} bash"
 }
 
 # ---------------------------------------------------------------------------

--- a/sh/e2e/lib/clouds/hetzner.sh
+++ b/sh/e2e/lib/clouds/hetzner.sh
@@ -149,17 +149,15 @@ _hetzner_exec_long() {
   local ip
   ip=$(cat "${ip_file}")
 
-  # Base64-encode the command to avoid shell injection via single-quote breakout
-  local encoded_cmd
-  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
-
-  ssh -o StrictHostKeyChecking=no \
+  # Pipe the command via stdin to avoid interpolating it into the remote
+  # command string — eliminates shell injection risk from base64 encoding.
+  printf '%s' "${cmd}" | ssh -o StrictHostKeyChecking=no \
       -o UserKnownHostsFile=/dev/null \
       -o LogLevel=ERROR \
       -o BatchMode=yes \
       -o ConnectTimeout=10 \
       -o ServerAliveInterval=15 \
-      "root@${ip}" "timeout ${timeout_secs} bash -c \"\$(printf '%s' '${encoded_cmd}' | base64 -d)\""
+      "root@${ip}" "timeout ${timeout_secs} bash"
 }
 
 # ---------------------------------------------------------------------------

--- a/sh/e2e/lib/clouds/sprite.sh
+++ b/sh/e2e/lib/clouds/sprite.sh
@@ -216,14 +216,12 @@ _sprite_exec_long() {
   local _max=3
   local _stderr_tmp="/tmp/sprite-execl-err.$$"
 
-  # Base64-encode the command to avoid shell injection via single-quote breakout
-  local encoded_cmd
-  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
-
   while [ "${_attempt}" -lt "${_max}" ]; do
     _sprite_fix_config
+    # Pipe the command via stdin to avoid interpolating it into the remote
+    # command string — eliminates shell injection risk from base64 encoding.
     # shellcheck disable=SC2046
-    sprite $(_sprite_org_flags) exec -s "${app}" -- bash -c "timeout '${timeout}' bash -c \"\$(printf '%s' '${encoded_cmd}' | base64 -d)\"" 2>"${_stderr_tmp}"
+    printf '%s' "${cmd}" | sprite $(_sprite_org_flags) exec -s "${app}" -- timeout "${timeout}" bash 2>"${_stderr_tmp}"
     local _rc=$?
     if [ "${_rc}" -eq 0 ]; then
       rm -f "${_stderr_tmp}"


### PR DESCRIPTION
Why: Fixes command injection in cloud driver SSH exec functions — base64 interpolation allows shell metacharacter execution

## Summary

Replace the unsafe pattern where base64-encoded commands were interpolated into remote command strings (e.g., `bash -c "$(printf '%s' '${encoded_cmd}' | base64 -d)"`) with secure stdin piping (`printf '%s' "${cmd}" | ssh ... "timeout N bash"`).

Command data now travels as stdin rather than as part of the command string, eliminating injection risk.

### Affected functions (all 5 cloud drivers):
- `_hetzner_exec_long` in `sh/e2e/lib/clouds/hetzner.sh`
- `_aws_exec_long` in `sh/e2e/lib/clouds/aws.sh`
- `_gcp_exec_long` in `sh/e2e/lib/clouds/gcp.sh`
- `_digitalocean_exec_long` in `sh/e2e/lib/clouds/digitalocean.sh`
- `_sprite_exec_long` in `sh/e2e/lib/clouds/sprite.sh`

### Pattern applied (same as #2284 for verify.sh):
```bash
# Before (unsafe — base64 interpolated into shell string):
encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
ssh ... "timeout N bash -c \"$(printf '%s' '${encoded_cmd}' | base64 -d)\""

# After (safe — command piped via stdin):
printf '%s' "${cmd}" | ssh ... "timeout N bash"
```

Note: `cloud_exec_long` has zero remaining callers after #2284 migrated verify.sh to `cloud_exec`, so this change is safe to apply without backward compatibility concerns.

Fixes #2286
Fixes #2287

-- refactor/code-health