### PR TITLE
fix: add timeout protection to uploadFile across all SSH-based clouds

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.8",
+  "version": "0.15.9",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1140,8 +1140,13 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
       ],
     },
   );
-  if ((await proc.exited) !== 0) {
-    throw new Error(`upload_file failed for ${remotePath}`);
+  const timer = setTimeout(() => killWithTimeout(proc), 120_000);
+  try {
+    if ((await proc.exited) !== 0) {
+      throw new Error(`upload_file failed for ${remotePath}`);
+    }
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1126,9 +1126,14 @@ export async function uploadFile(localPath: string, remotePath: string, ip?: str
       ],
     },
   );
-  const exitCode = await proc.exited;
-  if (exitCode !== 0) {
-    throw new Error(`upload_file failed for ${remotePath}`);
+  const timer = setTimeout(() => killWithTimeout(proc), 120_000);
+  try {
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      throw new Error(`upload_file failed for ${remotePath}`);
+    }
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -948,9 +948,14 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
       env: process.env,
     },
   );
-  const exitCode = await proc.exited;
-  if (exitCode !== 0) {
-    throw new Error(`upload_file failed for ${remotePath}`);
+  const timer = setTimeout(() => killWithTimeout(proc), 120_000);
+  try {
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      throw new Error(`upload_file failed for ${remotePath}`);
+    }
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -608,9 +608,14 @@ export async function uploadFile(localPath: string, remotePath: string, ip?: str
       ],
     },
   );
-  const exitCode = await proc.exited;
-  if (exitCode !== 0) {
-    throw new Error(`upload_file failed for ${remotePath}`);
+  const timer = setTimeout(() => killWithTimeout(proc), 120_000);
+  try {
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      throw new Error(`upload_file failed for ${remotePath}`);
+    }
+  } finally {
+    clearTimeout(timer);
   }
 }
 


### PR DESCRIPTION
## Why

All four SSH-based `uploadFile` functions (Hetzner, DigitalOcean, AWS, GCP) use `await proc.exited` on SCP subprocesses **without any timeout or kill guard**. If SCP hangs due to a network issue (connection drop, stalled transfer, unresponsive remote), the CLI hangs indefinitely — the user must Ctrl+C and start over.

This is inconsistent with `runServer` and `runServerCapture` in the same files, which all correctly use `setTimeout(() => killWithTimeout(proc), timeout)` with a `try/finally { clearTimeout(timer) }` pattern.

## What

Adds a 120-second timeout guard to `uploadFile` in all four SSH-based cloud modules, matching the existing pattern from `runServer`/`runServerCapture`. The 120s timeout is appropriate for config file uploads (small files — a few KB at most).

**Files changed:**
- `packages/cli/src/hetzner/hetzner.ts`
- `packages/cli/src/digitalocean/digitalocean.ts`
- `packages/cli/src/aws/aws.ts`
- `packages/cli/src/gcp/gcp.ts`
- `packages/cli/package.json` (patch bump 0.15.8 → 0.15.9)

## Verification

- All 1416 tests pass
- Biome check clean (0 errors)

-- refactor/code-health