### PR TITLE
test: Remove theatrical tests from manifest-integrity

### DIFF
--- a/packages/cli/src/__tests__/manifest-integrity.test.ts
+++ b/packages/cli/src/__tests__/manifest-integrity.test.ts
@@ -30,16 +30,6 @@ describe("Manifest Integrity", () => {
   // ── Basic structure ─────────────────────────────────────────────────
 
   describe("structure", () => {
-    it("should parse as valid JSON", () => {
-      expect(() => JSON.parse(manifestRaw)).not.toThrow();
-    });
-
-    it("should have agents, clouds, and matrix top-level keys", () => {
-      expect(manifest).toHaveProperty("agents");
-      expect(manifest).toHaveProperty("clouds");
-      expect(manifest).toHaveProperty("matrix");
-    });
-
     it("should have at least one agent", () => {
       expect(agents.length).toBeGreaterThan(0);
     });


### PR DESCRIPTION
## Summary

- Removed 2 theatrical tests from `manifest-integrity.test.ts` that can never fail and provide no signal

## What was found

Scanning `packages/cli/src/__tests__/` for anti-patterns revealed that the `structure` describe block in `manifest-integrity.test.ts` contained 2 tests that are guaranteed to pass whenever the test file loads:

**"should parse as valid JSON"** — `manifest.json` is already parsed via `JSON.parse(manifestRaw)` at module scope (line 23). If JSON parsing fails, the module itself throws and every test in the file fails with a load error — this individual `it()` block can never be the first thing to catch a parse failure.

**"should have agents, clouds, and matrix top-level keys"** — After parsing, `Object.keys(manifest.agents)`, `Object.keys(manifest.clouds)`, and `Object.entries(manifest.matrix)` are called at module scope (lines 25-27). If those top-level keys were absent from the JSON, `Object.keys(undefined)` would throw at module load time, before any `it()` block runs.

These tests match the "always-pass" anti-pattern described in the QA protocol: they silently pass even when the condition they claim to test has already been verified by prior module-level execution.

## Impact

- **2 tests removed**, 1403 remain (down from 1405)
- `bun test`: 1403 pass, 0 fail
- `bunx @biomejs/biome check src/`: 0 errors

## No other issues found

After exhaustive scanning of all 64 test files for:
- Duplicate describe blocks (same function in multiple files) — none found
- Always-pass conditional expects (`if (cond) { expect(...) } else { /* skip */ }`) — none found
- Bash-grep style tests (checking function existence, not behavior) — none found
- Excessive subprocess spawning with trivially different inputs — none found (existing loops are already data-driven)

The test suite is well-structured. Same-named `it()` descriptions appearing across files (e.g., "should reject empty strings" in `validateConnectionIP`, `validateUsername`, `validateServerIdentifier`) are all in separate `describe()` blocks testing different functions — not duplicates.

-- qa/dedup-scanner