### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/with-retry-result.test.ts
+++ b/packages/cli/src/__tests__/with-retry-result.test.ts
@@ -6,34 +6,6 @@ spyOn(process.stderr, "write").mockImplementation(() => true);
 const { withRetry, Ok, Err } = await import("../shared/ui.js");
 const { wrapSshCall } = await import("../shared/agent-setup.js");
 
-// ── Result constructors ──────────────────────────────────────────────
-
-describe("Result constructors", () => {
-  it("Ok creates a success result", () => {
-    const r = Ok(42);
-    expect(r.ok).toBe(true);
-    expect(r).toEqual({
-      ok: true,
-      data: 42,
-    });
-  });
-
-  it("Ok works with void", () => {
-    const r = Ok(undefined);
-    expect(r.ok).toBe(true);
-  });
-
-  it("Err creates a failure result", () => {
-    const r = Err(new Error("boom"));
-    expect(r).toMatchObject({
-      ok: false,
-      error: {
-        message: "boom",
-      },
-    });
-  });
-});
-
 // ── withRetry with Result monad ──────────────────────────────────────
 
 describe("withRetry", () => {


### PR DESCRIPTION
## Summary

- Removed the `"Result constructors"` describe block (3 tests) from `packages/cli/src/__tests__/with-retry-result.test.ts`
- This block tested `Ok()` and `Err()` constructors imported via `../shared/ui.js`, which re-exports them from `../shared/result.ts`
- `result-helpers.test.ts` already provides thorough coverage of the same `Ok`/`Err` constructors through `tryCatch`, `asyncTryCatch`, `mapResult`, `unwrapOr`, and `bug propagation` tests
- The removed tests were theatrical: they only verified the constructors produce objects with `ok: true/false` — signal already present in dozens of other tests

## Scan findings

**Anti-patterns checked:**
- Duplicate describe blocks across files: none found (145 top-level describe blocks, all unique names)
- Bash-grep / `type FUNCTION_NAME` tests: none found
- Always-pass conditional patterns: none found (all `if`/`else` patterns are env cleanup guards in `beforeEach`/`afterEach`)
- Excessive subprocess spawning: none (subprocess mocks use `spyOn(Bun, "spawnSync")`, not real spawning)
- **Duplicate coverage** (found + fixed): `"Result constructors"` describe in `with-retry-result.test.ts` duplicated `result-helpers.test.ts`

## Test results

- Before: 1431 tests pass, 0 fail
- After: 1428 tests pass, 0 fail (3 duplicate tests removed)

-- qa/dedup-scanner