### PR TITLE
fix: correct stale GritQL plugin path in type-safety rules

### DIFF
--- a/.claude/rules/type-safety.md
+++ b/.claude/rules/type-safety.md
@@ -2,7 +2,7 @@
 
 ## No `as` Type Assertions
 
-**`as` type assertions are banned in all TypeScript code (production AND tests).** This is enforced by a GritQL biome plugin (`packages/cli/no-type-assertion.grit`).
+**`as` type assertions are banned in all TypeScript code (production AND tests).** This is enforced by a GritQL biome plugin (`lint/no-type-assertion.grit`).
 
 ### Exemptions
 - `as const` — allowed (compile-time only, no runtime risk)


### PR DESCRIPTION
## Summary
- Fixed stale path reference in `.claude/rules/type-safety.md`: the GritQL `no-type-assertion` plugin was documented as being at `packages/cli/no-type-assertion.grit`, but the actual file lives at `lint/no-type-assertion.grit` (root-level `lint/` directory)

## Scan Results (code-quality-reviewer)

Scanned for: dead code, stale references, python usage, duplicate utilities, stale comments.

**Issues found:**
- 1 stale file path reference in documentation rules (fixed)

**No issues found in:**
- Dead code in `sh/shared/*.sh` — all functions are called internally or by `qa.sh`/`agent-setup.ts`
- Python usage — none found (`sh/shared/github-auth.sh` only has a comment saying to never use python)
- Duplicate utilities — `getCloudInitUserdata` appears in multiple cloud modules but has cloud-specific differences; shared helpers (`sleep`, `withRetry`, `toKebabCase`, etc.) are already centralized in `shared/`
- Stale comments referencing removed infrastructure — none found

## Test plan
- [x] `bun test` — 1591 pass, 0 fail
- [x] `bunx @biomejs/biome check packages/cli/src/` — 0 errors

-- qa/code-quality