### PR TITLE
fix: improve cloud descriptions for non-technical users

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -249,7 +249,7 @@
   "clouds": {
     "local": {
       "name": "Local Machine",
-      "description": "Run agents on your own machine — no cloud needed",
+      "description": "Your computer — no account or payment needed",
       "url": "https://github.com/OpenRouterTeam/spawn",
       "type": "local",
       "auth": "none",
@@ -260,7 +260,7 @@
     },
     "hetzner": {
       "name": "Hetzner Cloud",
-      "description": "Affordable European cloud servers from ~€3/mo",
+      "description": "European cloud servers from ~€3/mo (account required)",
       "url": "https://www.hetzner.com/cloud/",
       "type": "api",
       "auth": "HCLOUD_TOKEN",
@@ -276,7 +276,7 @@
     },
     "aws": {
       "name": "AWS Lightsail",
-      "description": "Simple AWS instances starting at $3.50/mo",
+      "description": "Amazon cloud servers from $3.50/mo (AWS account required)",
       "url": "https://aws.amazon.com/lightsail/",
       "type": "cli",
       "auth": "AWS_ACCESS_KEY_ID+AWS_SECRET_ACCESS_KEY",
@@ -293,7 +293,7 @@
     },
     "digitalocean": {
       "name": "DigitalOcean",
-      "description": "Developer-friendly Droplets from $4/mo",
+      "description": "Cloud servers from $4/mo (account + payment method required)",
       "url": "https://www.digitalocean.com/",
       "type": "api",
       "auth": "DO_API_TOKEN",
@@ -309,7 +309,7 @@
     },
     "gcp": {
       "name": "GCP Compute Engine",
-      "description": "Google Cloud VMs with $300 free trial credit",
+      "description": "Google cloud servers — $300 free trial (Google account required)",
       "url": "https://cloud.google.com/compute",
       "type": "cli",
       "auth": "gcloud auth login",
@@ -326,7 +326,7 @@
     },
     "sprite": {
       "name": "Sprite",
-      "description": "Managed cloud VMs — one command to deploy",
+      "description": "Managed cloud servers — one command to deploy",
       "url": "https://sprites.dev",
       "type": "cli",
       "auth": "sprite login",

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -80,7 +80,7 @@ async function selectCloud(
   hintOverrides: Record<string, string>,
 ): Promise<string> {
   const cloudChoice = await p.autocomplete({
-    message: "Select a cloud provider (type to filter)",
+    message: "Where should your agent run? (type to filter)",
     options: mapToSelectOptions(cloudList, manifest.clouds, hintOverrides),
     placeholder: "Start typing to search...",
   });


### PR DESCRIPTION
**Why:** Users don't know what "Droplets", "VMs", or "Lightsail" are. Plain language descriptions with upfront account/payment requirements reduce confusion and failed signups.

## Summary
- Rewrote cloud descriptions in manifest.json to use plain language instead of jargon
- Added "(account required)" or "(account + payment method required)" so users know upfront
- Changed cloud selection prompt to "Where should your agent run?"

Cherry-picks UX improvements from closed PR #2321 (which was blocked by merge conflicts).

Fixes #2323

-- refactor/ux-engineer
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openrouterteam/spawn/pull/2328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
