### PR TITLE
fix: use asyncTryCatch for tarball install + add chown ownership fix

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/agent-tarball.test.ts
+++ b/packages/cli/src/__tests__/agent-tarball.test.ts
@@ -168,4 +168,68 @@ describe("tryTarballInstall", () => {
     expect(result).toBe(false);
     expect(runner.runServer).not.toHaveBeenCalled();
   });
+
+  describe("non-root home directory mirroring", () => {
+    it("mirrors dotfiles from /root/ to $HOME for non-root users", async () => {
+      const fetchFn = mockFetch(new Response(JSON.stringify(RELEASE_PAYLOAD)));
+      const runner = createMockRunner();
+
+      await tryTarballInstall(runner, "openclaw", fetchFn);
+
+      const mirrorCmd = String(runner.runServer.mock.calls[1][0]);
+      expect(mirrorCmd).toContain("cp -a");
+      expect(mirrorCmd).toContain('"$HOME/$_d"');
+      for (const dir of [
+        ".claude",
+        ".local",
+        ".npm-global",
+        ".cargo",
+        ".opencode",
+        ".hermes",
+        ".bun",
+      ]) {
+        expect(mirrorCmd).toContain(dir);
+      }
+    });
+
+    it("mirrors the .spawn-tarball marker file", async () => {
+      const fetchFn = mockFetch(new Response(JSON.stringify(RELEASE_PAYLOAD)));
+      const runner = createMockRunner();
+
+      await tryTarballInstall(runner, "openclaw", fetchFn);
+
+      const mirrorCmd = String(runner.runServer.mock.calls[1][0]);
+      expect(mirrorCmd).toContain('cp /root/.spawn-tarball "$HOME/.spawn-tarball"');
+    });
+
+    it("returns true even when mirror step fails (non-fatal)", async () => {
+      const fetchFn = mockFetch(new Response(JSON.stringify(RELEASE_PAYLOAD)));
+      const runner = createMockRunner();
+      runner.runServer.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("cp failed"));
+
+      const result = await tryTarballInstall(runner, "openclaw", fetchFn);
+
+      expect(result).toBe(true);
+    });
+
+    it("guards mirror behind non-root check (id -u)", async () => {
+      const fetchFn = mockFetch(new Response(JSON.stringify(RELEASE_PAYLOAD)));
+      const runner = createMockRunner();
+
+      await tryTarballInstall(runner, "openclaw", fetchFn);
+
+      const mirrorCmd = String(runner.runServer.mock.calls[1][0]);
+      expect(mirrorCmd).toContain('if [ "$(id -u)" != "0" ]; then');
+    });
+
+    it("fixes ownership of mirrored files with chown", async () => {
+      const fetchFn = mockFetch(new Response(JSON.stringify(RELEASE_PAYLOAD)));
+      const runner = createMockRunner();
+
+      await tryTarballInstall(runner, "openclaw", fetchFn);
+
+      const mirrorCmd = String(runner.runServer.mock.calls[1][0]);
+      expect(mirrorCmd).toContain('chown -R "$(id -u):$(id -g)"');
+    });
+  });
 });

--- a/packages/cli/src/shared/agent-tarball.ts
+++ b/packages/cli/src/shared/agent-tarball.ts
@@ -5,6 +5,7 @@
 import type { CloudRunner } from "./agent-setup";
 
 import * as v from "valibot";
+import { asyncTryCatch } from "./result";
 import { getErrorMessage } from "./type-guards";
 import { logDebug, logInfo, logStep, logWarn } from "./ui";
 
@@ -104,12 +105,11 @@ export async function tryTarballInstall(
     downloadCmd = `curl -fsSL --connect-timeout 10 --max-time 120 '${url}' | ${sudo} tar xz -C / && ${sudo} test -f /root/.spawn-tarball`;
   }
 
-  // Phase 3: Remote execution
-  try {
-    await runner.runServer(downloadCmd, 150);
-  } catch (err) {
+  // Phase 3: Remote execution — catch-all because any failure means "fall back to live install"
+  const extractResult = await asyncTryCatch(() => runner.runServer(downloadCmd, 150));
+  if (!extractResult.ok) {
     logWarn("Tarball download/extract failed on remote VM");
-    logDebug(getErrorMessage(err));
+    logDebug(getErrorMessage(extractResult.error));
     return false;
   }
 
@@ -126,11 +126,18 @@ export async function tryTarballInstall(
     "  done",
     "  # Copy marker file",
     '  cp /root/.spawn-tarball "$HOME/.spawn-tarball" 2>/dev/null || true',
+    "  # Fix ownership — files were extracted as root",
+    '  chown -R "$(id -u):$(id -g)" "$HOME/.spawn-tarball" 2>/dev/null || true',
+    "  for _d in .claude .local .npm-global .cargo .opencode .hermes .bun; do",
+    '    if [ -d "$HOME/$_d" ]; then',
+    '      chown -R "$(id -u):$(id -g)" "$HOME/$_d" 2>/dev/null || true',
+    "    fi",
+    "  done",
     "fi",
   ].join("\n");
-  try {
-    await runner.runServer(mirrorCmd, 30);
-  } catch {
+  // Non-fatal — mirror failure should not block tarball install
+  const mirrorResult = await asyncTryCatch(() => runner.runServer(mirrorCmd, 30));
+  if (!mirrorResult.ok) {
     logWarn("Tarball file mirroring failed (non-fatal)");
   }
 


### PR DESCRIPTION
## Summary

- Replace try/catch in `agent-tarball.ts` with `asyncTryCatch` Result helpers (from #2477)
- Add `chown` ownership fix for non-root SSH users (GCP, AWS Lightsail) — files extracted as root need ownership corrected after mirroring to `$HOME`
- Add 5 anti-regression tests for non-root home directory mirroring

Supersedes #2466 — same functionality but uses the new Result helpers instead of `.then()/.catch()` promise patterns.

## Test plan

- [x] `bunx @biomejs/biome check src/` — 115 files, 0 errors
- [x] `bun test` — 1568 pass, 0 fail
- [x] `bun test src/__tests__/agent-tarball.test.ts` — 12 pass (5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)