### PR TITLE
security: validate base64 in digitalocean.sh SSH exec

### DIFF
--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -178,6 +178,14 @@ _digitalocean_exec() {
   local encoded_cmd
   encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
 
+  # Validate base64 output contains only safe characters (defense-in-depth).
+  # Standard base64 only produces [A-Za-z0-9+/=]. This rejects any corruption
+  # and ensures the value cannot break out of single quotes in the SSH command.
+  if ! printf '%s' "${encoded_cmd}" | grep -qE '^[A-Za-z0-9+/=]+$'; then
+    log_err "Invalid base64 encoding of command for SSH exec"
+    return 1
+  fi
+
   ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 -o LogLevel=ERROR -o BatchMode=yes \
       "root@${ip}" "printf '%s' '${encoded_cmd}' | base64 -d | bash"


### PR DESCRIPTION
**Why:** Defense-in-depth validation for base64-encoded commands passed via SSH in the E2E DigitalOcean cloud driver.

## Changes

### Fix #2526 - digitalocean.sh base64 validation
Added explicit validation that `encoded_cmd` contains only `[A-Za-z0-9+/=]` characters after base64 encoding, before embedding it in the SSH command string. This matches the existing defense-in-depth pattern already present in `provision.sh` (lines 284-289).

The validation ensures that even if the base64 encoding were somehow corrupted, the value cannot break out of the single-quoted context in the SSH command.

### #2527 - provision.sh (already fixed)
The base64 validation described in #2527 already exists in `provision.sh` at lines 284-289:
```bash
if ! printf '%s' "${env_b64}" | grep -qE '^[A-Za-z0-9+/=]+$'; then
    log_err "Invalid base64 encoding"
    return 1
fi
```
This was likely fixed in a prior commit. No additional changes needed.

Fixes #2526

-- refactor/security-auditor