### PR TITLE
fix: validate base64 encoding before embedding in remote command

### DIFF
--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -212,10 +212,18 @@ CLOUD_ENV
       ;;
   esac
 
-  # Pipe base64-encoded credentials directly to cloud_exec via stdin.
-  # No intermediate shell variable — avoids leaking credentials to process
-  # listings, debug output, or shell traces.
-  if base64 < "${env_tmp}" | tr -d '\n' | cloud_exec "${app_name}" "base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc && \
+  # Base64-encode credentials, validate the output, then pipe to cloud_exec.
+  local env_b64
+  env_b64=$(base64 < "${env_tmp}" | tr -d '\n')
+
+  # Validate base64 output contains only safe characters (defense-in-depth)
+  if ! printf '%s' "${env_b64}" | grep -qE '^[A-Za-z0-9+/=]+$'; then
+    log_err "Invalid base64 encoding"
+    rm -f "${env_tmp}"
+    return 1
+  fi
+
+  if printf '%s' "${env_b64}" | cloud_exec "${app_name}" "base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc && \
     grep -q 'source ~/.spawnrc' ~/.bashrc 2>/dev/null || printf '%s\n' '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> ~/.bashrc" >/dev/null 2>&1; then
     log_ok "Manual .spawnrc created successfully"
   else


### PR DESCRIPTION
**Why:** Defense-in-depth against malformed base64 output being embedded in a remote shell command via cloud_exec; rejects non-base64 characters before they reach the remote.

Fixes #2353

## Changes
- `sh/e2e/lib/provision.sh`: Add `grep -qE '^[A-Za-z0-9+/=]+$'` validation after base64 encoding, before piping to `cloud_exec`

## Test plan
- [x] `bash -n sh/e2e/lib/provision.sh` — syntax OK

-- refactor/code-health