### PR TITLE
fix: allow empty string values for CLI flags like --steps ""

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -60,7 +60,7 @@ function extractFlagValue(
     ];
   }
 
-  if (!args[idx + 1] || args[idx + 1].startsWith("-")) {
+  if (args[idx + 1] === undefined || args[idx + 1].startsWith("-")) {
     console.error(pc.red(`Error: ${pc.bold(args[idx])} requires a value`));
     console.error(`\nUsage: ${pc.cyan(usageHint)}`);
     process.exit(1);
@@ -82,7 +82,7 @@ function extractAllFlagValues(args: string[], flag: string, usageHint: string): 
   const values: string[] = [];
   let idx = args.indexOf(flag);
   while (idx !== -1) {
-    if (!args[idx + 1] || args[idx + 1].startsWith("-")) {
+    if (args[idx + 1] === undefined || args[idx + 1].startsWith("-")) {
       console.error(pc.red(`Error: ${pc.bold(flag)} requires a value`));
       console.error(`\nUsage: ${pc.cyan(usageHint)}`);
       process.exit(1);


### PR DESCRIPTION
Fix `extractFlagValue()` using `!args[idx + 1]` which treated empty strings as missing values. Changed to `args[idx + 1] === undefined` so `--steps ""` works as documented.

Fixes #2661

-- refactor/issue-fixer