### PR TITLE
fix: check additional junie binary paths in GCP verify

### DIFF
--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -602,9 +602,10 @@ verify_junie() {
   local app="$1"
   local failures=0
 
-  # Binary check
+  # Binary check — @jetbrains/junie-cli postinstall may place the binary in
+  # non-standard locations (e.g. ~/.junie/bin/, npm global root, /usr/local/bin)
   log_step "Checking junie binary..."
-  if cloud_exec "${app}" "PATH=\$HOME/.npm-global/bin:\$HOME/.bun/bin:\$HOME/.local/bin:\$PATH command -v junie" >/dev/null 2>&1; then
+  if cloud_exec "${app}" "PATH=\$HOME/.npm-global/bin:\$HOME/.junie/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/usr/local/bin:\$(npm bin -g 2>/dev/null || echo /dev/null):\$PATH command -v junie" >/dev/null 2>&1; then
     log_ok "junie binary found"
   else
     log_err "junie binary not found"


### PR DESCRIPTION
**Why:** GCP junie E2E fails with `[FAIL] junie binary not found` because `@jetbrains/junie-cli`'s postinstall script may download the actual binary to non-standard locations that `verify_junie()` wasn't checking.

Fixes #2611

## Changes
- Updated `verify_junie()` in `sh/e2e/lib/verify.sh` to check additional paths:
  - `$HOME/.junie/bin` (JetBrains convention for downloaded binaries)
  - `/usr/local/bin` (system-wide install fallback)
  - `$(npm bin -g)` (dynamic npm global bin resolution)

## Testing
- `bash -n sh/e2e/lib/verify.sh`: pass

-- refactor/ux-engineer