### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/__tests__/README.md
+++ b/packages/cli/src/__tests__/README.md
@@ -73,12 +73,19 @@ bun test src/__tests__/manifest.test.ts
 
 ### Cloud-specific
 - `aws.test.ts` — AWS credential cache, SigV4 signing helpers
+- `billing-guidance.test.ts` — `isBillingError`, `handleBillingError`, `showNonBillingError`
 - `cloud-init.test.ts` — `getPackagesForTier`, `needsNode`, `needsBun`, `NODE_INSTALL_CMD`
 - `check-entity.test.ts` / `check-entity-messages.test.ts` — Entity validation
 - `agent-tarball.test.ts` — `tryTarballInstall`: GitHub Release tarball install, fallback, URL validation
 - `gateway-resilience.test.ts` — `startGateway` systemd unit with auto-restart and cron heartbeat
 - `do-snapshot.test.ts` — `findSpawnSnapshot`: DigitalOcean snapshot lookup, filtering, error handling
-- `ui-utils.test.ts` — `validateServerName`, `validateRegionName`, `validateModelId`, `toKebabCase`, `sanitizeTermValue`, `jsonEscape`
+- `ui-utils.test.ts` — `validateServerName`, `validateRegionName`, `toKebabCase`, `sanitizeTermValue`, `jsonEscape`
+
+### Agent-specific
+- `junie-agent.test.ts` — Junie CLI agent configuration validation
+
+### Shared helpers
+- `shared-helpers.test.ts` — `generateEnvConfig`, `hasStatus`, `toObjectArray`, `toRecord`
 
 ### OAuth and auth
 - `oauth-code-validation.test.ts` — `OAUTH_CODE_REGEX` format validation

--- a/packages/cli/src/__tests__/billing-guidance.test.ts
+++ b/packages/cli/src/__tests__/billing-guidance.test.ts
@@ -13,9 +13,7 @@ mock.module("../shared/ui", () => ({
   prompt: mockPrompt,
 }));
 
-const { getBillingUrl, getSetupSteps, handleBillingError, isBillingError, showNonBillingError } = await import(
-  "../shared/billing-guidance"
-);
+const { handleBillingError, isBillingError, showNonBillingError } = await import("../shared/billing-guidance");
 
 describe("isBillingError", () => {
   describe("hetzner", () => {
@@ -84,48 +82,10 @@ describe("isBillingError", () => {
     });
   });
 
-  describe("daytona", () => {
-    it("matches billing/plan errors", () => {
-      expect(isBillingError("daytona", "quota exceeded")).toBe(true);
-      expect(isBillingError("daytona", "plan limit reached")).toBe(true);
-    });
-
-    it("returns false for non-billing errors", () => {
-      expect(isBillingError("daytona", "sandbox creation failed")).toBe(false);
-      expect(isBillingError("daytona", "internal server error")).toBe(false);
-    });
-  });
-
   describe("unknown cloud", () => {
     it("returns false for unknown clouds", () => {
       expect(isBillingError("unknown", "billing error")).toBe(false);
     });
-  });
-});
-
-describe("getBillingUrl", () => {
-  it("returns correct URLs for known clouds", () => {
-    expect(getBillingUrl("hetzner")).toBe("https://console.hetzner.cloud/");
-    expect(getBillingUrl("digitalocean")).toBe("https://cloud.digitalocean.com/account/billing");
-    expect(getBillingUrl("aws")).toBe("https://lightsail.aws.amazon.com/");
-    expect(getBillingUrl("gcp")).toBe("https://console.cloud.google.com/billing");
-    expect(getBillingUrl("daytona")).toBe("https://app.daytona.io/dashboard");
-  });
-
-  it("returns undefined for unknown clouds", () => {
-    expect(getBillingUrl("unknown")).toBeUndefined();
-  });
-});
-
-describe("getSetupSteps", () => {
-  it("returns steps for known clouds", () => {
-    const steps = getSetupSteps("hetzner");
-    expect(steps.length).toBeGreaterThan(0);
-    expect(steps[0]).toContain("Hetzner");
-  });
-
-  it("returns empty array for unknown clouds", () => {
-    expect(getSetupSteps("unknown")).toEqual([]);
   });
 });
 

--- a/packages/cli/src/__tests__/ui-utils.test.ts
+++ b/packages/cli/src/__tests__/ui-utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
 
-const { validateServerName, validateRegionName, validateModelId, toKebabCase, sanitizeTermValue, jsonEscape } =
-  await import("../shared/ui.js");
+const { validateServerName, validateRegionName, toKebabCase, sanitizeTermValue, jsonEscape } = await import(
+  "../shared/ui.js"
+);
 
 // ── validateServerName ──────────────────────────────────────────────
 
