### PR TITLE
fix(cli): improve visual spacing in spawn list output

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.12",
+  "version": "0.15.13",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -192,7 +192,7 @@ function renderListTable(records: SpawnRecord[], manifest: Manifest | null): voi
     const r = records[i];
     const name = r.name || r.connection?.server_name || "unnamed";
     console.log(pc.bold(name));
-    console.log(`  ${buildRecordSubtitle(r, manifest)}`);
+    console.log(pc.dim(`  ${buildRecordSubtitle(r, manifest)}`));
     if (i < records.length - 1) {
       console.log();
     }

--- a/packages/cli/src/picker.ts
+++ b/packages/cli/src/picker.ts
@@ -324,7 +324,9 @@ export function pickToTTYWithActions(config: PickConfig): PickResult {
         : "\u2191/\u2193 move  \u23ce select  Ctrl-C cancel";
 
       const linesPerOption = config.options.map((o) => (o.subtitle ? 2 : 1));
-      pickerHeight = 1 + linesPerOption.reduce((a, b) => a + b, 0) + 1;
+      // Add 1 blank separator line between each pair of adjacent options
+      const separatorCount = config.options.length > 1 ? config.options.length - 1 : 0;
+      pickerHeight = 1 + linesPerOption.reduce((a, b) => a + b, 0) + separatorCount + 1;
 
       render = (wr: WriteFn, first: boolean) => {
         if (!first) {
@@ -347,10 +349,14 @@ export function pickToTTYWithActions(config: PickConfig): PickResult {
               wr(`  ${A.dim}${trunc(opt.subtitle, maxW - 2)}${A.reset}\r\n`);
             }
           } else {
-            wr(`  ${A.dim}${trunc(opt.label, maxW - 2)}${A.reset}\r\n`);
+            wr(`  ${trunc(opt.label, maxW - 2)}\r\n`);
             if (opt.subtitle) {
               wr(`  ${A.dim}${trunc(opt.subtitle, maxW - 2)}${A.reset}\r\n`);
             }
+          }
+          // Blank separator between entries for visual clarity
+          if (i < config.options.length - 1) {
+            wr("\r\n");
           }
         }
         wr(`${A.dim}  ${trunc(footerHint, maxW - 2)}${A.reset}\r\n`);


### PR DESCRIPTION
## Summary

- **Interactive picker**: add blank separator line between consecutive entries so each `label + subtitle` pair is visually grouped and doesn't blend into adjacent entries
- **Non-interactive table** (`spawn list | cat`): wrap subtitle in `pc.dim()` so the bold entry name stands out clearly against the dimmed `agent · cloud · time` metadata
- Update `pickerHeight` calculation to account for the added separator lines (prevents cursor-positioning corruption)

## Before / After

**Before** (interactive picker, entries with subtitles run together):
```
? Select a spawn (3 servers)
> my-claude-1
  Claude Code · Sprite · 5 min ago
  my-claude-2
  Claude Code · Hetzner · 2h ago
  my-codex-1
  Codex · Sprite · yesterday
```

**After** (clear blank line separates each entry):
```
? Select a spawn (3 servers)
> my-claude-1
  Claude Code · Sprite · 5 min ago

  my-claude-2
  Claude Code · Hetzner · 2h ago

  my-codex-1
  Codex · Sprite · yesterday
```

Fixes #2309

-- refactor/issue-fixer