### PR TITLE
fix(ux): clarify auth ordering and remote machine context in setup messages

### DIFF
--- a/packages/cli/src/commands/shared.ts
+++ b/packages/cli/src/commands/shared.ts
@@ -543,7 +543,7 @@ export function collectMissingCredentials(authVars: string[], cloud?: string): s
 
 function getCredentialGuidance(cloud: string, onlyOpenRouter: boolean): string {
   if (onlyOpenRouter) {
-    return "The script will open your browser to authenticate with OpenRouter.";
+    return "You will be prompted to authenticate with OpenRouter during setup.";
   }
   return `Run ${pc.cyan(`spawn ${cloud}`)} for setup instructions.`;
 }

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -261,7 +261,7 @@ export async function offerGithubAuth(runner: CloudRunner): Promise<void> {
     }
   }
 
-  logStep("Installing and authenticating GitHub CLI...");
+  logStep("Installing and authenticating GitHub CLI on the remote server...");
   try {
     await runner.runServer(ghCmd);
   } catch {
@@ -278,7 +278,7 @@ export async function offerGithubAuth(runner: CloudRunner): Promise<void> {
 
   // Propagate host git identity to the remote VM
   if (hostGitName || hostGitEmail) {
-    logStep("Configuring git identity...");
+    logStep("Configuring git identity on the remote server...");
     const cmds: string[] = [];
     if (hostGitName) {
       const escaped = hostGitName.replace(/'/g, "'\\''");
@@ -290,7 +290,7 @@ export async function offerGithubAuth(runner: CloudRunner): Promise<void> {
     }
     try {
       await runner.runServer(cmds.join(" && "));
-      logInfo("Git identity configured from host");
+      logInfo("Git identity configured on remote server");
     } catch {
       logWarn("Git identity setup failed (non-fatal, continuing)");
     }


### PR DESCRIPTION
**Why:** The preflight credential message told users "The script will open your browser to authenticate with OpenRouter" but cloud provider auth (e.g. DigitalOcean OAuth) actually runs first, creating confusion. Additionally, GitHub CLI setup messages said "this machine" which is ambiguous for users who just provisioned a remote cloud server.

## Changes
- Reword preflight OpenRouter credential message from "will open your browser" to "You will be prompted to authenticate" — removes false expectation of immediate browser open
- Update GitHub CLI setup log messages to explicitly say "on the remote server"
- Update git identity setup messages for consistency

Fixes #2396

-- refactor/ux-engineer