### PR TITLE
feat: rename Enter to Open Dashboard for agents with web UI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -287,11 +287,12 @@ export async function handleRecordAction(
   const launchCmd = conn.launch_cmd || agentDef?.launch;
 
   if (!conn.deleted && launchCmd) {
+    const hasDashboard = Boolean(conn.metadata?.tunnel_remote_port);
     const agentName = agentDef?.name || selected.agent;
     options.push({
       value: "enter",
-      label: `Enter ${agentName}`,
-      hint: agentDef?.launch || launchCmd,
+      label: hasDashboard ? `Open ${agentName} Dashboard` : `Enter ${agentName}`,
+      hint: hasDashboard ? "Launch agent + open web dashboard" : agentDef?.launch || launchCmd,
     });
   }
 


### PR DESCRIPTION
## Summary

- When an agent has tunnel metadata (i.e., a web dashboard), the `spawn ls` action menu now shows **"Open OpenClaw Dashboard"** with hint "Launch agent + open web dashboard" instead of the generic "Enter OpenClaw"
- Non-dashboard agents (Claude Code, Codex, etc.) keep the original "Enter <Agent>" label

Stacked on #2620.

## Test plan

- [x] Biome lint — 0 errors
- [x] `bun test` — 1414 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)