### PR TITLE
feat: add spawn fix command to re-run agent setup on existing VMs

### DIFF
--- a/packages/cli/src/__tests__/cmd-fix.test.ts
+++ b/packages/cli/src/__tests__/cmd-fix.test.ts
@@ -1,0 +1,415 @@
+/**
+ * cmd-fix.test.ts — Tests for the `spawn fix` command.
+ *
+ * Uses DI (options.runScript) instead of mock.module for SSH execution
+ * to avoid process-global mock pollution (pattern from delete-spinner.test.ts).
+ */
+
+import type { SpawnRecord } from "../history";
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createMockManifest, mockClackPrompts } from "./test-helpers";
+
+// ── Clack prompts mock (must be at module top level) ───────────────────────
+const clack = mockClackPrompts();
+
+// ── Import modules under test (no mock.module for core modules) ────────────
+const { buildFixScript, fixSpawn, cmdFix } = await import("../commands/fix.js");
+const { loadManifest, _resetCacheForTesting } = await import("../manifest.js");
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeRecord(overrides: Partial<SpawnRecord> = {}): SpawnRecord {
+  return {
+    id: "test-id-123",
+    agent: "claude",
+    cloud: "hetzner",
+    timestamp: new Date().toISOString(),
+    name: "my-spawn",
+    connection: {
+      ip: "1.2.3.4",
+      user: "root",
+      server_name: "spawn-abc",
+      server_id: "12345",
+      cloud: "hetzner",
+    },
+    ...overrides,
+  };
+}
+
+const mockManifest = createMockManifest();
+
+// ── Test Setup ─────────────────────────────────────────────────────────────
+
+describe("buildFixScript", () => {
+  it("generates a script with env re-injection and install command", () => {
+    const script = buildFixScript(mockManifest, "claude");
+
+    expect(script).toContain("set -eo pipefail");
+    expect(script).toContain("Re-injecting credentials");
+    expect(script).toContain("ANTHROPIC_API_KEY");
+    expect(script).toContain("~/.spawnrc");
+    expect(script).toContain("Re-installing agent");
+    expect(script).toContain("npm install -g claude");
+    expect(script).toContain("Done! Your spawn is ready.");
+    expect(script).toContain("claude"); // launch command hint
+  });
+
+  it("resolves ${VAR} template references from process.env", () => {
+    const savedKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "sk-or-test-key";
+    const manifest = {
+      ...mockManifest,
+      agents: {
+        ...mockManifest.agents,
+        claude: {
+          ...mockManifest.agents.claude,
+          env: {
+            OPENROUTER_API_KEY: "${OPENROUTER_API_KEY}",
+          },
+        },
+      },
+    };
+    const script = buildFixScript(manifest, "claude");
+    // Restore before asserting (even though test will continue)
+    if (savedKey === undefined) {
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = savedKey;
+    }
+    expect(script).toContain("sk-or-test-key");
+  });
+
+  it("handles agents without install command", () => {
+    const manifest = {
+      ...mockManifest,
+      agents: {
+        claude: {
+          name: "Claude Code",
+          description: "AI coding assistant",
+          url: "https://claude.ai",
+          launch: "claude",
+          env: {
+            ANTHROPIC_API_KEY: "test-key",
+          },
+        },
+      },
+    };
+    const script = buildFixScript(manifest, "claude");
+
+    expect(script).not.toContain("Re-installing agent");
+    expect(script).toContain("Re-injecting credentials");
+    expect(script).toContain("Done!");
+  });
+
+  it("handles agents without env vars", () => {
+    const manifest = {
+      ...mockManifest,
+      agents: {
+        claude: {
+          name: "Claude Code",
+          description: "AI coding assistant",
+          url: "https://claude.ai",
+          install: "npm install -g claude",
+          launch: "claude",
+        },
+      },
+    };
+    const script = buildFixScript(manifest, "claude");
+
+    expect(script).not.toContain(".spawnrc");
+    expect(script).toContain("Re-installing agent");
+  });
+
+  it("throws for unknown agent", () => {
+    expect(() => buildFixScript(mockManifest, "unknown-agent")).toThrow("Unknown agent: unknown-agent");
+  });
+
+  it("shell-escapes single quotes in env var values", () => {
+    const manifest = {
+      ...mockManifest,
+      agents: {
+        claude: {
+          name: "Claude Code",
+          description: "AI coding assistant",
+          url: "https://claude.ai",
+          launch: "claude",
+          env: {
+            API_KEY: "it's-a-key",
+          },
+        },
+      },
+    };
+    const script = buildFixScript(manifest, "claude");
+    // Single quote in value should be escaped as '\''
+    expect(script).toContain("it'\\''s-a-key");
+  });
+});
+
+// ── Tests: fixSpawn (DI for SSH runner) ─────────────────────────────────────
+
+describe("fixSpawn", () => {
+  beforeEach(() => {
+    clack.logError.mockReset();
+    clack.logSuccess.mockReset();
+    clack.logInfo.mockReset();
+    clack.logStep.mockReset();
+  });
+
+  it("shows error for record without connection info", async () => {
+    const record = makeRecord({
+      connection: undefined,
+    });
+    await fixSpawn(record, mockManifest);
+    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("no connection information"));
+  });
+
+  it("shows error for deleted server", async () => {
+    const record = makeRecord({
+      connection: {
+        ip: "1.2.3.4",
+        user: "root",
+        deleted: true,
+      },
+    });
+    await fixSpawn(record, mockManifest);
+    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("deleted"));
+  });
+
+  it("shows error for sprite-console connections", async () => {
+    const record = makeRecord({
+      connection: {
+        ip: "sprite-console",
+        user: "root",
+        server_name: "my-sprite",
+      },
+    });
+    await fixSpawn(record, mockManifest);
+    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("Sprite console"));
+  });
+
+  it("shows error for unknown agent", async () => {
+    const record = makeRecord({
+      agent: "nonexistent",
+    });
+    await fixSpawn(record, mockManifest);
+    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("Unknown agent"));
+  });
+
+  it("calls the script runner with correct args on success", async () => {
+    const mockRunner = mock(async () => true);
+    const record = makeRecord();
+
+    await fixSpawn(record, mockManifest, {
+      runScript: mockRunner,
+    });
+
+    expect(mockRunner).toHaveBeenCalledWith("1.2.3.4", "root", expect.stringContaining("set -eo pipefail"), []);
+    expect(clack.logSuccess).toHaveBeenCalled();
+  });
+
+  it("shows error when runner returns false", async () => {
+    const mockRunner = mock(async () => false);
+    const record = makeRecord();
+
+    await fixSpawn(record, mockManifest, {
+      runScript: mockRunner,
+    });
+
+    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("error"));
+  });
+
+  it("shows error when runner throws", async () => {
+    const mockRunner = mock(async () => {
+      throw new Error("SSH failed");
+    });
+    const record = makeRecord();
+
+    await fixSpawn(record, mockManifest, {
+      runScript: mockRunner,
+    });
+
+    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("Fix failed"));
+  });
+
+  it("loads manifest from network if not provided", async () => {
+    const record = makeRecord();
+    const mockRunner = mock(async () => true);
+
+    // Prime manifest cache with test data
+    const savedFetch = global.fetch;
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
+    _resetCacheForTesting();
+    await loadManifest(true);
+    global.fetch = savedFetch;
+
+    await fixSpawn(record, null, {
+      runScript: mockRunner,
+    });
+
+    expect(clack.logSuccess).toHaveBeenCalled();
+  });
+});
+
+// ── Tests: cmdFix (reads real history file, DI for SSH) ─────────────────────
+
+describe("cmdFix", () => {
+  let testDir: string;
+  let savedSpawnHome: string | undefined;
+  let processExitSpy: ReturnType<typeof spyOn>;
+
+  function writeHistory(records: SpawnRecord[]) {
+    writeFileSync(
+      join(testDir, "history.json"),
+      JSON.stringify({
+        version: 1,
+        records,
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    testDir = join(process.env.HOME ?? "", `spawn-fix-test-${Date.now()}`);
+    mkdirSync(testDir, {
+      recursive: true,
+    });
+    savedSpawnHome = process.env.SPAWN_HOME;
+    process.env.SPAWN_HOME = testDir;
+    clack.logError.mockReset();
+    clack.logSuccess.mockReset();
+    clack.logInfo.mockReset();
+    processExitSpy = spyOn(process, "exit").mockImplementation((_code?: number): never => {
+      throw new Error("process.exit");
+    });
+  });
+
+  afterEach(() => {
+    process.env.SPAWN_HOME = savedSpawnHome;
+    processExitSpy.mockRestore();
+    if (existsSync(testDir)) {
+      rmSync(testDir, {
+        recursive: true,
+        force: true,
+      });
+    }
+  });
+
+  it("shows message when no active spawns", async () => {
+    // No history file written — empty history
+    await cmdFix();
+    expect(clack.logInfo).toHaveBeenCalledWith(expect.stringContaining("No active spawns"));
+  });
+
+  it("fixes by spawn ID when passed as argument", async () => {
+    const mockRunner = mock(async () => true);
+    const record = makeRecord({
+      id: "my-spawn-id",
+    });
+    writeHistory([
+      record,
+    ]);
+
+    // Prime manifest cache
+    const savedFetch = global.fetch;
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
+    _resetCacheForTesting();
+    await loadManifest(true);
+    global.fetch = savedFetch;
+
+    await cmdFix("my-spawn-id", {
+      runScript: mockRunner,
+    });
+
+    expect(mockRunner).toHaveBeenCalled();
+  });
+
+  it("fixes by spawn name", async () => {
+    const mockRunner = mock(async () => true);
+    const record = makeRecord({
+      name: "my-named-spawn",
+    });
+    writeHistory([
+      record,
+    ]);
+
+    const savedFetch = global.fetch;
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
+    _resetCacheForTesting();
+    await loadManifest(true);
+    global.fetch = savedFetch;
+
+    await cmdFix("my-named-spawn", {
+      runScript: mockRunner,
+    });
+
+    expect(mockRunner).toHaveBeenCalled();
+  });
+
+  it("fixes by server_name", async () => {
+    const mockRunner = mock(async () => true);
+    const record = makeRecord({
+      connection: {
+        ip: "1.2.3.4",
+        user: "root",
+        server_name: "spawn-xyz",
+        cloud: "hetzner",
+      },
+    });
+    writeHistory([
+      record,
+    ]);
+
+    const savedFetch = global.fetch;
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
+    _resetCacheForTesting();
+    await loadManifest(true);
+    global.fetch = savedFetch;
+
+    await cmdFix("spawn-xyz", {
+      runScript: mockRunner,
+    });
+
+    expect(mockRunner).toHaveBeenCalled();
+  });
+
+  it("shows error when spawn ID not found", async () => {
+    const record = makeRecord({
+      id: "other-id",
+    });
+    writeHistory([
+      record,
+    ]);
+
+    const savedFetch = global.fetch;
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
+    _resetCacheForTesting();
+    await loadManifest(true);
+    global.fetch = savedFetch;
+
+    await cmdFix("nonexistent-id");
+
+    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("not found"));
+  });
+
+  it("directly fixes when only one active server exists (no picker)", async () => {
+    const mockRunner = mock(async () => true);
+    const record = makeRecord();
+    writeHistory([
+      record,
+    ]);
+
+    const savedFetch = global.fetch;
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
+    _resetCacheForTesting();
+    await loadManifest(true);
+    global.fetch = savedFetch;
+
+    await cmdFix(undefined, {
+      runScript: mockRunner,
+    });
+
+    expect(mockRunner).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/fix.ts
+++ b/packages/cli/src/commands/fix.ts
@@ -1,0 +1,268 @@
+import type { SpawnRecord } from "../history.js";
+import type { Manifest } from "../manifest.js";
+
+import { spawnSync } from "node:child_process";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { getActiveServers } from "../history.js";
+import { loadManifest } from "../manifest.js";
+import { validateConnectionIP, validateServerIdentifier, validateUsername } from "../security.js";
+import { getHistoryPath } from "../shared/paths.js";
+import { asyncTryCatch, tryCatch } from "../shared/result.js";
+import { SSH_INTERACTIVE_OPTS } from "../shared/ssh.js";
+import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys.js";
+import { isString } from "../shared/type-guards.js";
+import { buildRecordLabel, buildRecordSubtitle } from "./list.js";
+import { getErrorMessage, handleCancel, isInteractiveTTY } from "./shared.js";
+
+/** Shell-escape a value for safe embedding in a single-quoted string. */
+function shellSingleQuote(value: string): string {
+  // Replace ' with '\'' — exit quote, insert literal ', re-enter quote
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+/** Resolve ${VAR} template references from process.env. */
+function resolveEnvTemplate(template: string): string {
+  return template.replace(/\$\{([^}]+)\}/g, (_, name) => {
+    const envName = isString(name) ? name : "";
+    return process.env[envName] ?? "";
+  });
+}
+
+/** Build a bash script to re-inject env vars and reinstall the agent remotely. */
+export function buildFixScript(manifest: Manifest, agentKey: string): string {
+  const agentDef = manifest.agents[agentKey];
+  if (!agentDef) {
+    throw new Error(`Unknown agent: ${agentKey}`);
+  }
+
+  const lines: string[] = [
+    "#!/bin/bash",
+    "set -eo pipefail",
+    "",
+  ];
+
+  // Re-inject env vars into ~/.spawnrc
+  const env = agentDef.env ?? {};
+  const envEntries = Object.entries(env);
+  if (envEntries.length > 0) {
+    lines.push("echo '==> Re-injecting credentials...'");
+    // Write new .spawnrc atomically: write to .new then mv into place
+    lines.push("{");
+    for (const [key, template] of envEntries) {
+      const value = resolveEnvTemplate(template);
+      lines.push(`  printf 'export %s=%s\\n' ${shellSingleQuote(key)} ${shellSingleQuote(value)}`);
+    }
+    lines.push("} > ~/.spawnrc.new");
+    lines.push("mv ~/.spawnrc.new ~/.spawnrc");
+    lines.push("chmod 600 ~/.spawnrc");
+    lines.push("echo '    Credentials updated in ~/.spawnrc'");
+    lines.push("");
+  }
+
+  // Re-run the agent's install command to get the latest version
+  const installCmd = agentDef.install;
+  if (installCmd) {
+    lines.push("echo '==> Re-installing agent (latest version)...'");
+    lines.push(installCmd);
+    lines.push("echo '    Agent reinstalled successfully'");
+    lines.push("");
+  }
+
+  const launchCmd = agentDef.launch ?? agentKey;
+  lines.push("echo '==> Done! Your spawn is ready.'");
+  lines.push(`echo "    Run '${launchCmd}' inside the VM to start the agent."`);
+
+  return lines.join("\n") + "\n";
+}
+
+/** Dependency-injectable SSH fix script runner type. */
+export type FixScriptRunner = (ip: string, user: string, script: string, keyOpts: string[]) => Promise<boolean>;
+
+/** Run the fix script on a remote VM by piping it to SSH's stdin. */
+async function defaultRunFixScript(ip: string, user: string, script: string, keyOpts: string[]): Promise<boolean> {
+  const result = spawnSync(
+    "ssh",
+    [
+      ...SSH_INTERACTIVE_OPTS,
+      ...keyOpts,
+      `${user}@${ip}`,
+      "--",
+      "bash -s",
+    ],
+    {
+      input: script,
+      stdio: [
+        "pipe",
+        "inherit",
+        "inherit",
+      ],
+      encoding: "utf8",
+    },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return (result.status ?? 1) === 0;
+}
+
+/** Fix options — injectable for testing. */
+export interface FixOptions {
+  /** Override the SSH script runner (injectable for tests). */
+  runScript?: FixScriptRunner;
+}
+
+/** Fix a specific spawn: re-inject env vars and reinstall agent on the VM. */
+export async function fixSpawn(record: SpawnRecord, manifest: Manifest | null, options?: FixOptions): Promise<void> {
+  const conn = record.connection;
+  if (!conn) {
+    p.log.error("Cannot fix: spawn has no connection information.");
+    p.log.info("This usually means provisioning failed before SSH was established.");
+    return;
+  }
+  if (conn.deleted) {
+    p.log.error("Cannot fix: server has been deleted.");
+    return;
+  }
+  if (conn.ip === "sprite-console") {
+    p.log.error("Cannot fix: Sprite console connections are not supported by 'spawn fix'.");
+    p.log.info("SSH directly into the VM and re-run the setup script manually.");
+    return;
+  }
+
+  // SECURITY: validate all connection fields before use
+  const validationResult = tryCatch(() => {
+    validateConnectionIP(conn.ip);
+    validateUsername(conn.user);
+    if (conn.server_name) {
+      validateServerIdentifier(conn.server_name);
+    }
+    if (conn.server_id) {
+      validateServerIdentifier(conn.server_id);
+    }
+  });
+  if (!validationResult.ok) {
+    p.log.error(`Security validation failed: ${getErrorMessage(validationResult.error)}`);
+    p.log.info("Your spawn history file may be corrupted or tampered with.");
+    p.log.info(`Location: ${getHistoryPath()}`);
+    return;
+  }
+
+  // Load manifest if not provided
+  let man = manifest;
+  if (!man) {
+    const manifestResult = await asyncTryCatch(() => loadManifest());
+    if (!manifestResult.ok) {
+      p.log.error(`Failed to load manifest: ${getErrorMessage(manifestResult.error)}`);
+      return;
+    }
+    man = manifestResult.data;
+  }
+
+  const agentDef = man.agents[record.agent];
+  if (!agentDef) {
+    p.log.error(`Unknown agent: ${pc.bold(record.agent)}`);
+    p.log.info("This spawn may have been created with an agent that no longer exists.");
+    return;
+  }
+
+  // Build the remote fix script
+  const scriptResult = tryCatch(() => buildFixScript(man!, record.agent));
+  if (!scriptResult.ok) {
+    p.log.error(`Failed to build fix script: ${getErrorMessage(scriptResult.error)}`);
+    return;
+  }
+  const script = scriptResult.data;
+
+  const label = record.name || conn.server_name || conn.ip;
+  const agentName = agentDef.name;
+
+  p.log.step(`Fixing ${pc.bold(agentName)} on ${pc.bold(label)}...`);
+  p.log.info(`Connecting to ${pc.dim(`${conn.user}@${conn.ip}`)}`);
+  console.log();
+
+  const runner = options?.runScript ?? defaultRunFixScript;
+  const keyOpts = options?.runScript ? [] : getSshKeyOpts(await ensureSshKeys());
+  const fixResult = await asyncTryCatch(() => runner(conn.ip, conn.user, script, keyOpts));
+
+  console.log();
+
+  if (!fixResult.ok) {
+    p.log.error(`Fix failed: ${getErrorMessage(fixResult.error)}`);
+    p.log.info(`Try manually: ${pc.cyan(`ssh ${conn.user}@${conn.ip}`)}`);
+    return;
+  }
+
+  if (!fixResult.data) {
+    p.log.error("Fix script exited with an error. Check the output above for details.");
+    p.log.info(`Try manually: ${pc.cyan(`ssh ${conn.user}@${conn.ip}`)}`);
+    return;
+  }
+
+  p.log.success(`${pc.bold(agentName)} fixed successfully!`);
+  p.log.info(`Reconnect: ${pc.cyan("spawn last")}`);
+}
+
+export async function cmdFix(spawnId?: string, options?: FixOptions): Promise<void> {
+  const servers = getActiveServers();
+
+  if (servers.length === 0) {
+    p.log.info("No active spawns to fix.");
+    p.log.info(`Run ${pc.cyan("spawn <agent> <cloud>")} to create a spawn first.`);
+    return;
+  }
+
+  const manifestResult = await asyncTryCatch(() => loadManifest());
+  const manifest = manifestResult.ok ? manifestResult.data : null;
+
+  // If a specific name/id is given, find and fix it directly
+  if (spawnId) {
+    const record = servers.find((r) => r.id === spawnId || r.name === spawnId || r.connection?.server_name === spawnId);
+    if (!record) {
+      p.log.error(`Spawn not found: ${pc.bold(spawnId)}`);
+      p.log.info(`Run ${pc.cyan("spawn list")} to see your active spawns.`);
+      return;
+    }
+    await fixSpawn(record, manifest, options);
+    return;
+  }
+
+  // Only one server — fix it directly without prompting (works in non-interactive mode too)
+  if (servers.length === 1) {
+    await fixSpawn(servers[0], manifest, options);
+    return;
+  }
+
+  // Non-interactive fallback (multiple servers require picking)
+  if (!isInteractiveTTY()) {
+    p.log.error("spawn fix requires an interactive terminal or a spawn name/ID.");
+    p.log.info(`Usage: ${pc.cyan("spawn fix <spawn-id>")}`);
+    return;
+  }
+
+  // Interactive picker: show active servers and let user choose
+  const options2 = servers.map((r) => ({
+    value: r.id || r.timestamp,
+    label: buildRecordLabel(r),
+    hint: buildRecordSubtitle(r, manifest),
+  }));
+
+  const selected = await p.select({
+    message: "Select a spawn to fix",
+    options: options2,
+  });
+
+  if (p.isCancel(selected)) {
+    handleCancel();
+  }
+
+  const record = servers.find((r) => (r.id || r.timestamp) === selected);
+  if (!record) {
+    p.log.error("Spawn not found.");
+    return;
+  }
+
+  await fixSpawn(record, manifest, options);
+}

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -35,6 +35,8 @@ function getHelpUsageSection(): string {
   spawn status -a <agent>            Filter status by agent (or --agent)
   spawn status -c <cloud>            Filter status by cloud (or --cloud)
   spawn status --prune               Remove gone servers from history
+  spawn fix                          Re-run agent setup on an existing VM (re-inject credentials, reinstall)
+  spawn fix <spawn-id>               Fix a specific spawn by name or ID
   spawn last                         Instantly rerun the most recent spawn (alias: rerun)
   spawn matrix                       Full availability matrix (alias: m)
   spawn agents                       List all agents with descriptions

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -4,6 +4,8 @@
 export { cmdDelete } from "./delete.js";
 // feedback.ts — cmdFeedback
 export { cmdFeedback } from "./feedback.js";
+// fix.ts — cmdFix, fixSpawn, buildFixScript
+export { buildFixScript, cmdFix, fixSpawn } from "./fix.js";
 // help.ts — cmdHelp
 export { cmdHelp } from "./help.js";
 // info.ts — cmdMatrix, cmdAgents, cmdClouds, cmdAgentInfo, cmdCloudInfo

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -9,6 +9,7 @@ import { agentKeys, cloudKeys, loadManifest } from "../manifest.js";
 import { asyncTryCatch, tryCatch, unwrapOr } from "../shared/result.js";
 import { cmdConnect, cmdEnterAgent } from "./connect.js";
 import { confirmAndDelete } from "./delete.js";
+import { fixSpawn } from "./fix.js";
 import { cmdRun } from "./run.js";
 import {
   buildRetryCommand,
@@ -308,6 +309,15 @@ export async function handleRecordAction(
     hint: "Create a fresh instance",
   });
 
+  const canFix = !conn.deleted && conn.ip && conn.ip !== "sprite-console" && conn.user;
+  if (canFix) {
+    options.push({
+      value: "fix",
+      label: "Fix this server",
+      hint: "Re-inject credentials and reinstall agent",
+    });
+  }
+
   if (canDelete) {
     options.push({
       value: "delete",
@@ -353,6 +363,11 @@ export async function handleRecordAction(
       );
     }
     return RecordActionOutcome.Exit;
+  }
+
+  if (action === "fix") {
+    await fixSpawn(selected, manifest);
+    return RecordActionOutcome.Back;
   }
 
   if (action === "delete") {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import {
   cmdClouds,
   cmdDelete,
   cmdFeedback,
+  cmdFix,
   cmdHelp,
   cmdInteractive,
   cmdLast,
@@ -499,6 +500,13 @@ const DELETE_COMMANDS = new Set([
   "kill",
 ]);
 
+// fix handled separately for optional positional spawn-id argument
+const FIX_COMMANDS = new Set([
+  "fix",
+  "repair",
+  "refresh",
+]);
+
 // status handled separately for --prune/--json flag parsing
 const STATUS_COMMANDS = new Set([
   "status",
@@ -700,6 +708,16 @@ async function dispatchCommand(
   }
   if (DELETE_COMMANDS.has(cmd)) {
     await dispatchDeleteCommand(filteredArgs);
+    return;
+  }
+  if (FIX_COMMANDS.has(cmd)) {
+    if (hasTrailingHelpFlag(filteredArgs)) {
+      cmdHelp();
+      return;
+    }
+    // Optional positional argument: spawn fix [spawn-id]
+    const spawnId = filteredArgs[1] && !filteredArgs[1].startsWith("-") ? filteredArgs[1] : undefined;
+    await cmdFix(spawnId);
     return;
   }
   if (STATUS_COMMANDS.has(cmd)) {


### PR DESCRIPTION
## Summary

- Adds `spawn fix [spawn-id]` command that SSHes into an existing VM and re-applies agent setup without re-provisioning
- Re-injects OpenRouter credentials/env vars into `~/.spawnrc` and re-runs the agent's install command
- Also adds "Fix this server" option to the `spawn list` interactive menu
- 20 unit tests with 0 regressions in the full suite (1411 tests pass)

## Details

The fix command:
- Accepts an optional spawn name/ID as positional argument, or falls back to interactive picker
- Single active server is fixed directly without prompting
- Uses dependency injection (`FixScriptRunner`) for testability (same pattern as `confirmAndDelete`)
- Shell-escapes all env var values in the remote script (no injection risk)
- Validates connection parameters (IP, username, server_name) before use

Fixes #2589

## Test plan

- [x] `bun test` passes (1411 tests, 0 failures)
- [x] `bunx @biomejs/biome check src/` passes with 0 errors
- [x] New `cmd-fix.test.ts` with 20 tests covering: buildFixScript (pure logic), fixSpawn (DI), cmdFix (real filesystem history)

-- refactor/issue-fixer