### PR TITLE
fix(github-auth): always run gh setup when user explicitly opts in

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -257,11 +257,11 @@ async function detectGithubAuth(): Promise<void> {
   hostGitEmail = readHostGitConfig("user.email");
 }
 
-export async function offerGithubAuth(runner: CloudRunner): Promise<void> {
+export async function offerGithubAuth(runner: CloudRunner, explicitlyRequested?: boolean): Promise<void> {
   if (process.env.SPAWN_SKIP_GITHUB_AUTH) {
     return;
   }
-  if (!githubAuthRequested) {
+  if (!githubAuthRequested && !explicitlyRequested) {
     return;
   }
 

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -250,7 +250,9 @@ export async function runOrchestration(
 
   // GitHub CLI setup (skip if user unchecked in setup options)
   if (!enabledSteps || enabledSteps.has("github")) {
-    await offerGithubAuth(cloud.runner);
+    // Pass explicitlyRequested=true when user opted in via setup options so the
+    // step always runs even if no local gh token was found during detectGithubAuth.
+    await offerGithubAuth(cloud.runner, enabledSteps?.has("github"));
   }
 
   // 11. Pre-launch hooks (e.g. OpenClaw gateway)


### PR DESCRIPTION
## Summary

When the user selects the GitHub CLI step in setup options (interactive prompt or `--steps github`), `offerGithubAuth()` was silently returning early if no local gh token was found. This made the step unreachable for users without `gh` installed — exactly who the step is designed to help.

**Root cause:** Two independent guards, both required to pass:
1. `orchestrate.ts:252` — checks `enabledSteps.has("github")` ✅
2. `agent-setup.ts:264` — checks `githubAuthRequested` ❌ (silently blocks if no local token)

`githubAuthRequested` is only set to `true` when a token is detected locally. Users without `gh` installed or not authenticated get `githubAuthRequested = false` → silent skip.

## Fix

- Added `explicitlyRequested?: boolean` parameter to `offerGithubAuth()`
- Guard is now `!githubAuthRequested && !explicitlyRequested` — either condition unblocks the step
- `orchestrate.ts` passes `enabledSteps?.has("github")` as `explicitlyRequested`
- When `enabledSteps` is `undefined` (run all steps), existing auto-detection behavior is preserved

`detectGithubAuth()` still auto-enables the step for token forwarding (convenience), but can no longer silently block a user-explicit request.

Fixes #2672

## Test plan
- [ ] All 1417 existing tests pass (`bun test`)
- [ ] Biome lint clean (`bunx @biomejs/biome check`)
- [ ] User with no local `gh` and `--steps github`: step runs and installs gh on remote
- [ ] User with local `gh` token: token forwarded as before
- [ ] Default flow (no `--steps` flag): auto-detection behavior unchanged

-- refactor/issue-fixer