### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/billing-guidance.test.ts
+++ b/packages/cli/src/__tests__/billing-guidance.test.ts
@@ -1,6 +1,6 @@
 import type { BillingGuidanceDeps } from "../shared/billing-guidance";
 
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { handleBillingError, isBillingError, showNonBillingError } from "../shared/billing-guidance";
 
 // ── Mock deps (injected via DI, not mock.module) ──────────────────────────
@@ -101,20 +101,22 @@ describe("handleBillingError", () => {
     mockPrompt.mockClear();
   });
 
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
   it("opens billing URL and returns true when user presses Enter", async () => {
     mockPrompt.mockImplementation(() => Promise.resolve(""));
     const deps = createMockDeps();
     const result = await handleBillingError("hetzner", deps);
     expect(result).toBe(true);
     expect(deps.openBrowser).toHaveBeenCalledWith("https://console.hetzner.cloud/");
-    stderrSpy.mockRestore();
   });
 
   it("returns false when prompt throws (Ctrl+C)", async () => {
     mockPrompt.mockImplementation(() => Promise.reject(new Error("cancelled")));
     const result = await handleBillingError("digitalocean", createMockDeps());
     expect(result).toBe(false);
-    stderrSpy.mockRestore();
   });
 
   it("works for clouds without billing URL", async () => {
@@ -123,7 +125,6 @@ describe("handleBillingError", () => {
     const result = await handleBillingError("unknown", deps);
     expect(result).toBe(true);
     expect(deps.openBrowser).not.toHaveBeenCalled();
-    stderrSpy.mockRestore();
   });
 });
 
@@ -132,6 +133,10 @@ describe("showNonBillingError", () => {
 
   beforeEach(() => {
     stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
   });
 
   it("does not throw", () => {
@@ -145,6 +150,5 @@ describe("showNonBillingError", () => {
         deps,
       );
     }).not.toThrow();
-    stderrSpy.mockRestore();
   });
 });

--- a/packages/cli/src/__tests__/cloud-init.test.ts
+++ b/packages/cli/src/__tests__/cloud-init.test.ts
@@ -47,44 +47,68 @@ describe("getPackagesForTier", () => {
 });
 
 describe("needsNode", () => {
-  it("returns true for 'node' tier", () => {
-    expect(needsNode("node")).toBe(true);
-  });
-
-  it("returns true for 'full' tier", () => {
-    expect(needsNode("full")).toBe(true);
-  });
-
-  it("returns false for 'minimal' tier", () => {
-    expect(needsNode("minimal")).toBe(false);
-  });
-
-  it("returns false for 'bun' tier", () => {
-    expect(needsNode("bun")).toBe(false);
-  });
-
+  const cases: Array<
+    [
+      Parameters<typeof needsNode>[0],
+      boolean,
+    ]
+  > = [
+    [
+      "node",
+      true,
+    ],
+    [
+      "full",
+      true,
+    ],
+    [
+      "minimal",
+      false,
+    ],
+    [
+      "bun",
+      false,
+    ],
+  ];
+  for (const [tier, expected] of cases) {
+    it(`returns ${expected} for '${tier}' tier`, () => {
+      expect(needsNode(tier)).toBe(expected);
+    });
+  }
   it("defaults to true (full tier)", () => {
     expect(needsNode()).toBe(true);
   });
 });
 
 describe("needsBun", () => {
-  it("returns true for 'bun' tier", () => {
-    expect(needsBun("bun")).toBe(true);
-  });
-
-  it("returns true for 'full' tier", () => {
-    expect(needsBun("full")).toBe(true);
-  });
-
-  it("returns false for 'minimal' tier", () => {
-    expect(needsBun("minimal")).toBe(false);
-  });
-
-  it("returns false for 'node' tier", () => {
-    expect(needsBun("node")).toBe(false);
-  });
-
+  const cases: Array<
+    [
+      Parameters<typeof needsBun>[0],
+      boolean,
+    ]
+  > = [
+    [
+      "bun",
+      true,
+    ],
+    [
+      "full",
+      true,
+    ],
+    [
+      "minimal",
+      false,
+    ],
+    [
+      "node",
+      false,
+    ],
+  ];
+  for (const [tier, expected] of cases) {
+    it(`returns ${expected} for '${tier}' tier`, () => {
+      expect(needsBun(tier)).toBe(expected);
+    });
+  }
   it("defaults to true (full tier)", () => {
     expect(needsBun()).toBe(true);
   });

--- a/packages/cli/src/__tests__/junie-agent.test.ts
+++ b/packages/cli/src/__tests__/junie-agent.test.ts
@@ -8,7 +8,7 @@
  * - cloudInitTier is 'node' (npm-installed agent)
  */
 
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 // ── Suppress stderr output from logStep/logError during tests ────────────────
 
@@ -16,6 +16,10 @@ let stderrSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
   stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
 });
 
 // ── Import module under test ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **billing-guidance.test.ts**: moved `stderrSpy.mockRestore()` from inside each test body to `afterEach`, so the spy is always restored even if a test assertion throws
- **junie-agent.test.ts**: added missing `afterEach(() => stderrSpy.mockRestore())` — the spy was set up in `beforeEach` but never cleaned up, causing it to leak across tests and subsequent test files
- **cloud-init.test.ts**: consolidated 8 individual `it()` blocks in `needsNode` and `needsBun` into data-driven loops, eliminating copy-paste repetition while preserving coverage

## Test plan

- [x] `bun test packages/cli/src/__tests__` passes: 1407 tests, 0 failures
- [x] `bunx @biomejs/biome check src/` passes with zero errors

-- qa/dedup-scanner