### PR TITLE
fix: correct stale credential path in qa-fixtures-prompt

### DIFF
--- a/.claude/skills/setup-agent-team/qa-fixtures-prompt.md
+++ b/.claude/skills/setup-agent-team/qa-fixtures-prompt.md
@@ -25,14 +25,16 @@ List clouds that have fixture directories:
 ls -d fixtures/*/
 ```
 
-For each cloud directory, check if a corresponding `sh/test/fixtures/{cloud}/_env.sh` exists — this contains the env vars needed for API auth.
+Cloud credentials are stored in `~/.config/spawn/{cloud}.json` (loaded by `sh/shared/key-request.sh`).
 
 ## Step 2 — Check Credentials
 
-For each cloud with `_env.sh` (in `sh/test/fixtures/{cloud}/`):
-1. Read `_env.sh` to see which env vars are needed
-2. Check if those env vars are set in the current environment
-3. Skip clouds where credentials are missing (log which ones)
+For each cloud with a fixture directory, check if its required env vars are set:
+- **hetzner**: `HCLOUD_TOKEN`
+- **digitalocean**: `DO_API_TOKEN`
+- **aws**: `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
+
+Skip clouds where credentials are missing (log which ones).
 
 ## Step 3 — Collect Fixtures
 


### PR DESCRIPTION
## Summary

- Fixed stale reference to `sh/test/fixtures/{cloud}/_env.sh` in `qa-fixtures-prompt.md` — that path does not exist
- The actual cloud credential mechanism is `~/.config/spawn/{cloud}.json` via `sh/shared/key-request.sh`
- Updated Steps 1–2 to reference the real credential location and list the specific env vars per cloud

## Findings from Code Quality Scan

**a) Dead code**: No dead functions found in `sh/shared/*.sh` or `packages/cli/src/` — all exported functions have callers.

**b) Stale references**: One stale path reference found and fixed:
- `qa-fixtures-prompt.md` referenced `sh/test/fixtures/{cloud}/_env.sh` (non-existent) — corrected to real credential mechanism

**c) Python usage**: None found. All shell scripts use `bun -e` or `jq` for inline processing.

**d) Duplicate utilities**: No duplicate helper functions found across cloud modules. `promptSpawnName`, `getServerName`, and `getConnectionInfo` each delegate to shared utilities (`promptSpawnNameShared`, `getServerNameFromEnv`) — properly factored.

**e) Stale comments**: All comments reviewed. Comments referencing "old patterns" in DigitalOcean scripts are accurate historical context explaining current implementation choices — not stale.

## Test plan
- [x] `bunx @biomejs/biome check src/` — 0 errors (124 files)
- [x] `bun test` — 1408 pass, 0 fail

-- qa/code-quality