### PR TITLE
fix: remove WhatsApp from setup, nothing pre-selected

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/steps-flag.test.ts
+++ b/packages/cli/src/__tests__/steps-flag.test.ts
@@ -35,13 +35,11 @@ describe("validateStepNames", () => {
       "github",
       "browser",
       "telegram",
-      "whatsapp",
     ]);
     expect(valid).toEqual([
       "github",
       "browser",
       "telegram",
-      "whatsapp",
     ]);
     expect(invalid).toEqual([]);
   });
@@ -87,13 +85,6 @@ describe("OptionalStep metadata", () => {
     const telegram = steps.find((s) => s.value === "telegram");
     expect(telegram).toBeDefined();
     expect(telegram?.dataEnvVar).toBe("TELEGRAM_BOT_TOKEN");
-  });
-
-  it("openclaw whatsapp step should be marked interactive", () => {
-    const steps = getAgentOptionalSteps("openclaw");
-    const whatsapp = steps.find((s) => s.value === "whatsapp");
-    expect(whatsapp).toBeDefined();
-    expect(whatsapp?.interactive).toBe(true);
   });
 
   it("common steps should not have dataEnvVar or interactive", () => {

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -172,19 +172,10 @@ async function promptSetupOptions(agentName: string): Promise<Set<string> | unde
     return undefined;
   }
 
-  // "None" is shown first and pre-selected by default so that:
-  // 1. Arrow keys work immediately (multiple items to navigate)
-  // 2. Users can explicitly skip all steps without pressing Enter on an empty list
-  // 3. Users who accidentally select another option can deselect it and choose None
-  // Pre-select browser + telegram by default (telegram has the smoothest setup UX)
-  const recommendedDefaults = [
-    "browser",
-    "telegram",
+  // Nothing pre-selected — let users opt in to what they want
+  const defaultValues = [
+    NONE_STEP,
   ];
-  const defaultValues = filteredSteps.filter((s) => recommendedDefaults.includes(s.value)).map((s) => s.value);
-  if (defaultValues.length === 0) {
-    defaultValues.push(NONE_STEP);
-  }
 
   const selected = await p.multiselect({
     message: "Setup options (↑/↓ navigate, space to select, enter to confirm)",

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -385,14 +385,6 @@ async function setupOpenclawConfig(
     logInfo("Telegram bot token configured");
   }
 
-  if (enabledSteps?.has("whatsapp")) {
-    channels.whatsapp = {
-      dmPolicy: "pairing",
-      groupPolicy: "open",
-      sendReadReceipts: true,
-    };
-  }
-
   if (Object.keys(channels).length > 0) {
     configObj.channels = channels;
   }
@@ -429,26 +421,19 @@ async function setupOpenclawConfig(
     logWarn("Gateway auth re-assertion failed (non-fatal) — dashboard may show Unauthorized");
   }
 
-  // Channel pairing (Telegram/WhatsApp) happens in orchestrate.ts after the gateway starts.
+  // Channel pairing (Telegram) happens in orchestrate.ts after the gateway starts.
 
-  // Write USER.md bootstrap file — guides users to the web dashboard for
-  // visual tasks like WhatsApp QR code scanning that don't work in the TUI.
+  // Write USER.md bootstrap file
   const messagingLines: string[] = [];
-  if (enabledSteps?.has("telegram") || enabledSteps?.has("whatsapp")) {
-    messagingLines.push("", "## Messaging Channels", "", "The user selected messaging channels during setup.");
-    if (enabledSteps.has("telegram")) {
-      messagingLines.push(
-        "- **Telegram**: If a bot token was provided, it is already configured.",
-        "  To verify: `openclaw config get channels.telegram.botToken`",
-      );
-    }
-    if (enabledSteps.has("whatsapp")) {
-      messagingLines.push(
-        "- **WhatsApp**: Requires QR code scanning. Guide the user to the web",
-        "  dashboard to complete setup: http://localhost:18789",
-      );
-    }
-    messagingLines.push("");
+  if (enabledSteps?.has("telegram")) {
+    messagingLines.push(
+      "",
+      "## Messaging Channels",
+      "",
+      "- **Telegram**: If a bot token was provided, it is already configured.",
+      "  To verify: `openclaw config get channels.telegram.botToken`",
+      "",
+    );
   }
 
   const userMd = [

--- a/packages/cli/src/shared/agents.ts
+++ b/packages/cli/src/shared/agents.ts
@@ -63,14 +63,8 @@ const AGENT_EXTRA_STEPS: Record<string, OptionalStep[]> = {
     {
       value: "telegram",
       label: "Telegram",
-      hint: "recommended — connect via bot token from @BotFather",
+      hint: "connect via bot token from @BotFather",
       dataEnvVar: "TELEGRAM_BOT_TOKEN",
-    },
-    {
-      value: "whatsapp",
-      label: "WhatsApp",
-      hint: "scan QR code during setup",
-      interactive: true,
     },
   ],
 };

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -231,11 +231,6 @@ export async function runOrchestration(
       // --steps "" → disable all optional steps
       enabledSteps = new Set();
     }
-    // Skip interactive WhatsApp in headless mode
-    if (process.env.SPAWN_HEADLESS === "1" && enabledSteps.has("whatsapp")) {
-      logWarn("WhatsApp requires interactive QR scanning — skipping in headless mode");
-      enabledSteps.delete("whatsapp");
-    }
   }
 
   // 10b. Agent-specific configuration
@@ -336,19 +331,6 @@ export async function runOrchestration(
     } else {
       logInfo("No code entered — pair later via: openclaw pairing approve telegram <CODE>");
     }
-  }
-
-  if (enabledSteps?.has("whatsapp")) {
-    logStep("Linking WhatsApp — scan the QR code with your phone...");
-    logInfo("Open WhatsApp > Settings > Linked Devices > Link a Device");
-    process.stderr.write("\n");
-    const whatsappCmd = `source ~/.spawnrc 2>/dev/null; ${ocPath}; openclaw channels login --channel whatsapp`;
-    prepareStdinForHandoff();
-    await cloud.interactiveSession(whatsappCmd);
-    logInfo("WhatsApp linked! To pair a contact:");
-    logInfo("  1. Have someone message your WhatsApp number");
-    logInfo("  2. They'll get a pairing code from the bot");
-    logInfo("  3. Approve via: openclaw pairing approve whatsapp <CODE>");
   }
 
   // 11d. Agent-specific pre-launch tip (e.g. channel setup ordering hint)


### PR DESCRIPTION
## Summary
- Remove WhatsApp from setup options — too complex for normal users (QR scan + separate device + pairing)
- Nothing pre-selected in multiselect by default — let users opt in
- Clean up WhatsApp references from orchestrate.ts, agent-setup.ts, and tests

## Test plan
- [ ] Run `spawn openclaw digitalocean` — setup options show None, Chrome, Telegram, GitHub (no WhatsApp)
- [ ] Nothing is pre-selected, user must explicitly choose

🤖 Generated with [Claude Code](https://claude.com/claude-code)