### PR TITLE
fix(digitalocean): catch billing 403 thrown by doApi on droplet creation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/billing-guidance.test.ts
+++ b/packages/cli/src/__tests__/billing-guidance.test.ts
@@ -50,6 +50,20 @@ describe("isBillingError", () => {
       expect(isBillingError("digitalocean", "droplet limit reached")).toBe(false);
       expect(isBillingError("digitalocean", "region unavailable")).toBe(false);
     });
+
+    it("matches billing error embedded in doApi thrown error message (regression #2395)", () => {
+      // doApi throws: `DigitalOcean API error ${status} for ${method} ${endpoint}: ${body}`
+      // The response body contains the billing message — isBillingError must detect it.
+      const apiErr =
+        'DigitalOcean API error 403 for POST /droplets: {"id":"forbidden","message":"A payment on file is required to create resources."}';
+      expect(isBillingError("digitalocean", apiErr)).toBe(true);
+    });
+
+    it("returns false for non-billing 403 in doApi error format", () => {
+      const apiErr =
+        'DigitalOcean API error 403 for POST /droplets: {"id":"forbidden","message":"Droplet limit exceeded for this account."}';
+      expect(isBillingError("digitalocean", apiErr)).toBe(false);
+    });
   });
 
   describe("aws", () => {

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -917,11 +917,11 @@ export async function createServer(
 
   const body = JSON.stringify(dropletConfig);
 
-  const createText = await doApi("POST", "/droplets", body);
-  const createData = parseJsonObj(createText);
-
-  if (!createData?.droplet?.id) {
-    const errMsg = String(createData?.message || "Unknown error");
+  // Wrap in asyncTryCatch so billing-related 403 errors thrown by doApi()
+  // can be caught and handled before propagating as a generic "API error".
+  const createApiResult = await asyncTryCatch(() => doApi("POST", "/droplets", body));
+  if (!createApiResult.ok) {
+    const errMsg = createApiResult.error.message;
     logError(`Failed to create DigitalOcean droplet: ${errMsg}`);
 
     if (isBillingError("digitalocean", errMsg)) {
@@ -942,8 +942,7 @@ export async function createServer(
             cloud: "digitalocean",
           };
         }
-        const retryErr = String(retryData?.message || "Unknown error");
-        logError(`Retry failed: ${retryErr}`);
+        logError(`Retry failed: ${String(retryData?.message || "Unknown error")}`);
       }
     } else {
       showNonBillingError("digitalocean", [
@@ -951,6 +950,17 @@ export async function createServer(
         "Droplet limit reached (check account limits)",
       ]);
     }
+    throw new Error("Droplet creation failed");
+  }
+
+  const createData = parseJsonObj(createApiResult.data);
+
+  if (!createData?.droplet?.id) {
+    logError("Failed to create DigitalOcean droplet: unexpected API response");
+    showNonBillingError("digitalocean", [
+      "Region/size unavailable (try different DO_REGION or DO_DROPLET_SIZE)",
+      "Droplet limit reached (check account limits)",
+    ]);
     throw new Error("Droplet creation failed");
   }
 


### PR DESCRIPTION
## Root Cause

\`doApi()\` throws an \`Error\` on any non-2xx response (line 165 in \`digitalocean.ts\`). When \`POST /droplets\` returns a 403 (billing required), the error is thrown *before* the code at lines 927–928 can call \`isBillingError()\` + \`handleBillingError()\`. Those functions were dead code — unreachable for 403 errors.

Existing users with a saved token would see the raw \`DigitalOcean API error 403\` message and generic "Common causes" list instead of the billing-specific guidance with the billing page link.

## Fix

Wrap the \`doApi("POST", "/droplets", body)\` call in \`asyncTryCatch()\`. If it throws:
1. Check if the error message matches a billing pattern (the thrown error includes the response body)
2. If yes → call \`handleBillingError()\` with the billing URL + retry prompt
3. If no → call \`showNonBillingError()\` with diagnostics

The 2xx path still has a safety check for unexpected response shapes.

## Tests

- Added 2 regression tests to \`billing-guidance.test.ts\` verifying \`isBillingError()\` detects billing errors in the exact format that \`doApi\` throws them
- Full test suite: 1415 pass, 0 fail

Fixes #2395

Note: PR #2403 added the proactive first-time-user warning (which was correct). This PR fixes the separate regression where returning users with a saved token got no billing guidance on droplet creation failure.

-- refactor/issue-fixer