### PR TITLE
feat: add custom model selection to all agents

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.18.10",
+  "version": "0.19.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -726,6 +726,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
     kilocode: {
       name: "Kilo Code",
       cloudInitTier: "node",
+      modelEnvVar: "KILOCODE_MODEL",
       preProvision: detectGithubAuth,
       install: () =>
         installAgent(
@@ -744,6 +745,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
     zeroclaw: {
       name: "ZeroClaw",
       cloudInitTier: "minimal",
+      modelEnvVar: "ZEROCLAW_MODEL",
       preProvision: detectGithubAuth,
       install: async () => {
         // Direct binary install from pinned release (v0.1.9a "latest" has no assets,
@@ -774,6 +776,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
     hermes: {
       name: "Hermes Agent",
       cloudInitTier: "minimal",
+      modelEnvVar: "LLM_MODEL",
       preProvision: detectGithubAuth,
       install: () =>
         installAgent(
@@ -794,6 +797,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
     junie: {
       name: "Junie",
       cloudInitTier: "node",
+      modelEnvVar: "JUNIE_MODEL",
       preProvision: detectGithubAuth,
       install: () =>
         installAgent(

--- a/packages/cli/src/shared/agents.ts
+++ b/packages/cli/src/shared/agents.ts
@@ -22,6 +22,8 @@ export interface AgentConfig {
   name: string;
   /** Default model ID passed to configure() (no interactive prompt — override via MODEL_ID env var). */
   modelDefault?: string;
+  /** Env var name for setting the model on the remote (e.g. ZEROCLAW_MODEL, LLM_MODEL). */
+  modelEnvVar?: string;
   /** Pre-provision hook (runs before server creation, e.g., prompt for GitHub auth). */
   preProvision?: () => Promise<void>;
   /** Install the agent on the remote machine. */
@@ -66,11 +68,6 @@ const AGENT_EXTRA_STEPS: Record<string, OptionalStep[]> = {
       hint: "connect via bot token from @BotFather",
       dataEnvVar: "TELEGRAM_BOT_TOKEN",
     },
-    {
-      value: "custom-model",
-      label: "Custom model",
-      hint: "enter an OpenRouter model ID manually",
-    },
   ],
 };
 
@@ -85,6 +82,11 @@ const COMMON_STEPS: OptionalStep[] = [
     value: "reuse-api-key",
     label: "Reuse saved OpenRouter key",
     hint: "off = create a fresh key via OAuth",
+  },
+  {
+    value: "custom-model",
+    label: "Custom model",
+    hint: "enter an OpenRouter model ID manually",
   },
 ];
 

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -174,7 +174,12 @@ export async function runOrchestration(
   // 7. Wait for readiness
   await cloud.waitForReady();
 
-  const envContent = generateEnvConfig(agent.envVars(apiKey));
+  const envPairs = agent.envVars(apiKey);
+  // Inject agent-specific model env var when a custom model is selected
+  if (modelId && agent.modelEnvVar) {
+    envPairs.push(`${agent.modelEnvVar}=${modelId}`);
+  }
+  const envContent = generateEnvConfig(envPairs);
 
   // 8. Install agent (skip entirely for snapshot boots, try tarball first on cloud VMs)
   if (cloud.skipAgentInstall) {


### PR DESCRIPTION
## Summary
- Moves "Custom model" from OpenClaw-only to **common setup steps** — every agent now shows it in the setup menu
- Adds `modelEnvVar` field to `AgentConfig` for agents that support model override via env var
- When a custom model is entered, the agent-specific env var is injected into `.spawnrc`:

| Agent | Env Var |
|-------|---------|
| Kilo Code | `KILOCODE_MODEL` |
| ZeroClaw | `ZEROCLAW_MODEL` |
| Hermes | `LLM_MODEL` |
| Junie | `JUNIE_MODEL` |
| OpenClaw | Uses `configure()` path (unchanged) |
| Claude | No env var (routes via Anthropic) |
| Codex | No env var (uses config.toml) |
| OpenCode | No env var (uses config file) |

## Test plan
- [x] All 1417 tests pass, lint clean
- [ ] Spawn kilocode/hermes/junie/zeroclaw with custom model, verify env var is in `.spawnrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)