### PR TITLE
fix: harden env var parsing and pkill patterns in provision.sh

### DIFF
--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -69,7 +69,19 @@ provision_agent() {
       if [ -z "${_env_name}" ]; then
         continue
       fi
-      # Validate value against a safe character whitelist
+      # Block dangerous system env vars that could enable privilege escalation
+      case "${_env_name}" in
+        PATH|LD_PRELOAD|LD_LIBRARY_PATH|HOME|SHELL|USER|IFS|ENV|BASH_ENV|CDPATH)
+          log_err "Blocked dangerous env var: ${_env_name}"
+          continue
+          ;;
+      esac
+      # Validate env var name matches strict alphanumeric pattern
+      if ! printf '%s' "${_env_name}" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*$'; then
+        log_err "Invalid env var name: ${_env_name}"
+        continue
+      fi
+      # Validate value against a safe character whitelist BEFORE export
       if printf '%s' "${_env_val}" | grep -qE '[^A-Za-z0-9@%+=:,./_-]'; then
         log_err "Invalid characters in env value for ${_env_name}"
         continue
@@ -104,8 +116,12 @@ CLOUD_ENV
     pkill -P "${pid}" 2>/dev/null || true
     kill "${pid}" 2>/dev/null || true
     wait "${pid}" 2>/dev/null || true
-    # Also kill any lingering sprite exec processes for this specific app
-    pkill -f "sprite.*exec.*${app_name}" 2>/dev/null || true
+    # Also kill any lingering sprite exec processes for this specific app.
+    # Validate app_name is non-empty and contains only safe characters to
+    # prevent overly broad pkill -f patterns from killing unrelated processes.
+    if [ -n "${app_name}" ] && printf '%s' "${app_name}" | grep -qE '^[A-Za-z0-9._-]+$'; then
+      pkill -f "sprite exec.*${app_name}" 2>/dev/null || true
+    fi
     sleep 1
   fi
 


### PR DESCRIPTION
**Why:** Prevents potential command injection via crafted env var names (e.g., PATH, LD_PRELOAD) and prevents overly broad pkill -f patterns from killing unrelated processes when app_name is empty or contains special characters.

## Changes

- **Env var name blocklist** (#2330): Block dangerous system env vars (PATH, LD_PRELOAD, LD_LIBRARY_PATH, HOME, SHELL, USER, IFS, ENV, BASH_ENV, CDPATH) before export in the cloud_headless_env parsing loop
- **Explicit name validation** (#2330): Add grep-based alphanumeric pattern check on env var names as defense-in-depth (supplements the sed extraction pattern)
- **pkill guard** (#2332): Validate app_name is non-empty and matches `^[A-Za-z0-9._-]+$` before running `pkill -f`; tighten regex from `sprite.*exec.*` to `sprite exec.*` to reduce false matches

## Testing

- `bash -n sh/e2e/lib/provision.sh` passes
- Changes are additive guards — existing valid env vars and app names are unaffected

Fixes #2330
Fixes #2332

-- refactor/security-auditor