### PR TITLE
refactor: Fix stale references in qa-quality-prompt and test README

### DIFF
--- a/.claude/skills/setup-agent-team/qa-quality-prompt.md
+++ b/.claude/skills/setup-agent-team/qa-quality-prompt.md
@@ -100,14 +100,14 @@ cd REPO_ROOT_PLACEHOLDER && git worktree remove WORKTREE_BASE_PLACEHOLDER/TASK_N
 
    **b) Stale references**: Scripts or code referencing files that no longer exist
    - Shell scripts are under `sh/` (e.g., `sh/shared/`, `sh/e2e/`, `sh/test/`, `sh/{cloud}/`)
-   - TypeScript is under `packages/cli/src/` and `packages/shared/src/`
+   - TypeScript is under `packages/cli/src/`
    - Grep for paths that reference old locations or deleted files and fix them
 
    **c) Python usage**: Any `python3 -c` or `python -c` calls in shell scripts
    - Replace with `bun eval` or `jq` as appropriate per CLAUDE.md rules
 
    **d) Duplicate utilities**: Same helper function defined in multiple TypeScript cloud modules
-   - If identical, move to `packages/shared/src/` and have cloud modules import it
+   - If identical, move to `packages/cli/src/shared/` and have cloud modules import it
 
    **e) Stale comments**: Comments referencing removed infrastructure, old test files, or deleted functions
    - Remove or update these comments

--- a/packages/cli/src/__tests__/README.md
+++ b/packages/cli/src/__tests__/README.md
@@ -77,6 +77,8 @@ bun test src/__tests__/manifest.test.ts
 - `check-entity.test.ts` / `check-entity-messages.test.ts` — Entity validation
 - `agent-tarball.test.ts` — `tryTarballInstall`: GitHub Release tarball install, fallback, URL validation
 - `gateway-resilience.test.ts` — `startGateway` systemd unit with auto-restart and cron heartbeat
+- `do-snapshot.test.ts` — `findSpawnSnapshot`: DigitalOcean snapshot lookup, filtering, error handling
+- `ui-utils.test.ts` — `validateServerName`, `validateRegionName`, `validateModelId`, `toKebabCase`, `sanitizeTermValue`, `jsonEscape`
 
 ### OAuth and auth
 - `oauth-code-validation.test.ts` — `OAUTH_CODE_REGEX` format validation


### PR DESCRIPTION
## Summary
- Fix `qa-quality-prompt.md` references to non-existent `packages/shared/src/` directory (only `packages/cli/` exists; shared code lives in `packages/cli/src/shared/`)
- Add missing test file entries to `packages/cli/src/__tests__/README.md`: `do-snapshot.test.ts` and `ui-utils.test.ts`

## Scan Results

### Dead code
No dead code found. All functions in `sh/shared/*.sh` and `packages/cli/src/shared/` are called by other modules.

### Stale references
- **Fixed**: `qa-quality-prompt.md` lines 103 and 110 referenced `packages/shared/src/` which does not exist
- **Fixed**: `__tests__/README.md` was missing entries for two test files

### Python usage
None found. All inline scripting uses `bun eval` or `jq`.

### Duplicate utilities
`getServerName`/`promptSpawnName` patterns are similar across cloud modules (aws, hetzner, digitalocean, gcp, sprite) but differ in cloud-specific env var names and prompt strings. Not worth extracting — the parameterization overhead exceeds the duplication cost.

### Stale comments
None found.

## Test plan
- [x] `bun test` — 1416 tests pass, 0 failures
- [x] Biome lint — 0 errors

-- qa/code-quality