### PR TITLE
fix: eliminate GitHub token temp file exposure in agent-setup

### DIFF
--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -240,25 +240,9 @@ export async function offerGithubAuth(runner: CloudRunner): Promise<void> {
   }
 
   let ghCmd = "curl --proto '=https' -fsSL https://openrouter.ai/labs/spawn/shared/github-auth.sh | bash";
-  let localTmpFile = "";
   if (githubToken) {
     const escaped = githubToken.replace(/'/g, "'\\''");
-    localTmpFile = join(getTmpDir(), `gh_token_${Date.now()}_${Math.random().toString(36).slice(2)}`);
-    writeFileSync(localTmpFile, `export GITHUB_TOKEN='${escaped}'`, {
-      mode: 0o600,
-    });
-    const remoteTmpFile = `/tmp/gh_token_${Date.now()}`;
-    try {
-      await runner.uploadFile(localTmpFile, remoteTmpFile);
-      ghCmd = `. ${remoteTmpFile} && rm -f ${remoteTmpFile} && ${ghCmd}`;
-    } catch {
-      try {
-        unlinkSync(localTmpFile);
-      } catch {
-        /* ignore */
-      }
-      localTmpFile = "";
-    }
+    ghCmd = `export GITHUB_TOKEN='${escaped}' && ${ghCmd}`;
   }
 
   logStep("Installing and authenticating GitHub CLI on the remote server...");
@@ -266,14 +250,6 @@ export async function offerGithubAuth(runner: CloudRunner): Promise<void> {
     await runner.runServer(ghCmd);
   } catch {
     logWarn("GitHub CLI setup failed (non-fatal, continuing)");
-  } finally {
-    if (localTmpFile) {
-      try {
-        unlinkSync(localTmpFile);
-      } catch {
-        /* ignore */
-      }
-    }
   }
 
   // Propagate host git identity to the remote VM


### PR DESCRIPTION
**Why:** GitHub tokens written to disk (even with 0o600 perms) have a brief exposure window via temp files on both local and remote machines. Eliminating disk writes removes the race condition entirely.

Fixes #2462

## What Changed

- Removed temp file creation (`writeFileSync`) and upload (`runner.uploadFile`) for GitHub token transfer
- Instead, pass `GITHUB_TOKEN` directly via inline `export` in the remote SSH command: `export GITHUB_TOKEN='...' && curl ... | bash`
- The `github-auth.sh` script on the remote already handles `GITHUB_TOKEN` env var natively (line 282), so this is a drop-in replacement
- Removed all associated cleanup logic (`unlinkSync`, `finally` blocks) since no temp files are created
- Net result: -26 lines of code, zero temp files, same functionality

## Test plan

- [x] All 1497 tests pass (`bun test`)
- [x] Biome lint passes with zero errors on all 114 files
- [x] `github-auth.sh` already supports `GITHUB_TOKEN` env var — no changes needed on remote side
- [ ] Manual verification: `spawn run` with a valid GitHub token should authenticate on the remote VM

-- refactor/code-health