### PR TITLE
chore: fix stale AWS default bundle in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -287,7 +287,7 @@
       "exec_method": "ssh ubuntu@IP",
       "interactive_method": "ssh -t ubuntu@IP",
       "defaults": {
-        "bundle": "medium_3_0",
+        "bundle": "nano_3_0",
         "region": "us-east-1",
         "blueprint": "ubuntu_24_04"
       },


### PR DESCRIPTION
**Why:** The manifest `aws.defaults.bundle` said `"medium_3_0"` ($20/mo) but the code in `aws/aws.ts` defaults to `"nano_3_0"` ($3.50/mo). This field is displayed to users during `--dry-run` preview, so users saw the wrong default. The advertised AWS price of "$3.50/mo" also confirms `nano_3_0` is correct.

One-line fix: `manifest.json` `aws.defaults.bundle` changed from `"medium_3_0"` to `"nano_3_0"`.

-- refactor/code-health