### PR TITLE
test: Fix environment-dependent credential hint tests

### DIFF
--- a/packages/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/packages/cli/src/__tests__/script-failure-guidance.test.ts
@@ -187,7 +187,9 @@ describe("getScriptFailureGuidance", () => {
   describe("auth hint parameter", () => {
     it("should show specific env var name and setup hint for exit code 1 when authHint is provided", () => {
       const savedOR = process.env.OPENROUTER_API_KEY;
+      const savedHC = process.env.HCLOUD_TOKEN;
       delete process.env.OPENROUTER_API_KEY;
+      delete process.env.HCLOUD_TOKEN;
       try {
         const lines = getScriptFailureGuidance(1, "hetzner", "HCLOUD_TOKEN");
         const joined = lines.join("\n");
@@ -198,6 +200,9 @@ describe("getScriptFailureGuidance", () => {
       } finally {
         if (savedOR !== undefined) {
           process.env.OPENROUTER_API_KEY = savedOR;
+        }
+        if (savedHC !== undefined) {
+          process.env.HCLOUD_TOKEN = savedHC;
         }
       }
     });
@@ -211,7 +216,9 @@ describe("getScriptFailureGuidance", () => {
 
     it("should show specific env var name and setup hint for default case when authHint is provided", () => {
       const savedOR = process.env.OPENROUTER_API_KEY;
+      const savedDO = process.env.DO_API_TOKEN;
       delete process.env.OPENROUTER_API_KEY;
+      delete process.env.DO_API_TOKEN;
       try {
         const lines = getScriptFailureGuidance(42, "digitalocean", "DO_API_TOKEN");
         const joined = lines.join("\n");
@@ -222,6 +229,9 @@ describe("getScriptFailureGuidance", () => {
       } finally {
         if (savedOR !== undefined) {
           process.env.OPENROUTER_API_KEY = savedOR;
+        }
+        if (savedDO !== undefined) {
+          process.env.DO_API_TOKEN = savedDO;
         }
       }
     });


### PR DESCRIPTION
## Summary
- Fixed 2 tests in `script-failure-guidance.test.ts` that failed when cloud credential env vars (`HCLOUD_TOKEN`, `DO_API_TOKEN`) were set in the test environment
- The tests checked that `credentialHints()` lists specific vars as "missing", but didn't unset those vars first -- so when they were present, the function correctly filtered them out, causing assertion failures
- Applied the same save/unset/restore pattern already used by `credential-hints.test.ts`

## Test plan
- [x] `bun test` passes (1416 tests, 0 failures)
- [x] `biome check` passes on changed file

-- qa/dedup-scanner