### PR TITLE
feat: gate tarball install behind --beta=tarball flag

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.16.15",
+  "version": "0.16.16",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
## Summary
- Add `--beta <feature>` repeatable CLI flag for opt-in experimental features
- Add `extractAllFlagValues()` helper in `index.ts` for repeatable flags
- Gate tarball install behind `--beta=tarball` (sets `SPAWN_BETA` env var)
- Valid beta features defined in `VALID_BETA_FEATURES` set

Cherry-picked from commit 9a1dad7f (previously on feature branch, never merged to main).

## Test plan
- [x] `bunx @biomejs/biome check src/` — zero errors
- [x] `bun test` — 1498 tests passing
- [x] New tests cover: tarball with beta flag, without beta flag, tarball success skips install, local cloud skips tarball, skipTarball agent flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)