### PR TITLE
feat: install Playwright Chromium for OpenClaw browser tool

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.23",
+  "version": "0.15.24",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -569,14 +569,21 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       cloudInitTier: "full",
       preProvision: detectGithubAuth,
       modelDefault: "openrouter/auto",
-      install: () =>
-        installAgent(
+      install: async () => {
+        await installAgent(
           runner,
           "openclaw",
           `source ~/.bashrc 2>/dev/null; ${NPM_PREFIX_SETUP} && npm install -g \${_NPM_G_FLAGS} openclaw && ` +
             "{ grep -qF '.npm-global/bin' ~/.bashrc 2>/dev/null || echo 'export PATH=\"$HOME/.npm-global/bin:$PATH\"' >> ~/.bashrc; } && " +
             "{ [ ! -f ~/.zshrc ] || grep -qF '.npm-global/bin' ~/.zshrc 2>/dev/null || echo 'export PATH=\"$HOME/.npm-global/bin:$PATH\"' >> ~/.zshrc; }",
-        ),
+        );
+        // Install Playwright Chromium for OpenClaw's browser tool (headless, no snap dependency)
+        try {
+          await runner.runServer("npx playwright install chromium --with-deps 2>/dev/null", 300);
+        } catch {
+          logWarn("Playwright Chromium install failed (browser tool will be unavailable)");
+        }
+      },
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,
         `ANTHROPIC_API_KEY=${apiKey}`,


### PR DESCRIPTION
## Summary
- Install Playwright's bundled Chromium after OpenClaw npm install
- Fixes headless browser on Ubuntu 24.04 cloud VMs where `apt install chromium-browser` fails due to snap/dpkg conflict
- Non-fatal: if Playwright install fails, agent works without browser capabilities
- ~170MB self-contained binary, no snapd dependency

## Context
Alex reported that OpenClaw can't install a headless browser on any spawn cloud VM. `openclaw browser status` shows `browser: unknown`. This blocks web scraping, screenshots, and browser automation.

## Test plan
- [x] All 1457 tests pass
- [x] Biome lint clean
- [ ] Deploy OpenClaw on cloud VM, verify `openclaw browser status` shows detected browser
- [ ] Verify browser tool works for web scraping in the TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)