### PR TITLE
fix: remove broken WhatsApp setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Available steps vary by agent:
 | `reuse-api-key` | All | Reuse saved OpenRouter key |
 | `browser` | openclaw | Chrome browser (~400 MB) |
 | `telegram` | openclaw | Telegram bot (set `TELEGRAM_BOT_TOKEN` for non-interactive) |
-| `whatsapp` | openclaw | WhatsApp linking (interactive QR scan, skipped in headless) |
 
 #### Beta Features
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/steps-flag.test.ts
+++ b/packages/cli/src/__tests__/steps-flag.test.ts
@@ -40,13 +40,11 @@ describe("validateStepNames", () => {
       "github",
       "browser",
       "telegram",
-      "whatsapp",
     ]);
     expect(valid).toEqual([
       "github",
       "browser",
       "telegram",
-      "whatsapp",
     ]);
     expect(invalid).toEqual([]);
   });
@@ -92,13 +90,6 @@ describe("OptionalStep metadata", () => {
     const telegram = steps.find((s) => s.value === "telegram");
     expect(telegram).toBeDefined();
     expect(telegram?.dataEnvVar).toBe("TELEGRAM_BOT_TOKEN");
-  });
-
-  it("openclaw whatsapp step should be marked interactive", () => {
-    const steps = getAgentOptionalSteps("openclaw");
-    const whatsapp = steps.find((s) => s.value === "whatsapp");
-    expect(whatsapp).toBeDefined();
-    expect(whatsapp?.interactive).toBe(true);
   });
 
   it("common steps should not have dataEnvVar or interactive", () => {

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -388,27 +388,17 @@ async function setupOpenclawConfig(
     }
   }
 
-  // WhatsApp — QR code scanning happens interactively in orchestrate.ts
-  // after the gateway starts and tunnel is set up. No config needed here.
-
-  // Write USER.md bootstrap file — guides users to the web dashboard for
-  // visual tasks like WhatsApp QR code scanning that don't work in the TUI.
+  // Write USER.md bootstrap file — guides users to the web dashboard.
   const messagingLines: string[] = [];
-  if (enabledSteps?.has("telegram") || enabledSteps?.has("whatsapp")) {
-    messagingLines.push("", "## Messaging Channels", "", "The user selected messaging channels during setup.");
-    if (enabledSteps.has("telegram")) {
-      messagingLines.push(
-        "- **Telegram**: If a bot token was provided, it is already configured.",
-        "  To verify: `openclaw config get channels.telegram.botToken`",
-      );
-    }
-    if (enabledSteps.has("whatsapp")) {
-      messagingLines.push(
-        "- **WhatsApp**: Requires QR code scanning. Guide the user to the web",
-        "  dashboard to complete setup: http://localhost:18791",
-      );
-    }
-    messagingLines.push("");
+  if (enabledSteps?.has("telegram")) {
+    messagingLines.push(
+      "",
+      "## Messaging Channels",
+      "",
+      "- **Telegram**: If a bot token was provided, it is already configured.",
+      "  To verify: `openclaw config get channels.telegram.botToken`",
+      "",
+    );
   }
 
   const userMd = [
@@ -417,10 +407,6 @@ async function setupOpenclawConfig(
     "## Web Dashboard",
     "",
     "This machine has a web dashboard running on port 18791.",
-    "When helping the user set up channels that require QR code scanning",
-    "(WhatsApp, Telegram, etc.), always guide them to use the web dashboard",
-    "instead of the TUI — QR codes cannot be scanned from a terminal.",
-    "",
     "The dashboard URL is: http://localhost:18791",
     "(It may also be SSH-tunneled to the user's local machine automatically.)",
     ...messagingLines,
@@ -652,7 +638,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         configure: (apiKey: string, modelId?: string, enabledSteps?: Set<string>) =>
           setupOpenclawConfig(runner, apiKey, modelId || "openrouter/openrouter/auto", dashboardToken, enabledSteps),
         preLaunch: () => startGateway(runner),
-        preLaunchMsg: "Your web dashboard will open automatically — use it for WhatsApp QR scanning and channel setup.",
+        preLaunchMsg: "Your web dashboard will open automatically for channel setup.",
         launchCmd: () =>
           "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; openclaw tui",
         tunnel: {

--- a/packages/cli/src/shared/agents.ts
+++ b/packages/cli/src/shared/agents.ts
@@ -66,12 +66,6 @@ const AGENT_EXTRA_STEPS: Record<string, OptionalStep[]> = {
       hint: "connect via bot token from @BotFather",
       dataEnvVar: "TELEGRAM_BOT_TOKEN",
     },
-    {
-      value: "whatsapp",
-      label: "WhatsApp",
-      hint: "scan QR code during setup",
-      interactive: true,
-    },
   ],
 };
 

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -229,11 +229,6 @@ export async function runOrchestration(
       // --steps "" → disable all optional steps
       enabledSteps = new Set();
     }
-    // Skip interactive WhatsApp in headless mode
-    if (process.env.SPAWN_HEADLESS === "1" && enabledSteps.has("whatsapp")) {
-      logWarn("WhatsApp requires interactive QR scanning — skipping in headless mode");
-      enabledSteps.delete("whatsapp");
-    }
   }
 
   // 10b. Agent-specific configuration
@@ -291,20 +286,7 @@ export async function runOrchestration(
     }
   }
 
-  // 11c. Interactive channel login (WhatsApp QR scan, Telegram bot link)
-  // Runs before the TUI so users can link messaging channels during setup.
-  if (enabledSteps?.has("whatsapp")) {
-    logStep("Linking WhatsApp — scan the QR code with your phone...");
-    logInfo("Open WhatsApp > Settings > Linked Devices > Link a Device");
-    process.stderr.write("\n");
-    const whatsappCmd =
-      "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
-      "openclaw channels login --channel whatsapp";
-    prepareStdinForHandoff();
-    await cloud.interactiveSession(whatsappCmd);
-  }
-
-  // 11d. Agent-specific pre-launch tip (e.g. channel setup ordering hint)
+  // 11c. Agent-specific pre-launch tip
   if (agent.preLaunchMsg) {
     process.stderr.write("\n");
     logInfo(`Tip: ${agent.preLaunchMsg}`);


### PR DESCRIPTION
## Summary
- Remove WhatsApp from OpenClaw setup steps
- `openclaw channels login --channel whatsapp` does not exist, causing "Unsupported channel: whatsapp" error
- Cleaned up all WhatsApp references from orchestrate.ts, agent-setup.ts, agents.ts, README, and tests

## Test plan
- [ ] Run `spawn openclaw <cloud>` and verify WhatsApp no longer appears in setup options
- [ ] Verify Telegram still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)