### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/fs-sandbox.test.ts
+++ b/packages/cli/src/__tests__/fs-sandbox.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { existsSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tryCatch } from "@openrouter/spawn-shared";
 
@@ -46,21 +46,6 @@ describe("Filesystem sandbox", () => {
   it("XDG_CACHE_HOME should point to temp sandbox", () => {
     const cacheHome = process.env.XDG_CACHE_HOME ?? "";
     expect(cacheHome).toContain("spawn-test-home-");
-  });
-
-  it("real home ~/.spawn/history.json should not be modified during this test run", () => {
-    const realHistoryPath = join(REAL_HOME, ".spawn", "history.json");
-    if (!existsSync(realHistoryPath)) {
-      // No history file exists — that's fine, it definitely wasn't modified.
-      expect(true).toBe(true);
-      return;
-    }
-    // Record the mtime. If any test modifies the real file, the mtime
-    // changes. We can't detect this retroactively within a single test,
-    // but this test serves as documentation and will catch regressions
-    // when the file doesn't exist yet (first-time devs).
-    const stat = statSync(realHistoryPath);
-    expect(stat.isFile()).toBe(true);
   });
 
   it("sandbox directories should exist", () => {


### PR DESCRIPTION
## Summary

- Scanned all 60 test files (1399 tests) for duplicate describes, bash-grep style tests, always-pass patterns, and excessive subprocess spawning
- Found and removed 1 theatrical always-pass test in `fs-sandbox.test.ts`

## Finding

**`fs-sandbox.test.ts` — always-pass test** (`"real home ~/.spawn/history.json should not be modified during this test run"`):
- If `~/.spawn/history.json` doesn't exist → `expect(true).toBe(true)` (vacuously true, never fails)
- If the file does exist → only asserts `stat.isFile()` (the file being a file is not what was claimed to be tested)
- The comment in the test itself admitted: *"We can't detect this retroactively within a single test"*
- This test could never catch the regression it claimed to guard against

## What was NOT changed

After thorough scanning:
- **No duplicate top-level describe blocks** — all top-level describes are unique across files
- **No bash-grep style tests** — no `type FUNCTION_NAME` or function body grepping patterns found
- **No excessive subprocess spawning** — all `Bun.spawnSync` calls in tests use `spyOn` mocking
- **Conditional `if` guards on `expect(r.ok)` checks** in `result-helpers.test.ts`, `prompt-file-security.test.ts`, `security.test.ts` are legitimate TypeScript narrowing patterns, not always-pass
- `check-entity.test.ts` and `check-entity-messages.test.ts` are intentionally separate — one tests return values, the other tests user-facing messages

## Test Results

Before: 1399 pass, 0 fail  
After: 1398 pass, 0 fail (1 theatrical test removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)