### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/custom-flag.test.ts
+++ b/packages/cli/src/__tests__/custom-flag.test.ts
@@ -36,9 +36,9 @@ describe("AWS --custom prompts", () => {
   it("promptBundle should respect env var over --custom", async () => {
     process.env.LIGHTSAIL_BUNDLE = "small_3_0";
     process.env.SPAWN_CUSTOM = "1";
-    const { promptBundle } = await import("../aws/aws");
-    // Should use env var without prompting
+    const { promptBundle, getState } = await import("../aws/aws");
     await promptBundle();
+    expect(getState().selectedBundle).toBe("small_3_0");
   });
 });
 

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -207,6 +207,7 @@ export function getState() {
     lightsailMode: _state.lightsailMode,
     instanceName: _state.instanceName,
     instanceIp: _state.instanceIp,
+    selectedBundle: _state.selectedBundle,
   };
 }
 


### PR DESCRIPTION
## Summary

- Found one theatrical test in `custom-flag.test.ts`: `promptBundle should respect env var over --custom` called `promptBundle()` but asserted nothing about the result — it was testing that the function doesn't throw/hang rather than that it actually uses the env var
- Fixed by adding `selectedBundle` to the `getState()` test helper in `aws/aws.ts`, matching the pattern used by the parallel `promptRegion` tests
- The codebase is otherwise clean after two recent cleanup PRs (#2694, #2700)

## Test plan

- [x] `bun test` passes: 1431 tests, 0 failures, 3829 expect() calls (+1 from the new assertion)
- [x] `bunx @biomejs/biome check src/` passes: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)