### PR TITLE
fix: tunnel OpenClaw gateway port (18789) instead of internal control service (18791)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.20",
+  "version": "0.17.21",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -445,7 +445,7 @@ async function setupOpenclawConfig(
     if (enabledSteps.has("whatsapp")) {
       messagingLines.push(
         "- **WhatsApp**: Requires QR code scanning. Guide the user to the web",
-        "  dashboard to complete setup: http://localhost:18791",
+        "  dashboard to complete setup: http://localhost:18789",
       );
     }
     messagingLines.push("");
@@ -456,12 +456,12 @@ async function setupOpenclawConfig(
     "",
     "## Web Dashboard",
     "",
-    "This machine has a web dashboard running on port 18791.",
+    "This machine has a web dashboard running on port 18789.",
     "When helping the user set up channels that require QR code scanning",
     "(WhatsApp, Telegram, etc.), always guide them to use the web dashboard",
     "instead of the TUI — QR codes cannot be scanned from a terminal.",
     "",
-    "The dashboard URL is: http://localhost:18791",
+    "The dashboard URL is: http://localhost:18789",
     "(It may also be SSH-tunneled to the user's local machine automatically.)",
     ...messagingLines,
     "",
@@ -696,7 +696,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         launchCmd: () =>
           "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; openclaw tui",
         tunnel: {
-          remotePort: 18791,
+          remotePort: 18789,
           browserUrl: (localPort: number) => `http://localhost:${localPort}/#token=${dashboardToken}`,
         },
       };


### PR DESCRIPTION
## Summary

The previous fix (#2617) addressed auth mode and fragment token transport, but the dashboard was still showing "Unauthorized" because **we were tunneling the wrong port**.

OpenClaw's port architecture:
| Port | Role |
|------|------|
| **18789** | Gateway — serves the dashboard (Control UI), WebSocket, and API |
| **18791** | Internal Control Service (not the user-facing dashboard) |

We were SSH-tunneling port **18791** (internal Control Service), but the actual dashboard that accepts `#token=` auth is served by the Gateway on port **18789**. The Control Service on 18791 doesn't understand token-based dashboard authentication, so every connection showed "Unauthorized".

- Changed `tunnel.remotePort` from `18791` → `18789`
- Updated all USER.md references from port 18791 → 18789

## Test plan

- [x] Biome lint — 0 errors
- [x] `bun test` — 1414 pass, 0 fail
- [ ] Manual: deploy OpenClaw on any cloud, verify dashboard loads authenticated at `http://localhost:18789/#token=...`
- [ ] Manual: verify WebSocket connection succeeds (no "gateway token missing" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)