### PR TITLE
fix: GCP billing retry fails due to deleted temp startup script

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.22",
+  "version": "0.15.23",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -731,9 +731,11 @@ export async function createInstance(
 
   logStep(`Creating GCP instance '${name}' (type: ${machineType}, zone: ${zone})...`);
 
-  // Write startup script to a temp file
-  const tmpFile = `/tmp/spawn_startup_${Date.now()}.sh`;
-  writeFileSync(tmpFile, getStartupScript(username, tier));
+  // Write startup script to a temp file (random suffix prevents collisions and predictable paths)
+  const tmpFile = `/tmp/spawn_startup_${Date.now()}_${Math.random().toString(36).slice(2)}.sh`;
+  writeFileSync(tmpFile, getStartupScript(username, tier), {
+    mode: 0o600,
+  });
 
   const args = [
     "compute",
@@ -752,70 +754,74 @@ export async function createInstance(
     "--quiet",
   ];
 
-  let result = await gcloud(args);
-
-  // Auto-reauth on expired tokens
-  if (
-    result.exitCode !== 0 &&
-    /reauthentication|refresh.*auth|token.*expired|credentials.*invalid/i.test(result.stderr)
-  ) {
-    logWarn("Auth tokens expired -- running gcloud auth login...");
-    const reauth = await gcloudInteractive([
-      "auth",
-      "login",
-    ]);
-    if (reauth === 0) {
-      await gcloudInteractive([
-        "config",
-        "set",
-        "project",
-        _state.project,
-      ]);
-      logInfo("Re-authenticated, retrying instance creation...");
-      result = await gcloud(args);
-    }
-  }
-
-  // Clean up temp file
+  // Wrap all gcloud calls in try/finally so the temp file is cleaned up
+  // even when billing retry re-uses it (the args array references tmpFile).
   try {
-    Bun.spawnSync([
-      "rm",
-      "-f",
-      tmpFile,
-    ]);
-  } catch {
-    /* ignore */
-  }
+    let result = await gcloud(args);
 
-  if (result.exitCode !== 0) {
-    const errMsg = result.stderr || "Unknown error";
-    logError("Failed to create GCP instance");
-    if (result.stderr) {
-      logError(`gcloud error: ${result.stderr}`);
+    // Auto-reauth on expired tokens
+    if (
+      result.exitCode !== 0 &&
+      /reauthentication|refresh.*auth|token.*expired|credentials.*invalid/i.test(result.stderr)
+    ) {
+      logWarn("Auth tokens expired -- running gcloud auth login...");
+      const reauth = await gcloudInteractive([
+        "auth",
+        "login",
+      ]);
+      if (reauth === 0) {
+        await gcloudInteractive([
+          "config",
+          "set",
+          "project",
+          _state.project,
+        ]);
+        logInfo("Re-authenticated, retrying instance creation...");
+        result = await gcloud(args);
+      }
     }
 
-    if (isBillingError("gcp", errMsg)) {
-      const shouldRetry = await handleBillingError("gcp");
-      if (shouldRetry) {
-        logStep("Retrying instance creation...");
-        const retryResult = await gcloud(args);
-        if (retryResult.exitCode === 0) {
-          // Fall through to IP extraction below
+    if (result.exitCode !== 0) {
+      const errMsg = result.stderr || "Unknown error";
+      logError("Failed to create GCP instance");
+      if (result.stderr) {
+        logError(`gcloud error: ${result.stderr}`);
+      }
+
+      if (isBillingError("gcp", errMsg)) {
+        const shouldRetry = await handleBillingError("gcp");
+        if (shouldRetry) {
+          logStep("Retrying instance creation...");
+          const retryResult = await gcloud(args);
+          if (retryResult.exitCode === 0) {
+            // Fall through to IP extraction below
+          } else {
+            const retryErr = retryResult.stderr || "Unknown error";
+            logError(`Retry failed: ${retryErr}`);
+            throw new Error("Instance creation failed");
+          }
         } else {
-          const retryErr = retryResult.stderr || "Unknown error";
-          logError(`Retry failed: ${retryErr}`);
           throw new Error("Instance creation failed");
         }
       } else {
+        showNonBillingError("gcp", [
+          "Compute Engine API not enabled (enable at https://console.cloud.google.com/apis)",
+          "Instance quota exceeded (try different GCP_ZONE)",
+          "Machine type unavailable (try different GCP_MACHINE_TYPE or GCP_ZONE)",
+        ]);
         throw new Error("Instance creation failed");
       }
-    } else {
-      showNonBillingError("gcp", [
-        "Compute Engine API not enabled (enable at https://console.cloud.google.com/apis)",
-        "Instance quota exceeded (try different GCP_ZONE)",
-        "Machine type unavailable (try different GCP_MACHINE_TYPE or GCP_ZONE)",
+    }
+  } finally {
+    // Clean up temp file after all retry paths have completed
+    try {
+      Bun.spawnSync([
+        "rm",
+        "-f",
+        tmpFile,
       ]);
-      throw new Error("Instance creation failed");
+    } catch {
+      /* ignore */
     }
   }
 


### PR DESCRIPTION
**Why:** The GCP `createInstance` function deletes the startup script temp file immediately after the first `gcloud` call (line 779-788), but the billing retry path at line 801 re-uses the same `args` array which references that now-deleted file via `--metadata-from-file=startup-script=${tmpFile}`. This means billing retries **always fail** with a file-not-found error, leaving users stranded after fixing their billing.

## Changes
- Move temp file cleanup from between the initial call and retry to a `try/finally` block that wraps all retry paths
- Add random suffix to temp file name (matches existing pattern in `agent-setup.ts`)
- Set `mode: 0o600` on the temp file for restricted permissions
- Bump CLI version to 0.15.23

## Test plan
- [x] `bunx @biomejs/biome check src/gcp/gcp.ts` — zero errors
- [x] `bun test` — 1457 pass, 0 fail

-- refactor/code-health