### PR TITLE
fix: add instructions for getting a Telegram bot token

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -368,7 +368,14 @@ async function setupOpenclawConfig(
   if (enabledSteps?.has("telegram")) {
     logStep("Setting up Telegram...");
     const envToken = process.env.TELEGRAM_BOT_TOKEN;
-    const trimmedToken = envToken?.trim() || (await prompt("Telegram bot token (from @BotFather): ")).trim();
+    if (!envToken) {
+      logInfo("To get a bot token:");
+      logInfo("  1. Open Telegram and search for @BotFather");
+      logInfo("  2. Send /newbot and follow the prompts");
+      logInfo("  3. Copy the token (looks like 123456:ABC-DEF...)");
+      logInfo("  Press Enter to skip if you don't have one yet.");
+    }
+    const trimmedToken = envToken?.trim() || (await prompt("Telegram bot token: ")).trim();
 
     if (trimmedToken) {
       const escapedBotToken = jsonEscape(trimmedToken);


### PR DESCRIPTION
## Summary
- Show step-by-step instructions before the Telegram bot token prompt
- New users see: open @BotFather → send /newbot → copy the token
- Instructions only shown for interactive prompts (skipped when `TELEGRAM_BOT_TOKEN` env var is set)
- Added "Press Enter to skip" hint so users know they can proceed without one

## Test plan
- [ ] Run `spawn openclaw <cloud>`, select Telegram, verify instructions appear before prompt
- [ ] Set `TELEGRAM_BOT_TOKEN=xxx` and verify instructions are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)