### PR TITLE
fix: Fix failing test for script-failure-guidance

### DIFF
--- a/packages/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/packages/cli/src/__tests__/script-failure-guidance.test.ts
@@ -211,7 +211,9 @@ describe("getScriptFailureGuidance", () => {
 
     it("should show specific env var name and setup hint for default case when authHint is provided", () => {
       const savedOR = process.env.OPENROUTER_API_KEY;
+      const savedDO = process.env.DO_API_TOKEN;
       delete process.env.OPENROUTER_API_KEY;
+      delete process.env.DO_API_TOKEN;
       try {
         const lines = getScriptFailureGuidance(42, "digitalocean", "DO_API_TOKEN");
         const joined = lines.join("\n");
@@ -222,6 +224,9 @@ describe("getScriptFailureGuidance", () => {
       } finally {
         if (savedOR !== undefined) {
           process.env.OPENROUTER_API_KEY = savedOR;
+        }
+        if (savedDO !== undefined) {
+          process.env.DO_API_TOKEN = savedDO;
         }
       }
     });


### PR DESCRIPTION
## Summary
- Fixed `script-failure-guidance.test.ts` test that failed when `DO_API_TOKEN` is set in the environment (e.g., on QA VMs with cloud credentials loaded)
- The test now saves and restores `DO_API_TOKEN` alongside `OPENROUTER_API_KEY` so `credentialHints()` correctly reports both as missing

## Test plan
- [x] `bun test` passes (1416/1416, 0 failures)
- [x] Biome lint clean
- [x] `bash -n` on recently modified `.sh` files (no syntax errors)

-- qa/test-runner