### PR TITLE
fix: wire maxAttempts in waitForCloudInit for hetzner and digitalocean

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.26",
+  "version": "0.15.27",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1009,7 +1009,7 @@ export async function waitForSshOnly(ip?: string): Promise<void> {
 
 // ─── SSH Execution ───────────────────────────────────────────────────────────
 
-export async function waitForCloudInit(ip?: string, _maxAttempts = 60): Promise<void> {
+export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<void> {
   const serverIp = ip || _state.serverIp;
   const selectedKeys = await ensureSshKeys();
   const keyOpts = getSshKeyOpts(selectedKeys);
@@ -1062,7 +1062,7 @@ export async function waitForCloudInit(ip?: string, _maxAttempts = 60): Promise<
   }
 
   // Fallback poll if streaming failed (e.g. log file not yet created)
-  for (let attempt = 1; attempt <= 20; attempt++) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       const proc = Bun.spawn(
         [
@@ -1093,7 +1093,7 @@ export async function waitForCloudInit(ip?: string, _maxAttempts = 60): Promise<
     } catch {
       /* ignore */
     }
-    logStepInline(`Cloud-init in progress (${attempt}/20)`);
+    logStepInline(`Cloud-init in progress (${attempt}/${maxAttempts})`);
     await sleep(5000);
   }
   logStepDone();

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -497,7 +497,7 @@ export async function createServer(
 
 // ─── SSH Execution ───────────────────────────────────────────────────────────
 
-export async function waitForCloudInit(ip?: string, _maxAttempts = 60): Promise<void> {
+export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<void> {
   const serverIp = ip || _state.serverIp;
   const selectedKeys = await ensureSshKeys();
   const keyOpts = getSshKeyOpts(selectedKeys);
@@ -509,7 +509,7 @@ export async function waitForCloudInit(ip?: string, _maxAttempts = 60): Promise<
   });
 
   logStep("Waiting for cloud-init to complete...");
-  for (let attempt = 1; attempt <= 60; attempt++) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       const proc = Bun.spawn(
         [
@@ -541,12 +541,12 @@ export async function waitForCloudInit(ip?: string, _maxAttempts = 60): Promise<
     } catch {
       // ignore
     }
-    if (attempt >= 60) {
+    if (attempt >= maxAttempts) {
       logStepDone();
       logWarn("Cloud-init marker not found, continuing anyway...");
       return;
     }
-    logStepInline(`Cloud-init in progress (${attempt}/60)`);
+    logStepInline(`Cloud-init in progress (${attempt}/${maxAttempts})`);
     await sleep(5000);
   }
 }


### PR DESCRIPTION
## Summary

- Rename `_maxAttempts` → `maxAttempts` in `waitForCloudInit()` for both Hetzner and DigitalOcean
- Wire the parameter through loop bounds, early-exit checks, and progress logs
- Now consistent with AWS/GCP implementations which correctly use `maxAttempts`
- Bump patch version to 0.15.27

## Changes

**`hetzner.ts`**: Loop bound `<= 60` → `<= maxAttempts`, early-exit `>= 60` → `>= maxAttempts`, log `/60` → `/${maxAttempts}`

**`digitalocean.ts`**: Fallback poll loop bound `<= 20` → `<= maxAttempts`, log `/20` → `/${maxAttempts}`

## Test plan

- [x] `bunx @biomejs/biome check src/` — zero errors
- [x] `bun test` — 1447 tests pass

Fixes #2378

-- refactor/issue-fixer