### PR TITLE
fix: add per-process timeout to SSH handshake probes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/ssh.ts
+++ b/packages/cli/src/shared/ssh.ts
@@ -251,23 +251,32 @@ export async function waitForSsh(opts: WaitForSshOpts): Promise<void> {
           ],
         },
       );
-      const [stdout, stderr] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      const exitCode = await proc.exited;
+      // Per-process timeout: ConnectTimeout=10 only covers TCP connect, not
+      // the full SSH handshake. If sshd accepts the connection but stalls
+      // during key exchange or auth, the process hangs indefinitely. Kill it
+      // after 30s so the retry loop can continue.
+      const timer = setTimeout(() => killWithTimeout(proc), 30_000);
+      try {
+        const [stdout, stderr] = await Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        const exitCode = await proc.exited;
 
-      if (exitCode === 0 && stdout.includes("ok")) {
-        logInfo("SSH is ready");
-        return;
-      }
+        if (exitCode === 0 && stdout.includes("ok")) {
+          logInfo("SSH is ready");
+          return;
+        }
 
-      // Show the actual SSH error reason dimly so users can debug
-      const reason = stderr.trim();
-      if (reason) {
-        logStep(`SSH handshake failed (${i}/${handshakeAttempts}): ${reason}`);
-      } else {
-        logStep(`SSH handshake failed (${i}/${handshakeAttempts})`);
+        // Show the actual SSH error reason dimly so users can debug
+        const reason = stderr.trim();
+        if (reason) {
+          logStep(`SSH handshake failed (${i}/${handshakeAttempts}): ${reason}`);
+        } else {
+          logStep(`SSH handshake failed (${i}/${handshakeAttempts})`);
+        }
+      } finally {
+        clearTimeout(timer);
       }
     } catch {
       logStep(`SSH handshake error (${i}/${handshakeAttempts})`);


### PR DESCRIPTION
## Summary

- Add 30s `killWithTimeout` guard to each SSH handshake probe in `waitForSsh` Phase 2 (`packages/cli/src/shared/ssh.ts`)
- Prevents indefinite hang when sshd accepts TCP but stalls during key exchange/auth (`ConnectTimeout=10` only covers TCP connect)
- Matches the timeout pattern already used in every cloud-specific `runServer`, `uploadFile`, and `runServerCapture` function

## Why

`waitForSsh` Phase 2 spawns SSH processes in a retry loop but has no per-process timeout. If a cloud VM's sshd is partially initialized (common during cloud-init), it may accept TCP connections on port 22 but hang during key exchange. The SSH process blocks forever at `await proc.exited`, freezing the user's entire `spawn` command with no indication or recovery path.

## Test plan

- [x] All 1416 existing tests pass
- [x] Biome lint/format clean (0 errors)
- [x] No behavior change on happy path (SSH exits well within 30s on success or failure)
- [x] Only affects the hang case: stuck SSH processes are killed and retried

-- refactor/code-health