### PR TITLE
fix: install.sh printf format strings and e2e source documentation

### DIFF
--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -24,10 +24,10 @@ NC='\033[0m'
 
 CYAN='\033[0;36m'
 
-log_info()  { printf "${GREEN}[spawn]${NC} %s\n" "$1"; }
-log_step()  { printf "${CYAN}[spawn]${NC} %s\n" "$1"; }
-log_warn()  { printf "${YELLOW}[spawn]${NC} %s\n" "$1"; }
-log_error() { printf "${RED}[spawn]${NC} %s\n" "$1"; }
+log_info()  { printf '%b[spawn]%b %s\n' "$GREEN" "$NC" "$1"; }
+log_step()  { printf '%b[spawn]%b %s\n' "$CYAN" "$NC" "$1"; }
+log_warn()  { printf '%b[spawn]%b %s\n' "$YELLOW" "$NC" "$1"; }
+log_error() { printf '%b[spawn]%b %s\n' "$RED" "$NC" "$1"; }
 
 # --- Helper: compare semver strings ---
 # Returns 0 (true) if $1 >= $2
@@ -239,9 +239,9 @@ ensure_in_path() {
         all_ready=false
     fi
     if [ "$all_ready" = true ]; then
-        printf "${GREEN}[spawn]${NC} Run ${BOLD}spawn${NC} to get started\n"
+        printf '%b[spawn]%b Run %bspawn%b to get started\n' "$GREEN" "$NC" "$BOLD" "$NC"
     else
-        printf "${GREEN}[spawn]${NC} To start using spawn, run:\n"
+        printf '%b[spawn]%b To start using spawn, run:\n' "$GREEN" "$NC"
         echo ""
         echo "    exec \$SHELL"
         echo ""

--- a/sh/e2e/lib/common.sh
+++ b/sh/e2e/lib/common.sh
@@ -37,39 +37,42 @@ _TRACKED_APPS=""
 # Logging (with optional cloud prefix for parallel output)
 # ---------------------------------------------------------------------------
 log_header() {
-  printf "\n${BOLD}${BLUE}%s=== %s ===${NC}\n" "${CLOUD_LOG_PREFIX}" "$1"
+  printf '\n%b%b%s=== %s ===%b\n' "$BOLD" "$BLUE" "${CLOUD_LOG_PREFIX}" "$1" "$NC"
 }
 
 log_step() {
-  printf "${CYAN}%s  -> %s${NC}\n" "${CLOUD_LOG_PREFIX}" "$1"
+  printf '%b%s  -> %s%b\n' "$CYAN" "${CLOUD_LOG_PREFIX}" "$1" "$NC"
 }
 
 log_ok() {
-  printf "${GREEN}%s  [PASS] %s${NC}\n" "${CLOUD_LOG_PREFIX}" "$1"
+  printf '%b%s  [PASS] %s%b\n' "$GREEN" "${CLOUD_LOG_PREFIX}" "$1" "$NC"
 }
 
 log_err() {
-  printf "${RED}%s  [FAIL] %s${NC}\n" "${CLOUD_LOG_PREFIX}" "$1"
+  printf '%b%s  [FAIL] %s%b\n' "$RED" "${CLOUD_LOG_PREFIX}" "$1" "$NC"
 }
 
 log_warn() {
-  printf "${YELLOW}%s  [WARN] %s${NC}\n" "${CLOUD_LOG_PREFIX}" "$1"
+  printf '%b%s  [WARN] %s%b\n' "$YELLOW" "${CLOUD_LOG_PREFIX}" "$1" "$NC"
 }
 
 log_info() {
-  printf "${BLUE}%s  [INFO] %s${NC}\n" "${CLOUD_LOG_PREFIX}" "$1"
+  printf '%b%s  [INFO] %s%b\n' "$BLUE" "${CLOUD_LOG_PREFIX}" "$1" "$NC"
 }
 
 # ---------------------------------------------------------------------------
 # load_cloud_driver CLOUD
 #
 # Sources the cloud-specific driver and sets ACTIVE_CLOUD for wrapper dispatch.
+# NOTE: Uses BASH_SOURCE and source with a filesystem path. This is intentional —
+# e2e scripts are always run from the filesystem, never via bash <(curl ...).
 # ---------------------------------------------------------------------------
 load_cloud_driver() {
   local cloud="$1"
   ACTIVE_CLOUD="${cloud}"
 
-  # Resolve driver file (relative to this script's location)
+  # Resolve driver file (relative to this script's location).
+  # BASH_SOURCE[0] is safe here — e2e scripts run from disk, not curl|bash.
   local driver_dir
   driver_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/clouds"
   local driver_file="${driver_dir}/${cloud}.sh"
@@ -79,6 +82,7 @@ load_cloud_driver() {
     return 1
   fi
 
+  # shellcheck source=/dev/null  # driver path is dynamic
   source "${driver_file}"
 
   log_step "Loaded cloud driver: ${cloud}"


### PR DESCRIPTION
## Summary

- **install.sh**: Replace color variable interpolation in `printf` format strings with `%b` arguments. Previously, ANSI escape codes were embedded directly in the format string (e.g., `printf "${GREEN}[spawn]${NC} %s\n"`), which is a format string injection vector. Now uses `printf '%b[spawn]%b %s\n' "$GREEN" "$NC" "$1"`.
- **common.sh (e2e)**: Apply the same `%b` fix to all logging functions (`log_header`, `log_step`, `log_ok`, `log_err`, `log_warn`, `log_info`). Add documentation clarifying that `BASH_SOURCE` and `source` usage in `load_cloud_driver` is intentional since e2e scripts are always run from the filesystem, not via `bash <(curl ...)`.

Closes #2443
Closes #2438

-- refactor/ux-engineer