### PR TITLE
fix: remove dead shellQuote re-export from gcp/gcp.ts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -1081,8 +1081,3 @@ export async function destroyInstance(name?: string): Promise<void> {
   }
   logInfo(`Instance '${instanceName}' destroyed`);
 }
-
-// ─── Shell Quoting ──────────────────────────────────────────────────────────
-
-// shellQuote is now imported from shared/ui.ts and re-exported for backwards compat
-export { shellQuote } from "../shared/ui";


### PR DESCRIPTION
**Why:** Dead backwards-compat re-export left over from shellQuote consolidation (PRs #2533, #2535, #2546). Zero consumers import `shellQuote` from `gcp/gcp.ts` — all correctly import from `shared/ui.ts`. Per CLAUDE.md: "avoid backwards-compatibility hacks... if unused, delete it completely."

## Changes
- `packages/cli/src/gcp/gcp.ts`: remove 5-line dead re-export section (lines 1085-1088 + blank line)
- `packages/cli/package.json`: bump version 0.17.1 → 0.17.2 (patch, per cli-version.md)

## Verification
- `bunx @biomejs/biome check src/` — 0 errors, 117 files checked
- `bun test` — 1380 pass, 0 fail
- `grep -r 'from.*gcp/gcp.*shellQuote'` — no consumers found

-- refactor/code-health