### PR TITLE
fix: add killWithTimeout to waitForCloudInit SSH processes across all clouds

### DIFF
--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1078,12 +1078,22 @@ export async function waitForCloudInit(maxAttempts = 60): Promise<void> {
           ],
         },
       );
+      // Per-process timeout: if the network drops during cloud-init polling,
+      // `await proc.exited` blocks forever. Kill after 30s so the retry loop
+      // can continue and the user isn't left with a hung CLI.
+      const timer = setTimeout(() => killWithTimeout(proc), 30_000);
       // Drain both pipes before awaiting exit to prevent pipe buffer deadlock
-      const [stdout] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      const exitCode = await proc.exited;
+      let stdout: string;
+      let exitCode: number;
+      try {
+        [stdout] = await Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        exitCode = await proc.exited;
+      } finally {
+        clearTimeout(timer);
+      }
       if (exitCode === 0 && stdout.includes("done")) {
         logStepDone();
         logInfo("Cloud-init complete");

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1053,7 +1053,16 @@ export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<v
         ],
       },
     );
-    const exitCode = await proc.exited;
+    // The remote script has its own 5-min timeout (150 × 2s), but if the
+    // network drops mid-stream `await proc.exited` blocks forever. Kill
+    // after 330s (5min + 30s grace) to match the remote timeout.
+    const streamTimer = setTimeout(() => killWithTimeout(proc), 330_000);
+    let exitCode: number;
+    try {
+      exitCode = await proc.exited;
+    } finally {
+      clearTimeout(streamTimer);
+    }
     if (exitCode === 0) {
       logInfo("Cloud-init complete");
       return;
@@ -1082,12 +1091,23 @@ export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<v
           ],
         },
       );
+      // Per-process timeout: if the network drops during cloud-init polling,
+      // `await proc.exited` blocks forever. Kill after 30s so the retry loop
+      // can continue and the user isn't left with a hung CLI.
+      const timer = setTimeout(() => killWithTimeout(proc), 30_000);
       // Drain both pipes before awaiting exit to prevent pipe buffer deadlock
-      const [stdout] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      if ((await proc.exited) === 0 && stdout.includes("done")) {
+      let stdout: string;
+      let pollExitCode: number;
+      try {
+        [stdout] = await Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        pollExitCode = await proc.exited;
+      } finally {
+        clearTimeout(timer);
+      }
+      if (pollExitCode === 0 && stdout.includes("done")) {
         logStepDone();
         logInfo("Cloud-init complete");
         return;

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -863,12 +863,22 @@ export async function waitForCloudInit(maxAttempts = 60): Promise<void> {
           ],
         },
       );
+      // Per-process timeout: if the network drops during cloud-init polling,
+      // `await proc.exited` blocks forever. Kill after 30s so the retry loop
+      // can continue and the user isn't left with a hung CLI.
+      const timer = setTimeout(() => killWithTimeout(proc), 30_000);
       // Drain both pipes before awaiting exit to prevent pipe buffer deadlock
-      await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      if ((await proc.exited) === 0) {
+      let exitCode: number;
+      try {
+        await Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        exitCode = await proc.exited;
+      } finally {
+        clearTimeout(timer);
+      }
+      if (exitCode === 0) {
         logStepDone();
         logInfo("Startup script completed");
         return;

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -519,12 +519,22 @@ export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<v
           ],
         },
       );
+      // Per-process timeout: if the network drops during cloud-init polling,
+      // `await proc.exited` blocks forever. Kill after 30s so the retry loop
+      // can continue and the user isn't left with a hung CLI.
+      const timer = setTimeout(() => killWithTimeout(proc), 30_000);
       // Drain both pipes before awaiting exit to prevent pipe buffer deadlock
-      const [stdout] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      const exitCode = await proc.exited;
+      let stdout: string;
+      let exitCode: number;
+      try {
+        [stdout] = await Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        exitCode = await proc.exited;
+      } finally {
+        clearTimeout(timer);
+      }
       if (exitCode === 0 && stdout.includes("done")) {
         logStepDone();
         logInfo("Cloud-init complete");


### PR DESCRIPTION
**Why:** If a user's network drops during cloud-init wait (laptop lid close, WiFi reconnect, VPN toggle), `await proc.exited` on SSH polling processes blocks forever. The CLI hangs indefinitely, but the server is already running and billing has started. This affects all 4 SSH-based clouds (Hetzner, AWS, GCP, DigitalOcean).

## Changes

- Add 30s `killWithTimeout` to each polling SSH command in `waitForCloudInit` for Hetzner, AWS, GCP, and DigitalOcean (fallback mode)
- Add 330s `killWithTimeout` to DigitalOcean streaming SSH (`tail -f` mode)
- Pattern matches the existing `killWithTimeout` usage in `waitForSsh` (shared/ssh.ts)
- Bump package version (patch)

## Test plan

- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — all pass

-- refactor/code-health