@@ -59,26 +60,6 @@ describe("validateRegionName", () => {
     expect(validateRegionName("us east")).toBe(false);
     expect(validateRegionName("us.east")).toBe(false);
     expect(validateRegionName("us@east")).toBe(false);
-  });
-});
-
-// ── validateModelId ─────────────────────────────────────────────────
-
-describe("validateModelId", () => {
-  it("accepts valid model IDs", () => {
-    expect(validateModelId("anthropic/claude-3.5-sonnet")).toBe(true);
-    expect(validateModelId("openai/gpt-4")).toBe(true);
-    expect(validateModelId("meta-llama/llama-3:70b")).toBe(true);
-  });
-
-  it("returns true for empty string", () => {
-    expect(validateModelId("")).toBe(true);
-  });
-
-  it("rejects model IDs with invalid characters", () => {
-    expect(validateModelId("model name")).toBe(false);
-    expect(validateModelId("model@id")).toBe(false);
-    expect(validateModelId("model;id")).toBe(false);
   });
 });
 

--- a/packages/cli/src/shared/billing-guidance.ts
+++ b/packages/cli/src/shared/billing-guidance.ts
@@ -9,7 +9,6 @@ const BILLING_URLS: Record<string, string> = {
   digitalocean: "https://cloud.digitalocean.com/account/billing",
   aws: "https://lightsail.aws.amazon.com/",
   gcp: "https://console.cloud.google.com/billing",
-  daytona: "https://app.daytona.io/dashboard",
 };
 
 // ─── Setup steps per cloud ──────────────────────────────────────────────────
@@ -38,11 +37,6 @@ const SETUP_STEPS: Record<string, string[]> = {
     "2. Link a billing account to your project",
     "3. Enable the Compute Engine API",
     "4. Return here and press Enter to retry",
-  ],
-  daytona: [
-    "1. Open the Daytona dashboard",
-    "2. Complete account setup or upgrade your plan",
-    "3. Return here and press Enter to retry",
   ],
 };
 
@@ -76,13 +70,6 @@ const ERROR_PATTERNS: Record<string, RegExp[]> = {
     /project.*has.*no.*billing/i,
     /account[_ ](?:is[_ ])?(?:suspended|closed)/i,
   ],
-  daytona: [
-    /billing/i,
-    /payment/i,
-    /subscription/i,
-    /quota[_ ]exceeded/i,
-    /plan[_ ]limit/i,
-  ],
 };
 
 /** Check if an error message matches known billing error patterns for a cloud. */
@@ -92,16 +79,6 @@ export function isBillingError(cloud: string, errorMsg: string): boolean {
     return false;
   }
   return patterns.some((p) => p.test(errorMsg));
-}
-
-/** Get billing setup URL for a cloud. */
-export function getBillingUrl(cloud: string): string | undefined {
-  return BILLING_URLS[cloud];
-}
-
-/** Get setup steps for a cloud. */
-export function getSetupSteps(cloud: string): string[] {
-  return SETUP_STEPS[cloud] || [];
 }
 
 /**

--- a/packages/cli/src/shared/ui.ts
+++ b/packages/cli/src/shared/ui.ts
@@ -272,14 +272,6 @@ export function validateRegionName(region: string): boolean {
   return /^[a-zA-Z0-9_-]{1,63}$/.test(region);
 }
 
-/** Validate model ID format. */
-export function validateModelId(id: string): boolean {
-  if (!id) {
-    return true;
-  }
-  return /^[a-zA-Z0-9/_:.-]+$/.test(id);
-}
-
 /** Convert display name to kebab-case. */
 export function toKebabCase(name: string): string {
   return name


### PR DESCRIPTION
## Summary

- Remove 3 unused exported functions (`getBillingUrl`, `getSetupSteps`, `validateModelId`) that were only exercised by their own tests but never called from production code
- Remove stale `daytona` cloud entries from `billing-guidance.ts` data structures (daytona is not in `manifest.json` and has no cloud module)
- Update `__tests__/README.md` to document 3 test files that were missing from the index (`billing-guidance.test.ts`, `junie-agent.test.ts`, `shared-helpers.test.ts`)
- Remove corresponding dead test cases and update imports

## Files changed
- `packages/cli/src/shared/billing-guidance.ts` — removed `getBillingUrl()`, `getSetupSteps()`, daytona entries
- `packages/cli/src/shared/ui.ts` — removed `validateModelId()`
- `packages/cli/src/__tests__/billing-guidance.test.ts` — removed dead tests
- `packages/cli/src/__tests__/ui-utils.test.ts` — removed dead tests
- `packages/cli/src/__tests__/README.md` — added missing test file entries

## Test plan
- [x] `bunx @biomejs/biome check` passes with 0 errors
- [x] `bun test` passes (1457 tests, 0 failures)

-- qa/code-quality