### PR TITLE
fix: openclaw dashboard Unauthorized — add auth.mode and fragment token

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.19",
+  "version": "0.17.20",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -353,6 +353,7 @@ async function setupOpenclawConfig(
     gateway: {
       mode: "local",
       auth: {
+        mode: "token",
         token: gatewayToken,
       },
     },
@@ -414,17 +415,18 @@ async function setupOpenclawConfig(
     logWarn("Browser config setup failed (non-fatal)");
   }
 
-  // Re-assert gateway auth token after browser config set calls — each `openclaw config set`
+  // Re-assert gateway auth mode + token after browser config set calls — each `openclaw config set`
   // does a read-modify-write on the config file and may drop fields written by uploadConfigFile.
-  // Re-setting the token here ensures it survives those cycles and the gateway starts authenticated.
+  // Re-setting both here ensures they survive those cycles and the gateway starts authenticated.
   const gatewayTokenResult = await asyncTryCatchIf(isOperationalError, () =>
     runner.runServer(
       "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
+        "openclaw config set gateway.auth.mode token >/dev/null; " +
         `openclaw config set gateway.auth.token ${shellQuote(gatewayToken)} >/dev/null`,
     ),
   );
   if (!gatewayTokenResult.ok) {
-    logWarn("Gateway token re-assertion failed (non-fatal) — dashboard may show Unauthorized");
+    logWarn("Gateway auth re-assertion failed (non-fatal) — dashboard may show Unauthorized");
   }
 
   // Channel pairing (Telegram/WhatsApp) happens in orchestrate.ts after the gateway starts.
@@ -695,7 +697,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
           "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; openclaw tui",
         tunnel: {
           remotePort: 18791,
-          browserUrl: (localPort: number) => `http://localhost:${localPort}/?token=${dashboardToken}`,
+          browserUrl: (localPort: number) => `http://localhost:${localPort}/#token=${dashboardToken}`,
         },
       };
     })(),


### PR DESCRIPTION
## Summary

- **Add `gateway.auth.mode: "token"`** to the OpenClaw config — required since OpenClaw 2026.3.7 when `gateway.auth.token` is set, otherwise the gateway rejects authentication and the dashboard shows "Unauthorized"
- **Switch token transport from query param to URL fragment** (`?token=` → `#token=`) to match the updated auth flow and avoid leaking the token in server logs / Referer headers (GHSA-rchv-x836-w7xp)
- **Re-assert `gateway.auth.mode`** alongside the token in the post-browser-config fixup step, so both survive the `openclaw config set` read-modify-write cycles

## Test plan

- [x] Biome lint — 0 errors
- [x] `bun test` — 1414 pass, 0 fail
- [ ] Manual: deploy OpenClaw on any cloud, verify dashboard opens authenticated (no "Unauthorized" page)
- [ ] Manual: confirm `~/.openclaw/openclaw.json` contains `gateway.auth.mode: "token"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)