### PR TITLE
fix: precise try/catch error handling with logDebug diagnostics

### DIFF
--- a/packages/cli/src/history.ts
+++ b/packages/cli/src/history.ts
@@ -13,6 +13,8 @@ import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import * as v from "valibot";
 import { tryCatch } from "./shared/result.js";
+import { getErrorMessage } from "./shared/type-guards.js";
+import { logDebug, logWarn } from "./shared/ui.js";
 
 export interface VMConnection {
   ip: string;
@@ -132,8 +134,7 @@ function writeHistory(records: SpawnRecord[]): void {
 /** Save launch command to a history record's connection.
  *  Matches by spawnId when provided; falls back to most recent record with a connection. */
 export function saveLaunchCmd(launchCmd: string, spawnId?: string): void {
-  // non-fatal — discard errors
-  tryCatch(() => {
+  const result = tryCatch(() => {
     const history = loadHistory();
     let found = false;
 
@@ -159,14 +160,21 @@ export function saveLaunchCmd(launchCmd: string, spawnId?: string): void {
       writeHistory(history);
     }
   });
+  if (!result.ok) {
+    logWarn("Could not save launch command");
+    logDebug(getErrorMessage(result.error));
+  }
 }
 
 /** Back up a corrupted file before discarding it. Non-fatal (best-effort). */
 function backupCorruptedFile(filePath: string): void {
-  tryCatch(() => {
+  const result = tryCatch(() => {
     copyFileSync(filePath, `${filePath}.corrupt.${Date.now()}`);
     console.error(`Warning: ${filePath} was corrupted. A backup has been saved with .corrupt suffix.`);
   });
+  if (!result.ok) {
+    logDebug(`Could not back up corrupted file: ${getErrorMessage(result.error)}`);
+  }
 }
 
 /** Try to parse valid records from a single archive file. */
@@ -241,6 +249,8 @@ export function loadHistory(): SpawnRecord[] {
   }
   const readResult = tryCatch(() => readFileSync(path, "utf-8"));
   if (!readResult.ok) {
+    logWarn("Could not read spawn history");
+    logDebug(getErrorMessage(readResult.error));
     return [];
   }
   const text = readResult.data;

--- a/packages/cli/src/shared/agent-tarball.ts
+++ b/packages/cli/src/shared/agent-tarball.ts
@@ -5,7 +5,8 @@
 import type { CloudRunner } from "./agent-setup";
 
 import * as v from "valibot";
-import { logInfo, logStep, logWarn } from "./ui";
+import { getErrorMessage } from "./type-guards";
+import { logDebug, logInfo, logStep, logWarn } from "./ui";
 
 const REPO = "OpenRouterTeam/spawn";
 
@@ -33,6 +34,10 @@ export async function tryTarballInstall(
   const tag = `agent-${agentName}-latest`;
   logStep(`Checking for pre-built tarball (${tag})...`);
 
+  // Phase 1: Fetch + parse tarball metadata
+  let x86Url: string;
+  let armUrl: string;
+  let url: string;
   try {
     // Query GitHub Releases API for the rolling release tag
     const resp = await fetchFn(`https://api.github.com/repos/${REPO}/releases/tags/${tag}`, {
@@ -64,43 +69,50 @@ export async function tryTarballInstall(
       return false;
     }
 
-    // Build arch-aware download: remote VM detects its own arch and picks the right URL
-    const x86Url = x86Asset?.browser_download_url || "";
-    const armUrl = armAsset?.browser_download_url || "";
-    const url = x86Url || armUrl;
-
-    // SECURITY: Validate URLs match expected GitHub releases pattern.
-    // Prevents shell injection via crafted API responses.
-    const urlPattern = /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/releases\/download\/[^\s'"`;|&$()]+$/;
-    if ((x86Url && !urlPattern.test(x86Url)) || (armUrl && !urlPattern.test(armUrl))) {
-      logWarn("Tarball URL failed safety validation");
-      return false;
-    }
-
-    logStep("Downloading pre-built agent tarball...");
-
-    // Build arch-aware download command: remote VM picks the right URL based on uname -m
-    // Use sudo for tar extraction — on clouds like AWS Lightsail, SSH user is 'ubuntu' (non-root)
-    // but tarballs extract to /root/. The ubuntu user has passwordless sudo.
-    const sudo = '$([ "$(id -u)" != "0" ] && echo sudo || echo "")';
-    let downloadCmd: string;
-    if (x86Url && armUrl) {
-      downloadCmd =
-        "_arch=$(uname -m); " +
-        `if [ "$_arch" = "aarch64" ] || [ "$_arch" = "arm64" ]; then ` +
-        `_url='${armUrl}'; else _url='${x86Url}'; fi; ` +
-        `curl -fsSL --connect-timeout 10 --max-time 120 "$_url" | ${sudo} tar xz -C / && ${sudo} test -f /root/.spawn-tarball`;
-    } else {
-      downloadCmd = `curl -fsSL --connect-timeout 10 --max-time 120 '${url}' | ${sudo} tar xz -C / && ${sudo} test -f /root/.spawn-tarball`;
-    }
-
-    // Download and extract on the remote VM
-    await runner.runServer(downloadCmd, 150);
-
-    logInfo("Agent installed from pre-built tarball");
-    return true;
-  } catch {
-    logWarn("Tarball install failed, falling back to live install");
+    x86Url = x86Asset?.browser_download_url || "";
+    armUrl = armAsset?.browser_download_url || "";
+    url = x86Url || armUrl;
+  } catch (err) {
+    logWarn("Failed to fetch pre-built tarball metadata");
+    logDebug(getErrorMessage(err));
     return false;
   }
+
+  // Phase 2: URL validation + command building (deterministic — no try/catch needed)
+  // SECURITY: Validate URLs match expected GitHub releases pattern.
+  // Prevents shell injection via crafted API responses.
+  const urlPattern = /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/releases\/download\/[^\s'"`;|&$()]+$/;
+  if ((x86Url && !urlPattern.test(x86Url)) || (armUrl && !urlPattern.test(armUrl))) {
+    logWarn("Tarball URL failed safety validation");
+    return false;
+  }
+
+  logStep("Downloading pre-built agent tarball...");
+
+  // Build arch-aware download command: remote VM picks the right URL based on uname -m
+  // Use sudo for tar extraction — on clouds like AWS Lightsail, SSH user is 'ubuntu' (non-root)
+  // but tarballs extract to /root/. The ubuntu user has passwordless sudo.
+  const sudo = '$([ "$(id -u)" != "0" ] && echo sudo || echo "")';
+  let downloadCmd: string;
+  if (x86Url && armUrl) {
+    downloadCmd =
+      "_arch=$(uname -m); " +
+      `if [ "$_arch" = "aarch64" ] || [ "$_arch" = "arm64" ]; then ` +
+      `_url='${armUrl}'; else _url='${x86Url}'; fi; ` +
+      `curl -fsSL --connect-timeout 10 --max-time 120 "$_url" | ${sudo} tar xz -C / && ${sudo} test -f /root/.spawn-tarball`;
+  } else {
+    downloadCmd = `curl -fsSL --connect-timeout 10 --max-time 120 '${url}' | ${sudo} tar xz -C / && ${sudo} test -f /root/.spawn-tarball`;
+  }
+
+  // Phase 3: Remote execution
+  try {
+    await runner.runServer(downloadCmd, 150);
+  } catch (err) {
+    logWarn("Tarball download/extract failed on remote VM");
+    logDebug(getErrorMessage(err));
+    return false;
+  }
+
+  logInfo("Agent installed from pre-built tarball");
+  return true;
 }

--- a/packages/cli/src/shared/oauth.ts
+++ b/packages/cli/src/shared/oauth.ts
@@ -5,8 +5,8 @@ import { dirname } from "node:path";
 import * as v from "valibot";
 import { OAUTH_CODE_REGEX } from "./oauth-constants";
 import { parseJsonWith } from "./parse";
-import { isString } from "./type-guards";
-import { getSpawnCloudConfigPath, logError, logInfo, logStep, logWarn, openBrowser, prompt } from "./ui";
+import { getErrorMessage, isString } from "./type-guards";
+import { getSpawnCloudConfigPath, logDebug, logError, logInfo, logStep, logWarn, openBrowser, prompt } from "./ui";
 
 // ─── Schemas ─────────────────────────────────────────────────────────────────
 
@@ -237,8 +237,9 @@ async function saveOpenRouterKey(key: string): Promise<void> {
         mode: 0o600,
       },
     );
-  } catch {
-    // non-fatal — key still works in memory for this session
+  } catch (err) {
+    logWarn("Could not save API key — you may need to re-authenticate next run");
+    logDebug(getErrorMessage(err));
   }
 }
 

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -10,7 +10,8 @@ import { offerGithubAuth, wrapSshCall } from "./agent-setup";
 import { tryTarballInstall } from "./agent-tarball";
 import { generateEnvConfig } from "./agents";
 import { getOrPromptApiKey } from "./oauth";
-import { logInfo, logStep, logWarn, prepareStdinForHandoff, withRetry } from "./ui";
+import { getErrorMessage } from "./type-guards";
+import { logDebug, logInfo, logStep, logWarn, prepareStdinForHandoff, withRetry } from "./ui";
 
 export interface CloudOrchestrator {
   cloudName: string;
@@ -74,8 +75,9 @@ export async function runOrchestration(
   if (cloud.checkAccountReady) {
     try {
       await cloud.checkAccountReady();
-    } catch {
-      // non-fatal — let createServer be the final arbiter
+    } catch (err) {
+      logWarn("Account readiness check failed — proceeding anyway");
+      logDebug(getErrorMessage(err));
     }
   }
 
@@ -87,8 +89,9 @@ export async function runOrchestration(
   if (agent.preProvision) {
     try {
       await agent.preProvision();
-    } catch {
-      // non-fatal
+    } catch (err) {
+      logWarn("Pre-provision hook failed — continuing");
+      logDebug(getErrorMessage(err));
     }
   }
 

--- a/packages/cli/src/shared/ui.ts
+++ b/packages/cli/src/shared/ui.ts
@@ -11,10 +11,18 @@ const RED = "\x1b[0;31m";
 const GREEN = "\x1b[0;32m";
 const YELLOW = "\x1b[1;33m";
 const CYAN = "\x1b[0;36m";
+const DIM = "\x1b[2m";
 const NC = "\x1b[0m";
 
 export function logInfo(msg: string): void {
   process.stderr.write(`${GREEN}${msg}${NC}\n`);
+}
+
+/** Log a debug message to stderr (dim text). Only visible when SPAWN_DEBUG=1. */
+export function logDebug(msg: string): void {
+  if (process.env.SPAWN_DEBUG === "1") {
+    process.stderr.write(`${DIM}[debug] ${msg}${NC}\n`);
+  }
 }
 
 export function logWarn(msg: string): void {

--- a/packages/cli/src/update-check.ts
+++ b/packages/cli/src/update-check.ts
@@ -9,7 +9,8 @@ import pc from "picocolors";
 import pkg from "../package.json" with { type: "json" };
 import { RAW_BASE, SPAWN_CDN, VERSION_URL } from "./manifest.js";
 import { PkgVersionSchema, parseJsonWith } from "./shared/parse";
-import { hasStatus } from "./shared/type-guards";
+import { getErrorMessage, hasStatus } from "./shared/type-guards";
+import { logDebug, logWarn } from "./shared/ui";
 
 const VERSION = pkg.version;
 
@@ -277,17 +278,18 @@ export async function checkForUpdates(): Promise<void> {
   }
 
   // Always fetch the latest version on every run
-  try {
-    const latestVersion = await fetchLatestVersion();
-    if (!latestVersion) {
-      return;
-    }
+  const latestVersion = await fetchLatestVersion();
+  if (!latestVersion) {
+    return;
+  }
 
-    // Auto-update if newer version is available
-    if (compareVersions(VERSION, latestVersion)) {
+  // Auto-update if newer version is available
+  if (compareVersions(VERSION, latestVersion)) {
+    try {
       performAutoUpdate(latestVersion);
+    } catch (err) {
+      logWarn("Auto-update encountered an error");
+      logDebug(getErrorMessage(err));
     }
-  } catch {
-    // Silently fail - update check is non-critical
   }
 }


### PR DESCRIPTION
## Summary
- Adds `logDebug(msg)` function to `shared/ui.ts`, gated on `SPAWN_DEBUG=1` — dim text to stderr, matching existing `logWarn`/`logInfo` pattern
- Splits the 70-line try/catch in `agent-tarball.ts` into two focused phases: fetch+parse and remote execution
- Removes overly-broad outer try in `update-check.ts`, wrapping only `performAutoUpdate()`
- Adds warnings to 3 swallowed `tryCatch()` results in `history.ts` (saveLaunchCmd, backupCorruptedFile, loadHistory)
- Adds user-facing warning in `oauth.ts` when API key save fails
- Adds warnings to 2 silent catches in `orchestrate.ts` (checkAccountReady, preProvision)
- Bumps CLI version to 0.15.32

## Test plan
- [x] `bunx @biomejs/biome check src/` — zero errors
- [x] `bun test` — all 1461 tests pass
- [ ] Manual: `SPAWN_DEBUG=1 spawn list` — verify `logDebug` output appears dimmed on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)