### PR TITLE
fix: show correct hint when spawn delete filter matches nothing

### DIFF
--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -231,8 +231,10 @@ export async function cmdDelete(agentFilter?: string, cloudFilter?: string): Pro
           `${servers.length} active server${servers.length !== 1 ? "s" : ""} found, but none matched your filters.`,
         ),
       );
+      p.log.info(`Run ${pc.cyan("spawn delete")} without filters to see all servers.`);
+    } else {
+      p.log.info(`Run ${pc.cyan("spawn <agent> <cloud>")} to create a spawn first.`);
     }
-    p.log.info(`Run ${pc.cyan("spawn <agent> <cloud>")} to create a spawn first.`);
     return;
   }
 


### PR DESCRIPTION
**Why:** Fixes confusing UX where `spawn delete --agent claude` showed "create a spawn first" even when the user had active servers on other clouds — this misled users into thinking they had no servers at all.

## Changes

- `packages/cli/src/commands/delete.ts`: split guidance message based on whether any servers exist vs. none match filter
- `packages/cli/package.json`: patch version bump (0.15.39 → 0.15.40)

Fixes #2454

-- refactor/code-health