### PR TITLE
fix: address SSH command injection risks in e2e cloud drivers

### DIFF
--- a/sh/e2e/lib/clouds/aws.sh
+++ b/sh/e2e/lib/clouds/aws.sh
@@ -136,6 +136,13 @@ _aws_exec() {
       log_err "Could not resolve IP for instance ${app}"
       return 1
     fi
+    # Validate IP looks like an IPv4 address (defense-in-depth against API/file tampering)
+    if ! printf '%s' "${_AWS_INSTANCE_IP}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+      log_err "Invalid IP address for instance ${app}: ${_AWS_INSTANCE_IP}"
+      _AWS_INSTANCE_IP=""
+      _AWS_INSTANCE_APP=""
+      return 1
+    fi
   fi
 
   ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \

--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -149,6 +149,12 @@ _digitalocean_exec() {
     return 1
   fi
 
+  # Validate IP looks like an IPv4 address (defense-in-depth against file tampering)
+  if ! printf '%s' "${ip}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+    log_err "Invalid IP address in ${ip_file}: ${ip}"
+    return 1
+  fi
+
   ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
       "root@${ip}" "${cmd}"
@@ -182,6 +188,9 @@ _digitalocean_teardown() {
     untrack_app "${app}"
     return 0
   fi
+
+  # Validate droplet ID is numeric (defense-in-depth against metadata tampering)
+  case "${droplet_id}" in ''|*[!0-9]*) log_warn "Non-numeric droplet ID: ${droplet_id}"; untrack_app "${app}"; return 0 ;; esac
 
   # Retry DELETE up to 3 times with --max-time to prevent hangs
   local attempt=0
@@ -280,6 +289,9 @@ _digitalocean_cleanup_stale() {
     droplet_id=$(printf '%s' "${line}" | cut -d' ' -f1)
     local droplet_name
     droplet_name=$(printf '%s' "${line}" | cut -d' ' -f2)
+
+    # Validate droplet ID is numeric before using it in API URL
+    case "${droplet_id}" in ''|*[!0-9]*) log_warn "Skipping ${line} — non-numeric droplet ID"; skipped=$((skipped + 1)); continue ;; esac
 
     # Extract timestamp from name: e2e-AGENT-TIMESTAMP
     # The timestamp is the last dash-separated segment

--- a/sh/e2e/lib/clouds/gcp.sh
+++ b/sh/e2e/lib/clouds/gcp.sh
@@ -126,6 +126,12 @@ _gcp_exec() {
   local cmd="$2"
   local ssh_user="${GCP_SSH_USER:-$(whoami)}"
 
+  # Validate SSH user contains only safe characters (defense-in-depth)
+  if ! printf '%s' "${ssh_user}" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+    log_err "Invalid SSH user for instance ${app}: ${ssh_user}"
+    return 1
+  fi
+
   # Resolve instance IP (cached per app)
   if [ "${_GCP_INSTANCE_APP}" != "${app}" ] || [ -z "${_GCP_INSTANCE_IP}" ]; then
     # Try reading from the IP file first (written by _gcp_provision_verify)
@@ -141,6 +147,13 @@ _gcp_exec() {
     _GCP_INSTANCE_APP="${app}"
     if [ -z "${_GCP_INSTANCE_IP}" ]; then
       log_err "Could not resolve IP for instance ${app}"
+      return 1
+    fi
+    # Validate IP looks like an IPv4 address (defense-in-depth against API/file tampering)
+    if ! printf '%s' "${_GCP_INSTANCE_IP}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+      log_err "Invalid IP address for instance ${app}: ${_GCP_INSTANCE_IP}"
+      _GCP_INSTANCE_IP=""
+      _GCP_INSTANCE_APP=""
       return 1
     fi
   fi

--- a/sh/e2e/lib/clouds/hetzner.sh
+++ b/sh/e2e/lib/clouds/hetzner.sh
@@ -54,10 +54,14 @@ _hetzner_provision_verify() {
   local app="$1"
   local log_dir="$2"
 
+  # URL-encode the app name to prevent query parameter injection
+  local encoded_app
+  encoded_app=$(jq -rn --arg v "${app}" '$v|@uri')
+
   local response
   response=$(curl -sf \
     -H "Authorization: Bearer ${HCLOUD_TOKEN}" \
-    "${_HETZNER_API}/servers?name=${app}" 2>/dev/null || true)
+    "${_HETZNER_API}/servers?name=${encoded_app}" 2>/dev/null || true)
 
   if [ -z "${response}" ]; then
     log_err "Failed to query Hetzner API for server ${app}"
@@ -120,6 +124,17 @@ _hetzner_exec() {
   local ip
   ip=$(cat "${ip_file}")
 
+  if [ -z "${ip}" ]; then
+    log_err "Empty IP in ${ip_file}"
+    return 1
+  fi
+
+  # Validate IP looks like an IPv4 address (defense-in-depth against file tampering)
+  if ! printf '%s' "${ip}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+    log_err "Invalid IP address in ${ip_file}: ${ip}"
+    return 1
+  fi
+
   ssh -o StrictHostKeyChecking=no \
       -o UserKnownHostsFile=/dev/null \
       -o LogLevel=ERROR \
@@ -152,6 +167,9 @@ _hetzner_teardown() {
     untrack_app "${app}"
     return 0
   fi
+
+  # Validate server ID is numeric (defense-in-depth against metadata tampering)
+  case "${server_id}" in ''|*[!0-9]*) log_warn "Non-numeric server ID: ${server_id}"; untrack_app "${app}"; return 0 ;; esac
 
   log_step "Deleting Hetzner server ${app} (id=${server_id})"
 
@@ -219,6 +237,9 @@ _hetzner_cleanup_stale() {
 
     local server_name
     server_name=$(printf '%s' "${entry}" | cut -d: -f2-)
+
+    # Validate server ID is numeric before using it in API URL
+    case "${server_id}" in ''|*[!0-9]*) log_warn "Skipping ${entry} — non-numeric server ID"; skipped=$((skipped + 1)); continue ;; esac
 
     # Extract timestamp from name: e2e-AGENT-TIMESTAMP
     local ts

--- a/sh/e2e/lib/common.sh
+++ b/sh/e2e/lib/common.sh
@@ -9,6 +9,11 @@ ALL_AGENTS="claude openclaw zeroclaw codex opencode kilocode hermes junie"
 PROVISION_TIMEOUT="${PROVISION_TIMEOUT:-720}"
 INSTALL_WAIT="${INSTALL_WAIT:-600}"
 INPUT_TEST_TIMEOUT="${INPUT_TEST_TIMEOUT:-120}"
+# Validate numeric env vars that get interpolated into remote command strings.
+# A non-numeric value here could lead to shell injection via SSH commands.
+case "${PROVISION_TIMEOUT}" in ''|*[!0-9]*) PROVISION_TIMEOUT=720 ;; esac
+case "${INSTALL_WAIT}" in ''|*[!0-9]*) INSTALL_WAIT=600 ;; esac
+case "${INPUT_TEST_TIMEOUT}" in ''|*[!0-9]*) INPUT_TEST_TIMEOUT=120 ;; esac
 
 # Active cloud (set by load_cloud_driver)
 ACTIVE_CLOUD=""


### PR DESCRIPTION
## Summary

Add defense-in-depth validation across all e2e cloud driver scripts to prevent SSH command injection and API URL manipulation:

- **IP address validation**: All `_exec` functions now validate that IPs read from cache/files/APIs match IPv4 format (`^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$`) before passing them to SSH `user@host` arguments (aws, digitalocean, gcp, hetzner)
- **SSH username validation**: GCP driver validates `GCP_SSH_USER` contains only safe characters (`[a-zA-Z0-9._-]`)
- **Resource ID validation**: Numeric ID validation before interpolating into API DELETE URLs (digitalocean droplet IDs, hetzner server IDs)
- **URL query parameter encoding**: Hetzner `_provision_verify` now URL-encodes the app name via `jq @uri` before embedding in query string
- **Numeric env var validation**: `INPUT_TEST_TIMEOUT`, `PROVISION_TIMEOUT`, and `INSTALL_WAIT` are validated as numeric in `common.sh` — these get interpolated into remote SSH command strings in `verify.sh`

## Risk Assessment

Low risk. All changes are additive validation checks that reject invalid input early. No behavioral change for valid inputs. All files pass `bash -n` syntax check.

Closes #2432
Closes #2433
Closes #2434
Closes #2435
Closes #2442

-- refactor/security-auditor