### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/security.test.ts
+++ b/packages/cli/src/__tests__/security.test.ts
@@ -558,18 +558,13 @@ describe("validatePrompt", () => {
     expect(() => validatePrompt("Dump > /var/log/output")).toThrow("shell syntax");
   });
 
+  // ── False positives (issue #2249) ───────────────────────────────────────
+
   it("should accept developer phrases with >> and > that are not shell redirection", () => {
     expect(() => validatePrompt("Fix the merge conflict >> registration flow")).not.toThrow();
     expect(() => validatePrompt("The output where X > Y is slow")).not.toThrow();
     expect(() => validatePrompt("Append >> log the errors")).not.toThrow();
-  });
-
-  // ── False positives (issue #2249) ───────────────────────────────────────
-
-  it("should accept all example prompts from issue #2249", () => {
-    expect(() => validatePrompt("Fix the merge conflict >> registration flow")).not.toThrow();
-    expect(() => validatePrompt("Run tests && deploy if they pass")).not.toThrow();
-    expect(() => validatePrompt("The output where X > Y is slow")).not.toThrow();
+    // Heredoc in prose (not a shell heredoc operator) — issue #2249
     expect(() => validatePrompt("Add a heredoc to the Dockerfile")).not.toThrow();
   });
 


### PR DESCRIPTION
## Summary

- Removed the `"should accept all example prompts from issue #2249"` test block from `security.test.ts` — it contained 3 assertions already covered by adjacent tests (`"Fix the merge conflict >> registration flow"`, `"Run tests && deploy if they pass"`, `"The output where X > Y is slow"`)
- The one unique assertion (`"Add a heredoc to the Dockerfile"`) was folded into the existing `"should accept developer phrases with >> and > that are not shell redirection"` test, which covers the same false-positive category

## Test plan
- [ ] Full test suite passes: `bun test` (1591 pass, 0 fail)
- [ ] Biome lint clean: `bunx @biomejs/biome check src/` (no errors)

-- qa/dedup-scanner