### PR TITLE
fix: isolate cmd-interactive tests from host spawn history

### DIFF
--- a/packages/cli/src/__tests__/cmd-interactive.test.ts
+++ b/packages/cli/src/__tests__/cmd-interactive.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { homedir } from "node:os";
 import { loadManifest } from "../manifest";
 import { isString } from "../shared/type-guards";
 import { createConsoleMocks, createMockManifest, mockClackPrompts, restoreMocks } from "./test-helpers";
@@ -57,9 +58,14 @@ describe("cmdInteractive", () => {
   let consoleMocks: ReturnType<typeof createConsoleMocks>;
   let originalFetch: typeof global.fetch;
   let processExitSpy: ReturnType<typeof spyOn>;
+  let originalSpawnHome: string | undefined;
 
   beforeEach(async () => {
     consoleMocks = createConsoleMocks();
+
+    // Isolate from host history so getActiveServers() returns []
+    originalSpawnHome = process.env.SPAWN_HOME;
+    process.env.SPAWN_HOME = `${homedir()}/.spawn-test-${Date.now()}`;
     mockLogError.mockClear();
     mockLogInfo.mockClear();
     mockLogStep.mockClear();
@@ -92,6 +98,11 @@ describe("cmdInteractive", () => {
     global.fetch = originalFetch;
     processExitSpy.mockRestore();
     restoreMocks(consoleMocks.log, consoleMocks.error);
+    if (originalSpawnHome === undefined) {
+      delete process.env.SPAWN_HOME;
+    } else {
+      process.env.SPAWN_HOME = originalSpawnHome;
+    }
   });
 
   // ── Cancel handling ──────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Fixed 13 failing tests in `cmd-interactive.test.ts` by isolating the test environment from the host machine's spawn history.

## Why

`getActiveServers()` was reading real history records from `~/.spawn/history.json` on the host, causing an extra `p.select()` call ("What would you like to do?") that shifted the mock prompt index. This made `manifest.agents[agent]` resolve to `undefined` because the agent selection prompt consumed the wrong value from `selectReturnValues`.

## Fix

Set `SPAWN_HOME` to an isolated directory under the user's home in `beforeEach`, ensuring `getActiveServers()` always returns `[]` regardless of host state.

-- qa/test-runner