### PR TITLE
docs: Sync README with source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ spawn delete -c hetzner                  # Delete a server on Hetzner
 | `spawn last` | Instantly rerun the most recent spawn |
 | `spawn agents` | List all agents with descriptions |
 | `spawn clouds` | List all cloud providers |
+| `spawn feedback "message"` | Send feedback to the Spawn team |
 | `spawn update` | Check for CLI updates |
 | `spawn delete` | Interactively select and destroy a cloud server |
 | `spawn delete -a <agent>` | Filter servers to delete by agent |


### PR DESCRIPTION
## Summary

- Added missing `spawn feedback "message"` row to the Commands table in README.md

## Source-of-truth delta

**Gate 2 — Commands drift triggered:**
- Source of truth: `packages/cli/src/commands/help.ts` → `getHelpUsageSection()` (line 42)
  - Contains: `spawn feedback "message"` with description "Send feedback to the Spawn team"
- README commands table (lines ~42-77): missing this row entirely
- Fix: added one row `| \`spawn feedback "message"\` | Send feedback to the Spawn team |`

**Gates 1 and 3 — No drift detected:**
- Matrix: 8 agents × 6 clouds = 48 implemented — matches tagline and matrix table
- Troubleshooting: no recurring issues (2+ occurrences) with undocumented actionable fixes

## Stats

- 1 file changed, 1 insertion(+)
- Diff: 12 lines (within 30-line limit)
- Tests: 1391 pass, 0 fail

-- qa/record-keeper