### PR TITLE
feat: persist tunnel metadata for dashboard reconnect via spawn ls

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.17.22",
+  "version": "0.18.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -1,5 +1,6 @@
 import type { VMConnection } from "../history.js";
 import type { Manifest } from "../manifest.js";
+import type { SshTunnelHandle } from "../shared/ssh.js";
 
 import * as p from "@clack/prompts";
 import pc from "picocolors";
@@ -11,10 +12,10 @@ import {
   validateUsername,
 } from "../security.js";
 import { getHistoryPath } from "../shared/paths.js";
-import { tryCatch } from "../shared/result.js";
-import { SSH_INTERACTIVE_OPTS, spawnInteractive } from "../shared/ssh.js";
+import { asyncTryCatchIf, isOperationalError, tryCatch } from "../shared/result.js";
+import { SSH_INTERACTIVE_OPTS, spawnInteractive, startSshTunnel } from "../shared/ssh.js";
 import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys.js";
-import { shellQuote } from "../shared/ui.js";
+import { logWarn, openBrowser, shellQuote } from "../shared/ui.js";
 import { getErrorMessage } from "./shared.js";
 
 /** Execute a shell command and resolve/reject on process close/error */
@@ -179,11 +180,34 @@ export async function cmdEnterAgent(
     );
   }
 
+  // Re-establish SSH tunnel for web dashboard if tunnel metadata was persisted at spawn time
+  let tunnelHandle: SshTunnelHandle | undefined;
+  const tunnelPort = connection.metadata?.tunnel_remote_port;
+  if (tunnelPort && connection.ip !== "sprite-console") {
+    const tunnelResult = await asyncTryCatchIf(isOperationalError, async () => {
+      const keys = await ensureSshKeys();
+      tunnelHandle = await startSshTunnel({
+        host: connection.ip,
+        user: connection.user,
+        remotePort: Number(tunnelPort),
+        sshKeyOpts: getSshKeyOpts(keys),
+      });
+      const urlTemplate = connection.metadata?.tunnel_browser_url_template;
+      if (urlTemplate) {
+        const url = urlTemplate.replace("__PORT__", String(tunnelHandle.localPort));
+        openBrowser(url);
+      }
+    });
+    if (!tunnelResult.ok) {
+      logWarn("Web dashboard tunnel failed — dashboard unavailable this session");
+    }
+  }
+
   // Standard SSH connection with agent launch
   p.log.step(`Entering ${pc.bold(agentName)} on ${pc.bold(connection.ip)}...`);
   const quotedRemoteCmd = shellQuote(remoteCmd);
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
-  return runInteractiveCommand(
+  await runInteractiveCommand(
     "ssh",
     [
       ...SSH_INTERACTIVE_OPTS,
@@ -195,4 +219,7 @@ export async function cmdEnterAgent(
     `Failed to enter ${agentName}`,
     `ssh -t ${connection.user}@${connection.ip} -- bash -lc ${quotedRemoteCmd}`,
   );
+  if (tunnelHandle) {
+    tunnelHandle.stop();
+  }
 }

--- a/packages/cli/src/history.ts
+++ b/packages/cli/src/history.ts
@@ -133,6 +133,47 @@ export function saveLaunchCmd(launchCmd: string, spawnId?: string): void {
   }
 }
 
+/** Merge metadata key-value pairs into a history record's connection.
+ *  Matches by spawnId when provided; falls back to most recent record with a connection. */
+export function saveMetadata(entries: Record<string, string>, spawnId?: string): void {
+  const result = tryCatchIf(isFileError, () => {
+    const history = loadHistory();
+    let found = false;
+
+    if (spawnId) {
+      const idx = history.findIndex((r) => r.id === spawnId);
+      if (idx >= 0 && history[idx].connection) {
+        const conn = history[idx].connection;
+        conn.metadata = {
+          ...conn.metadata,
+          ...entries,
+        };
+        found = true;
+      }
+    } else {
+      for (let i = history.length - 1; i >= 0; i--) {
+        const conn = history[i].connection;
+        if (conn) {
+          conn.metadata = {
+            ...conn.metadata,
+            ...entries,
+          };
+          found = true;
+          break;
+        }
+      }
+    }
+
+    if (found) {
+      writeHistory(history);
+    }
+  });
+  if (!result.ok) {
+    logWarn("Could not save metadata");
+    logDebug(getErrorMessage(result.error));
+  }
+}
+
 /** Back up a corrupted file before discarding it. Non-fatal (best-effort). */
 function backupCorruptedFile(filePath: string): void {
   const result = tryCatchIf(isFileError, () => {

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -8,7 +8,7 @@ import type { SshTunnelHandle } from "./ssh";
 
 import { readFileSync } from "node:fs";
 import * as v from "valibot";
-import { generateSpawnId, saveLaunchCmd, saveSpawnRecord } from "../history.js";
+import { generateSpawnId, saveLaunchCmd, saveMetadata, saveSpawnRecord } from "../history.js";
 import { offerGithubAuth, wrapSshCall } from "./agent-setup";
 import { tryTarballInstall } from "./agent-tarball";
 import { generateEnvConfig } from "./agents";
@@ -291,6 +291,21 @@ export async function runOrchestration(
         }
       }
     }
+
+    // Persist tunnel metadata so `spawn ls` → "Enter agent" can re-establish the tunnel.
+    // Store the remote port and browser URL template (with PORT placeholder) so the
+    // tunnel can be reconstructed with whatever local port is available on reconnect.
+    const tunnelMeta: Record<string, string> = {
+      tunnel_remote_port: String(agent.tunnel.remotePort),
+    };
+    if (agent.tunnel.browserUrl) {
+      // Use port 0 as a placeholder — on reconnect we replace it with the actual local port
+      const templateUrl = agent.tunnel.browserUrl(0);
+      if (templateUrl) {
+        tunnelMeta.tunnel_browser_url_template = templateUrl.replace("localhost:0", "localhost:__PORT__");
+      }
+    }
+    saveMetadata(tunnelMeta, spawnId);
   }
 
   // 11c. Channel setup (runs after gateway is up)


### PR DESCRIPTION
## Summary

- **Add `saveMetadata()`** to `history.ts` — merges key-value pairs into a spawn record's `connection.metadata` field (follows the same pattern as `saveLaunchCmd`)
- **Store tunnel info at spawn time** (`orchestrate.ts`) — persists `tunnel_remote_port` and `tunnel_browser_url_template` so the tunnel can be reconstructed on reconnect
- **Re-establish SSH tunnel on reconnect** (`connect.ts`) — when a user selects "Enter agent" from `spawn ls`, checks for tunnel metadata, starts an SSH tunnel to the dashboard port, and opens the browser with the correct URL + token

### How it works

1. At spawn time, after the SSH tunnel is established, the remote port and a browser URL template (with `__PORT__` placeholder) are saved to `connection.metadata`
2. When reconnecting via `spawn ls` → "Enter OpenClaw", `cmdEnterAgent` reads the metadata, starts a new SSH tunnel, substitutes the actual local port into the URL template, and opens the browser
3. The tunnel is cleaned up when the SSH session ends

## Test plan

- [x] Biome lint — 0 errors
- [x] `bun test` — 1414 pass, 0 fail
- [ ] Manual: spawn OpenClaw, verify `~/.spawn/history.json` contains `tunnel_remote_port` and `tunnel_browser_url_template` in metadata
- [ ] Manual: exit, run `spawn ls`, select the server → "Enter OpenClaw", verify dashboard opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)