### PR TITLE
fix: enable channel stubs so dashboard renders properly

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -424,8 +424,8 @@ async function setupOpenclawConfig(
   await asyncTryCatchIf(isOperationalError, () =>
     runner.runServer(
       "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
-        "openclaw config set channels.telegram.enabled false >/dev/null; " +
-        "openclaw config set channels.whatsapp.enabled false >/dev/null",
+        "openclaw config set channels.telegram.enabled true >/dev/null; " +
+        "openclaw config set channels.whatsapp.enabled true >/dev/null",
     ),
   );
 


### PR DESCRIPTION
## Summary
- Changes channel stubs from `enabled: false` to `enabled: true`
- OpenClaw channel extensions only load and register their UI schemas when `enabled: true`
- With `enabled: false` (#2657), the dashboard still shows "Unsupported type: . Use Raw mode"

## Test plan
- [ ] Spawn openclaw, verify Telegram and WhatsApp channel cards render with proper forms in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)