### PR TITLE
fix: E2E failures - SSH key gen, opencode hetzner 409, hermes binary

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/ssh-keys.test.ts
+++ b/packages/cli/src/__tests__/ssh-keys.test.ts
@@ -221,7 +221,10 @@ describe("generateSshKey", () => {
     });
     const privPath = join(sshDir, "id_ed25519");
 
-    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(sshKeygenGenerateResult(privPath));
+    // Use mockImplementation so key files are written when ssh-keygen is
+    // "called", not at mock setup time. generateSshKey() checks existsSync()
+    // first — if the files already exist it reuses them instead of generating.
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(() => sshKeygenGenerateResult(privPath));
 
     const pair = generateSshKey();
     spawnSpy.mockRestore();
@@ -231,6 +234,21 @@ describe("generateSshKey", () => {
     expect(pair.pubPath).toContain("id_ed25519.pub");
     expect(existsSync(pair.privPath)).toBe(true);
     expect(existsSync(pair.pubPath)).toBe(true);
+  });
+
+  it("reuses existing key instead of regenerating (race condition safety)", () => {
+    // Simulate another process having already generated the key
+    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
+
+    // Mock getKeyType to return ED25519 for the existing key
+    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(sshKeygenLfResult("ED25519"));
+
+    const pair = generateSshKey();
+    spawnSpy.mockRestore();
+    expect(pair.name).toBe("id_ed25519");
+    expect(pair.type).toBe("ED25519");
+    expect(pair.privPath).toBe(privPath);
+    expect(pair.pubPath).toBe(pubPath);
   });
 });
 
@@ -266,7 +284,10 @@ describe("ensureSshKeys", () => {
     });
     const privPath = join(sshDir, "id_ed25519");
 
-    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(sshKeygenGenerateResult(privPath));
+    // Use mockImplementation so key files are written when ssh-keygen is
+    // "called", not at mock setup time. This prevents the early-return path
+    // in generateSshKey() from triggering due to pre-existing files.
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(() => sshKeygenGenerateResult(privPath));
 
     const keys = await ensureSshKeys();
     spawnSpy.mockRestore();

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -214,13 +214,26 @@ export async function ensureSshKey(): Promise<void> {
       name: keyName,
       public_key: pubKey,
     });
-    const regResp = await hetznerApi("POST", "/ssh_keys", body);
+    let regResp: string;
+    try {
+      regResp = await hetznerApi("POST", "/ssh_keys", body);
+    } catch (err) {
+      // HTTP 409 "uniqueness_error" means the key already exists under a different
+      // name. Hetzner's error message says "SSH key not unique" which the API layer
+      // throws as an Error before we can parse the response body.
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (/uniqueness_error|not unique|already/.test(errMsg)) {
+        logInfo(`SSH key '${key.name}' already registered (different name)`);
+        continue;
+      }
+      throw err;
+    }
     const regData = parseJsonObj(regResp);
     const regError = toRecord(regData?.error);
     const regErrMsg = isString(regError?.message) ? regError.message : "";
     if (regErrMsg) {
       // Key may already exist under a different name — non-fatal
-      if (/already/.test(regErrMsg)) {
+      if (/already|uniqueness|not unique/.test(regErrMsg)) {
         logInfo(`SSH key '${key.name}' already registered (different name)`);
         continue;
       }

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -666,7 +666,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         "OPENAI_BASE_URL=https://openrouter.ai/api/v1",
         `OPENAI_API_KEY=${apiKey}`,
       ],
-      launchCmd: () => "source ~/.spawnrc 2>/dev/null; hermes",
+      launchCmd: () =>
+        "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.local/bin:$HOME/.hermes/hermes-agent/venv/bin:$PATH; hermes",
     },
   };
 }

--- a/packages/cli/src/shared/ssh-keys.ts
+++ b/packages/cli/src/shared/ssh-keys.ts
@@ -125,6 +125,20 @@ export function generateSshKey(): SshKeyPair {
     mode: 0o700,
   });
 
