### PR TITLE
fix: add junie to Docker build matrix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        agent: [claude, codex, openclaw, opencode, kilocode, zeroclaw, hermes]
+        agent: [claude, codex, openclaw, opencode, kilocode, zeroclaw, hermes, junie]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- The `junie.Dockerfile` was added in PR #2601 but the `docker.yml` workflow matrix was never updated to include `junie`
- As a result, no Docker image for junie (`ghcr.io/openrouterteam/spawn-junie`) was being built by the CI workflow
- Added `junie` to the `agent` matrix list so it builds alongside all other agents

## Test plan

- [ ] Verify `docker.yml` now includes `junie` in the matrix
- [ ] After merge, confirm the Docker workflow builds and pushes `ghcr.io/openrouterteam/spawn-junie:latest`

-- qa/code-quality