### PR TITLE
test: remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/cmdrun-happy-path.test.ts
+++ b/packages/cli/src/__tests__/cmdrun-happy-path.test.ts
@@ -389,22 +389,14 @@ describe("cmdRun happy-path pipeline", () => {
   // ── Env var passing via runBash ───────────────────────────────────────────
 
   describe("SPAWN_PROMPT and SPAWN_MODE env var passing", () => {
-    it("should pass prompt to bash script via SPAWN_PROMPT env var", async () => {
-      // Use a script that echoes the env var so we can verify it was set
-      const echoScript = '#!/bin/bash\nset -eo pipefail\ntest "$SPAWN_PROMPT" = "Fix all bugs"';
-      global.fetch = mockFetchForDownload({
-        primaryOk: true,
-        scriptContent: echoScript,
-      });
-      await loadManifest(true);
-
-      // If SPAWN_PROMPT is set correctly, the test command succeeds (exit 0)
-      await cmdRun("claude", "sprite", "Fix all bugs");
-      expect(processExitSpy).not.toHaveBeenCalled();
-    });
-
-    it("should set SPAWN_MODE to non-interactive when prompt is provided", async () => {
-      const checkScript = '#!/bin/bash\nset -eo pipefail\ntest "$SPAWN_MODE" = "non-interactive"';
+    it("should set both SPAWN_PROMPT and SPAWN_MODE when prompt is provided", async () => {
+      // Single script checks both vars — avoids two separate bash invocations
+      const checkScript = [
+        "#!/bin/bash",
+        "set -eo pipefail",
+        'test "$SPAWN_PROMPT" = "Fix all bugs"',
+        'test "$SPAWN_MODE" = "non-interactive"',
+      ].join("\n");
       global.fetch = mockFetchForDownload({
         primaryOk: true,
         scriptContent: checkScript,
@@ -415,21 +407,14 @@ describe("cmdRun happy-path pipeline", () => {
       expect(processExitSpy).not.toHaveBeenCalled();
     });
 
-    it("should NOT set SPAWN_PROMPT when no prompt is provided", async () => {
-      // This script fails if SPAWN_PROMPT is set (non-empty)
-      const checkScript = '#!/bin/bash\nset -eo pipefail\ntest -z "${SPAWN_PROMPT:-}"';
-      global.fetch = mockFetchForDownload({
-        primaryOk: true,
-        scriptContent: checkScript,
-      });
-      await loadManifest(true);
-
-      await cmdRun("claude", "sprite");
-      expect(processExitSpy).not.toHaveBeenCalled();
-    });
-
-    it("should NOT set SPAWN_MODE when no prompt is provided", async () => {
-      const checkScript = '#!/bin/bash\nset -eo pipefail\ntest -z "${SPAWN_MODE:-}"';
+    it("should NOT set SPAWN_PROMPT or SPAWN_MODE when no prompt is provided", async () => {
+      // Single script verifies both vars are unset
+      const checkScript = [
+        "#!/bin/bash",
+        "set -eo pipefail",
+        'test -z "${SPAWN_PROMPT:-}"',
+        'test -z "${SPAWN_MODE:-}"',
+      ].join("\n");
       global.fetch = mockFetchForDownload({
         primaryOk: true,
         scriptContent: checkScript,

--- a/packages/cli/src/__tests__/steps-flag.test.ts
+++ b/packages/cli/src/__tests__/steps-flag.test.ts
@@ -1,19 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import { findUnknownFlag, KNOWN_FLAGS } from "../flags";
+import { findUnknownFlag } from "../flags";
 import { getAgentOptionalSteps, validateStepNames } from "../shared/agents";
 
 describe("--steps and --config flags", () => {
-  it("should recognize --steps as a known flag", () => {
-    expect(KNOWN_FLAGS.has("--steps")).toBe(true);
+  it("should recognize --steps and --config as known flags", () => {
     expect(
       findUnknownFlag([
         "--steps",
       ]),
     ).toBeNull();
-  });
-
-  it("should recognize --config as a known flag", () => {
-    expect(KNOWN_FLAGS.has("--config")).toBe(true);
     expect(
       findUnknownFlag([
         "--config",


### PR DESCRIPTION
## Summary

- Consolidated 4 redundant bash-subprocess env var tests (`SPAWN_PROMPT`/`SPAWN_MODE`) in `cmdrun-happy-path.test.ts` into 2 tests. Previously each test spawned a separate bash process to check a single env var; now each test checks both related vars in one subprocess call, eliminating 2 subprocess invocations (~200ms overhead).
- Removed theatrical `KNOWN_FLAGS.has()` assertions from `steps-flag.test.ts`. The `findUnknownFlag()` call already subsumes the Set membership check, making the `.has()` assertions pure duplication. Cleaned up the now-unused `KNOWN_FLAGS` import.

## Test plan

- [x] `bun test` passes: 1400 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` passes with zero errors
- [x] Net: 3 tests removed, all remaining tests are behaviorally distinct

-- qa/dedup-scanner