### PR TITLE
fix: write channel stubs in openclaw config for dashboard

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.18.8",
+  "version": "0.18.9",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -418,6 +418,17 @@ async function setupOpenclawConfig(
     logWarn("Browser config setup failed (non-fatal)");
   }
 
+  // Write channel stubs so the dashboard renders channel cards properly,
+  // even when the user hasn't configured them yet. Without stubs the
+  // dashboard shows "Unsupported type: . Use Raw mode."
+  await asyncTryCatchIf(isOperationalError, () =>
+    runner.runServer(
+      "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
+        "openclaw config set channels.telegram.enabled false >/dev/null; " +
+        "openclaw config set channels.whatsapp.enabled false >/dev/null",
+    ),
+  );
+
   // Configure Telegram channel if a bot token was provided
   if (telegramBotToken) {
     const telegramResult = await asyncTryCatchIf(isOperationalError, () =>


### PR DESCRIPTION
## Summary
- Writes `channels.telegram.enabled = false` and `channels.whatsapp.enabled = false` during setup
- This gives the OpenClaw dashboard proper channel entries to render instead of "Unsupported type: . Use Raw mode"
- If the user provided a Telegram bot token, the stub is overwritten with the full config immediately after

## Test plan
- [ ] Spawn openclaw without selecting Telegram, verify dashboard shows proper channel cards
- [x] All 1417 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)