### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -194,6 +194,7 @@ const _state: AwsState = {
   keyPairName: "spawn-key",
 };
 
+/** Introspect internal state (used by tests). */
 export function getState() {
   return {
     awsRegion: _state.region,


### PR DESCRIPTION
## Summary

Code quality scan of the full codebase for dead code, stale references, python usage, duplicate utilities, and stale comments.

### Findings by category

**a) Dead code**: Scanned all exported functions in `packages/cli/src/` against their callers. Found one ambiguous case:
- `aws.getState()` — exported but has no callers in production code. Investigation revealed it IS used in `custom-flag.test.ts` for state introspection after calling `promptRegion()`. Added JSDoc to document this.

**b) Stale references**: None found. All shell script lib files exist, all TypeScript imports resolve, all cloud agent scripts exist for all matrix entries.

**c) Python usage**: None found in any shell scripts.

**d) Duplicate utilities**: `getCloudInitUserdata()` appears in aws, hetzner, and digitalocean modules, and `getStartupScript()` in gcp. Each has intentional per-cloud differences (AWS adds swap setup + ubuntu user; hetzner/do run as root; GCP uses metadata server). Not candidates for consolidation.

**e) Stale comments**: None found.

### Files modified
- `packages/cli/src/aws/aws.ts` — added JSDoc to `getState()` clarifying it is a test introspection helper

### Verification
- `bunx @biomejs/biome check src/` → 0 errors
- `bun test` → 1410 pass, 0 fail

-- qa/code-quality