### PR TITLE
refactor: remove dead code and stale references

### DIFF
--- a/packages/cli/src/shared/parse.ts
+++ b/packages/cli/src/shared/parse.ts
@@ -1,27 +1,5 @@
 export { parseJsonObj, parseJsonWith } from "@openrouter/spawn-shared";
 
-import { isPlainObject } from "@openrouter/spawn-shared";
-
-/**
- * Recursively deep-merge `source` into `target`, returning a new object.
- * Arrays and non-plain-objects are overwritten (not merged).
- */
-export function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {
-    ...target,
-  };
-  for (const key of Object.keys(source)) {
-    const tVal = target[key];
-    const sVal = source[key];
-    if (isPlainObject(tVal) && isPlainObject(sVal)) {
-      result[key] = deepMerge(tVal, sVal);
-    } else {
-      result[key] = sVal;
-    }
-  }
-  return result;
-}
-
 // CLI-specific schema — not in shared package
 import * as v from "valibot";
 


### PR DESCRIPTION
## Summary

- Removes the unused `deepMerge` function export from `packages/cli/src/shared/parse.ts`
- This function was defined and exported but never imported or called from any other module
- Biome linter confirms it as an unused variable (`noUnusedVariables`)
- Also removes the now-unused `isPlainObject` import that was only used by `deepMerge`

## Scan Results

**a) Dead code in sh/shared/ and packages/cli/src/**
- `deepMerge` in `shared/parse.ts`: exported but never imported by any other module — **removed**
- All other apparent "dead exports" (generateCodeVerifier, startGateway, ssh-keys helpers) are imported by test files — **not dead, kept**
- Internal shell functions in `key-request.sh` and `github-auth.sh` are all used within their respective files as intended

**b) Stale references**: No stale references found. All shell scripts correctly reference existing CDN paths and all TypeScript imports resolve to existing files.

**c) Python usage**: None found. All shell scripts correctly use `bun -e` or `jq` for inline scripting.

**d) Duplicate utilities**: Cloud-specific functions (`getServerName`, `promptSpawnName`, etc.) are intentionally duplicated per-cloud with cloud-specific env var names — not candidates for shared extraction.

**e) Stale comments**: The DigitalOcean PKCE TODO comment (`digitalocean.ts:78`) is current and actionable — kept as-is.

## Test plan
- [x] `bunx @biomejs/biome check packages/cli/src/` — 0 errors
- [x] `bun test` — 1417 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)