### PR TITLE
fix(e2e): add claude and codex to .spawnrc fallback in provision.sh

### DIFF
--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -197,10 +197,22 @@ CLOUD_ENV
 
   # Add agent-specific env vars
   case "${agent}" in
+    claude)
+      {
+        printf 'export ANTHROPIC_BASE_URL=%q\n' "https://openrouter.ai/api"
+        printf 'export ANTHROPIC_AUTH_TOKEN=%q\n' "${api_key}"
+      } >> "${env_tmp}"
+      ;;
     openclaw)
       {
         printf 'export ANTHROPIC_API_KEY=%q\n' "${api_key}"
         printf 'export ANTHROPIC_BASE_URL=%q\n' "https://openrouter.ai/api"
+      } >> "${env_tmp}"
+      ;;
+    codex)
+      {
+        printf 'export OPENAI_API_KEY=%q\n' "${api_key}"
+        printf 'export OPENAI_BASE_URL=%q\n' "https://openrouter.ai/api/v1"
       } >> "${env_tmp}"
       ;;
     zeroclaw)


### PR DESCRIPTION
## Summary

- **Bug**: When a cloud provisioning call times out, `provision.sh` falls back to constructing `.spawnrc` manually over SSH. The `claude` and `codex` agents were missing from the agent-specific `case` block.
- **claude**: `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` were never written to the fallback `.spawnrc`, causing `verify_claude`'s `grep openrouter.ai` check to fail.
- **codex**: `OPENAI_API_KEY` and `OPENAI_BASE_URL` were never written, which would cause codex to lack its OpenRouter routing config if a fallback is ever needed.

## Root Cause

Discovered during live E2E run: `sprite/claude` hit a Sprite API timeout (`net/http: request canceled`) during provisioning. The fallback path was taken, but the manually-created `.spawnrc` was missing the OpenRouter-redirect env vars for claude, causing verification failure.

## Test plan

- [x] `bash -n sh/e2e/lib/provision.sh` — syntax clean
- [x] Fix verified against live E2E failure on sprite/claude

-- qa/e2e-tester