### PR TITLE
refactor: use shared getErrorMessage() and deduplicate OAuth CSS

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.20",
+  "version": "0.15.21",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -18,6 +18,7 @@ import {
   spawnInteractive,
 } from "../shared/ssh";
 import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys";
+import { getErrorMessage } from "../shared/type-guards";
 import {
   defaultSpawnName,
   getSpawnCloudConfigPath,
@@ -860,7 +861,7 @@ export async function createInstance(name: string, tier?: CloudInitTier): Promis
         userdata,
       ]);
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
+      const errMsg = getErrorMessage(err);
       logError(`Failed to create Lightsail instance: ${errMsg}`);
 
       if (isBillingError("aws", errMsg)) {
@@ -914,7 +915,7 @@ export async function createInstance(name: string, tier?: CloudInitTier): Promis
         }),
       );
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
+      const errMsg = getErrorMessage(err);
       logError(`Failed to create Lightsail instance: ${errMsg}`);
 
       if (isBillingError("aws", errMsg)) {

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -6,6 +6,7 @@ import { mkdirSync, readFileSync } from "node:fs";
 import { saveVmConnection } from "../history.js";
 import { handleBillingError, isBillingError, showNonBillingError } from "../shared/billing-guidance";
 import { getPackagesForTier, NODE_INSTALL_CMD, needsBun, needsNode } from "../shared/cloud-init";
+import { OAUTH_CSS } from "../shared/oauth";
 import { parseJsonObj } from "../shared/parse";
 import {
   killWithTimeout,
@@ -16,7 +17,7 @@ import {
   spawnInteractive,
 } from "../shared/ssh";
 import { ensureSshKeys, getSshFingerprint, getSshKeyOpts } from "../shared/ssh-keys";
-import { isNumber, isString, toObjectArray, toRecord } from "../shared/type-guards";
+import { getErrorMessage, isNumber, isString, toObjectArray, toRecord } from "../shared/type-guards";
 import {
   defaultSpawnName,
   getSpawnCloudConfigPath,
@@ -280,9 +281,6 @@ export async function checkAccountStatus(): Promise<void> {
 }
 
 // ─── DO OAuth Flow ──────────────────────────────────────────────────────────
-
-const OAUTH_CSS =
-  "*{margin:0;padding:0;box-sizing:border-box}body{font-family:system-ui,-apple-system,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;background:#fff;color:#090a0b}@media(prefers-color-scheme:dark){body{background:#090a0b;color:#fafafa}}.card{text-align:center;max-width:400px;padding:2rem}.icon{font-size:2.5rem;margin-bottom:1rem}h1{font-size:1.25rem;font-weight:600;margin-bottom:.5rem}p{font-size:.875rem;color:#6b7280}@media(prefers-color-scheme:dark){p{color:#9ca3af}}";
 
 const OAUTH_SUCCESS_HTML = `<html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>${OAUTH_CSS}</style></head><body><div class="card"><div class="icon">&#10003;</div><h1>DigitalOcean Authorization Successful</h1><p>You can close this tab and return to your terminal.</p></div><script>setTimeout(function(){try{window.close()}catch(e){}},3000)</script></body></html>`;
 
@@ -651,7 +649,7 @@ export async function ensureSshKey(): Promise<void> {
     try {
       regText = await doApi("POST", "/account/keys", body);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = getErrorMessage(err);
       // Key may already exist under a different name — non-fatal
       if (msg.includes("already been taken") || msg.includes("already in use")) {
         logInfo(`SSH key '${key.name}' already registered (under a different name)`);

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -16,7 +16,7 @@ import {
   spawnInteractive,
 } from "../shared/ssh";
 import { ensureSshKeys, getSshFingerprint, getSshKeyOpts } from "../shared/ssh-keys";
-import { isNumber, isString, toObjectArray, toRecord } from "../shared/type-guards";
+import { getErrorMessage, isNumber, isString, toObjectArray, toRecord } from "../shared/type-guards";
 import {
   defaultSpawnName,
   getSpawnCloudConfigPath,
@@ -222,7 +222,7 @@ export async function ensureSshKey(): Promise<void> {
       // HTTP 409 "uniqueness_error" means the key already exists under a different
       // name. Hetzner's error message says "SSH key not unique" which the API layer
       // throws as an Error before we can parse the response body.
-      const errMsg = err instanceof Error ? err.message : String(err);
+      const errMsg = getErrorMessage(err);
       if (/uniqueness_error|not unique|already/.test(errMsg)) {
         logInfo(`SSH key '${key.name}' already registered (different name)`);
         continue;

--- a/packages/cli/src/shared/oauth.ts
+++ b/packages/cli/src/shared/oauth.ts
@@ -53,7 +53,7 @@ function generateCsrfState(): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-const OAUTH_CSS =
+export const OAUTH_CSS =
   "*{margin:0;padding:0;box-sizing:border-box}body{font-family:system-ui,-apple-system,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;background:#fff;color:#090a0b}@media(prefers-color-scheme:dark){body{background:#090a0b;color:#fafafa}}.card{text-align:center;max-width:400px;padding:2rem}.icon{font-size:2.5rem;margin-bottom:1rem}h1{font-size:1.25rem;font-weight:600;margin-bottom:.5rem}p{font-size:.875rem;color:#6b7280}@media(prefers-color-scheme:dark){p{color:#9ca3af}}";
 
 const SUCCESS_HTML = `<html><head><meta name="viewport" content="width=device-width,initial-scale=1"><style>${OAUTH_CSS}</style></head><body><div class="card"><div class="icon">&#10003;</div><h1>Authentication Successful</h1><p>You can close this tab and return to your terminal.</p></div><script>setTimeout(function(){try{window.close()}catch(e){}},3000)</script></body></html>`;


### PR DESCRIPTION
**Why:** Inline `err instanceof Error ? err.message : String(err)` patterns in 3 cloud modules bypass the shared `getErrorMessage()` helper. The `instanceof Error` check fails across realms/prototypes (e.g. errors from Worker threads or cross-package boundaries in Bun), causing error messages to render as `[object Object]` instead of the actual message. This also deduplicates 250+ chars of identical OAuth CSS between `shared/oauth.ts` and `digitalocean/digitalocean.ts`.

## Changes

- **aws/aws.ts**: Import `getErrorMessage` from `shared/type-guards`, replace 2 inline `instanceof Error` patterns
- **digitalocean/digitalocean.ts**: Import `getErrorMessage` from `shared/type-guards`, replace 1 inline pattern; import `OAUTH_CSS` from `shared/oauth` instead of duplicating it
- **hetzner/hetzner.ts**: Import `getErrorMessage` from `shared/type-guards`, replace 1 inline pattern
- **shared/oauth.ts**: Export `OAUTH_CSS` (was private `const`)
- **package.json**: Bump version 0.15.20 -> 0.15.21

## Test plan

- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — 1466 pass, 0 fail

-- refactor/code-health