### PR TITLE
fix: re-assert OpenClaw gateway auth token after browser config set calls

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -380,6 +380,19 @@ async function setupOpenclawConfig(
     );
   }
 
+  // Re-assert gateway auth token after browser config set calls — each `openclaw config set`
+  // does a read-modify-write on the config file and may drop fields written by uploadConfigFile.
+  // Re-setting the token here ensures it survives those cycles and the gateway starts authenticated.
+  const gatewayTokenResult = await asyncTryCatchIf(isOperationalError, () =>
+    runner.runServer(
+      "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
+        `openclaw config set gateway.auth.token ${shellQuote(gatewayToken)}`,
+    ),
+  );
+  if (!gatewayTokenResult.ok) {
+    logWarn("Gateway token re-assertion failed (non-fatal) — dashboard may show Unauthorized");
+  }
+
   // Telegram channel setup — check env var first, then prompt interactively
   if (enabledSteps?.has("telegram")) {
     logStep("Setting up Telegram...");


### PR DESCRIPTION
## Summary

`openclaw config set` does a **read-modify-write** on the config file. Each of the four browser config calls in `setupOpenclawConfig()` can silently drop the `gateway.auth.token` field written by `uploadConfigFile()` — causing the dashboard to return **Unauthorized** on every fresh deploy.

### Fix

After the browser config block, re-assert the gateway token via `openclaw config set gateway.auth.token <token>` (same non-fatal pattern as the existing Telegram bot token call). This ensures the token survives read-modify-write cycles regardless of OpenClaw version behavior.

### Files changed

- `packages/cli/src/shared/agent-setup.ts` — added gateway token re-assertion after browser config calls
- `packages/cli/package.json` — bumped to 0.17.6

Fixes #2570

## Test plan

- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — 1400 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- refactor/issue-fixer