### PR TITLE
fix: set browser.defaultProfile for headless VM browser

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.27",
+  "version": "0.15.28",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -374,7 +374,8 @@ async function setupOpenclawConfig(runner: CloudRunner, apiKey: string, modelId:
       "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
         "openclaw config set browser.executablePath /usr/bin/google-chrome-stable; " +
         "openclaw config set browser.noSandbox true; " +
-        "openclaw config set browser.headless true",
+        "openclaw config set browser.headless true; " +
+        "openclaw config set browser.defaultProfile openclaw",
     );
   } catch {
     logWarn("Browser config setup failed (non-fatal)");


### PR DESCRIPTION
## Summary
- Set `browser.defaultProfile` to `openclaw` during OpenClaw config setup
- On headless VMs there's no Chrome extension to attach to — managed mode launches Chrome via CDP directly
- Without this, `openclaw browser status` shows `running: false` even with Chrome installed

## Test plan
- [ ] `spawn openclaw` on fresh VM — `openclaw browser status` shows `running: true` after agent starts
- [ ] Browser tool works when asked to open a page

🤖 Generated with [Claude Code](https://claude.com/claude-code)