### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/__tests__/README.md
+++ b/packages/cli/src/__tests__/README.md
@@ -33,6 +33,7 @@ bun test src/__tests__/manifest.test.ts
 - `commands-update-download.test.ts` — `cmdUpdate`, script download and execution
 - `cmd-feedback.test.ts` — `spawn feedback` command: empty message rejection, URL construction
 - `cmd-fix.test.ts` — `spawn fix` command: SSH connection repair via DI-injected runScript
+- `cmd-link.test.ts` — `spawn link` command: TCP reachability check, SSH agent detection via DI
 
 ### Commands: error paths
 - `commands-error-paths.test.ts` — Validation failures, unknown agents/clouds, prompt rejection


### PR DESCRIPTION
## Summary

- Comprehensive scan for dead code, stale references, python usage, and duplicate utilities across `sh/shared/*.sh`, `packages/cli/src/`, and `sh/e2e/`
- **Finding**: The codebase is largely clean — no python usage, no dead functions, no stale file references, no duplicate utilities requiring extraction
- **Fix**: `packages/cli/src/__tests__/README.md` was missing an entry for `cmd-link.test.ts` (28 other recently-added tests were already documented at the bottom of the README, but this one was omitted from the "Commands: happy paths" section)

## Issues checked by category

| Category | Result |
|---|---|
| Dead code in `sh/shared/*.sh` | None found — all functions called |
| Dead code in TypeScript `shared/` | None found — all exports used |
| Stale references to deleted files | None found — all imports resolve |
| Python usage in shell scripts | None found — bun/jq used throughout |
| Duplicate TypeScript utilities | `getCloudInitUserdata` appears in aws/hetzner/do but has cloud-specific content (different users, swap setup) — not extractable as identical |
| Stale comments | None found beyond valid TODOs with explicit tracking dates |
| Test README index | `cmd-link.test.ts` was missing — added |

## Test plan

- [x] `bun test` — 1428 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)