### PR TITLE
fix: align cloud defaults with manifest (DO size, Hetzner location)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.28",
+  "version": "0.15.29",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -702,7 +702,7 @@ const DROPLET_SIZES: DropletSize[] = [
   },
 ];
 
-export const DEFAULT_DROPLET_SIZE = "s-2vcpu-4gb";
+export const DEFAULT_DROPLET_SIZE = "s-2vcpu-2gb";
 
 // ─── Region Options ──────────────────────────────────────────────────────────
 
@@ -831,7 +831,7 @@ export async function createServer(
   region?: string,
   snapshotId?: string,
 ): Promise<void> {
-  const size = dropletSize || process.env.DO_DROPLET_SIZE || "s-2vcpu-4gb";
+  const size = dropletSize || process.env.DO_DROPLET_SIZE || "s-2vcpu-2gb";
   const effectiveRegion = region || process.env.DO_REGION || "nyc3";
 
   if (!validateRegionName(effectiveRegion)) {

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -340,7 +340,7 @@ const LOCATIONS: LocationOption[] = [
   },
 ];
 
-export const DEFAULT_LOCATION = "nbg1";
+export const DEFAULT_LOCATION = "fsn1";
 
 // ─── Interactive Pickers ─────────────────────────────────────────────────────
 
@@ -391,7 +391,7 @@ export async function createServer(
   tier?: CloudInitTier,
 ): Promise<void> {
   const sType = serverType || process.env.HETZNER_SERVER_TYPE || DEFAULT_SERVER_TYPE;
-  const loc = location || process.env.HETZNER_LOCATION || "nbg1";
+  const loc = location || process.env.HETZNER_LOCATION || "fsn1";
   const image = "ubuntu-24.04";
 
   if (!validateRegionName(loc)) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -96,7 +96,7 @@ function checkUnknownFlags(args: string[]): void {
     console.error(`    ${pc.cyan("--output json")}       Output structured JSON to stdout`);
     console.error(`    ${pc.cyan("--custom")}            Show interactive size/region pickers`);
     console.error(`    ${pc.cyan("--zone, --region")}    Set zone/region (e.g. us-east1-b, nyc3)`);
-    console.error(`    ${pc.cyan("--size, --machine-type")}  Set instance size (e.g. e2-standard-4, s-2vcpu-4gb)`);
+    console.error(`    ${pc.cyan("--size, --machine-type")}  Set instance size (e.g. e2-standard-4, s-2vcpu-2gb)`);
     console.error(`    ${pc.cyan("--name")}              Set the spawn/resource name`);
     console.error(`    ${pc.cyan("--reauth")}            Force re-prompting for cloud credentials`);
     console.error(`    ${pc.cyan("--help, -h")}          Show help information`);


### PR DESCRIPTION
## Summary
- **DigitalOcean**: Default size was `s-2vcpu-4gb` but that's not available in `nyc3`, causing `422 unprocessable_entity` errors. Changed to `s-2vcpu-2gb` to match `manifest.json`
- **Hetzner**: Default location was `nbg1` in code but `fsn1` in manifest. Aligned to `fsn1`
- Updated help text example to show correct slug

## Test plan
- [x] `bunx @biomejs/biome check` — 0 errors
- [x] `bun test` — 1415 pass, 0 fail
- [ ] Manual: `spawn run digitalocean claude` should create droplet without 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)