### PR TITLE
feat(qa): wire Telegram soak test into scheduled QA workflow

### DIFF
--- a/.claude/skills/setup-agent-team/qa.sh
+++ b/.claude/skills/setup-agent-team/qa.sh
@@ -226,6 +226,29 @@ if [[ "${RUN_MODE}" == "e2e" ]]; then
     fi
 fi
 
+# --- Load Telegram credentials for soak mode ---
+if [[ "${RUN_MODE}" == "soak" ]]; then
+    if [[ -f /etc/spawn-qa-auth.env ]]; then
+        while IFS='=' read -r _tkey _tval || [[ -n "${_tkey}" ]]; do
+            _tkey="${_tkey#"${_tkey%%[! ]*}"}"
+            _tkey="${_tkey%"${_tkey##*[! ]}"}"
+            [[ -z "${_tkey}" || "${_tkey}" == \#* ]] && continue
+            case "${_tkey}" in
+                TELEGRAM_BOT_TOKEN|TELEGRAM_TEST_CHAT_ID)
+                    export "${_tkey}=${_tval}"
+                    ;;
+            esac
+        done < /etc/spawn-qa-auth.env
+        if [[ -n "${TELEGRAM_BOT_TOKEN:-}" ]] && [[ -n "${TELEGRAM_TEST_CHAT_ID:-}" ]]; then
+            log "Telegram credentials loaded for soak test"
+        else
+            log "WARNING: TELEGRAM_BOT_TOKEN or TELEGRAM_TEST_CHAT_ID missing from /etc/spawn-qa-auth.env — soak test will fail"
+        fi
+    else
+        log "WARNING: /etc/spawn-qa-auth.env not found — soak test requires TELEGRAM_BOT_TOKEN and TELEGRAM_TEST_CHAT_ID"
+    fi
+fi
+
 # Launch Claude Code with mode-specific prompt
 # Enable agent teams (required for team-based workflows)
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,7 +1,8 @@
 name: QA
 on:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 */4 * * *'   # Every 4 hours — quality sweep
+    - cron: '0 3 * * 1'     # Every Monday 3am UTC — Telegram soak test
   workflow_dispatch:
     inputs:
       reason:
@@ -24,7 +25,11 @@ jobs:
           SPRITE_URL: ${{ secrets.QA_SPRITE_URL }}
           TRIGGER_SECRET: ${{ secrets.QA_TRIGGER_SECRET }}
         run: |
-          REASON="${{ github.event.inputs.reason || 'schedule' }}"
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "${{ github.event.schedule }}" = "0 3 * * 1" ]; then
+            REASON="soak"
+          else
+            REASON="${{ github.event.inputs.reason || 'schedule' }}"
+          fi
           curl -sS --fail-with-body -X POST \
             "${SPRITE_URL}/trigger?reason=${REASON}" \
             -H "Authorization: Bearer ${TRIGGER_SECRET}"


### PR DESCRIPTION
## Summary

- **`qa.sh`**: loads `TELEGRAM_BOT_TOKEN` + `TELEGRAM_TEST_CHAT_ID` from `/etc/spawn-qa-auth.env` in soak mode — same pattern as how e2e mode loads email creds from `/etc/spawn-key-server-auth.env`
- **`qa.yml`**: adds a weekly Monday 3am UTC cron schedule that triggers `reason=soak`; uses `github.event.schedule` to differentiate it from the existing 4-hour quality sweep

## Before merging

Add to `/etc/spawn-qa-auth.env` on the QA VM:
\`\`\`
TELEGRAM_BOT_TOKEN=<bot token from @BotFather>
TELEGRAM_TEST_CHAT_ID=<numeric chat ID>
\`\`\`

## Test plan

- [x] `bash -n qa.sh` — syntax OK
- [x] `bash -n sh/e2e/e2e.sh` — syntax OK
- [x] `bash -n sh/e2e/lib/soak.sh` — syntax OK
- [x] `bunx @biomejs/biome check src/` — 0 errors
- [ ] Manual trigger via `POST /trigger?reason=soak` after adding Telegram creds to env file

🤖 Generated with [Claude Code](https://claude.com/claude-code)