### PR TITLE
refactor: remove dead exports only used within their own files

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.37",
+  "version": "0.15.38",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -960,7 +960,7 @@ export async function createInstance(name: string, tier?: CloudInitTier): Promis
 
 // ─── Wait for Instance ──────────────────────────────────────────────────────
 
-export async function waitForInstance(maxAttempts = 60): Promise<VMConnection> {
+async function waitForInstance(maxAttempts = 60): Promise<VMConnection> {
   logStep("Waiting for instance to become running...");
   const pollDelay = 5000;
 

--- a/packages/cli/src/commands/shared.ts
+++ b/packages/cli/src/commands/shared.ts
@@ -28,7 +28,7 @@ export function handleCancel(): never {
   process.exit(0);
 }
 
-export async function withSpinner<T>(msg: string, fn: () => Promise<T>, doneMsg?: string): Promise<T> {
+async function withSpinner<T>(msg: string, fn: () => Promise<T>, doneMsg?: string): Promise<T> {
   const s = p.spinner();
   s.start(msg);
   try {
@@ -191,7 +191,7 @@ interface EntityDef {
   listCmd: string;
   opposite: string;
 }
-export const ENTITY_DEFS: Record<"agent" | "cloud", EntityDef> = {
+const ENTITY_DEFS: Record<"agent" | "cloud", EntityDef> = {
   agent: {
     label: "agent",
     labelPlural: "agents",

--- a/packages/cli/src/guidance-data.ts
+++ b/packages/cli/src/guidance-data.ts
@@ -5,13 +5,13 @@
 
 import pc from "picocolors";
 
-export interface SignalEntry {
+interface SignalEntry {
   header: string;
   causes: string[];
   includeDashboard: boolean;
 }
 
-export interface ExitCodeEntry {
+interface ExitCodeEntry {
   header: string;
   lines: string[];
   includeDashboard: boolean;

--- a/packages/cli/src/manifest.ts
+++ b/packages/cli/src/manifest.ts
@@ -144,7 +144,7 @@ function stripDangerousKeys(obj: unknown): unknown {
   return clean;
 }
 
-export function isValidManifest(data: unknown): data is Manifest {
+function isValidManifest(data: unknown): data is Manifest {
   return (
     data !== null &&
     typeof data === "object" &&


### PR DESCRIPTION
## Summary

- Remove unnecessary `export` keywords from 6 symbols that are only used within their defining files:
  - `withSpinner` in `commands/shared.ts`
  - `ENTITY_DEFS` in `commands/shared.ts`
  - `isValidManifest` in `manifest.ts`
  - `waitForInstance` in `aws/aws.ts`
  - `SignalEntry` interface in `guidance-data.ts`
  - `ExitCodeEntry` interface in `guidance-data.ts`
- All functions/types remain in place (they are used internally) — only the `export` keyword is removed
- Bump version: 0.15.37 -> 0.15.38

## Test plan

- [x] `bunx @biomejs/biome check src/` passes with zero errors
- [x] `bun test` passes all 1497 tests with zero failures
- [x] Verified no external callers or test imports for any removed export