### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/commands-cloud-info.test.ts
+++ b/packages/cli/src/__tests__/commands-cloud-info.test.ts
@@ -196,16 +196,12 @@ describe("cmdCloudInfo", () => {
   // ── Error paths: unknown cloud ────────────────────────────────────
 
   describe("unknown cloud", () => {
-    it("should exit with error for unknown cloud", async () => {
+    it("should exit with error and suggest spawn clouds for unknown cloud", async () => {
       await expect(cmdCloudInfo("nonexistent")).rejects.toThrow("process.exit");
       expect(processExitSpy).toHaveBeenCalledWith(1);
 
       const errorCalls = mockLogError.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(errorCalls.some((msg: string) => msg.includes("Unknown cloud"))).toBe(true);
-    });
-
-    it("should suggest spawn clouds command", async () => {
-      await expect(cmdCloudInfo("nonexistent")).rejects.toThrow("process.exit");
 
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("spawn clouds"))).toBe(true);

--- a/packages/cli/src/__tests__/commands-error-paths.test.ts
+++ b/packages/cli/src/__tests__/commands-error-paths.test.ts
@@ -114,32 +114,23 @@ describe("Commands Error Paths", () => {
   // ── cmdRun: unknown agent/cloud ───────────────────────────────────────
 
   describe("cmdRun - unknown agent or cloud", () => {
-    it("should exit with error for unknown agent", async () => {
+    it("should exit with error and suggest spawn agents for unknown agent", async () => {
       await expect(cmdRun("nonexistent", "sprite")).rejects.toThrow("process.exit");
       expect(processExitSpy).toHaveBeenCalledWith(1);
 
-      // Should show "Unknown agent" error via @clack/prompts log.error
       const errorCalls = mockLogError.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(errorCalls.some((msg: string) => msg.includes("Unknown agent"))).toBe(true);
-    });
-
-    it("should suggest spawn agents command for unknown agent", async () => {
-      await expect(cmdRun("nonexistent", "sprite")).rejects.toThrow("process.exit");
 
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("spawn agents"))).toBe(true);
     });
 
-    it("should exit with error for unknown cloud", async () => {
+    it("should exit with error and suggest spawn clouds for unknown cloud", async () => {
       await expect(cmdRun("claude", "nonexistent")).rejects.toThrow("process.exit");
       expect(processExitSpy).toHaveBeenCalledWith(1);
 
       const errorCalls = mockLogError.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(errorCalls.some((msg: string) => msg.includes("Unknown cloud"))).toBe(true);
-    });
-
-    it("should suggest spawn clouds command for unknown cloud", async () => {
-      await expect(cmdRun("claude", "nonexistent")).rejects.toThrow("process.exit");
 
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("spawn clouds"))).toBe(true);
@@ -149,25 +140,14 @@ describe("Commands Error Paths", () => {
   // ── cmdRun: unimplemented combination ─────────────────────────────────
 
   describe("cmdRun - unimplemented combination", () => {
-    it("should exit with error for unimplemented agent/cloud combination", async () => {
-      // hetzner/codex is "missing" in mock manifest
+    it("should exit with error and suggest available clouds for unimplemented combo", async () => {
+      // hetzner/codex is "missing" in mock manifest, but sprite/codex is "implemented"
       await expect(cmdRun("codex", "hetzner")).rejects.toThrow("process.exit");
       expect(processExitSpy).toHaveBeenCalledWith(1);
-    });
-
-    it("should suggest available clouds when combination is not implemented", async () => {
-      // hetzner/codex is "missing", but sprite/codex is "implemented"
-      await expect(cmdRun("codex", "hetzner")).rejects.toThrow("process.exit");
 
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       // Should suggest sprite as an alternative
       expect(infoCalls.some((msg: string) => msg.includes("spawn codex sprite"))).toBe(true);
-    });
-
-    it("should show how many clouds are available", async () => {
-      await expect(cmdRun("codex", "hetzner")).rejects.toThrow("process.exit");
-
-      const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       // codex has 1 implemented cloud (sprite)
       expect(infoCalls.some((msg: string) => msg.includes("1 cloud"))).toBe(true);
     });

--- a/packages/cli/src/__tests__/commands-name-suggestions.test.ts
+++ b/packages/cli/src/__tests__/commands-name-suggestions.test.ts
@@ -152,46 +152,26 @@ describe("Display Name Suggestions in Validation Errors", () => {
   // ── validateEntity (agent): display name suggestion path ────────────
 
   describe("validateEntity (agent) - display name suggestion", () => {
-    it("should suggest key via display name when key-based suggestion fails", async () => {
-      // "codex" is far from keys ["cc", "ap", "oi"] (all distance > 3)
-      // But "Codex Pro" display name is close to "codex" via findClosestMatch
-      // on display names: findClosestMatch("codex", ["Claude Code", "Codex Pro", "GPTMe"])
-      // "codex" vs "Codex Pro" -> lowercase: "codex" vs "codex pro" -> distance 4 (too far)
-      // Let's use a closer typo: "codex-pro" would match "ap" display name "Codex Pro"
-      // Actually, findClosestMatch is case-insensitive and max distance 3.
-      // So we need a name within distance 3 of a display name.
-      // "codex-pr" is 6 chars, "Codex Pro" is 9 chars. Distance too high.
-      // Let's try: user types "claude-cod" (10 chars), display name "Claude Code" (11 chars) -> distance 2.
-      // But validateIdentifier rejects hyphens... wait no, hyphens are valid in identifiers.
+    it("should suggest key via display name and show Unknown agent error", async () => {
       // User types "claude-code" -> key check fails (no key "claude-code"),
-      // findClosestMatch("claude-code", ["cc", "ap", "oi"]) -> all distance > 3 -> null.
-      // findClosestMatch("claude-code", ["Claude Code", "Codex Pro", "GPTMe"]):
-      //   "claude-code" vs "claude code" -> distance 1 (hyphen vs space)
-      //   That's within threshold 3 -> returns "Claude Code"
+      // findClosestMatch on display names: "claude-code" vs "claude code" -> distance 1 -> match!
       // Then it looks up the key for "Claude Code" -> "cc"
-      // This tests the nameSuggestion branch!
       await expect(cmdRun("claude-code", "sp")).rejects.toThrow("process.exit");
 
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       // Should suggest "cc" (the key for "Claude Code") with the display name
       expect(infoCalls.some((msg: string) => msg.includes("cc") && msg.includes("Claude Code"))).toBe(true);
+
+      const errorCalls = mockLogError.mock.calls.map((c: unknown[]) => c.join(" "));
+      expect(errorCalls.some((msg: string) => msg.includes("Unknown agent"))).toBe(true);
     });
 
     it("should suggest key via display name for close display name typo", async () => {
-      // "gptme-x" (7 chars) vs display name "GPTMe" (5 chars) -> distance 2 (close enough)
-      // Let's try "codex-pro" -> display "Codex Pro":
-      //   "codex-pro" vs "codex pro" -> distance 1 -> match!
+      // "codex-pro" vs display "Codex Pro": "codex-pro" vs "codex pro" -> distance 1 -> match!
       await expect(cmdRun("codex-pro", "sp")).rejects.toThrow("process.exit");
 
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("ap") && msg.includes("Codex Pro"))).toBe(true);
-    });
-
-    it("should show 'Unknown agent' error even with display name suggestion", async () => {
-      await expect(cmdRun("claude-code", "sp")).rejects.toThrow("process.exit");
-
-      const errorCalls = mockLogError.mock.calls.map((c: unknown[]) => c.join(" "));
-      expect(errorCalls.some((msg: string) => msg.includes("Unknown agent"))).toBe(true);
     });
 
     it("should not show display name suggestion when both key and name fail", async () => {
@@ -223,7 +203,7 @@ describe("Display Name Suggestions in Validation Errors", () => {
   // ── validateEntity (cloud): display name suggestion path ────────────
 
   describe("validateEntity (cloud) - display name suggestion", () => {
-    it("should suggest key via display name when key-based suggestion fails", async () => {
+    it("should suggest key via display name and show Unknown cloud error", async () => {
       // "hetzner-cloud" -> display name "Hetzner Cloud":
       //   "hetzner-cloud" vs "hetzner cloud" -> distance 1 -> match!
       // But key "hz" is far (distance > 3) from "hetzner-cloud"
@@ -231,6 +211,9 @@ describe("Display Name Suggestions in Validation Errors", () => {
 
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("hz") && msg.includes("Hetzner Cloud"))).toBe(true);
+
+      const errorCalls = mockLogError.mock.calls.map((c: unknown[]) => c.join(" "));
+      expect(errorCalls.some((msg: string) => msg.includes("Unknown cloud"))).toBe(true);
     });
 
     it("should suggest key via display name for digitalocean typo", async () => {
@@ -241,13 +224,6 @@ describe("Display Name Suggestions in Validation Errors", () => {
 
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("dc") && msg.includes("DigitalOcean"))).toBe(true);
-    });
-
-    it("should show 'Unknown cloud' error even with display name suggestion", async () => {
-      await expect(cmdRun("cc", "hetzner-cloud")).rejects.toThrow("process.exit");
-
-      const errorCalls = mockLogError.mock.calls.map((c: unknown[]) => c.join(" "));
-      expect(errorCalls.some((msg: string) => msg.includes("Unknown cloud"))).toBe(true);
     });
 
     it("should not show display name suggestion when both key and name fail", async () => {

--- a/packages/cli/src/__tests__/commands-resolve-run.test.ts
+++ b/packages/cli/src/__tests__/commands-resolve-run.test.ts
@@ -312,17 +312,7 @@ describe("cmdRun - display name resolution", () => {
   // ── validateImplementation: > 3 clouds available suggestion ─────────
 
   describe("validateImplementation - many clouds suggestion", () => {
-    it("should show 'see all N options' when > 3 clouds available and combination missing", async () => {
-      await setManifestAndScript(manyCloudManifest);
-
-      // claude has 5 implemented clouds; request a cloud that doesn't exist
-      // Actually we need a cloud that exists but where the combination is "missing"
-      // In manyCloudManifest, codex is only on sprite; hetzner/codex is missing
-      // But codex only has 1 implemented cloud so it won't trigger "> 3"
-      // claude has 5 clouds, but all are implemented so it won't trigger
-      // Let's use the manifest differently: request a non-implemented combo
-      // We need an agent with > 3 implemented clouds but where a specific cloud is missing
-
+    it("should show 'see all N options' and at most 3 example commands when > 3 clouds available", async () => {
       // Create a manifest where claude has 4 implemented clouds but digitalocean is missing
       const partialManifest = {
         ...manyCloudManifest,
@@ -342,32 +332,11 @@ describe("cmdRun - display name resolution", () => {
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       // Should show the "see all N options" message since claude has 4 implemented clouds
       expect(infoCalls.some((msg: string) => msg.includes("4") && msg.includes("cloud"))).toBe(true);
-      // Should also suggest up to 3 example commands
-      const exampleCmds = infoCalls.filter((msg: string) => msg.includes("spawn claude"));
-      expect(exampleCmds.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it("should show at most 3 example commands when many clouds available", async () => {
-      const partialManifest = {
-        ...manyCloudManifest,
-        matrix: {
-          ...manyCloudManifest.matrix,
-          "digitalocean/claude": "missing",
-        },
-      };
-      await setManifestAndScript(partialManifest);
-
-      try {
-        await cmdRun("claude", "digitalocean");
-      } catch {
-        // Expected
-      }
-
-      const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
-      // Count example spawn commands (not the "see all" hint)
+      // Should suggest up to 3 example commands
       const exampleCmds = infoCalls.filter(
         (msg: string) => msg.includes("spawn claude") && !msg.includes("see all") && !msg.includes("to see"),
       );
+      expect(exampleCmds.length).toBeGreaterThanOrEqual(1);
       expect(exampleCmds.length).toBeLessThanOrEqual(3);
     });
 
@@ -391,7 +360,7 @@ describe("cmdRun - display name resolution", () => {
   // ── validateImplementation: no implemented clouds ──────────────────
 
   describe("validateImplementation - no implemented clouds", () => {
-    it("should show 'no implemented cloud providers' for agent with zero clouds", async () => {
+    it("should show 'no implemented cloud providers' and suggest 'spawn matrix'", async () => {
       await setManifestAndScript(noCloudManifest);
 
       try {
@@ -402,18 +371,6 @@ describe("cmdRun - display name resolution", () => {
 
       const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("no implemented cloud providers"))).toBe(true);
-    });
-
-    it("should suggest 'spawn matrix' when no clouds available", async () => {
-      await setManifestAndScript(noCloudManifest);
-
-      try {
-        await cmdRun("codex", "sprite");
-      } catch {
-        // Expected
-      }
-
-      const infoCalls = mockLogInfo.mock.calls.map((c: unknown[]) => c.join(" "));
       expect(infoCalls.some((msg: string) => msg.includes("spawn matrix"))).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- Consolidated 9 test cases across 4 files that made duplicate function calls with the same arguments
- Each pair/triple of tests called the same function (e.g., `cmdRun("claude", "nonexistent")`) but checked different assertions in separate `it()` blocks -- merged them into single tests that verify all assertions in one call
- Net reduction: 91 lines removed, 1456 -> 1447 tests (same coverage, fewer redundant function invocations)

## Files changed

- `commands-error-paths.test.ts`: merged "exit with error" + "suggest command" pairs for unknown agent, unknown cloud, and unimplemented combination
- `commands-cloud-info.test.ts`: merged "exit with error" + "suggest spawn clouds" for unknown cloud
- `commands-resolve-run.test.ts`: merged "see all N options" + "at most 3 examples" tests; merged "no implemented clouds" + "suggest spawn matrix" tests
- `commands-name-suggestions.test.ts`: merged "suggest key via display name" + "show Unknown error" tests for both agent and cloud paths

## Test plan

- [x] `bun test` passes: 1447 tests, 0 failures (644ms)
- [x] `bunx @biomejs/biome check src/` passes with zero errors
- [x] No test coverage lost -- same assertions, just consolidated into fewer test cases

-- qa/dedup-scanner