### PR TITLE
fix: preserve openclaw channel config across config set calls

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -426,21 +426,25 @@ async function setupOpenclawConfig(
     logWarn("Browser config setup failed (non-fatal)");
   }
 
-  // Re-assert gateway auth mode + token after browser config set calls — each `openclaw config set`
-  // does a read-modify-write on the config file and may drop fields written by uploadConfigFile.
-  // Re-setting both here ensures they survive those cycles and the gateway starts authenticated.
-  const gatewayTokenResult = await asyncTryCatchIf(isOperationalError, () =>
-    runner.runServer(
-      "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
-        "openclaw config set gateway.auth.mode token >/dev/null; " +
-        `openclaw config set gateway.auth.token ${shellQuote(gatewayToken)} >/dev/null`,
-    ),
-  );
-  if (!gatewayTokenResult.ok) {
-    logWarn("Gateway auth re-assertion failed (non-fatal) — dashboard may show Unauthorized");
+  // Re-upload our full config after `config set` calls — each `openclaw config set`
+  // does a read-modify-write that can drop fields (channels, gateway auth, etc.).
+  // Downloading first preserves any new fields `config set` added, then our
+  // configObj is deep-merged on top to restore channels and gateway auth.
+  const tmpRedownload = join(getTmpDir(), `spawn_occonfig_re_${Date.now()}`);
+  const reDlResult = await asyncTryCatch(() => runner.downloadFile("$HOME/.openclaw/openclaw.json", tmpRedownload));
+  let postSetConfig: Record<string, unknown> = {};
+  if (reDlResult.ok && existsSync(tmpRedownload)) {
+    const raw = readFileSync(tmpRedownload, "utf-8").trim();
+    if (raw) {
+      const parsed: unknown = JSON.parse(raw);
+      if (isPlainObject(parsed)) {
+        postSetConfig = parsed;
+      }
+    }
+    unlinkSync(tmpRedownload);
   }
-
-  // Channel pairing (Telegram) happens in orchestrate.ts after the gateway starts.
+  const finalConfig = deepMerge(postSetConfig, configObj);
+  await uploadConfigFile(runner, JSON.stringify(finalConfig, null, 2), "$HOME/.openclaw/openclaw.json");
 
   // Write USER.md bootstrap file
   const messagingLines: string[] = [];


### PR DESCRIPTION
## Summary
- `openclaw config set browser.*` and `gateway.*` calls each do a read-modify-write on the config file, dropping fields like `channels`
- This caused Telegram (and any future channels) to show as "raw mode" on spawned VMs despite the JSON being written correctly
- Fix: after all `config set` calls, re-download the config, deep-merge our full configObj on top, and re-upload — restoring channels and gateway auth in one shot

## Test plan
- [ ] Spawn openclaw with Telegram enabled, verify channel config survives setup
- [x] All 1410 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)