### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/sh/e2e/lib/clouds/aws.sh
+++ b/sh/e2e/lib/clouds/aws.sh
@@ -144,45 +144,6 @@ _aws_exec() {
 }
 
 # ---------------------------------------------------------------------------
-# _aws_exec_long APP CMD TIMEOUT
-#
-# Same as _aws_exec but with ServerAliveInterval keep-alives and the remote
-# command wrapped in `timeout` for long-running operations.
-# ---------------------------------------------------------------------------
-_aws_exec_long() {
-  local app="$1"
-  local cmd="$2"
-  local timeout="${3:-120}"
-
-  # Resolve instance IP (cached per app)
-  if [ "${_AWS_INSTANCE_APP}" != "${app}" ] || [ -z "${_AWS_INSTANCE_IP}" ]; then
-    if [ -n "${LOG_DIR:-}" ] && [ -f "${LOG_DIR}/${app}.ip" ]; then
-      _AWS_INSTANCE_IP=$(cat "${LOG_DIR}/${app}.ip")
-    else
-      _AWS_INSTANCE_IP=$(aws lightsail get-instance \
-        --instance-name "${app}" \
-        --region "${AWS_REGION:-us-east-1}" \
-        --query 'instance.publicIpAddress' \
-        --output text 2>/dev/null || true)
-    fi
-    _AWS_INSTANCE_APP="${app}"
-    if [ -z "${_AWS_INSTANCE_IP}" ] || [ "${_AWS_INSTANCE_IP}" = "None" ]; then
-      log_err "Could not resolve IP for instance ${app}"
-      return 1
-    fi
-  fi
-
-  local alive_count=$((timeout / 15 + 1))
-
-  # Pipe the command via stdin to avoid interpolating it into the remote
-  # command string — eliminates shell injection risk from base64 encoding.
-  printf '%s' "${cmd}" | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
-      -o "ServerAliveInterval=15" -o "ServerAliveCountMax=${alive_count}" \
-      "ubuntu@${_AWS_INSTANCE_IP}" "timeout ${timeout} bash"
-}
-
-# ---------------------------------------------------------------------------
 # _aws_teardown APP
 #
 # Delete the Lightsail instance, verify deletion, and untrack it.

--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -155,39 +155,6 @@ _digitalocean_exec() {
 }
 
 # ---------------------------------------------------------------------------
-# _digitalocean_exec_long APP CMD TIMEOUT
-#
-# Same as _digitalocean_exec but with ServerAliveInterval for long-running
-# commands, and wraps the command in `timeout`.
-# ---------------------------------------------------------------------------
-_digitalocean_exec_long() {
-  local app="$1"
-  local cmd="$2"
-  local timeout_secs="${3:-120}"
-
-  local ip_file="${LOG_DIR:-/tmp}/${app}.ip"
-  if [ ! -f "${ip_file}" ]; then
-    log_err "IP file not found: ${ip_file}"
-    return 1
-  fi
-
-  local ip
-  ip=$(cat "${ip_file}")
-
-  if [ -z "${ip}" ]; then
-    log_err "Empty IP in ${ip_file}"
-    return 1
-  fi
-
-  # Pipe the command via stdin to avoid interpolating it into the remote
-  # command string — eliminates shell injection risk from base64 encoding.
-  printf '%s' "${cmd}" | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
-      -o "ServerAliveInterval=15" -o "ServerAliveCountMax=$((timeout_secs / 15 + 1))" \
-      "root@${ip}" "timeout ${timeout_secs} bash"
-}
-
-# ---------------------------------------------------------------------------
 # _digitalocean_teardown APP
 #
 # Deletes the droplet by its ID (read from the .meta file) and untracks it.

--- a/sh/e2e/lib/clouds/gcp.sh
+++ b/sh/e2e/lib/clouds/gcp.sh
@@ -151,46 +151,6 @@ _gcp_exec() {
 }
 
 # ---------------------------------------------------------------------------
