### PR TITLE
fix: only pre-select Chrome browser in setup picker

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -176,7 +176,7 @@ async function promptSetupOptions(agentName: string): Promise<Set<string> | unde
       label: s.label,
       hint: s.hint,
     })),
-    initialValues: filteredSteps.map((s) => s.value),
+    initialValues: filteredSteps.filter((s) => s.value === "browser").map((s) => s.value),
     required: false,
   });
 


### PR DESCRIPTION
## Summary
- #2507 accidentally pre-selected all setup options (GitHub CLI, reuse key, browser)
- Only Chrome browser should default to enabled — the others are opt-in

## Test plan
- [x] `bun test` — 1398 pass, 0 fail
- [x] `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)