### PR TITLE
fix: enforce minimum 4GB RAM for openclaw on DigitalOcean

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.11",
+  "version": "0.17.12",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/digitalocean/main.ts
+++ b/packages/cli/src/digitalocean/main.ts
@@ -25,6 +25,11 @@ import {
   waitForSshOnly,
 } from "./digitalocean";
 
+/** Agents that need more than the default 2GB RAM (e.g. openclaw-plugins OOMs on 2GB) */
+const AGENT_MIN_SIZE: Record<string, string> = {
+  openclaw: "s-2vcpu-4gb",
+};
+
 /** DO marketplace image slugs — hardcoded from vendor portal (approved 2026-03-13) */
 const MARKETPLACE_IMAGES: Record<string, string> = {
   claude: "openrouter-spawnclaude",
@@ -69,6 +74,12 @@ async function main() {
     },
     async promptSize() {
       dropletSize = await promptDropletSize();
+      // Enforce minimum size for agents that need more RAM (e.g. openclaw-plugins OOMs on 2GB)
+      const minSize = AGENT_MIN_SIZE[agentName];
+      if (minSize && (!dropletSize || dropletSize === "s-2vcpu-2gb")) {
+        dropletSize = minSize;
+        logInfo(`Using ${minSize} (minimum for ${agentName})`);
+      }
       region = await promptDoRegion();
     },
     async createServer(name: string) {


### PR DESCRIPTION
## Summary
- openclaw-plugins OOMs on 2GB droplets (`s-2vcpu-2gb`) during config loading (~956MB heap)
- Auto-upgrades to `s-2vcpu-4gb` ($24/mo) when openclaw is selected and no custom size is set
- Respects user-chosen sizes via `--size` or `--custom` picker

## Test plan
- [ ] `spawn openclaw digitalocean` → uses `s-2vcpu-4gb`, no OOM
- [ ] `spawn openclaw digitalocean --size s-4vcpu-8gb` → respects explicit size
- [ ] `spawn claude digitalocean` → unchanged (`s-2vcpu-2gb`)
- [x] Unit tests pass (1407/1407)
- [x] Biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)