### PR TITLE
fix(cli): replace "spawn update" launch hint with "spawn feedback"

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -462,7 +462,7 @@ function showVersion(): void {
   const age = getCacheAge();
   console.log(pc.dim(`  manifest cache: ${formatCacheAge(age)}`));
   console.log(pc.dim("  https://github.com/OpenRouterTeam/spawn"));
-  console.log(pc.dim(`  Run ${pc.cyan("spawn update")} to check for updates.`));
+  console.log(pc.dim(`  Run ${pc.cyan("spawn feedback")} to tell us what to improve.`));
 }
 
 const IMMEDIATE_COMMANDS: Record<string, () => void> = {


### PR DESCRIPTION
## Summary

Replace the startup banner message:

**Before:**
```
Run `spawn update` to check for updates.
```

**After:**
```
Run `spawn feedback` to tell us what to improve.
```

**Change:** Single line in `packages/cli/src/index.ts` (line 465)

**Version bump:** `0.19.0` → `0.19.1` (patch, per CLI version policy)

Fixes #2664

---

**Tests:** 1417 pass, 0 fail
**Lint:** `biome check` — 0 errors

-- refactor/issue-fixer