### PR TITLE
fix: base64-encode commands in SSH cloud exec functions

### DIFF
--- a/sh/e2e/lib/clouds/aws.sh
+++ b/sh/e2e/lib/clouds/aws.sh
@@ -145,9 +145,16 @@ _aws_exec() {
     fi
   fi
 
+  # Base64-encode the command to prevent shell injection when passed as an
+  # SSH argument. The encoded string contains only [A-Za-z0-9+/=] characters,
+  # making it safe to embed in single quotes. Stdin is preserved for callers
+  # that pipe data into cloud_exec.
+  local encoded_cmd
+  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
+
   ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
-      "ubuntu@${_AWS_INSTANCE_IP}" "${cmd}"
+      "ubuntu@${_AWS_INSTANCE_IP}" "printf '%s' '${encoded_cmd}' | base64 -d | bash"
 }
 
 # ---------------------------------------------------------------------------

--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -155,9 +155,16 @@ _digitalocean_exec() {
     return 1
   fi
 
+  # Base64-encode the command to prevent shell injection when passed as an
+  # SSH argument. The encoded string contains only [A-Za-z0-9+/=] characters,
+  # making it safe to embed in single quotes. Stdin is preserved for callers
+  # that pipe data into cloud_exec.
+  local encoded_cmd
+  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
+
   ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
-      "root@${ip}" "${cmd}"
+      "root@${ip}" "printf '%s' '${encoded_cmd}' | base64 -d | bash"
 }
 
 # ---------------------------------------------------------------------------

--- a/sh/e2e/lib/clouds/gcp.sh
+++ b/sh/e2e/lib/clouds/gcp.sh
@@ -158,9 +158,16 @@ _gcp_exec() {
     fi
   fi
 
+  # Base64-encode the command to prevent shell injection when passed as an
+  # SSH argument. The encoded string contains only [A-Za-z0-9+/=] characters,
+  # making it safe to embed in single quotes. Stdin is preserved for callers
+  # that pipe data into cloud_exec.
+  local encoded_cmd
+  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
+
   ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
-      "${ssh_user}@${_GCP_INSTANCE_IP}" "${cmd}"
+      "${ssh_user}@${_GCP_INSTANCE_IP}" "printf '%s' '${encoded_cmd}' | base64 -d | bash"
 }
 
 # ---------------------------------------------------------------------------

--- a/sh/e2e/lib/clouds/hetzner.sh
+++ b/sh/e2e/lib/clouds/hetzner.sh
@@ -135,12 +135,19 @@ _hetzner_exec() {
     return 1
   fi
 
+  # Base64-encode the command to prevent shell injection when passed as an
+  # SSH argument. The encoded string contains only [A-Za-z0-9+/=] characters,
+  # making it safe to embed in single quotes. Stdin is preserved for callers
+  # that pipe data into cloud_exec.
+  local encoded_cmd
+  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
+
   ssh -o StrictHostKeyChecking=no \
       -o UserKnownHostsFile=/dev/null \
       -o LogLevel=ERROR \
       -o BatchMode=yes \
       -o ConnectTimeout=10 \
-      "root@${ip}" "${cmd}"
+      "root@${ip}" "printf '%s' '${encoded_cmd}' | base64 -d | bash"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Why:** Issues #2432, #2433, #2434, #2435 flag that all four SSH-based cloud drivers pass commands directly as SSH arguments, which get interpreted by the remote shell and could allow injection.

**Changes:**
All four cloud exec functions (`_aws_exec`, `_digitalocean_exec`, `_gcp_exec`, `_hetzner_exec`) now base64-encode the command locally and decode it on the remote side before piping to bash. The encoded string contains only `[A-Za-z0-9+/=]` characters, making it safe to embed in single quotes. Stdin is preserved so callers that pipe data into `cloud_exec` (e.g., verify.sh input tests) continue to work.

**Before:**
```bash
ssh ... "root@${ip}" "${cmd}"
```

**After:**
```bash
encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
ssh ... "root@${ip}" "printf '%s' '${encoded_cmd}' | base64 -d | bash"
```

Closes #2432, closes #2433, closes #2434, closes #2435

-- refactor/complexity-hunter