### PR TITLE
docs: add missing agent entries to all cloud READMEs

### DIFF
--- a/sh/aws/README.md
+++ b/sh/aws/README.md
@@ -54,6 +54,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/kilocode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/hermes.sh)
 ```
 
+#### Junie
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/aws/junie.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/sh/digitalocean/README.md
+++ b/sh/digitalocean/README.md
@@ -46,6 +46,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/kilocode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/hermes.sh)
 ```
 
+#### Junie
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/digitalocean/junie.sh)
+```
+
 ## Environment Variables
 
 | Variable | Description | Default |

--- a/sh/gcp/README.md
+++ b/sh/gcp/README.md
@@ -48,6 +48,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/kilocode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/hermes.sh)
 ```
 
+#### Junie
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/junie.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/sh/hetzner/README.md
+++ b/sh/hetzner/README.md
@@ -46,6 +46,12 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/kilocode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/hermes.sh)
 ```
 
+#### Junie
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/hetzner/junie.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash

--- a/sh/local/README.md
+++ b/sh/local/README.md
@@ -13,8 +13,10 @@ spawn claude local
 spawn openclaw local
 spawn zeroclaw local
 spawn codex local
+spawn opencode local
 spawn kilocode local
 spawn hermes local
+spawn junie local
 ```
 
 Or run directly without the CLI:
@@ -24,8 +26,10 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/claude.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/openclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/zeroclaw.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/codex.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/kilocode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/hermes.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/junie.sh)
 ```
 
 ## Non-Interactive Mode

--- a/sh/sprite/README.md
+++ b/sh/sprite/README.md
@@ -40,6 +40,18 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/opencode.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/kilocode.sh)
 ```
 
+#### Hermes
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/hermes.sh)
+```
+
+#### Junie
+
+```bash
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sprite/junie.sh)
+```
+
 ## Non-Interactive Mode
 
 ```bash


### PR DESCRIPTION
**Why:** Junie was added to all 6 clouds (scripts exist, matrix says "implemented", agent-setup.ts has config) but none of the cloud READMEs documented it — users visiting these docs couldn't discover the agent. Sprite README was also missing Hermes, and local README was missing OpenCode and Junie.

## Changes
- **hetzner/README.md** — add Junie section
- **aws/README.md** — add Junie section
- **digitalocean/README.md** — add Junie section
- **gcp/README.md** — add Junie section
- **sprite/README.md** — add Hermes + Junie sections
- **local/README.md** — add OpenCode + Junie to Quick Start and curl examples

All 6 cloud READMEs now list all 8 agents consistently.

-- refactor/code-health