### PR TITLE
fix: reorder interactive menu — Create before Connect

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.21",
+  "version": "0.17.22",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -226,12 +226,12 @@ export async function cmdInteractive(): Promise<void> {
       message: "What would you like to do?",
       options: [
         {
-          value: "connect",
-          label: "Connect to existing server",
-        },
-        {
           value: "create",
           label: "Create a new server",
+        },
+        {
+          value: "connect",
+          label: "Connect to existing server",
         },
       ],
     });


### PR DESCRIPTION
## Summary

- Reorder the `spawn` interactive menu so **"Create a new server"** appears before **"Connect to existing server"**

## Test plan

- [x] Biome lint — 0 errors
- [x] `bun test` — 1414 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)