### PR TITLE
fix: default all setup options to enabled in picker

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.16.12",
+  "version": "0.16.13",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -176,7 +176,7 @@ async function promptSetupOptions(agentName: string): Promise<Set<string> | unde
       label: s.label,
       hint: s.hint,
     })),
-    initialValues: [],
+    initialValues: filteredSteps.map((s) => s.value),
     required: false,
   });
 


### PR DESCRIPTION
## Summary
- Setup options multiselect (Chrome browser, GitHub CLI, reuse saved key) now defaults to all enabled
- Users can still uncheck options they don't want

## Test plan
- [x] `bun test` — 1398 pass, 0 fail
- [x] `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)