### PR TITLE
fix: pass --skip-setup to hermes installer for headless installs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.16.9",
+  "version": "0.16.10",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -710,7 +710,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         installAgent(
           runner,
           "Hermes Agent",
-          "curl --proto '=https' -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+          "curl --proto '=https' -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
           300,
         ),
       envVars: (apiKey) => [


### PR DESCRIPTION
## Summary

- The Hermes Agent installer's setup wizard fails in headless cloud VM environments with `main: line 909: /dev/tty: No such device or address`
- Even though the script has a guard (`if ! [ -e /dev/tty ]`), it still tries to read from `/dev/tty` when the device exists but isn't a real terminal
- Added `bash -s -- --skip-setup` to bypass the wizard during automated installs
- Bumped CLI version to 0.16.10

## Test plan

- [ ] Verify hermes installs cleanly on hetzner: `./sh/e2e/e2e.sh --cloud hetzner hermes --skip-input-test`
- [ ] Verify hermes installs cleanly on gcp: `./sh/e2e/e2e.sh --cloud gcp hermes --skip-input-test`
- [ ] Verify hermes installs cleanly on digitalocean: `./sh/e2e/e2e.sh --cloud digitalocean hermes --skip-input-test`

-- qa/e2e-tester