### PR TITLE
refactor: convert remaining 5 try/catch blocks to Result helpers

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -314,10 +314,9 @@ export async function handleRecordAction(selected: SpawnRecord, manifest: Manife
   }
 
   if (action === "enter") {
-    try {
-      await cmdEnterAgent(selected.connection, selected.agent, manifest);
-    } catch (err) {
-      p.log.error(`Connection failed: ${getErrorMessage(err)}`);
+    const r = await asyncTryCatch(() => cmdEnterAgent(selected.connection, selected.agent, manifest));
+    if (!r.ok) {
+      p.log.error(`Connection failed: ${getErrorMessage(r.error)}`);
       p.log.info(
         `VM may no longer be running. Use ${pc.cyan(`spawn ${selected.agent} ${selected.cloud}`)} to start a new one.`,
       );
@@ -326,10 +325,9 @@ export async function handleRecordAction(selected: SpawnRecord, manifest: Manife
   }
 
   if (action === "reconnect") {
-    try {
-      await cmdConnect(selected.connection);
-    } catch (err) {
-      p.log.error(`Connection failed: ${getErrorMessage(err)}`);
+    const r = await asyncTryCatch(() => cmdConnect(selected.connection));
+    if (!r.ok) {
+      p.log.error(`Connection failed: ${getErrorMessage(r.error)}`);
       p.log.info(
         `VM may no longer be running. Use ${pc.cyan(`spawn ${selected.agent} ${selected.cloud}`)} to start a new one.`,
       );

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -688,11 +688,9 @@ export async function ensureSshKey(): Promise<void> {
       name: `spawn-${key.name}`,
       public_key: pubKey,
     });
-    let regText: string;
-    try {
-      regText = await doApi("POST", "/account/keys", body);
-    } catch (err) {
-      const msg = getErrorMessage(err);
+    const regResult = await asyncTryCatch(async () => doApi("POST", "/account/keys", body));
+    if (!regResult.ok) {
+      const msg = getErrorMessage(regResult.error);
       // Key may already exist under a different name — non-fatal
       if (msg.includes("already been taken") || msg.includes("already in use")) {
         logInfo(`SSH key '${key.name}' already registered (under a different name)`);
@@ -701,6 +699,7 @@ export async function ensureSshKey(): Promise<void> {
       logWarn(`SSH key '${key.name}' registration may have failed, continuing...`);
       continue;
     }
+    const regText = regResult.data;
 
     if (regText.includes('"id"')) {
       logInfo(`SSH key '${key.name}' registered with DigitalOcean`);

--- a/packages/cli/src/shared/agent-tarball.ts
+++ b/packages/cli/src/shared/agent-tarball.ts
@@ -36,10 +36,7 @@ export async function tryTarballInstall(
   logStep(`Checking for pre-built tarball (${tag})...`);
 
   // Phase 1: Fetch + parse tarball metadata
-  let x86Url: string;
-  let armUrl: string;
-  let url: string;
-  try {
+  const metaResult = await asyncTryCatch(async () => {
     // Query GitHub Releases API for the rolling release tag
     const resp = await fetchFn(`https://api.github.com/repos/${REPO}/releases/tags/${tag}`, {
       headers: {
@@ -50,14 +47,14 @@ export async function tryTarballInstall(
 
     if (!resp.ok) {
       logWarn("No pre-built tarball available");
-      return false;
+      return null;
     }
 
     const json: unknown = await resp.json();
     const parsed = v.safeParse(ReleaseSchema, json);
     if (!parsed.success) {
       logWarn("Tarball release has unexpected format");
-      return false;
+      return null;
     }
 
     // Find both arch-specific .tar.gz assets and let the remote VM pick the right one.
@@ -67,17 +64,24 @@ export async function tryTarballInstall(
 
     if (!x86Asset && !armAsset) {
       logWarn("No tarball asset found in release");
-      return false;
+      return null;
     }
 
-    x86Url = x86Asset?.browser_download_url || "";
-    armUrl = armAsset?.browser_download_url || "";
-    url = x86Url || armUrl;
-  } catch (err) {
+    return {
+      x86Url: x86Asset?.browser_download_url || "",
+      armUrl: armAsset?.browser_download_url || "",
+      url: x86Asset?.browser_download_url || armAsset?.browser_download_url || "",
+    };
+  });
+  if (!metaResult.ok) {
     logWarn("Failed to fetch pre-built tarball metadata");
-    logDebug(getErrorMessage(err));
+    logDebug(getErrorMessage(metaResult.error));
     return false;
   }
+  if (!metaResult.data) {
+    return false;
+  }
+  const { x86Url, armUrl, url } = metaResult.data;
 
   // Phase 2: URL validation + command building (deterministic — no try/catch needed)
   // SECURITY: Validate URLs match expected GitHub releases pattern.

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -556,15 +556,17 @@ export async function uploadFileSprite(localPath: string, remotePath: string): P
 export async function installSpriteKeepAlive(): Promise<void> {
   logStep("Installing Sprite keep-alive...");
   const scriptUrl = "https://kurt-claw-f.sprites.app/sprite-keep-running.sh";
-  try {
+  const r = await asyncTryCatch(async () => {
     await runSprite(
       "mkdir -p ~/.local/bin && " +
         `curl -fsSL '${scriptUrl}' -o ~/.local/bin/sprite-keep-running && ` +
         "chmod +x ~/.local/bin/sprite-keep-running",
       60,
     );
+  });
+  if (r.ok) {
     logInfo("Sprite keep-alive installed");
-  } catch {
+  } else {
     logWarn("Could not install Sprite keep-alive — sprite may shut down during inactivity");
   }
 }


### PR DESCRIPTION
## Summary

- Converts the last 5 convertible try/catch blocks to Result helpers
- After this PR, all remaining `try` blocks (~43) are either:
  - **try/finally** (21): timer cleanup, env var restore, temp file delete, TTY state restore
  - **Complex patterns** (10+): billing/account validation, security catch-exit, headless error handlers, top-level main handler, SSH retry classify
- Bumps CLI to 0.16.5

## Changes

- **digitalocean.ts**: SSH key registration → `asyncTryCatch`
- **sprite.ts**: keep-alive install → `asyncTryCatch`
- **agent-tarball.ts**: tarball metadata fetch → `asyncTryCatch`
- **list.ts**: enter agent / reconnect error recovery → `asyncTryCatch` (2 blocks)

## Test plan

- [x] `bunx @biomejs/biome check src/` — 115 files, 0 errors
- [x] `bun test` — 1568 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)