### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/cloud-init.test.ts
+++ b/packages/cli/src/__tests__/cloud-init.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getPackagesForTier, NODE_INSTALL_CMD, needsBun, needsNode } from "../shared/cloud-init.js";
+import { getPackagesForTier, needsBun, needsNode } from "../shared/cloud-init.js";
 
 describe("getPackagesForTier", () => {
   const MINIMAL_PACKAGES = [
@@ -111,12 +111,5 @@ describe("needsBun", () => {
   }
   it("defaults to true (full tier)", () => {
     expect(needsBun()).toBe(true);
-  });
-});
-
-describe("NODE_INSTALL_CMD", () => {
-  it("is a curl-based install command targeting Node 22", () => {
-    expect(NODE_INSTALL_CMD).toContain("curl");
-    expect(NODE_INSTALL_CMD).toContain("22");
   });
 });

--- a/packages/cli/src/__tests__/paths.test.ts
+++ b/packages/cli/src/__tests__/paths.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   getCacheDir,
@@ -32,9 +32,11 @@ describe("paths", () => {
       expect(getUserHome()).toBe("/custom/home");
     });
 
-    it("falls back to os.homedir() when HOME is unset", () => {
+    it("falls back to a non-empty string when HOME is unset", () => {
       delete process.env.HOME;
-      expect(getUserHome()).toBe(homedir());
+      const result = getUserHome();
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- **Removed theatrical test**: `cloud-init.test.ts` — the `NODE_INSTALL_CMD` describe block only checked that a hardcoded string constant contained `"curl"` and `"22"`. This is a string snapshot, not a behavioral test — it provides no signal about whether the install command actually works.

- **Fixed banned `homedir` import**: `paths.test.ts` imported `{ homedir }` from `node:os`, which is explicitly banned by the testing rules. Named imports of `homedir()` bypass the preload sandbox mock (`os.homedir` default-export patch returns the sandboxed temp dir, but named imports capture the native binding which always returns the real home). Fixed by:
  1. Removing the import
  2. Replacing the `"falls back to os.homedir() when HOME is unset"` test with a behavioral assertion — the result is a non-empty string — instead of comparing against the bypassed `homedir()` call

## Test plan

- [x] `bun test` — 1420 pass, 0 fail (1 fewer than before = the removed theatrical test)
- [x] `bunx @biomejs/biome check` — no errors on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)