### PR TITLE
fix(e2e): dynamically calculate DigitalOcean parallel capacity from account limit

### DIFF
--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -355,8 +355,20 @@ EOF
 # ---------------------------------------------------------------------------
 # _digitalocean_max_parallel
 #
-# DigitalOcean accounts often have a 3-droplet limit.
+# Queries the DigitalOcean account to determine available droplet capacity.
+# Subtracts non-e2e droplets from the account limit so parallel test runs
+# don't fail due to pre-existing droplets consuming quota slots.
+# Falls back to 3 if the API is unavailable.
 # ---------------------------------------------------------------------------
 _digitalocean_max_parallel() {
-  printf '3'
+  local _account_json _limit _existing _available
+  _account_json=$(_do_curl_auth -sf "${_DO_API}/account" 2>/dev/null) || { printf '3'; return 0; }
+  _limit=$(printf '%s' "${_account_json}" | grep -o '"droplet_limit":[0-9]*' | grep -o '[0-9]*$') || { printf '3'; return 0; }
+  _existing=$(_do_curl_auth -sf "${_DO_API}/droplets?per_page=200" 2>/dev/null | grep -o '"id":[0-9]*' | wc -l | tr -d ' ') || { printf '3'; return 0; }
+  _available=$(( _limit - _existing ))
+  if [ "${_available}" -lt 1 ]; then
+    printf '1'
+  else
+    printf '%d' "${_available}"
+  fi
 }


### PR DESCRIPTION
## Summary
- `_digitalocean_max_parallel()` always returned 3, but pre-existing droplets consume quota slots and cause "droplet limit exceeded" errors when tests run 3-in-parallel
- Now queries `/v2/account` for the actual `droplet_limit` and subtracts current droplet count to compute available capacity
- Falls back to 3 if the API is unreachable

## Root Cause
The QA account has a 3-droplet limit. During this E2E run, a `spawn-5v48` droplet (created 2026-03-11) occupied 1 of 3 slots. Batch 1 tried to create 3 droplets (claude, openclaw, zeroclaw) in parallel — the 3rd slot was already taken, causing claude to fail. Same pattern caused opencode to fail in batch 2.

## Test plan
- [ ] Verify `_digitalocean_max_parallel` returns 2 when 1 droplet exists on a 3-limit account
- [ ] Verify returns 3 when no pre-existing droplets exist

-- qa/e2e-tester