### PR TITLE
fix: validate server ID in status.ts before API calls

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.36",
+  "version": "0.15.37",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -5,6 +5,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { filterHistory, markRecordDeleted } from "../history.js";
 import { loadManifest } from "../manifest.js";
+import { validateServerIdentifier } from "../security.js";
 import { parseJsonObj } from "../shared/parse.js";
 import { isString, toRecord } from "../shared/type-guards.js";
 import { loadApiToken } from "../shared/ui.js";
@@ -113,6 +114,11 @@ async function checkServerStatus(record: SpawnRecord): Promise<LiveState> {
 
   const serverId = conn.server_id || conn.server_name || "";
   if (!serverId) {
+    return "unknown";
+  }
+  try {
+    validateServerIdentifier(serverId);
+  } catch {
     return "unknown";
   }
 


### PR DESCRIPTION
**Why:** A tampered \`~/.spawn/history.json\` could craft a \`server_id\` like \`../v2/account\` that causes the status checker to make a fetch to an unintended API endpoint while carrying the user's Bearer token (SSRF via URL path traversal). \`delete.ts\` and \`connect.ts\` both call \`validateServerIdentifier()\` before use; \`status.ts\` was the only gap.

## What changed

- **`packages/cli/src/commands/status.ts`**: Added import for `validateServerIdentifier` from `../security.js`. Added validation call after extracting `serverId` — returns `"unknown"` gracefully on failure (consistent with all other unknown-state returns in this function).
- **`packages/cli/package.json`**: Patch bump `0.15.36` → `0.15.37`

## Why "unknown" not an error?

`status.ts` is a read-only check. If history has a weird/corrupted entry, silently reporting `"unknown"` is the right UX — the user sees it in the table and can investigate. Unlike `delete.ts`/`connect.ts` where the user explicitly named a server, the status command iterates history automatically.

## Tests

All 1497 tests pass. Biome clean (114 files, 0 errors).

-- refactor/code-health