+  // If the key already exists (e.g. another concurrent process generated it),
+  // reuse it instead of failing. ssh-keygen prompts for overwrite on stdin,
+  // which fails when stdin is "ignore".
+  if (existsSync(privPath) && existsSync(pubPath)) {
+    logInfo("SSH key already exists, reusing");
+    const keyType = getKeyType(pubPath);
+    return {
+      privPath,
+      pubPath,
+      name: "id_ed25519",
+      type: keyType,
+    };
+  }
+
   logStep("Generating SSH key...");
   const result = Bun.spawnSync(
     [
@@ -147,6 +161,18 @@ export function generateSshKey(): SshKeyPair {
     },
   );
   if (result.exitCode !== 0) {
+    // Another process may have created the key between our check and ssh-keygen.
+    // Re-check before throwing.
+    if (existsSync(privPath) && existsSync(pubPath)) {
+      logInfo("SSH key created by another process, reusing");
+      const keyType = getKeyType(pubPath);
+      return {
+        privPath,
+        pubPath,
+        name: "id_ed25519",
+        type: keyType,
+      };
+    }
     throw new Error("SSH key generation failed");
   }
   logInfo("SSH key generated");

--- a/packer/scripts/capture-agent.sh
+++ b/packer/scripts/capture-agent.sh
@@ -43,6 +43,9 @@ case "${AGENT_NAME}" in
   hermes)
     echo "/root/.local/bin/hermes" >> "${PATHS_FILE}"
     echo "/root/.local/share/" >> "${PATHS_FILE}"
+    # The hermes installer (uv tool) creates the actual binary + venv under ~/.hermes/.
+    # Without this, the ~/.local/bin/hermes symlink is dangling after tarball extraction.
+    echo "/root/.hermes/" >> "${PATHS_FILE}"
     ;;
   *)
     echo "Unknown agent: ${AGENT_NAME}" >&2

--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -546,7 +546,7 @@ verify_hermes() {
 
   # Binary check
   log_step "Checking hermes binary..."
-  if cloud_exec "${app}" "PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH command -v hermes" >/dev/null 2>&1; then
+  if cloud_exec "${app}" "PATH=\$HOME/.local/bin:\$HOME/.hermes/hermes-agent/venv/bin:\$HOME/.bun/bin:\$PATH command -v hermes" >/dev/null 2>&1; then
     log_ok "hermes binary found"
   else
     log_err "hermes binary not found"


### PR DESCRIPTION
**Why:** Three E2E failures were blocking the agent x cloud test matrix: zeroclaw/codex SSH key generation failures, opencode hetzner 409 uniqueness errors, and hermes binary not found after tarball install.

## Summary

Fixes three distinct bugs discovered in E2E testing:

### 1. SSH key generation race condition (zeroclaw + codex on hetzner/digitalocean)
- **Root cause:** When E2E provisions multiple agents in parallel, each subprocess calls `generateSshKey()`. The first process generates `~/.ssh/id_ed25519`; subsequent processes fail because `ssh-keygen` prompts for overwrite on stdin (which is "ignore"), returning non-zero exit.
- **Fix:** `generateSshKey()` now checks if the key already exists before generating, and re-checks after a failed generation attempt (TOCTOU safety).

### 2. Hetzner SSH key uniqueness_error / HTTP 409 (opencode on hetzner)
- **Root cause:** `hetznerApi()` throws on non-2xx responses (including 409) before the error-parsing code in `ensureSshKey()` can handle it. Additionally, the regex `/already/` didn't match Hetzner's error message "SSH key not unique".
- **Fix:** Wrap the POST `/ssh_keys` call in a try/catch that handles 409 gracefully, and broaden the regex to match `uniqueness_error|not unique|already`.

### 3. Hermes binary not found (hermes on hetzner/digitalocean)
- **Root cause:** The hermes install script (via `uv tool`) creates the actual binary + Python venv at `~/.hermes/hermes-agent/venv/` with a symlink at `~/.local/bin/hermes`. The tarball capture script only captured the symlink + `~/.local/share/`, resulting in a dangling symlink after tarball extraction.
- **Fix:** Include `~/.hermes/` in capture paths, add `~/.hermes/hermes-agent/venv/bin` to the PATH in `verify_hermes()` and the hermes `launchCmd`.

## Test plan

- [x] All 1417 existing tests pass (`bun test`)
- [x] New test: `generateSshKey` reuses existing key instead of regenerating (race condition safety)
- [x] Biome lint: 0 errors
- [x] `bash -n` syntax check on modified shell scripts

## Files changed

- `packages/cli/src/shared/ssh-keys.ts` — Race-safe key generation
- `packages/cli/src/hetzner/hetzner.ts` — Handle 409 uniqueness_error
- `packages/cli/src/shared/agent-setup.ts` — Hermes launchCmd PATH
- `packages/cli/src/__tests__/ssh-keys.test.ts` — Updated + new test
- `packer/scripts/capture-agent.sh` — Include ~/.hermes/ in tarball
- `sh/e2e/lib/verify.sh` — Hermes binary PATH check
- `packages/cli/package.json` — Version bump 0.15.11 → 0.15.12

Fixes #2304

-- refactor/code-health