### PR TITLE
feat(openclaw): add channel selection to setup options

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -446,13 +446,21 @@ async function setupOpenclawConfig(
   // Write channel stubs so the dashboard renders channel cards properly,
   // even when the user hasn't configured them yet. Without stubs the
   // dashboard shows "Unsupported type: . Use Raw mode."
-  await asyncTryCatchIf(isOperationalError, () =>
-    runner.runServer(
-      "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
-        "openclaw config set channels.telegram.enabled true >/dev/null; " +
-        "openclaw config set channels.whatsapp.enabled true >/dev/null",
-    ),
-  );
+  const channelNames = [
+    "telegram",
+    "whatsapp",
+    "discord",
+    "slack",
+    "signal",
+    "googlechat",
+    "bluebubbles",
+  ].filter((ch) => !enabledSteps || enabledSteps.has(ch));
+  if (channelNames.length > 0) {
+    const stubCmds = channelNames.map((ch) => `openclaw config set channels.${ch}.enabled true >/dev/null`).join("; ");
+    await asyncTryCatchIf(isOperationalError, () =>
+      runner.runServer("export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " + stubCmds),
+    );
+  }
 
   // Configure Telegram channel if a bot token was provided
   if (telegramBotToken) {

--- a/packages/cli/src/shared/agents.ts
+++ b/packages/cli/src/shared/agents.ts
@@ -68,6 +68,36 @@ const AGENT_EXTRA_STEPS: Record<string, OptionalStep[]> = {
       hint: "connect via bot token from @BotFather",
       dataEnvVar: "TELEGRAM_BOT_TOKEN",
     },
+    {
+      value: "whatsapp",
+      label: "WhatsApp",
+      hint: "link via QR code after launch",
+    },
+    {
+      value: "discord",
+      label: "Discord",
+      hint: "connect via bot token",
+    },
+    {
+      value: "slack",
+      label: "Slack",
+      hint: "connect via bot + app tokens",
+    },
+    {
+      value: "signal",
+      label: "Signal",
+      hint: "link via signal-cli",
+    },
+    {
+      value: "googlechat",
+      label: "Google Chat",
+      hint: "connect via webhook",
+    },
+    {
+      value: "bluebubbles",
+      label: "BlueBubbles",
+      hint: "iMessage bridge via BlueBubbles server",
+    },
   ],
 };
 


### PR DESCRIPTION
## Summary

- Add 5 new channels to OpenClaw's multi-select setup options: **BlueBubbles**, **Discord**, **Slack**, **Signal**, **Google Chat**
- Selected channels get `enabled: true` stubs via `openclaw config set`, fixing the dashboard "Unsupported type: . Use Raw mode." error for those channels
- Channel stubs are now gated by user selection — only checked channels get stubbed (previously telegram + whatsapp were always hardcoded)
- Bump CLI version 0.19.2 → 0.19.3

## Test plan

- [x] `bunx @biomejs/biome check packages/cli/src/` — 0 errors
- [x] `bun test` — 1417 pass, 0 fail
- [ ] Manual: run `spawn` with openclaw → verify new channel options appear in setup multi-select
- [ ] Manual: select channels → verify dashboard shows channel cards for selected channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)