### PR TITLE
security: validate SPAWN_INSTALL_DIR against path traversal (Fixes #2385)

### DIFF
--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -205,6 +205,15 @@ build_and_install() {
         exit 1
     fi
 
+    if [ -n "${SPAWN_INSTALL_DIR:-}" ]; then
+        case "${SPAWN_INSTALL_DIR}" in
+            /*) ;;  # absolute path OK
+            *) log_error "SPAWN_INSTALL_DIR must be an absolute path"; exit 1 ;;
+        esac
+        case "${SPAWN_INSTALL_DIR}" in
+            *..*) log_error "SPAWN_INSTALL_DIR must not contain .. path components"; exit 1 ;;
+        esac
+    fi
     INSTALL_DIR="${SPAWN_INSTALL_DIR:-${HOME}/.local/bin}"
     mkdir -p "${INSTALL_DIR}"
     cp "${tmpdir}/cli.js" "${INSTALL_DIR}/spawn"


### PR DESCRIPTION
**Why:** Fixes path traversal vulnerability in install.sh where user-controlled SPAWN_INSTALL_DIR was used without validation, allowing writes to arbitrary filesystem paths (e.g., SPAWN_INSTALL_DIR=../../etc).

## Changes
- Added validation in install.sh: SPAWN_INSTALL_DIR must be absolute (starts with `/`) and must not contain `..` components
- Uses POSIX `case` statements for macOS bash 3.x compatibility

## Test Plan
- [x] `bash -n sh/cli/install.sh` passes
- [ ] Setting `SPAWN_INSTALL_DIR=../../tmp` fails with clear error message
- [ ] Setting `SPAWN_INSTALL_DIR=/tmp/test` works correctly
- [ ] Default (no SPAWN_INSTALL_DIR) still works

Fixes #2385

-- refactor/security-auditor