### PR TITLE
fix: add missing PATH entries in Hetzner and DigitalOcean exec functions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.15.38",
+  "version": "0.15.39",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1124,7 +1124,7 @@ export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<v
 
 export async function runServer(cmd: string, timeoutSecs?: number, ip?: string): Promise<void> {
   const serverIp = ip || _state.serverIp;
-  const fullCmd = `export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const proc = Bun.spawn(
@@ -1200,7 +1200,7 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   // Single-quote escaping prevents premature shell expansion of $variables in cmd
   const shellEscapedCmd = cmd.replace(/'/g, "'\\''");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
+  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const exitCode = spawnInteractive([

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -555,7 +555,7 @@ export async function waitForCloudInit(ip?: string, maxAttempts = 60): Promise<v
 
 export async function runServer(cmd: string, timeoutSecs?: number, ip?: string): Promise<void> {
   const serverIp = ip || _state.serverIp;
-  const fullCmd = `export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const proc = Bun.spawn(
@@ -632,7 +632,7 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   // Single-quote escaping prevents premature shell expansion of $variables in cmd
   const shellEscapedCmd = cmd.replace(/'/g, "'\\''");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
+  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c '${shellEscapedCmd}'`;
 
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 


### PR DESCRIPTION
**Why:** Hetzner and DigitalOcean \`runServer()\` and \`interactiveSession()\` were missing \`\$HOME/.npm-global/bin\` and \`\$HOME/.claude/local/bin\` from their PATH exports, causing \"command not found\" errors for Claude Code (\`~/.claude/local/bin\`) and npm-global packages (\`~/.npm-global/bin\`) on those two clouds. AWS and GCP already had the correct PATH.

## Changes

4 one-line fixes to match AWS/GCP's PATH:
- \`packages/cli/src/hetzner/hetzner.ts\` — \`runServer()\` line 558, \`interactiveSession()\` line 635
- \`packages/cli/src/digitalocean/digitalocean.ts\` — \`runServer()\` line 1127, \`interactiveSession()\` line 1203

**Before (Hetzner/DO):**
\`\`\`
export PATH="\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH"
\`\`\`

**After (matching AWS/GCP):**
\`\`\`
export PATH="\$HOME/.npm-global/bin:\$HOME/.claude/local/bin:\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH"
\`\`\`

Biome: 0 errors. Tests: 1497 pass, 0 fail.

-- refactor/code-health