### PR TITLE
fix: move channel setup to after gateway starts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.8",
+  "version": "0.17.9",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { getTmpDir } from "./paths";
 import { asyncTryCatch, asyncTryCatchIf, isOperationalError, tryCatchIf } from "./result.js";
 import { getErrorMessage } from "./type-guards";
-import { Err, jsonEscape, logError, logInfo, logStep, logWarn, Ok, prompt, shellQuote, withRetry } from "./ui";
+import { Err, jsonEscape, logError, logInfo, logStep, logWarn, Ok, shellQuote, withRetry } from "./ui";
 
 /**
  * Wrap an SSH-based async operation into a Result for use with withRetry.
@@ -393,39 +393,8 @@ async function setupOpenclawConfig(
     logWarn("Gateway token re-assertion failed (non-fatal) — dashboard may show Unauthorized");
   }
 
-  // Telegram channel setup — check env var first, then prompt interactively
-  if (enabledSteps?.has("telegram")) {
-    logStep("Setting up Telegram...");
-    const envToken = process.env.TELEGRAM_BOT_TOKEN;
-    if (!envToken) {
-      logInfo("To get a bot token:");
-      logInfo("  1. Open Telegram and search for @BotFather");
-      logInfo("  2. Send /newbot and follow the prompts");
-      logInfo("  3. Copy the token (looks like 123456:ABC-DEF...)");
-      logInfo("  Press Enter to skip if you don't have one yet.");
-    }
-    const trimmedToken = envToken?.trim() || (await prompt("Telegram bot token: ")).trim();
-
-    if (trimmedToken) {
-      const escapedBotToken = shellQuote(trimmedToken);
-      const telegramResult = await asyncTryCatchIf(isOperationalError, () =>
-        runner.runServer(
-          "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
-            `openclaw config set channels.telegram.botToken ${escapedBotToken}`,
-        ),
-      );
-      if (telegramResult.ok) {
-        logInfo("Telegram bot token configured");
-      } else {
-        logWarn("Telegram config failed — set it up via the web dashboard after launch");
-      }
-    } else {
-      logInfo("No token entered — set up Telegram via the web dashboard after launch");
-    }
-  }
-
-  // WhatsApp — QR code scanning happens interactively in orchestrate.ts
-  // after the gateway starts and tunnel is set up. No config needed here.
+  // Channel configuration (Telegram token, WhatsApp QR) happens in orchestrate.ts
+  // AFTER the gateway starts — openclaw channels commands need a running gateway.
 
   // Write USER.md bootstrap file — guides users to the web dashboard for
   // visual tasks like WhatsApp QR code scanning that don't work in the TUI.

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -19,12 +19,14 @@ import { startSshTunnel } from "./ssh";
 import { ensureSshKeys, getSshKeyOpts } from "./ssh-keys";
 import { getErrorMessage } from "./type-guards";
 import {
+  jsonEscape,
   logDebug,
   logInfo,
   logStep,
   logWarn,
   openBrowser,
   prepareStdinForHandoff,
+  prompt,
   validateModelId,
   withRetry,
 } from "./ui";
@@ -291,15 +293,42 @@ export async function runOrchestration(
     }
   }
 
-  // 11c. Interactive channel login (WhatsApp QR scan, Telegram bot link)
-  // Runs before the TUI so users can link messaging channels during setup.
+  // 11c. Channel setup (runs after gateway is up so openclaw commands work)
+  const ocPath = "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH";
+
+  if (enabledSteps?.has("telegram")) {
+    logStep("Setting up Telegram...");
+    const envToken = process.env.TELEGRAM_BOT_TOKEN;
+    if (!envToken) {
+      logInfo("To get a bot token:");
+      logInfo("  1. Open Telegram and search for @BotFather");
+      logInfo("  2. Send /newbot and follow the prompts");
+      logInfo("  3. Copy the token (looks like 123456:ABC-DEF...)");
+      logInfo("  Press Enter to skip if you don't have one yet.");
+    }
+    const trimmedToken = envToken?.trim() || (await prompt("Telegram bot token: ")).trim();
+    if (trimmedToken) {
+      const escaped = jsonEscape(trimmedToken);
+      const result = await asyncTryCatchIf(isOperationalError, () =>
+        cloud.runner.runServer(
+          `source ~/.spawnrc 2>/dev/null; ${ocPath}; openclaw channels add --channel telegram --token ${escaped}`,
+        ),
+      );
+      if (result.ok) {
+        logInfo("Telegram channel added");
+      } else {
+        logWarn("Telegram setup failed — configure it via the web dashboard after launch");
+      }
+    } else {
+      logInfo("No token entered — set up Telegram via the web dashboard after launch");
+    }
+  }
+
   if (enabledSteps?.has("whatsapp")) {
     logStep("Linking WhatsApp — scan the QR code with your phone...");
     logInfo("Open WhatsApp > Settings > Linked Devices > Link a Device");
     process.stderr.write("\n");
-    const whatsappCmd =
-      "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
-      "openclaw channels login --channel whatsapp";
+    const whatsappCmd = `source ~/.spawnrc 2>/dev/null; ${ocPath}; openclaw channels login --channel whatsapp`;
     prepareStdinForHandoff();
     await cloud.interactiveSession(whatsappCmd);
   }


### PR DESCRIPTION
## Summary
- Telegram token configuration and WhatsApp QR login now run **after** the OpenClaw gateway starts (in `orchestrate.ts` step 11c)
- Plugin enables (`openclaw plugins enable telegram/whatsapp`) stay in `setupOpenclawConfig` (pre-gateway) so the gateway loads them on boot
- Fixes gateway hanging when Telegram bot token was configured before startup
- Fixes "agent config failed" errors from running `openclaw channels` commands without a running gateway

## Test plan
- [x] `bun test` — 1392 tests pass
- [x] `biome check` — 0 errors
- [ ] Manual: `spawn openclaw <cloud> --steps telegram` — should prompt for token after gateway starts
- [ ] Manual: `spawn openclaw <cloud> --steps whatsapp` — should show QR after gateway starts
- [ ] Manual: `TELEGRAM_BOT_TOKEN=xxx spawn openclaw <cloud> --steps telegram --headless` — non-interactive flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)