### PR TITLE
security: use shellQuote() in agent-setup.ts for consistent null-byte defense

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { getTmpDir } from "./paths";
 import { asyncTryCatch, asyncTryCatchIf, isOperationalError, tryCatchIf } from "./result.js";
 import { getErrorMessage } from "./type-guards";
-import { Err, jsonEscape, logError, logInfo, logStep, logWarn, Ok, withRetry } from "./ui";
+import { Err, jsonEscape, logError, logInfo, logStep, logWarn, Ok, shellQuote, withRetry } from "./ui";
 
 /**
  * Wrap an SSH-based async operation into a Result for use with withRetry.
@@ -240,8 +240,7 @@ export async function offerGithubAuth(runner: CloudRunner): Promise<void> {
 
   let ghCmd = "curl --proto '=https' -fsSL https://openrouter.ai/labs/spawn/shared/github-auth.sh | bash";
   if (githubToken) {
-    const escaped = githubToken.replace(/'/g, "'\\''");
-    ghCmd = `export GITHUB_TOKEN='${escaped}' && ${ghCmd}`;
+    ghCmd = `export GITHUB_TOKEN=${shellQuote(githubToken)} && ${ghCmd}`;
   }
 
   logStep("Installing and authenticating GitHub CLI on the remote server...");
@@ -255,12 +254,10 @@ export async function offerGithubAuth(runner: CloudRunner): Promise<void> {
     logStep("Configuring git identity on the remote server...");
     const cmds: string[] = [];
     if (hostGitName) {
-      const escaped = hostGitName.replace(/'/g, "'\\''");
-      cmds.push(`git config --global user.name '${escaped}'`);
+      cmds.push(`git config --global user.name ${shellQuote(hostGitName)}`);
     }
     if (hostGitEmail) {
-      const escaped = hostGitEmail.replace(/'/g, "'\\''");
-      cmds.push(`git config --global user.email '${escaped}'`);
+      cmds.push(`git config --global user.email ${shellQuote(hostGitEmail)}`);
     }
     const gitSetup = await asyncTryCatchIf(isOperationalError, () => runner.runServer(cmds.join(" && ")));
     if (gitSetup.ok) {


### PR DESCRIPTION
**Why:** PR #2535 consolidated shellQuote() across all cloud modules to add null-byte validation, but missed 3 inline .replace() calls in shared/agent-setup.ts. This closes that gap for GitHub tokens and git identity values passed over SSH.

## Changes

- `packages/cli/src/shared/agent-setup.ts`: Import `shellQuote` from `./ui` and replace 3 inline `.replace(/'/g, "'\\''")` patterns with `shellQuote()` calls — adds null-byte rejection as defense-in-depth
- `packages/cli/package.json`: Patch version bump (0.17.0 → 0.17.1)

## Verification

- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — 1380 pass, 0 fail

-- refactor/code-health