### PR TITLE
feat: rank agents by GitHub stars

### DIFF
--- a/.claude/skills/setup-agent-team/qa.sh
+++ b/.claude/skills/setup-agent-team/qa.sh
@@ -183,6 +183,18 @@ done
 
 log "Pre-cycle cleanup done."
 
+# --- Update GitHub star counts (quality mode only) ---
+if [[ "${RUN_MODE}" == "quality" ]]; then
+    log "Updating agent star counts..."
+    bash "${SCRIPT_DIR}/update-stars.sh" "${REPO_ROOT}" 2>&1 | tee -a "${LOG_FILE}" || true
+    if [[ -n "$(git diff --name-only -- manifest.json)" ]]; then
+        git add manifest.json
+        git commit -m "chore: update agent GitHub star counts" 2>&1 | tee -a "${LOG_FILE}" || true
+        git push origin main 2>&1 | tee -a "${LOG_FILE}" || true
+        log "Star counts committed"
+    fi
+fi
+
 # --- Load cloud credentials (quality + fixtures modes) ---
 if [[ "${RUN_MODE}" == "fixtures" ]] || [[ "${RUN_MODE}" == "quality" ]]; then
     if [[ -f "${REPO_ROOT}/sh/shared/key-request.sh" ]]; then

--- a/.claude/skills/setup-agent-team/update-stars.sh
+++ b/.claude/skills/setup-agent-team/update-stars.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eo pipefail
+
+# Update GitHub star counts in manifest.json
+# Called as a pre-step in the QA quality cycle — quick, no-op if gh is unavailable
+
+REPO_ROOT="${1:-.}"
+MANIFEST="${REPO_ROOT}/manifest.json"
+
+if [[ ! -f "${MANIFEST}" ]]; then
+    echo "[update-stars] manifest.json not found, skipping"
+    exit 0
+fi
+
+if ! command -v gh &>/dev/null; then
+    echo "[update-stars] gh CLI not available, skipping"
+    exit 0
+fi
+
+if ! command -v jq &>/dev/null; then
+    echo "[update-stars] jq not available, skipping"
+    exit 0
+fi
+
+TODAY=$(date -u +%Y-%m-%d)
+CHANGED=false
+
+for agent in $(jq -r '.agents | keys[]' "${MANIFEST}"); do
+    repo=$(jq -r ".agents[\"${agent}\"].repo // empty" "${MANIFEST}")
+    if [[ -z "${repo}" ]]; then
+        continue
+    fi
+
+    stars=$(gh api "repos/${repo}" --jq '.stargazers_count' 2>/dev/null || echo "")
+    if [[ -z "${stars}" ]] || [[ "${stars}" = "null" ]]; then
+        continue
+    fi
+
+    old_stars=$(jq -r ".agents[\"${agent}\"].github_stars // 0" "${MANIFEST}")
+    if [[ "${stars}" != "${old_stars}" ]]; then
+        echo "[update-stars] ${agent}: ${old_stars} → ${stars}"
+        CHANGED=true
+    fi
+
+    jq --arg agent "${agent}" \
+       --argjson stars "${stars}" \
+       --arg date "${TODAY}" \
+       '.agents[$agent].github_stars = $stars | .agents[$agent].stars_updated = $date' \
+       "${MANIFEST}" > "${MANIFEST}.tmp" && mv "${MANIFEST}.tmp" "${MANIFEST}"
+done
+
+if [[ "${CHANGED}" = "true" ]]; then
+    echo "[update-stars] Star counts updated"
+else
+    echo "[update-stars] No changes"
+fi

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.25",
+  "version": "0.12.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/manifest.ts
+++ b/packages/cli/src/manifest.ts
@@ -274,7 +274,7 @@ export async function loadManifest(forceRefresh = false): Promise<Manifest> {
 }
 
 export function agentKeys(m: Manifest): string[] {
-  return Object.keys(m.agents);
+  return Object.keys(m.agents).sort((a, b) => (m.agents[b].github_stars ?? 0) - (m.agents[a].github_stars ?? 0));
 }
 
 export function cloudKeys(m: Manifest): string[] {


### PR DESCRIPTION
## Summary
- Sort agent picker by `github_stars` descending — most popular agents appear first
- Add `update-stars.sh` script to the QA bot's quality sweep (every 4 hours) to keep star counts fresh
- Bump CLI version to 0.12.0

## Test plan
- [x] `bunx @biomejs/biome check` passes
- [x] `bun test` passes (2 pre-existing failures unrelated)
- [x] `bash -n` syntax check on modified scripts
- [ ] Verify agent picker shows agents sorted by popularity
- [ ] Verify QA quality sweep runs `update-stars.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)