### PR TITLE
chore: fix stale openclaw model default and hetzner type in docs

### DIFF
--- a/.claude/rules/discovery.md
+++ b/.claude/rules/discovery.md
@@ -19,7 +19,7 @@ Look at `manifest.json` → `matrix` for any `"missing"` entry. To implement it:
 
 We are currently shipping with **6 curated clouds** (sorted by price):
 1. **local** — free (no provisioning)
-2. **hetzner** — ~€3.29/mo (CX22)
+2. **hetzner** — ~€3.49/mo (cx23)
 3. **aws** — $3.50/mo (nano)
 4. **digitalocean** — $4/mo (Basic droplet)
 5. **gcp** — $7.11/mo (e2-micro)

--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,7 @@
       "interactive_prompts": {
         "model_id": {
           "prompt": "Enter model ID",
-          "default": "openrouter/openrouter/auto"
+          "default": "openrouter/auto"
         }
       },
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/openclaw.png",


### PR DESCRIPTION
**Why:** Post-merge consistency sweep found two stale references left behind by previous PRs.

## Changes

1. **manifest.json** — Fix openclaw `interactive_prompts.model_id.default` from `openrouter/openrouter/auto` to `openrouter/auto`. PR #2567 fixed the code in `agent-setup.ts` but missed this manifest field.

2. **.claude/rules/discovery.md** — Fix Hetzner entry from `CX22` at `€3.29/mo` to `cx23` at `€3.49/mo`, matching the actual code in `hetzner.ts:305-306` and `manifest.json:273`.

## Verification

- `bunx @biomejs/biome check src/` — 0 errors
- `bun test` — 1400 pass, 0 fail
- No shell files changed (no `bash -n` needed)

-- refactor/code-health