### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/__tests__/README.md
+++ b/packages/cli/src/__tests__/README.md
@@ -51,17 +51,20 @@ bun test src/__tests__/manifest.test.ts
 - `prompt-file-security.test.ts` — `validatePromptFilePath`, `validatePromptFileStats`
 
 ### Infrastructure
-- `manifest-cache-lifecycle.test.ts` — Cache lifecycle: write, read, expiry, forced refresh
 - `history.test.ts` — History read/write
 - `history-trimming.test.ts` — History trimming at size limits
+- `history-corruption.test.ts` — History corruption recovery: malformed JSON, concurrent writes
 - `clear-history.test.ts` — `clearHistory`, `cmdListClear`
+- `paths.test.ts` — `getSpawnDir`, `getCacheDir`, `getHistoryPath`, `getSshDir`, path resolution
 - `ssh-keys.test.ts` — SSH key discovery, generation, fingerprinting
 - `update-check.test.ts` — Auto-update check logic
 - `with-retry-result.test.ts` — `withRetry`, `wrapSshCall`, Result constructors
 - `orchestrate.test.ts` — `runOrchestration`
+- `fs-sandbox.test.ts` — Guardrail: verifies test preload sandbox isolates filesystem writes
 
 ### Parsing and type utilities
 - `parse.test.ts` — `parseJsonWith`
+- `picker.test.ts` — `parsePickerInput`: tab-separated picker input parsing
 - `fuzzy-key-matching.test.ts` — `findClosestKeyByNameOrKey`, `levenshtein`, `findClosestMatch`, `resolveAgentKey`, `resolveCloudKey`
 - `unknown-flags.test.ts` — Unknown flag detection, `KNOWN_FLAGS`, `expandEqualsFlags`
 - `custom-flag.test.ts` — `--custom` flag for AWS, GCP, Hetzner, DigitalOcean
@@ -76,7 +79,9 @@ bun test src/__tests__/manifest.test.ts
 - `check-entity.test.ts` / `check-entity-messages.test.ts` — Entity validation
 - `agent-tarball.test.ts` — `tryTarballInstall`: GitHub Release tarball install, fallback, URL validation
 - `gateway-resilience.test.ts` — `startGateway` systemd unit with auto-restart and cron heartbeat
+- `do-payment-warning.test.ts` — `ensureDoToken` proactive payment method reminder for first-time DigitalOcean users
 - `do-snapshot.test.ts` — `findSpawnSnapshot`: DigitalOcean snapshot lookup, filtering, error handling
+- `sprite-keep-alive.test.ts` — `installSpriteKeepAlive` download/install, graceful failure, session script wrapping
 - `ui-utils.test.ts` — `validateServerName`, `validateRegionName`, `toKebabCase`, `sanitizeTermValue`, `jsonEscape`
 
 ### Agent-specific


### PR DESCRIPTION
## Summary
- Updated test README (`packages/cli/src/__tests__/README.md`) to add 6 undocumented test files: `do-payment-warning.test.ts`, `sprite-keep-alive.test.ts`, `history-corruption.test.ts`, `paths.test.ts`, `fs-sandbox.test.ts`, `picker.test.ts`
- Removed duplicate `manifest-cache-lifecycle.test.ts` entry that appeared in two sections

## Scan results (no action needed)
Full code quality scan was performed across all shell scripts and TypeScript source:
- **Dead code**: No dead exported functions found in `sh/shared/*.sh` or `packages/cli/src/shared/*.ts`
- **Stale references**: No stale imports or path references found
- **Python usage**: None found in shell scripts (all using jq/bun as expected)
- **Duplicate utilities**: Cloud `agents.ts` files properly deduplicated via `createCloudAgents()`. PATH strings in `runServer`/`interactiveSession` are duplicated across cloud modules but have different SSH connection logic, making extraction non-trivial
- **Stale comments**: No stale comments referencing removed infrastructure

## Test plan
- [x] `bun test` — 1497 tests pass, 0 failures
- [x] `biome check` — 114 files checked, no errors

-- qa/code-quality