### PR TITLE
fix(security): add AWS secret key validation and harden path traversal check

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/aws.test.ts
+++ b/packages/cli/src/__tests__/aws.test.ts
@@ -65,12 +65,26 @@ describe("aws/credential-cache", () => {
       expect(loadCredsFromConfig()).toBeNull();
     });
 
+    it("returns null when secretAccessKey has invalid format", async () => {
+      await Bun.write(
+        getAwsConfigPath(),
+        JSON.stringify({
+          accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+          secretAccessKey: "has spaces and $pecial chars!!!!!!!!!!",
+        }),
+        {
+          mode: 0o600,
+        },
+      );
+      expect(loadCredsFromConfig()).toBeNull();
+    });
+
     it("returns null for invalid accessKeyId format", async () => {
       await Bun.write(
         getAwsConfigPath(),
         JSON.stringify({
           accessKeyId: "invalid key!",
-          secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCY",
+          secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         }),
         {
           mode: 0o600,
@@ -84,7 +98,7 @@ describe("aws/credential-cache", () => {
         getAwsConfigPath(),
         JSON.stringify({
           accessKeyId: "AKIAIOSFODNN7EXAMPLE",
-          secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCY",
+          secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
           region: "eu-west-1",
         }),
         {
@@ -94,7 +108,7 @@ describe("aws/credential-cache", () => {
       const result = loadCredsFromConfig();
       expect(result).not.toBeNull();
       expect(result?.accessKeyId).toBe("AKIAIOSFODNN7EXAMPLE");
-      expect(result?.secretAccessKey).toBe("wJalrXUtnFEMI/K7MDENG/bPxRfiCY");
+      expect(result?.secretAccessKey).toBe("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
       expect(result?.region).toBe("eu-west-1");
     });
 
@@ -103,7 +117,7 @@ describe("aws/credential-cache", () => {
         getAwsConfigPath(),
         JSON.stringify({
           accessKeyId: "AKIAIOSFODNN7EXAMPLE",
-          secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCY",
+          secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         }),
         {
           mode: 0o600,
@@ -119,10 +133,10 @@ describe("aws/credential-cache", () => {
       if (existsSync(getAwsConfigPath())) {
         unlinkSync(getAwsConfigPath());
       }
-      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCY", "us-west-2");
+      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "us-west-2");
       const result = loadCredsFromConfig();
       expect(result?.accessKeyId).toBe("AKIAIOSFODNN7EXAMPLE");
-      expect(result?.secretAccessKey).toBe("wJalrXUtnFEMI/K7MDENG/bPxRfiCY");
+      expect(result?.secretAccessKey).toBe("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
       expect(result?.region).toBe("us-west-2");
     });
 
@@ -130,15 +144,15 @@ describe("aws/credential-cache", () => {
       if (existsSync(getAwsConfigPath())) {
         unlinkSync(getAwsConfigPath());
       }
-      const secret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCY==";
+      const secret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEX/mpp+k==";
       await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE", secret, "ap-northeast-1");
       const result = loadCredsFromConfig();
       expect(result?.secretAccessKey).toBe(secret);
     });
 
     it("overwrites existing config file", async () => {
-      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCY", "us-east-1");
-      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE2", "newSecretKeyNewSecretKey1234567", "eu-central-1");
+      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "us-east-1");
+      await saveCredsToConfig("AKIAIOSFODNN7EXAMPLE2", "newSecretKeyNewSecretKey1234567123456789", "eu-central-1");
       const result = loadCredsFromConfig();
       expect(result?.accessKeyId).toBe("AKIAIOSFODNN7EXAMPLE2");
       expect(result?.region).toBe("eu-central-1");

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -5,6 +5,7 @@ import type { CloudInitTier } from "../shared/agents";
 
 import { createHash, createHmac } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { normalize } from "node:path";
 import { getErrorMessage } from "@openrouter/spawn-shared";
 import * as v from "valibot";
 import { handleBillingError, isBillingError, showNonBillingError } from "../shared/billing-guidance";
@@ -52,6 +53,11 @@ const AwsCredsSchema = v.object({
   region: v.optional(v.string()),
 });
 
+/** Validate that an AWS secret access key matches the expected 40-char base64 format. */
+function validateAwsSecretKey(key: string): boolean {
+  return /^[A-Za-z0-9/+=]{40}$/.test(key);
+}
+
 export async function saveCredsToConfig(accessKeyId: string, secretAccessKey: string, region: string): Promise<void> {
   const configPath = getAwsConfigPath();
   const dir = configPath.replace(/\/[^/]+$/, "");
@@ -80,7 +86,7 @@ export function loadCredsFromConfig(): {
       if (!/^[A-Za-z0-9/+]{16,128}$/.test(data.accessKeyId)) {
         return null;
       }
-      if (data.secretAccessKey.length < 16) {
+      if (!validateAwsSecretKey(data.secretAccessKey)) {
         return null;
       }
       return {
@@ -306,6 +312,9 @@ async function awsCli(args: string[]): Promise<string> {
 async function lightsailRest(target: string, body = "{}"): Promise<string> {
   if (!_state.accessKeyId || !_state.secretAccessKey) {
     throw new Error("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set for REST API calls");
+  }
+  if (!validateAwsSecretKey(_state.secretAccessKey)) {
+    throw new Error("AWS secret access key has invalid format: expected 40 characters matching /^[A-Za-z0-9/+=]{40}$/");
   }
 
   const region = _state.region;
@@ -1121,10 +1130,11 @@ export async function runServer(cmd: string, timeoutSecs?: number): Promise<void
 }
 
 export async function uploadFile(localPath: string, remotePath: string): Promise<void> {
+  const normalizedRemote = normalize(remotePath);
   if (
-    !/^[a-zA-Z0-9/_.~-]+$/.test(remotePath) ||
-    remotePath.includes("..") ||
-    remotePath.split("/").some((s) => s.startsWith("-"))
+    !/^[a-zA-Z0-9/_.~-]+$/.test(normalizedRemote) ||
+    normalizedRemote.includes("..") ||
+    normalizedRemote.split("/").some((s) => s.startsWith("-"))
   ) {
     throw new Error(`Invalid remote path: ${remotePath}`);
   }
@@ -1157,10 +1167,11 @@ export async function uploadFile(localPath: string, remotePath: string): Promise
 }
 
 export async function downloadFile(remotePath: string, localPath: string): Promise<void> {
+  const normalizedRemote = normalize(remotePath);
   if (
-    !/^[a-zA-Z0-9/_.~$-]+$/.test(remotePath) ||
-    remotePath.includes("..") ||
-    remotePath.split("/").some((s) => s.startsWith("-"))
+    !/^[a-zA-Z0-9/_.~$-]+$/.test(normalizedRemote) ||
+    normalizedRemote.includes("..") ||
+    normalizedRemote.split("/").some((s) => s.startsWith("-"))
   ) {
     throw new Error(`Invalid remote path: ${remotePath}`);
   }


### PR DESCRIPTION
**Why:** Fixes [CRITICAL] and [HIGH] security vulnerabilities — missing AWS secret key format validation allows malformed keys in HMAC operations, and path traversal check can have edge cases with path normalization.

## Changes
- Add `validateAwsSecretKey()` function validating key is 40 chars matching `/^[A-Za-z0-9/+=]{40}$/`
- Validate secret key in `loadCredsFromConfig()` and before HMAC operations in `lightsailRest()`
- Add `normalize()` from `node:path` to canonicalize paths before traversal check in `uploadFile()` and `downloadFile()`
- Update test fixtures to use properly-formatted 40-char mock secret keys
- Add new test for invalid secret key format rejection

Fixes #2686
Fixes #2687

-- refactor/security-auditor