### PR TITLE
security: add shell quoting for TERM in all cloud SSH commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/ui-utils.test.ts
+++ b/packages/cli/src/__tests__/ui-utils.test.ts
@@ -149,6 +149,39 @@ describe("sanitizeTermValue", () => {
     expect(sanitizeTermValue("term'quote")).toBe("xterm-256color");
     expect(sanitizeTermValue('term"double')).toBe("xterm-256color");
   });
+
+  it("passes through all allowlisted values", () => {
+    const allowlisted = [
+      "xterm-256color",
+      "xterm",
+      "screen-256color",
+      "screen",
+      "tmux-256color",
+      "tmux",
+      "linux",
+      "vt100",
+      "vt220",
+      "dumb",
+    ];
+    for (const val of allowlisted) {
+      expect(sanitizeTermValue(val)).toBe(val);
+    }
+  });
+
+  it("rejects pipe, redirect, and variable expansion attacks", () => {
+    expect(sanitizeTermValue("xterm|cat /etc/passwd")).toBe("xterm-256color");
+    expect(sanitizeTermValue("xterm>>/tmp/evil")).toBe("xterm-256color");
+    expect(sanitizeTermValue("${PATH}")).toBe("xterm-256color");
+    expect(sanitizeTermValue("$HOME")).toBe("xterm-256color");
+    expect(sanitizeTermValue("xterm&&curl attacker.com")).toBe("xterm-256color");
+    expect(sanitizeTermValue("xterm||true")).toBe("xterm-256color");
+  });
+
+  it("rejects empty and whitespace-only strings", () => {
+    expect(sanitizeTermValue("")).toBe("xterm-256color");
+    expect(sanitizeTermValue(" ")).toBe("xterm-256color");
+    expect(sanitizeTermValue("\t")).toBe("xterm-256color");
+  });
 });
 
 // ── jsonEscape ──────────────────────────────────────────────────────

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1133,7 +1133,7 @@ export async function interactiveSession(cmd: string): Promise<number> {
     throw new Error("Invalid command: must be non-empty and must not contain null bytes");
   }
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
+  const fullCmd = `export TERM='${term}' PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
   const exitCode = spawnInteractive([
     "ssh",

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1241,7 +1241,7 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   }
   const serverIp = ip || _state.serverIp;
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
+  const fullCmd = `export TERM='${term}' PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const exitCode = spawnInteractive([

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -1024,7 +1024,7 @@ export async function interactiveSession(cmd: string): Promise<number> {
   const username = resolveUsername();
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
   // Use shellQuote for consistent single-quote escaping (prevents shell expansion of $variables in cmd)
-  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
+  const fullCmd = `export TERM='${term}' PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const exitCode = spawnInteractive([

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -659,7 +659,7 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   }
   const serverIp = ip || _state.serverIp;
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM=${term} PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
+  const fullCmd = `export TERM='${term}' PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
 
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 


### PR DESCRIPTION
**Why:** Defense-in-depth against shell injection via attacker-controlled `TERM` env var in remote SSH commands. Fixes #2577.

## Audit Findings

All four SSH-based cloud modules (aws, hetzner, digitalocean, gcp) already call `sanitizeTermValue()` before interpolating TERM into shell commands. The `sanitizeTermValue()` function uses a strict allowlist of known-safe terminal names — any unrecognized value falls back to `xterm-256color`. Sprite and local modules do not interpolate TERM into shell commands. No shell scripts in `sh/` reference `$TERM`. No SSH `SendEnv` directives bypass the sanitization.

## Changes

- **Shell quoting (defense-in-depth):** Wrapped `${term}` in single quotes (`'${term}'`) in the `export TERM=` commands across all four cloud modules. The allowlist already prevents injection, but quoting adds a second protective layer in case the allowlist is ever expanded carelessly.
- **Extended test coverage:** Added tests for pipe/redirect/variable-expansion injection vectors, empty/whitespace strings, and a test verifying every value in the allowlist passes through correctly.
- **Version bump:** 0.17.7 → 0.17.8

-- refactor/security-auditor