### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/prompt-file-security.test.ts
+++ b/packages/cli/src/__tests__/prompt-file-security.test.ts
@@ -8,6 +8,8 @@ describe("validatePromptFilePath", () => {
     expect(() => validatePromptFilePath("prompts/task.md")).not.toThrow();
     expect(() => validatePromptFilePath("/home/user/prompt.txt")).not.toThrow();
     expect(() => validatePromptFilePath("/tmp/instructions.md")).not.toThrow();
+    expect(() => validatePromptFilePath("/etc/hosts")).not.toThrow();
+    expect(() => validatePromptFilePath("/home/user/.config/spawn/prompt.txt")).not.toThrow();
   });
 
   it("should reject empty paths", () => {
@@ -15,69 +17,90 @@ describe("validatePromptFilePath", () => {
     expect(() => validatePromptFilePath("   ")).toThrow("Prompt file path is required");
   });
 
-  it("should reject SSH private key files", () => {
-    expect(() => validatePromptFilePath("/home/user/.ssh/id_rsa")).toThrow("SSH");
-    expect(() => validatePromptFilePath("/home/user/.ssh/id_ed25519")).toThrow("SSH");
-    expect(() => validatePromptFilePath("~/.ssh/config")).toThrow("SSH directory");
-    expect(() => validatePromptFilePath("/root/.ssh/authorized_keys")).toThrow("SSH directory");
+  it("should reject credential files of all types", () => {
+    const cases: Array<
+      [
+        string,
+        string,
+      ]
+    > = [
+      [
+        "/home/user/.ssh/id_rsa",
+        "SSH",
+      ],
+      [
+        "/home/user/.ssh/id_ed25519",
+        "SSH",
+      ],
+      [
+        "~/.ssh/config",
+        "SSH directory",
+      ],
+      [
+        "/root/.ssh/authorized_keys",
+        "SSH directory",
+      ],
+      [
+        "/home/user/.aws/credentials",
+        "AWS",
+      ],
+      [
+        "/home/user/.aws/config",
+        "AWS",
+      ],
+      [
+        "/home/user/.config/gcloud/application_default_credentials.json",
+        "Google Cloud",
+      ],
+      [
+        "/home/user/.azure/accessTokens.json",
+        "Azure",
+      ],
+      [
+        "/home/user/.kube/config",
+        "Kubernetes",
+      ],
+      [
+        "/home/user/.docker/config.json",
+        "Docker",
+      ],
+      [
+        ".env",
+        "environment file",
+      ],
+      [
+        ".env.local",
+        "environment file",
+      ],
+      [
+        ".env.production",
+        "environment file",
+      ],
+      [
+        "/app/.env",
+        "environment file",
+      ],
+      [
+        "/home/user/.npmrc",
+        "npm",
+      ],
+      [
+        "/home/user/.netrc",
+        "netrc",
+      ],
+      [
+        "/home/user/.git-credentials",
+        "Git credentials",
+      ],
+    ];
+    for (const [path, expectedMsg] of cases) {
+      expect(() => validatePromptFilePath(path), path).toThrow(expectedMsg);
+    }
   });
 
-  it("should reject AWS credential files", () => {
-    expect(() => validatePromptFilePath("/home/user/.aws/credentials")).toThrow("AWS");
-    expect(() => validatePromptFilePath("/home/user/.aws/config")).toThrow("AWS");
-  });
-
-  it("should reject Google Cloud credential files", () => {
-    expect(() => validatePromptFilePath("/home/user/.config/gcloud/application_default_credentials.json")).toThrow(
-      "Google Cloud",
-    );
-  });
-
-  it("should reject Azure credential files", () => {
-    expect(() => validatePromptFilePath("/home/user/.azure/accessTokens.json")).toThrow("Azure");
-  });
-
-  it("should reject Kubernetes config files", () => {
-    expect(() => validatePromptFilePath("/home/user/.kube/config")).toThrow("Kubernetes");
-  });
-
-  it("should reject Docker credential files", () => {
-    expect(() => validatePromptFilePath("/home/user/.docker/config.json")).toThrow("Docker");
-  });
-
-  it("should reject .env files", () => {
-    expect(() => validatePromptFilePath(".env")).toThrow("environment file");
-    expect(() => validatePromptFilePath(".env.local")).toThrow("environment file");
-    expect(() => validatePromptFilePath(".env.production")).toThrow("environment file");
-    expect(() => validatePromptFilePath("/app/.env")).toThrow("environment file");
-  });
-
-  it("should reject npm credential files", () => {
-    expect(() => validatePromptFilePath("/home/user/.npmrc")).toThrow("npm");
-  });
-
-  it("should reject netrc files", () => {
-    expect(() => validatePromptFilePath("/home/user/.netrc")).toThrow("netrc");
-  });
-
-  it("should reject git credential files", () => {
-    expect(() => validatePromptFilePath("/home/user/.git-credentials")).toThrow("Git credentials");
-  });
-
-  it("should reject /etc/shadow", () => {
+  it("should reject system password files", () => {
     expect(() => validatePromptFilePath("/etc/shadow")).toThrow("password hashes");
-  });
-
-  it("should reject /etc/master.passwd", () => {
     expect(() => validatePromptFilePath("/etc/master.passwd")).toThrow("password hashes");
-  });
-
-  it("should accept /etc/hosts (non-sensitive system file)", () => {
-    expect(() => validatePromptFilePath("/etc/hosts")).not.toThrow();
-  });
-
-  it("should accept normal config-directory paths that are not sensitive", () => {
-    expect(() => validatePromptFilePath("/home/user/.config/spawn/prompt.txt")).not.toThrow();
   });
 
   it("should include helpful error message about exfiltration risk", () => {
@@ -95,43 +118,42 @@ describe("validatePromptFilePath", () => {
 
 describe("validatePromptFileStats", () => {
   it("should accept regular files within size limit", () => {
-    const stats = {
-      isFile: () => true,
-      size: 100,
-    };
-    expect(() => validatePromptFileStats("prompt.txt", stats)).not.toThrow();
-  });
-
-  it("should accept files at the 1MB limit", () => {
-    const stats = {
-      isFile: () => true,
-      size: 1024 * 1024,
-    };
-    expect(() => validatePromptFileStats("prompt.txt", stats)).not.toThrow();
+    expect(() =>
+      validatePromptFileStats("prompt.txt", {
+        isFile: () => true,
+        size: 100,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validatePromptFileStats("prompt.txt", {
+        isFile: () => true,
+        size: 1024 * 1024,
+      }),
+    ).not.toThrow();
   });
 
   it("should reject non-regular files", () => {
-    const stats = {
-      isFile: () => false,
-      size: 100,
-    };
-    expect(() => validatePromptFileStats("/dev/urandom", stats)).toThrow("not a regular file");
+    expect(() =>
+      validatePromptFileStats("/dev/urandom", {
+        isFile: () => false,
+        size: 100,
+      }),
+    ).toThrow("not a regular file");
   });
 
-  it("should reject files over 1MB", () => {
-    const stats = {
-      isFile: () => true,
-      size: 1024 * 1024 + 1,
-    };
-    expect(() => validatePromptFileStats("huge.txt", stats)).toThrow("too large");
-  });
-
-  it("should reject empty files", () => {
-    const stats = {
-      isFile: () => true,
-      size: 0,
-    };
-    expect(() => validatePromptFileStats("empty.txt", stats)).toThrow("empty");
+  it("should reject files over 1MB or empty files", () => {
+    expect(() =>
+      validatePromptFileStats("huge.txt", {
+        isFile: () => true,
+        size: 1024 * 1024 + 1,
+      }),
+    ).toThrow("too large");
+    expect(() =>
+      validatePromptFileStats("empty.txt", {
+        isFile: () => true,
+        size: 0,
+      }),
+    ).toThrow("empty");
   });
 
   it("should show file size in MB for large files", () => {

--- a/packages/cli/src/__tests__/security.test.ts
+++ b/packages/cli/src/__tests__/security.test.ts
@@ -134,31 +134,21 @@ describe("validateIdentifier", () => {
 
   // ── Encoding attacks ────────────────────────────────────────────────────
 
-  it("should reject null byte in identifier", () => {
-    expect(() => validateIdentifier("agent\x00name", "Test")).toThrow();
+  it("should reject unicode and control character attacks", () => {
+    const attacks = [
+      "agent\x00name", // null byte
+      "cl\u0430ude", // cyrillic homoglyph
+      "agent\u200Bname", // zero-width space
+      "agent\u202Ename", // right-to-left override
+    ];
+    for (const input of attacks) {
+      expect(() => validateIdentifier(input, "Test"), JSON.stringify(input)).toThrow();
+    }
   });
 
-  it("should reject unicode homoglyphs", () => {
-    expect(() => validateIdentifier("cl\u0430ude", "Test")).toThrow();
-  });
-
-  it("should reject zero-width characters", () => {
-    expect(() => validateIdentifier("agent\u200Bname", "Test")).toThrow();
-  });
-
-  it("should reject right-to-left override character", () => {
-    expect(() => validateIdentifier("agent\u202Ename", "Test")).toThrow();
-  });
-
-  it("should accept identifier with only hyphens", () => {
+  it("should accept identifiers with only hyphens, underscores, or digits", () => {
     expect(() => validateIdentifier("---", "Test")).not.toThrow();
-  });
-
-  it("should accept identifier with only underscores", () => {
     expect(() => validateIdentifier("___", "Test")).not.toThrow();
-  });
-
-  it("should accept numeric-only identifiers", () => {
     expect(() => validateIdentifier("123", "Test")).not.toThrow();
   });
 


### PR DESCRIPTION
## Summary

- Consolidated 9 per-credential-type `it()` blocks in `prompt-file-security.test.ts` into a single data-driven test covering all 17 sensitive path patterns (`[path, expectedError]` pairs)
- Merged 2 `validatePromptFileStats` "accept" tests into one
- Consolidated 4 unicode/encoding-attack `it()` blocks in `security.test.ts` into a single data-driven test using an array of inputs with inline comments
- Merged 3 "accept identifier" `it()` blocks into one

Removes 19 redundant tests (1400 → 1381) with no loss of coverage.

## Test plan
- [x] `bun test` passes: 1381 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` passes with zero errors

-- qa/dedup-scanner