### PR TITLE
feat(spa): add private channel support

### DIFF
--- a/.claude/skills/setup-spa/SKILL.md
+++ b/.claude/skills/setup-spa/SKILL.md
@@ -29,8 +29,8 @@ Subsequent thread replies in tracked threads auto-trigger new Claude Code runs.
 1. Go to https://api.slack.com/apps > **Create New App** > **From scratch**
 2. Name it `SPA`, select the workspace
 3. **Socket Mode**: Settings > Socket Mode > Enable > generate app-level token with `connections:write` scope > save `xapp-...`
-4. **Event Subscriptions**: Features > Event Subscriptions > Enable > subscribe to bot events: `app_mention`, `message.channels`
-5. **OAuth Scopes**: Features > OAuth & Permissions > Bot Token Scopes: `app_mentions:read`, `channels:history`, `channels:read`, `chat:write`, `reactions:write`
+4. **Event Subscriptions**: Features > Event Subscriptions > Enable > subscribe to bot events: `app_mention`, `message.channels`, `message.groups`
+5. **OAuth Scopes**: Features > OAuth & Permissions > Bot Token Scopes: `app_mentions:read`, `channels:history`, `channels:read`, `groups:history`, `groups:read`, `chat:write`, `reactions:write`
 6. **Install to Workspace** > save `xoxb-...` token
 7. **Invite** bot to channel, get channel ID
 

--- a/.claude/skills/setup-spa/slack-manifest.yml
+++ b/.claude/skills/setup-spa/slack-manifest.yml
@@ -16,12 +16,15 @@ oauth_config:
       - channels:read
       - chat:write
       - files:read
+      - groups:history
+      - groups:read
       - reactions:write
 settings:
   event_subscriptions:
     bot_events:
       - app_mention
       - message.channels
+      - message.groups
   org_deploy_enabled: false
   socket_mode_enabled: true
   is_hosted: false


### PR DESCRIPTION
## Summary
- Add `groups:history` and `groups:read` OAuth scopes to the Slack manifest
- Add `message.groups` event subscription so SPA receives events in private channels
- Update SKILL.md manual setup docs to include the new scopes

## Manual step required
After merging, go to https://api.slack.com/apps → SPA app:
1. **OAuth & Permissions** → add `groups:history` and `groups:read` scopes
2. **Event Subscriptions** → add `message.groups` bot event
3. **Reinstall to workspace** to pick up the new scopes
4. Restart the SPA service: `sudo systemctl restart spawn-spa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)