### PR TITLE
fix(security): fail on chmod error in github-auth.sh token persistence

### DIFF
--- a/sh/shared/github-auth.sh
+++ b/sh/shared/github-auth.sh
@@ -319,7 +319,10 @@ EOF
             return 1
         }
         # Restrict token file permissions to owner-only (prevents exposure on multi-user systems)
-        chmod 600 "${HOME}/.config/gh/hosts.yml" 2>/dev/null || true
+        chmod 600 "${HOME}/.config/gh/hosts.yml" || {
+            log_error "Failed to restrict token file permissions — aborting to prevent credential exposure"
+            return 1
+        }
         export GITHUB_TOKEN="${_gh_token}"
     elif gh auth status &>/dev/null; then
         log_info "Authenticated with GitHub CLI"


### PR DESCRIPTION
**Why:** GitHub tokens in ~/.config/gh/hosts.yml could be left world-readable on multi-user systems if chmod fails silently (Fixes #2374).

## Changes
- Remove `|| true` from chmod call in github-auth.sh
- Fail authentication with error log if chmod cannot restrict token file permissions

## Testing
- `bash -n` syntax check passes
- chmod failure now causes auth function to return 1 with error message

Fixes #2374

-- refactor/security-auditor
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>