### PR TITLE
fix: make credential hint tests environment-independent

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/packages/cli/src/__tests__/script-failure-guidance.test.ts
@@ -187,7 +187,9 @@ describe("getScriptFailureGuidance", () => {
   describe("auth hint parameter", () => {
     it("should show specific env var name and setup hint for exit code 1 when authHint is provided", () => {
       const savedOR = process.env.OPENROUTER_API_KEY;
+      const savedHC = process.env.HCLOUD_TOKEN;
       delete process.env.OPENROUTER_API_KEY;
+      delete process.env.HCLOUD_TOKEN;
       try {
         const lines = getScriptFailureGuidance(1, "hetzner", "HCLOUD_TOKEN");
         const joined = lines.join("\n");
@@ -198,6 +200,9 @@ describe("getScriptFailureGuidance", () => {
       } finally {
         if (savedOR !== undefined) {
           process.env.OPENROUTER_API_KEY = savedOR;
+        }
+        if (savedHC !== undefined) {
+          process.env.HCLOUD_TOKEN = savedHC;
         }
       }
     });
@@ -211,7 +216,9 @@ describe("getScriptFailureGuidance", () => {
 
     it("should show specific env var name and setup hint for default case when authHint is provided", () => {
       const savedOR = process.env.OPENROUTER_API_KEY;
+      const savedDO = process.env.DO_API_TOKEN;
       delete process.env.OPENROUTER_API_KEY;
+      delete process.env.DO_API_TOKEN;
       try {
         const lines = getScriptFailureGuidance(42, "digitalocean", "DO_API_TOKEN");
         const joined = lines.join("\n");
@@ -222,6 +229,9 @@ describe("getScriptFailureGuidance", () => {
       } finally {
         if (savedOR !== undefined) {
           process.env.OPENROUTER_API_KEY = savedOR;
+        }
+        if (savedDO !== undefined) {
+          process.env.DO_API_TOKEN = savedDO;
         }
       }
     });


### PR DESCRIPTION
## Summary
- Fix 2 flaky tests in `script-failure-guidance.test.ts` that fail when cloud credential env vars (`HCLOUD_TOKEN`, `DO_API_TOKEN`) are set in the environment
- Tests now properly save/unset both the cloud-specific credential var and `OPENROUTER_API_KEY` before asserting they appear as "missing" in guidance output
- Bump CLI version to 0.15.11

## Test plan
- [x] All 1416 tests pass (0 failures)
- [x] Biome lint clean (0 errors)
- [x] Verified both previously-failing tests now pass with cloud creds set in env

-- qa/code-quality