### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/icon-integrity.test.ts
+++ b/packages/cli/src/__tests__/icon-integrity.test.ts
@@ -57,7 +57,6 @@ describe("Icon Integrity", () => {
       });
 
       it(`${id}.png is actual PNG data`, () => {
-        expect(existsSync(pngPath)).toBe(true);
         expect(isPng(pngPath)).toBe(true);
       });
 
@@ -94,7 +93,6 @@ describe("Icon Integrity", () => {
       });
 
       it(`${id}.png is actual PNG data`, () => {
-        expect(existsSync(pngPath)).toBe(true);
         expect(isPng(pngPath)).toBe(true);
       });
 

--- a/packages/cli/src/__tests__/security.test.ts
+++ b/packages/cli/src/__tests__/security.test.ts
@@ -264,7 +264,7 @@ rm  -rf  /
     expect(() => validateScriptContent(script)).toThrow("destructive filesystem operation");
   });
 
-  it("should accept scripts with comments containing dangerous patterns", () => {
+  it("should reject scripts with dangerous patterns in comments (regex matches inside comments)", () => {
     const script = `#!/bin/bash
 # Don't do this: rm -rf /
 echo "safe"
@@ -434,20 +434,6 @@ describe("validatePrompt", () => {
   it("should provide helpful error message for command substitution", () => {
     expect(() => validatePrompt("Run $(echo test)")).toThrow("shell syntax");
     expect(() => validatePrompt("Run $(echo test)")).toThrow("plain English");
-  });
-
-  it("should detect multiple dangerous patterns", () => {
-    const dangerousPatterns = [
-      "$(whoami)",
-      "`id`",
-      "; rm -rf /tmp",
-      "| bash",
-      "| sh",
-    ];
-
-    for (const pattern of dangerousPatterns) {
-      expect(() => validatePrompt(`Test ${pattern} here`)).toThrow();
-    }
   });
 
   // ── Command injection patterns (issue #1400) ───────────────────────────


### PR DESCRIPTION
## Summary

- Remove redundant `existsSync(pngPath)` check from icon-integrity "is actual PNG data" tests — file existence is already asserted in the preceding `it()` block, and `isPng()` throws if the file is missing anyway
- Remove "should detect multiple dangerous patterns" test from `validatePrompt` — it retests the same `$(…)`, backtick, `; rm`, and `| bash/sh` patterns that each have their own dedicated `it()` block immediately above
- Fix misleading test description: "should accept scripts with comments containing dangerous patterns" — the test actually *expects* a throw (the comment says "this is a known trade-off"); renamed to "should reject…"

Removes 1 test (1381 → 1380) and 18 expect() calls with no loss of coverage.

-- qa/dedup-scanner