### PR TITLE
fix: remove duplicate --model flag from help and error output

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -17,7 +17,6 @@ function getHelpUsageSection(): string {
                                      Execute agent with prompt (non-interactive)
   spawn <agent> <cloud> --prompt-file <file>  (or -f)
                                      Execute agent with prompt from file
-  spawn <agent> <cloud> --model <id>   Set the model ID (overrides config/default)
   spawn <agent> <cloud> --config <file>
                                      Load all options from a JSON config file
   spawn <agent> <cloud> --steps <list>

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -115,10 +115,9 @@ function checkUnknownFlags(args: string[]): void {
     console.error(`    ${pc.cyan("--custom")}            Show interactive size/region pickers`);
     console.error(`    ${pc.cyan("--zone, --region")}    Set zone/region (e.g. us-east1-b, nyc3)`);
     console.error(`    ${pc.cyan("--size, --machine-type")}  Set instance size (e.g. e2-standard-4, s-2vcpu-2gb)`);
-    console.error(`    ${pc.cyan("--model, -m")}         Set the LLM model (e.g. openai/gpt-5.3-codex)`);
+    console.error(`    ${pc.cyan("--model, -m <id>")}    Set the LLM model (e.g. openai/gpt-5.3-codex)`);
     console.error(`    ${pc.cyan("--name")}              Set the spawn/resource name`);
     console.error(`    ${pc.cyan("--reauth")}            Force re-prompting for cloud credentials`);
-    console.error(`    ${pc.cyan("--model <id>")}        Set the model ID (e.g. openai/gpt-5.3-codex)`);
     console.error(`    ${pc.cyan("--config <path>")}     Load config from JSON file`);
     console.error(`    ${pc.cyan("--steps <list>")}      Comma-separated setup steps to enable`);
     console.error(`    ${pc.cyan("--beta tarball")}      Use pre-built tarball for agent install (repeatable)`);


### PR DESCRIPTION
**Why:** Users running \`spawn help\` or hitting an unknown-flag error see \`--model\` listed twice with contradictory descriptions, making the CLI look broken.

## What changed

The \`--model\` flag was duplicated in two user-facing outputs when it was introduced in #2543:

**\`spawn help\` USAGE section** (\`commands/help.ts\`):
- Line 11: \`--model <id>  Set the LLM model (e.g. openai/gpt-5.3-codex)\`
- Line 20: \`--model <id>   Set the model ID (overrides config/default)\` ← duplicate removed

**Unknown flag error** (\`index.ts\`):
- Line 118: \`--model, -m   Set the LLM model (e.g. openai/gpt-5.3-codex)\`
- Line 121: \`--model <id>  Set the model ID (e.g. openai/gpt-5.3-codex)\` ← duplicate removed

Consolidated into a single \`--model, -m <id>\` entry in the error output.

## Test plan

- [x] \`bunx @biomejs/biome check src/\` — 0 errors (121 files)
- [x] \`bun test\` — 1403 pass, 0 fail

-- refactor/ux-engineer