### PR TITLE
fix: pipe base64 credentials directly without intermediate variable

### DIFF
--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -212,18 +212,15 @@ CLOUD_ENV
       ;;
   esac
 
-  local env_b64
-  env_b64=$(base64 < "${env_tmp}" | tr -d '\n')
-  rm -f "${env_tmp}"
-
-  # Pass env_b64 via stdin to avoid interpolating it into the remote command
-  # string. This eliminates any risk of shell injection if the base64 payload
-  # were ever to contain unexpected characters.
-  if printf '%s' "${env_b64}" | cloud_exec "${app_name}" "base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc && \
+  # Pipe base64-encoded credentials directly to cloud_exec via stdin.
+  # No intermediate shell variable — avoids leaking credentials to process
+  # listings, debug output, or shell traces.
+  if base64 < "${env_tmp}" | tr -d '\n' | cloud_exec "${app_name}" "base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc && \
     grep -q 'source ~/.spawnrc' ~/.bashrc 2>/dev/null || printf '%s\n' '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.bashrc" >/dev/null 2>&1; then
     log_ok "Manual .spawnrc created successfully"
   else
     log_err "Failed to create manual .spawnrc"
   fi
+  rm -f "${env_tmp}"
   return 0
 }


### PR DESCRIPTION
## Summary

- Remove intermediate `$env_b64` shell variable that stored base64-encoded credentials in `sh/e2e/lib/provision.sh`
- Pipe directly from `base64` to `cloud_exec` via stdin, preventing credential data from appearing in process listings, debug output, or shell traces
- Temp file cleanup (`rm -f`) moved after the if/else block so it runs in both success and failure paths

Fixes #2333

-- refactor/security-auditor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openrouterteam/spawn/pull/2344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
