### PR TITLE
fix: replace stale bun -e with bun eval in key-request.sh

### DIFF
--- a/sh/shared/key-request.sh
+++ b/sh/shared/key-request.sh
@@ -29,7 +29,7 @@ _check_cli_auth_clouds() {
     if command -v jq &>/dev/null; then
         cli_clouds=$(jq -r '.clouds | to_entries[] | select(.value.auth != null) | select(.value.auth | test("\\b(login|configure|setup)\\b"; "i")) | "\(.key)|\(.value.auth)"' "${manifest_path}" 2>/dev/null)
     else
-        cli_clouds=$(_MANIFEST="${manifest_path}" bun -e "
+        cli_clouds=$(_MANIFEST="${manifest_path}" bun eval "
 import fs from 'fs';
 const m = JSON.parse(fs.readFileSync(process.env._MANIFEST, 'utf8'));
 for (const [key, cloud] of Object.entries(m.clouds || {})) {
@@ -58,7 +58,7 @@ for (const [key, cloud] of Object.entries(m.clouds || {})) {
                         if command -v jq &>/dev/null; then
                             project=$(jq -r '.GCP_PROJECT // .project // "" | select(. != null)' "${gcp_config}" 2>/dev/null)
                         else
-                            project=$(_FILE="${gcp_config}" bun -e "
+                            project=$(_FILE="${gcp_config}" bun eval "
 import fs from 'fs';
 const d = JSON.parse(fs.readFileSync(process.env._FILE, 'utf8'));
 process.stdout.write(d.GCP_PROJECT || d.project || '');


### PR DESCRIPTION
**Why:** PR #2505 migrated all `bun -e` → `bun eval` across shell scripts but missed 2 instances in `sh/shared/key-request.sh` (lines 32 and 61). This completes the migration — the rest of the same file already uses `bun eval` (lines 98, 137, 271), making this a clear half-migration straggler.

## Changes

- `sh/shared/key-request.sh` line 32: `bun -e` → `bun eval`
- `sh/shared/key-request.sh` line 61: `bun -e` → `bun eval`

## Verification

- `bash -n sh/shared/key-request.sh` — syntax OK
- No other `bun -e` occurrences remain in the repo

-- refactor/code-health