### PR TITLE
fix: add junie to tarball build pipeline

### DIFF
--- a/packer/agents.json
+++ b/packer/agents.json
@@ -42,5 +42,11 @@
     "install": [
       "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash || [ -f ~/.local/bin/hermes ]"
     ]
+  },
+  "junie": {
+    "tier": "node",
+    "install": [
+      "mkdir -p ~/.npm-global/bin && npm install -g --prefix ~/.npm-global @jetbrains/junie-cli"
+    ]
   }
 }

--- a/packer/scripts/capture-agent.sh
+++ b/packer/scripts/capture-agent.sh
@@ -13,9 +13,9 @@ fi
 
 # Validate agent name against allowed list to prevent injection
 case "${AGENT_NAME}" in
-  openclaw|codex|kilocode|claude|opencode|zeroclaw|hermes) ;;
+  openclaw|codex|kilocode|claude|opencode|zeroclaw|hermes|junie) ;;
   *)
-    printf 'Error: Invalid agent name: %s\nAllowed: openclaw, codex, kilocode, claude, opencode, zeroclaw, hermes\n' "${AGENT_NAME}" >&2
+    printf 'Error: Invalid agent name: %s\nAllowed: openclaw, codex, kilocode, claude, opencode, zeroclaw, hermes, junie\n' "${AGENT_NAME}" >&2
     exit 1
     ;;
 esac
@@ -32,7 +32,7 @@ case "${AGENT_NAME}" in
     echo "/usr/bin/google-chrome" >> "${PATHS_FILE}"
     echo "/opt/google/chrome/" >> "${PATHS_FILE}"
     ;;
-  codex|kilocode)
+  codex|kilocode|junie)
     echo "/root/.npm-global/" >> "${PATHS_FILE}"
     ;;
   claude)


### PR DESCRIPTION
## Summary
- Add junie entry to `packer/agents.json` (tier: node, `@jetbrains/junie-cli`)
- Add junie to `packer/scripts/capture-agent.sh` allowlist and path-capture case (npm-based, same as codex/kilocode)

## Why
Junie was added as a fully implemented agent (manifest, agent scripts, agent-setup.ts) but the packer/tarball pipeline was never updated. The nightly `agent-tarballs.yml` workflow could not build a pre-built tarball for Junie, forcing all deployments to do a live `npm install` on first boot.

No ARM build needed — Junie installs via npm which is arch-independent. No workflow changes needed — `agent-tarballs.yml` reads agent names from `packer/agents.json` dynamically.

## Test plan
- [x] `bash -n` passes on modified shell script
- [x] `bun test` — 1380 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` — 0 errors

-- refactor/code-health