### PR TITLE
fix(ui): remove confusing None checkbox from setup options

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -152,9 +152,6 @@ function hasLocalGithubToken(): boolean {
   );
 }
 
-/** Sentinel value for the "None" option in the setup options multiselect. */
-const NONE_STEP = "__none__";
-
 /**
  * Show a multiselect prompt for optional post-provision setup steps.
  * Returns a Set of enabled step values, or undefined if there are no steps.
@@ -173,26 +170,13 @@ async function promptSetupOptions(agentName: string): Promise<Set<string> | unde
     return undefined;
   }
 
-  // Nothing pre-selected — let users opt in to what they want
-  const defaultValues = [
-    NONE_STEP,
-  ];
-
   const selected = await p.multiselect({
-    message: "Setup options (↑/↓ navigate, space to select, enter to confirm)",
-    options: [
-      {
-        value: NONE_STEP,
-        label: "None",
-        hint: "skip all setup steps",
-      },
-      ...filteredSteps.map((s) => ({
-        value: s.value,
-        label: s.label,
-        hint: s.hint,
-      })),
-    ],
-    initialValues: defaultValues,
+    message: "Setup options (↑/↓ navigate, space=toggle, a=all, enter=confirm)",
+    options: filteredSteps.map((s) => ({
+      value: s.value,
+      label: s.label,
+      hint: s.hint,
+    })),
     required: false,
   });
 
@@ -200,9 +184,7 @@ async function promptSetupOptions(agentName: string): Promise<Set<string> | unde
     return new Set<string>();
   }
 
-  // Strip the "None" sentinel — it carries no real step value
-  const realSteps = selected.filter((v) => v !== NONE_STEP);
-  const stepSet = new Set(realSteps);
+  const stepSet = new Set(selected);
 
   // If user selected "Custom model", prompt for the model ID and set MODEL_ID env
   if (stepSet.has("custom-model")) {


### PR DESCRIPTION
## Summary

- Remove the "None" sentinel checkbox from the setup options multiselect
- It stayed checked alongside real selections, making it look like "None" was also selected
- The multiselect already supports submitting with nothing selected (`required: false`), so the sentinel was unnecessary

## Test plan

- [x] `bunx @biomejs/biome check packages/cli/src/` — 0 errors
- [x] `bun test` — 1417 pass, 0 fail
- [ ] Manual: run `spawn` → setup options should show only real options, no "None"

🤖 Generated with [Claude Code](https://claude.com/claude-code)