### PR TITLE
refactor: Fix stale type-guards export list in rules

### DIFF
--- a/.claude/rules/type-safety.md
+++ b/.claude/rules/type-safety.md
@@ -84,4 +84,4 @@ global.fetch = mock(() => Promise.resolve(new Response("Error", { status: 500 })
 
 ### Shared utilities
 - `packages/cli/src/shared/parse.ts` — `parseJsonWith(text, schema)` and `parseJsonObj(text)`
-- `packages/cli/src/shared/type-guards.ts` — `isString`, `isNumber`, `hasStatus`, `hasMessage`
+- `packages/cli/src/shared/type-guards.ts` — `isString`, `isNumber`, `hasStatus`, `getErrorMessage`, `toRecord`, `toObjectArray`


### PR DESCRIPTION
## Summary
- Fixed stale reference in `.claude/rules/type-safety.md`: the shared utilities section listed `hasMessage` as an export from `type-guards.ts`, but that function does not exist
- Updated to list the actual current exports: `isString`, `isNumber`, `hasStatus`, `getErrorMessage`, `toRecord`, `toObjectArray`

## Scan results
Performed a comprehensive code quality scan across the codebase:

| Category | Findings |
|---|---|
| Dead code (shell) | None — all functions in `sh/shared/*.sh` are called from other scripts |
| Dead code (TypeScript) | None — all shared module exports are imported by production or test code |
| Stale references | 1 found — `hasMessage` listed in type-safety rules but not in type-guards.ts |
| Python usage | None — no `python3 -c` or `python -c` in shell scripts |
| Duplicate utilities | None — cloud-specific functions (e.g., `ensureSshKey`) each contain provider-specific API logic |
| Stale comments | None found |
| Lint/format | 0 errors (biome check clean) |
| Tests | 1457 pass, 0 fail |

-- qa/code-quality