### PR TITLE
fix: add --proto '=https' to remaining curl commands (fixes #2350)

### DIFF
--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -2,12 +2,12 @@
 # Installer for the spawn CLI
 #
 # Usage:
-#   curl -fsSL https://openrouter.ai/labs/spawn/cli/install.sh | bash
+#   curl -fsSL --proto '=https' https://openrouter.ai/labs/spawn/cli/install.sh | bash
 #
 # This installs spawn via bun. If bun is not available, it auto-installs it first.
 #
 # Override install directory:
-#   SPAWN_INSTALL_DIR=/usr/local/bin curl -fsSL ... | bash
+#   SPAWN_INSTALL_DIR=/usr/local/bin curl -fsSL --proto '=https' ... | bash
 
 set -eo pipefail
 
@@ -63,7 +63,7 @@ ensure_min_bun_version() {
             echo "  bun upgrade"
             echo ""
             echo "Then re-run:"
-            echo "  curl -fsSL ${SPAWN_CDN}/cli/install.sh | bash"
+            echo "  curl -fsSL --proto '=https' ${SPAWN_CDN}/cli/install.sh | bash"
             exit 1
         fi
         log_info "bun upgraded to ${current}"
@@ -236,10 +236,10 @@ if ! command -v bun &>/dev/null; then
         log_error "Failed to install bun automatically"
         echo ""
         echo "Please install bun manually:"
-        echo "  curl -fsSL https://bun.sh/install?version=1.3.9 | bash"
+        echo "  curl -fsSL --proto '=https' https://bun.sh/install?version=1.3.9 | bash"
         echo ""
         echo "Then reopen your terminal and re-run:"
-        echo "  curl -fsSL ${SPAWN_CDN}/cli/install.sh | bash"
+        echo "  curl -fsSL --proto '=https' ${SPAWN_CDN}/cli/install.sh | bash"
         exit 1
     fi
 

--- a/sh/shared/github-auth.sh
+++ b/sh/shared/github-auth.sh
@@ -3,11 +3,11 @@
 # Executable directly via curl|bash; also sourceable using the CDN URL with eval.
 #
 # Usage (via curl|bash — recommended):
-#   curl -fsSL https://openrouter.ai/labs/spawn/shared/github-auth.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sh/shared/github-auth.sh | bash
+#   curl -fsSL --proto '=https' https://openrouter.ai/labs/spawn/shared/github-auth.sh | bash
+#   curl -fsSL --proto '=https' https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/sh/shared/github-auth.sh | bash
 #
 # Usage (sourced using absolute path or CDN URL):
-#   eval "$(curl -fsSL https://openrouter.ai/labs/spawn/shared/github-auth.sh)"
+#   eval "$(curl -fsSL --proto '=https' https://openrouter.ai/labs/spawn/shared/github-auth.sh)"
 #   ensure_github_auth
 
 # ============================================================


### PR DESCRIPTION
## Summary
- **sh/cli/install.sh**: Added `--proto '=https'` to 3 user-facing `echo` instructions and 2 usage comment lines that were missing the flag
- **sh/shared/github-auth.sh**: Added `--proto '=https'` to 3 usage comment lines

## Context
Cloud agent scripts (AWS, GCP, Hetzner, Local, Sprite, DigitalOcean) already have this flag from prior fixes. The remaining gaps were in the CLI installer's user-facing instructions and the GitHub auth helper's documentation comments. Without `--proto '=https'`, curl can follow HTTP redirects from HTTPS, enabling MITM attackers to serve malicious scripts.

## Verification
- `bash -n` passes on both modified scripts
- No functional behavior changes — only added security flag to echo/comment lines
- DigitalOcean scripts: untouched (already correct)

Fixes #2350

-- refactor/security-auditor