-# _gcp_exec_long APP CMD TIMEOUT
-#
-# Same as _gcp_exec but with ServerAliveInterval keep-alives and the remote
-# command wrapped in `timeout` for long-running operations.
-# ---------------------------------------------------------------------------
-_gcp_exec_long() {
-  local app="$1"
-  local cmd="$2"
-  local timeout="${3:-120}"
-  local ssh_user="${GCP_SSH_USER:-$(whoami)}"
-
-  # Resolve instance IP (cached per app)
-  if [ "${_GCP_INSTANCE_APP}" != "${app}" ] || [ -z "${_GCP_INSTANCE_IP}" ]; then
-    if [ -n "${LOG_DIR:-}" ] && [ -f "${LOG_DIR}/${app}.ip" ]; then
-      _GCP_INSTANCE_IP=$(cat "${LOG_DIR}/${app}.ip")
-    else
-      _GCP_INSTANCE_IP=$(gcloud compute instances describe "${app}" \
-        --zone="${GCP_ZONE:-us-central1-a}" \
-        --project="${GCP_PROJECT:-}" \
-        --format=json 2>/dev/null \
-        | jq -r '.networkInterfaces[0].accessConfigs[0].natIP // empty' 2>/dev/null || true)
-    fi
-    _GCP_INSTANCE_APP="${app}"
-    if [ -z "${_GCP_INSTANCE_IP}" ]; then
-      log_err "Could not resolve IP for instance ${app}"
-      return 1
-    fi
-  fi
-
-  local alive_count=$((timeout / 15 + 1))
-
-  # Pipe the command via stdin to avoid interpolating it into the remote
-  # command string — eliminates shell injection risk from base64 encoding.
-  printf '%s' "${cmd}" | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
-      -o "ServerAliveInterval=15" -o "ServerAliveCountMax=${alive_count}" \
-      "${ssh_user}@${_GCP_INSTANCE_IP}" "timeout ${timeout} bash"
-}
-
-# ---------------------------------------------------------------------------
 # _gcp_teardown APP
 #
 # Delete the GCP Compute Engine instance, verify deletion, and untrack it.

--- a/sh/e2e/lib/clouds/hetzner.sh
+++ b/sh/e2e/lib/clouds/hetzner.sh
@@ -129,38 +129,6 @@ _hetzner_exec() {
 }
 
 # ---------------------------------------------------------------------------
-# _hetzner_exec_long APP CMD TIMEOUT
-#
-# Execute a long-running command on the server via SSH with keepalive
-# and a remote-side timeout.
-# ---------------------------------------------------------------------------
-_hetzner_exec_long() {
-  local app="$1"
-  local cmd="$2"
-  local timeout_secs="$3"
-  local log_dir="${LOG_DIR:-/tmp}"
-
-  local ip_file="${log_dir}/${app}.ip"
-  if [ ! -f "${ip_file}" ]; then
-    log_err "No IP file found for ${app} at ${ip_file}"
-    return 1
-  fi
-
-  local ip
-  ip=$(cat "${ip_file}")
-
-  # Pipe the command via stdin to avoid interpolating it into the remote
-  # command string — eliminates shell injection risk from base64 encoding.
-  printf '%s' "${cmd}" | ssh -o StrictHostKeyChecking=no \
-      -o UserKnownHostsFile=/dev/null \
-      -o LogLevel=ERROR \
-      -o BatchMode=yes \
-      -o ConnectTimeout=10 \
-      -o ServerAliveInterval=15 \
-      "root@${ip}" "timeout ${timeout_secs} bash"
-}
-
-# ---------------------------------------------------------------------------
 # _hetzner_teardown APP
 #
 # Delete the server via Hetzner API using the stored server ID.

--- a/sh/e2e/lib/clouds/sprite.sh
+++ b/sh/e2e/lib/clouds/sprite.sh
@@ -199,51 +199,6 @@ _sprite_exec() {
 }
 
 # ---------------------------------------------------------------------------
