### PR TITLE
fix: always reject set -u in shell script validation hook

### DIFF
--- a/.claude/scripts/validate-file.ts
+++ b/.claude/scripts/validate-file.ts
@@ -66,9 +66,11 @@ if (file.endsWith(".sh")) {
     fail(`echo -e detected in ${file} — use printf instead (macOS bash 3.x compat)`);
   }
 
-  // Check for set -u without set -eo pipefail
-  if (/set\s+-.*u/.test(content) && !/set\s+-eo\s+pipefail/.test(content)) {
-    fail(`set -u (nounset) detected in ${file} — use set -eo pipefail instead`);
+  // Check for set -u (nounset) — always banned, even alongside set -eo pipefail.
+  // Only match lines that actually invoke set (not comments or string literals).
+  const setUPattern = /^\s*set\s+-[a-z]*u/m;
+  if (setUPattern.test(content)) {
+    fail(`set -u (nounset) detected in ${file} — use \${VAR:-} for optional vars instead`);
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixed the `validate-file.ts` PostToolUse hook to unconditionally reject `set -u` (nounset) in shell scripts
- Previously, the check only blocked `set -u` when `set -eo pipefail` was absent, which allowed scripts with both directives to pass validation — contradicting the shell rules
- Updated the regex to match only actual `set` invocation lines (not comments or string literals) and improved the error message to recommend `${VAR:-}`

## Scan results

Performed a comprehensive code quality scan across the codebase:

**Dead code**: No dead functions or unused exports found in `sh/shared/*.sh` or `packages/cli/src/`. All shared utilities are actively imported.

**Stale references**: No broken imports or references to non-existent files. Manifest matrix status is consistent with actual script files on disk.

**Python usage**: None found — all inline scripting uses `bun` or `jq` as required.

**Duplicate utilities**: Cloud modules (`waitForCloudInit`, `uploadFile`, `promptSpawnName`) share similar patterns but differ in cloud-specific details (SSH user, IP state, init marker paths). The shared `waitForSsh`, `promptSpawnNameShared`, and `getServerNameFromEnv` are already properly extracted. Remaining duplication is necessary variation.

**Stale comments**: No stale comments referencing removed infrastructure or deleted functions found.

## Test plan

- [x] `bun test` — 1484 tests pass, 0 failures
- [x] `biome check` — 112 files, no issues
- [x] `bash -n` on all `.sh` files — all pass syntax check

-- qa/code-quality