### PR TITLE
fix: save spawn record before createServer so spawn ls works

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -88,12 +88,8 @@ export async function runOrchestration(
   // 5. Size/bundle selection
   await cloud.promptSize();
 
-  // 6. Provision server
+  // 6. Record spawn + provision server
   const spawnId = generateSpawnId();
-  const serverName = await cloud.getServerName();
-  await cloud.createServer(serverName, spawnId);
-
-  // 6b. Record the spawn now that the server exists
   const spawnName = process.env.SPAWN_NAME_KEBAB || process.env.SPAWN_NAME || undefined;
   saveSpawnRecord({
     id: spawnId,
@@ -106,6 +102,9 @@ export async function runOrchestration(
         }
       : {}),
   });
+
+  const serverName = await cloud.getServerName();
+  await cloud.createServer(serverName, spawnId);
 
   // 7. Wait for readiness
   await cloud.waitForReady();


### PR DESCRIPTION
## Summary
- Moved `saveSpawnRecord()` before `cloud.createServer()` in `orchestrate.ts` so the history record exists when `saveVmConnection()` runs inside `createServer()`
- Previously, `saveVmConnection()` couldn't find the record by spawnId (it didn't exist yet), so connection data was silently lost and `spawn ls` showed no active servers
- Bumped CLI version to 0.15.1

## Test plan
- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — 1415 tests pass
- [x] Logic verified: all cloud modules' `saveVmConnection` calls `findIndex(r => r.id === spawnId)` which now finds the pre-existing record

🤖 Generated with [Claude Code](https://claude.com/claude-code)