### PR TITLE
fix(sprite): replace personal VM URL with official CDN for keep-alive script

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/sprite-keep-alive.test.ts
+++ b/packages/cli/src/__tests__/sprite-keep-alive.test.ts
@@ -83,7 +83,9 @@ describe("installSpriteKeepAlive", () => {
 
     await installSpriteKeepAlive();
 
-    expect(capturedCmds.some((cmd) => cmd.includes("kurt-claw-f.sprites.app/sprite-keep-running.sh"))).toBe(true);
+    expect(capturedCmds.some((cmd) => cmd.includes("openrouter.ai/labs/spawn/shared/sprite-keep-running.sh"))).toBe(
+      true,
+    );
     expect(capturedCmds.some((cmd) => cmd.includes("sprite-keep-running"))).toBe(true);
     expect(capturedCmds.some((cmd) => cmd.includes(".local/bin/sprite-keep-running"))).toBe(true);
     expect(capturedCmds.some((cmd) => cmd.includes("chmod +x"))).toBe(true);

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -610,11 +610,10 @@ export async function downloadFileSprite(remotePath: string, localPath: string):
  * as long as the agent is running — preventing inactivity shutdown.
  *
  * Non-fatal: logs a warning if download fails so deployment still proceeds.
- * Reference: https://kurt-claw-f.sprites.app/sprite-keep-running.sh
  */
 export async function installSpriteKeepAlive(): Promise<void> {
   logStep("Installing Sprite keep-alive...");
-  const scriptUrl = "https://kurt-claw-f.sprites.app/sprite-keep-running.sh";
+  const scriptUrl = "https://openrouter.ai/labs/spawn/shared/sprite-keep-running.sh";
   const keepAliveResult = await asyncTryCatch(() =>
     runSprite(
       "mkdir -p ~/.local/bin && " +


### PR DESCRIPTION
## Summary
- Replace hardcoded personal VM URL (`kurt-claw-f.sprites.app/sprite-keep-running.sh`) with the official CDN proxy (`openrouter.ai/labs/spawn/shared/sprite-keep-running.sh`) in `installSpriteKeepAlive()`
- Update the corresponding test assertion to expect the new URL
- Bump CLI version to 0.20.7

## Why
The keep-alive script download URL pointed to a personal Sprite VM that could go offline at any time, breaking all Sprite deployments. The official CDN proxy is the correct URL per project conventions.

Fixes #2699

## Test plan
- [x] `bun test` — 1434 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `sprite-keep-alive.test.ts` — 7 pass, 0 fail

-- refactor/code-health