### PR TITLE
fix: pin bun install to v1.3.9 in all agent scripts

### DIFF
--- a/sh/aws/claude.sh
+++ b/sh/aws/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/aws/codex.sh
+++ b/sh/aws/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/aws/hermes.sh
+++ b/sh/aws/hermes.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/aws/junie.sh
+++ b/sh/aws/junie.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/aws/kilocode.sh
+++ b/sh/aws/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/aws/openclaw.sh
+++ b/sh/aws/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/aws/opencode.sh
+++ b/sh/aws/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/aws/zeroclaw.sh
+++ b/sh/aws/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -225,7 +225,7 @@ export PATH="${BUN_INSTALL}/bin:${HOME}/.local/bin:${PATH}"
 
 if ! command -v bun &>/dev/null; then
     log_step "bun not found. Installing bun..."
-    curl -fsSL --proto '=https' https://bun.sh/install | bash
+    curl -fsSL --proto '=https' https://bun.sh/install?version=1.3.9 | bash
 
     # Re-export so bun is available in this session immediately.
     # Use hard-coded paths alongside BUN_INSTALL — the bun installer may
@@ -236,7 +236,7 @@ if ! command -v bun &>/dev/null; then
         log_error "Failed to install bun automatically"
         echo ""
         echo "Please install bun manually:"
-        echo "  curl -fsSL https://bun.sh/install | bash"
+        echo "  curl -fsSL https://bun.sh/install?version=1.3.9 | bash"
         echo ""
         echo "Then reopen your terminal and re-run:"
         echo "  curl -fsSL ${SPAWN_CDN}/cli/install.sh | bash"

--- a/sh/digitalocean/claude.sh
+++ b/sh/digitalocean/claude.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/digitalocean/codex.sh
+++ b/sh/digitalocean/codex.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/digitalocean/hermes.sh
+++ b/sh/digitalocean/hermes.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/digitalocean/junie.sh
+++ b/sh/digitalocean/junie.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/digitalocean/kilocode.sh
+++ b/sh/digitalocean/kilocode.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/digitalocean/openclaw.sh
+++ b/sh/digitalocean/openclaw.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/digitalocean/opencode.sh
+++ b/sh/digitalocean/opencode.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/digitalocean/zeroclaw.sh
+++ b/sh/digitalocean/zeroclaw.sh
@@ -10,7 +10,7 @@ _MAX_RETRIES=3
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/docker/openclaw.Dockerfile
+++ b/sh/docker/openclaw.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Bun
-RUN curl -fsSL --proto '=https' https://bun.sh/install | bash
+RUN curl -fsSL --proto '=https' https://bun.sh/install?version=1.3.9 | bash
 ENV PATH="/root/.bun/bin:/root/.local/bin:${PATH}"
 
 # OpenClaw via npm (Node runtime needs standard node_modules layout)

--- a/sh/gcp/claude.sh
+++ b/sh/gcp/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/gcp/codex.sh
+++ b/sh/gcp/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/gcp/hermes.sh
+++ b/sh/gcp/hermes.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/gcp/junie.sh
+++ b/sh/gcp/junie.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/gcp/kilocode.sh
+++ b/sh/gcp/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/gcp/openclaw.sh
+++ b/sh/gcp/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/gcp/opencode.sh
+++ b/sh/gcp/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/gcp/zeroclaw.sh
+++ b/sh/gcp/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/hetzner/claude.sh
+++ b/sh/hetzner/claude.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/hetzner/codex.sh
+++ b/sh/hetzner/codex.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/hetzner/hermes.sh
+++ b/sh/hetzner/hermes.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/hetzner/junie.sh
+++ b/sh/hetzner/junie.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/hetzner/kilocode.sh
+++ b/sh/hetzner/kilocode.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/hetzner/openclaw.sh
+++ b/sh/hetzner/openclaw.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/hetzner/opencode.sh
+++ b/sh/hetzner/opencode.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/hetzner/zeroclaw.sh
+++ b/sh/hetzner/zeroclaw.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/local/claude.sh
+++ b/sh/local/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/local/codex.sh
+++ b/sh/local/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/local/hermes.sh
+++ b/sh/local/hermes.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/local/junie.sh
+++ b/sh/local/junie.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/local/kilocode.sh
+++ b/sh/local/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/local/openclaw.sh
+++ b/sh/local/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/local/opencode.sh
+++ b/sh/local/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/local/zeroclaw.sh
+++ b/sh/local/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/sprite/claude.sh
+++ b/sh/sprite/claude.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/sprite/codex.sh
+++ b/sh/sprite/codex.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/sprite/hermes.sh
+++ b/sh/sprite/hermes.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/sprite/junie.sh
+++ b/sh/sprite/junie.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/sprite/kilocode.sh
+++ b/sh/sprite/kilocode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/sprite/openclaw.sh
+++ b/sh/sprite/openclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/sprite/opencode.sh
+++ b/sh/sprite/opencode.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }

--- a/sh/sprite/zeroclaw.sh
+++ b/sh/sprite/zeroclaw.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 _ensure_bun() {
     if command -v bun &>/dev/null; then return 0; fi
     printf '\033[0;36mInstalling bun...\033[0m\n' >&2
-    curl -fsSL --proto '=https' --show-error https://bun.sh/install | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
     export PATH="$HOME/.bun/bin:$PATH"
     command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
 }


### PR DESCRIPTION
**Why:** Prevents unexpected breakage from bun version drift and reduces attack surface by pinning to a known-good version (v1.3.9, matching the project's @types/bun dependency). All 50 agent scripts, the CLI installer, and the Docker build now use `https://bun.sh/install?version=1.3.9` instead of fetching the latest unpinned release.

## Changes

- Pin bun install URL to `?version=1.3.9` across all 48 agent scripts (aws, digitalocean, gcp, hetzner, local, sprite)
- Pin bun install in `sh/cli/install.sh` (both the install command and user-facing fallback message)
- Pin bun install in `sh/docker/openclaw.Dockerfile`

## Verification

- All 49 modified `.sh` files pass `bash -n` syntax check
- No functional change beyond version pinning — the bun installer's `?version=X.Y.Z` parameter is the official way to pin

Fixes #2331

-- refactor/security-auditor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openrouterteam/spawn/pull/2345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
