### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/script-failure-guidance.test.ts
+++ b/packages/cli/src/__tests__/script-failure-guidance.test.ts
@@ -380,11 +380,6 @@ describe("getSignalGuidance", () => {
       const joined = lines.join("\n");
       expect(joined).toContain("SIGUSR1");
     });
-
-    it("should always return a non-empty array", () => {
-      const lines = getSignalGuidance("SIGFOO");
-      expect(lines.length).toBeGreaterThan(0);
-    });
   });
 
   describe("signal output uniqueness", () => {
@@ -500,23 +495,34 @@ describe("dashboard URL in guidance", () => {
       expect(joined).toContain("dashboard");
     });
 
-    it("should include dashboard URL for exit code 130 when provided", () => {
-      const lines = getScriptFailureGuidance(130, "sprite", undefined, "https://sprite.sh");
-      const joined = lines.join("\n");
-      expect(joined).toContain("https://sprite.sh");
-      expect(joined).toContain("dashboard");
-    });
-
-    it("should include dashboard URL for exit code 137 when provided", () => {
-      const lines = getScriptFailureGuidance(137, "vultr", undefined, "https://my.vultr.com/");
-      const joined = lines.join("\n");
-      expect(joined).toContain("https://my.vultr.com/");
-    });
-
-    it("should include dashboard URL for default exit code when provided", () => {
-      const lines = getScriptFailureGuidance(42, "digitalocean", undefined, "https://cloud.digitalocean.com/");
-      const joined = lines.join("\n");
-      expect(joined).toContain("https://cloud.digitalocean.com/");
+    it("should include dashboard URL for all supported exit codes when provided", () => {
+      const cases: Array<
+        [
+          number,
+          string,
+          string,
+        ]
+      > = [
+        [
+          130,
+          "sprite",
+          "https://sprite.sh",
+        ],
+        [
+          137,
+          "vultr",
+          "https://my.vultr.com/",
+        ],
+        [
+          42,
+          "digitalocean",
+          "https://cloud.digitalocean.com/",
+        ],
+      ];
+      for (const [code, cloud, url] of cases) {
+        const joined = getScriptFailureGuidance(code, cloud, undefined, url).join("\n");
+        expect(joined, `exit code ${code}`).toContain(url);
+      }
     });
 
     it("should fall back to generic message when no dashboardUrl", () => {
@@ -548,16 +554,20 @@ describe("dashboard URL in guidance", () => {
       expect(joined).toContain("dashboard");
     });
 
-    it("should include dashboard URL for SIGTERM when provided", () => {
-      const lines = getSignalGuidance("SIGTERM", "https://my.vultr.com/");
-      const joined = lines.join("\n");
-      expect(joined).toContain("https://my.vultr.com/");
-    });
-
-    it("should include dashboard URL for SIGINT when provided", () => {
-      const lines = getSignalGuidance("SIGINT", "https://cloud.digitalocean.com/");
-      const joined = lines.join("\n");
-      expect(joined).toContain("https://cloud.digitalocean.com/");
+    it("should include dashboard URL for SIGTERM and SIGINT when provided", () => {
+      for (const [signal, url] of [
+        [
+          "SIGTERM",
+          "https://my.vultr.com/",
+        ],
+        [
+          "SIGINT",
+          "https://cloud.digitalocean.com/",
+        ],
+      ] as const) {
+        const joined = getSignalGuidance(signal, url).join("\n");
+        expect(joined, signal).toContain(url);
+      }
     });
 
     it("should fall back to generic message when no dashboardUrl", () => {


### PR DESCRIPTION
## Summary

- **Consolidated** 3 identical per-exit-code dashboard URL tests (exit codes 130, 137, and 42) into a single data-driven loop in `script-failure-guidance.test.ts` — all three were just checking that a URL string appears in output, using different exit codes and cloud names as decoration
- **Merged** 2 duplicate per-signal dashboard URL tests (SIGTERM and SIGINT) into one data-driven loop — same pattern: each just checked `url in output`
- **Removed** a weak always-true test (`"should always return a non-empty array"`) that was immediately redundant with the test above it (`"should show the signal name for unknown signals"` — which already verifies non-empty output via `toContain`)

Net: 4 fewer tests (1420 → 1416), no coverage loss, same `expect()` call coverage on meaningful assertions.

## Test plan

- [x] `bun test` passes with 1416 tests and 0 failures
- [x] `bunx @biomejs/biome check src/` passes with zero errors

-- qa/dedup-scanner