-# _sprite_exec_long APP CMD TIMEOUT
-#
-# Same as _sprite_exec but wraps the remote command in `timeout` for
-# long-running operations. Retries on sprite CLI errors.
-# ---------------------------------------------------------------------------
-_sprite_exec_long() {
-  local app="$1"
-  local cmd="$2"
-  local timeout="${3:-120}"
-
-  # Validate timeout is numeric to prevent command injection
-  if ! printf '%s' "${timeout}" | grep -qE '^[0-9]+$'; then
-    printf 'ERROR: timeout must be numeric, got: %s\n' "${timeout}" >&2
-    return 1
-  fi
-
-  local _attempt=0
-  local _max=3
-  local _stderr_tmp="/tmp/sprite-execl-err.$$"
-
-  while [ "${_attempt}" -lt "${_max}" ]; do
-    _sprite_fix_config
-    # Pipe the command via stdin to avoid interpolating it into the remote
-    # command string — eliminates shell injection risk from base64 encoding.
-    # shellcheck disable=SC2046
-    printf '%s' "${cmd}" | sprite $(_sprite_org_flags) exec -s "${app}" -- timeout "${timeout}" bash 2>"${_stderr_tmp}"
-    local _rc=$?
-    if [ "${_rc}" -eq 0 ]; then
-      rm -f "${_stderr_tmp}"
-      return 0
-    fi
-    if grep -qiE 'config|migrate|initialize|connection refused' "${_stderr_tmp}" 2>/dev/null; then
-      _attempt=$((_attempt + 1))
-      if [ "${_attempt}" -lt "${_max}" ]; then
-        sleep 2
-        continue
-      fi
-    fi
-    rm -f "${_stderr_tmp}"
-    return "${_rc}"
-  done
-  rm -f "${_stderr_tmp}"
-}
-
-# ---------------------------------------------------------------------------
 # _sprite_teardown APP
 #
 # Destroy the Sprite instance and untrack it.

--- a/sh/e2e/lib/common.sh
+++ b/sh/e2e/lib/common.sh
@@ -86,7 +86,6 @@ cloud_validate_env()     { "_${ACTIVE_CLOUD}_validate_env" "$@"; }
 cloud_headless_env()     { "_${ACTIVE_CLOUD}_headless_env" "$@"; }
 cloud_provision_verify() { "_${ACTIVE_CLOUD}_provision_verify" "$@"; }
 cloud_exec()             { "_${ACTIVE_CLOUD}_exec" "$@"; }
-cloud_exec_long()        { "_${ACTIVE_CLOUD}_exec_long" "$@"; }
 cloud_teardown()         { "_${ACTIVE_CLOUD}_teardown" "$@"; }
 cloud_cleanup_stale()    { "_${ACTIVE_CLOUD}_cleanup_stale" "$@"; }
 


### PR DESCRIPTION
## Summary

- Remove unused `cloud_exec_long()` dispatcher from `sh/e2e/lib/common.sh`
- Remove all five cloud-specific `_*_exec_long()` implementations (aws, digitalocean, gcp, hetzner, sprite)
- These functions were defined but never called by any code in the E2E test suite (190 lines removed)

## Scan Results

**Dead code found and removed:**
- `cloud_exec_long()` in `sh/e2e/lib/common.sh` (dispatcher, 0 callers)
- `_aws_exec_long()` in `sh/e2e/lib/clouds/aws.sh`
- `_digitalocean_exec_long()` in `sh/e2e/lib/clouds/digitalocean.sh`
- `_gcp_exec_long()` in `sh/e2e/lib/clouds/gcp.sh`
- `_hetzner_exec_long()` in `sh/e2e/lib/clouds/hetzner.sh`
- `_sprite_exec_long()` in `sh/e2e/lib/clouds/sprite.sh`

**Categories scanned with no issues found:**
- No dead code in `sh/shared/*.sh` or `packages/cli/src/` TypeScript
- No stale references to non-existent files
- No python3/python usage in shell scripts
- No stale comments referencing removed infrastructure
- No unused TypeScript exports (all barrel exports have callers)
- Biome lint: 0 errors across 109 files

## Verification

- `bash -n` passes on all 6 modified shell scripts
- All 1465 tests pass (0 failures)
- Biome check clean

-- qa/code-quality