### PR TITLE
fix(e2e): fix OPENROUTER_API_KEY fallback and sprite env whitelist

### DIFF
--- a/sh/e2e/lib/common.sh
+++ b/sh/e2e/lib/common.sh
@@ -15,6 +15,21 @@ case "${PROVISION_TIMEOUT}" in ''|*[!0-9]*) PROVISION_TIMEOUT=720 ;; esac
 case "${INSTALL_WAIT}" in ''|*[!0-9]*) INSTALL_WAIT=600 ;; esac
 case "${INPUT_TEST_TIMEOUT}" in ''|*[!0-9]*) INPUT_TEST_TIMEOUT=120 ;; esac
 
+# ---------------------------------------------------------------------------
+# OpenRouter API key fallback
+#
+# On QA VMs that run Claude Code via OpenRouter, the API key is stored as
+# ANTHROPIC_AUTH_TOKEN (because Claude Code uses ANTHROPIC_BASE_URL + token).
+# Export OPENROUTER_API_KEY from ANTHROPIC_AUTH_TOKEN when using OpenRouter.
+# ---------------------------------------------------------------------------
+if [ -z "${OPENROUTER_API_KEY:-}" ] && [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+  case "${ANTHROPIC_BASE_URL:-}" in
+    *openrouter*)
+      export OPENROUTER_API_KEY="${ANTHROPIC_AUTH_TOKEN}"
+      ;;
+  esac
+fi
+
 # Active cloud (set by load_cloud_driver)
 ACTIVE_CLOUD=""
 

--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -66,7 +66,7 @@ provision_agent() {
     # Uses sed instead of BASH_REMATCH for macOS bash 3.2 compatibility.
     # Positive whitelist: only variables actually emitted by cloud_headless_env
     # functions are allowed. This prevents injection of arbitrary env vars.
-    _ALLOWED_HEADLESS_VARS=" LIGHTSAIL_SERVER_NAME AWS_DEFAULT_REGION LIGHTSAIL_BUNDLE DO_DROPLET_NAME DO_DROPLET_SIZE DO_REGION GCP_INSTANCE_NAME GCP_PROJECT GCP_ZONE GCP_MACHINE_TYPE HETZNER_SERVER_NAME HETZNER_SERVER_TYPE HETZNER_LOCATION "
+    _ALLOWED_HEADLESS_VARS=" LIGHTSAIL_SERVER_NAME AWS_DEFAULT_REGION LIGHTSAIL_BUNDLE DO_DROPLET_NAME DO_DROPLET_SIZE DO_REGION GCP_INSTANCE_NAME GCP_PROJECT GCP_ZONE GCP_MACHINE_TYPE HETZNER_SERVER_NAME HETZNER_SERVER_TYPE HETZNER_LOCATION SPRITE_NAME SPRITE_ORG "
     while IFS= read -r _env_line; do
       # Skip lines that don't look like export VAR="VALUE"
       case "${_env_line}" in


### PR DESCRIPTION
## Summary
- On QA VMs running Claude Code via OpenRouter, `OPENROUTER_API_KEY` was never set — the key lives in `ANTHROPIC_AUTH_TOKEN`. All E2E clouds were skipped with "Credentials not configured". Added a fallback in `common.sh` to export `OPENROUTER_API_KEY` from `ANTHROPIC_AUTH_TOKEN` when `ANTHROPIC_BASE_URL` contains `openrouter`.
- `SPRITE_NAME` and `SPRITE_ORG` were missing from the env var whitelist in `provision.sh`, causing `_sprite_headless_env()` output to be silently dropped every run. Added both vars to the whitelist.

## E2E Results
- Before: all 5 clouds skipped (`OPENROUTER_API_KEY` not set)
- After fix: Hetzner, DigitalOcean, GCP, Sprite unblocked; AWS skipped (expected — no creds)
- Root cause #1 (`OPENROUTER_API_KEY`): confirmed resolved — clouds now pass credential validation
- Root cause #2 (Sprite whitelist): confirmed resolved — `SPRITE_NAME`/`SPRITE_ORG` no longer rejected

## Test plan
- [x] `bash -n` passes on both modified scripts (`common.sh`, `provision.sh`)
- [x] Re-ran `e2e.sh --cloud all` — clouds with credentials now reach provisioning phase
- [x] Sprite provisioning logs no longer show "Rejected unexpected env var" errors

-- qa/e2e-tester