### PR TITLE
fix(kilocode): add binary verification after npm install for postinstall failures

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -670,6 +670,50 @@ const NPM_GLOBAL_PATH_PERSIST =
   "{ [ ! -f ~/.zshrc ] || grep -qF '.npm-global/bin' ~/.zshrc 2>/dev/null || " +
   "echo 'export PATH=\"$HOME/.npm-global/bin:$PATH\"' >> ~/.zshrc; }";
 
+/**
+ * Shell snippet that verifies the kilocode binary is actually available after
+ * npm install. @kilocode/cli v7+ uses a postinstall script that downloads a
+ * native binary. On some clouds (notably GCP with cloudInitTier "node"), the
+ * postinstall can fail silently, leaving the bin symlink pointing to a JS
+ * wrapper but no actual native binary to exec.
+ *
+ * This snippet:
+ * 1. Checks if `kilocode` is already working
+ * 2. If not, finds the npm package dir and re-runs the postinstall
+ * 3. If still not found, searches for the native binary in the package dir
+ *    and symlinks it into a PATH-accessible location
+ */
+const KILOCODE_BINARY_VERIFY =
+  "{ " +
+  'export PATH="$HOME/.npm-global/bin:/usr/local/bin:$PATH"; ' +
+  // Quick check: if kilocode already works, nothing to do
+  "if command -v kilocode >/dev/null 2>&1 && kilocode --version >/dev/null 2>&1; then exit 0; fi; " +
+  // Find the npm package directory (works with both --prefix and default installs)
+  '_kc_pkg="$(npm prefix -g 2>/dev/null)/lib/node_modules/@kilocode/cli"; ' +
+  '[ -d "$_kc_pkg" ] || _kc_pkg="$HOME/.npm-global/lib/node_modules/@kilocode/cli"; ' +
+  'if [ -d "$_kc_pkg" ]; then ' +
+  // Re-run the postinstall script explicitly
+  'echo "==> kilocode binary not found, re-running postinstall..."; ' +
+  'cd "$_kc_pkg" && npm run postinstall 2>/dev/null || true; ' +
+  'export PATH="$HOME/.npm-global/bin:/usr/local/bin:$PATH"; ' +
+  "if command -v kilocode >/dev/null 2>&1 && kilocode --version >/dev/null 2>&1; then exit 0; fi; " +
+  // Postinstall re-run didn't help — search for native binary in the package
+  'echo "==> Searching for kilocode binary in package directory..."; ' +
+  '_kc_bin="$(find "$_kc_pkg" -name "kilocode*" -type f -perm /111 2>/dev/null | head -1)"; ' +
+  'if [ -n "$_kc_bin" ]; then ' +
+  '_kc_dest="$(npm prefix -g 2>/dev/null || echo /usr/local)/bin/kilocode"; ' +
+  '[ -w "$(dirname "$_kc_dest")" ] || _kc_dest="$HOME/.npm-global/bin/kilocode"; ' +
+  'mkdir -p "$(dirname "$_kc_dest")"; ' +
+  'ln -sf "$_kc_bin" "$_kc_dest"; ' +
+  'echo "==> Linked kilocode binary: $_kc_bin -> $_kc_dest"; ' +
+  "fi; " +
+  "fi; " +
+  // Final check
+  'export PATH="$HOME/.npm-global/bin:/usr/local/bin:$PATH"; ' +
+  "command -v kilocode >/dev/null 2>&1 || " +
+  '{ echo "WARNING: kilocode binary still not found after recovery attempts"; }; ' +
+  "}";
+
 // ─── Default Agent Definitions ───────────────────────────────────────────────
 
 // Last zeroclaw release that shipped Linux prebuilt binaries (v0.1.9a has none).
@@ -765,7 +809,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         installAgent(
           runner,
           "Kilo Code",
-          `${NPM_PREFIX_SETUP} && npm install -g \${_NPM_G_FLAGS} @kilocode/cli && ${NPM_GLOBAL_PATH_PERSIST}`,
+          `${NPM_PREFIX_SETUP} && npm install -g \${_NPM_G_FLAGS} @kilocode/cli && ${NPM_GLOBAL_PATH_PERSIST} && ${KILOCODE_BINARY_VERIFY}`,
         ),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,


### PR DESCRIPTION
**Why:** `@kilocode/cli` v7+ uses a native binary postinstall that downloads a platform-specific binary. On GCP with `cloudInitTier: "node"`, this postinstall can fail silently, leaving the npm bin symlink pointing to a JS wrapper with no actual native binary — causing `kilocode binary not found` at launch time.

## Changes

- Added `KILOCODE_BINARY_VERIFY` shell snippet in `shared/agent-setup.ts` that runs after `npm install -g @kilocode/cli`
- The snippet performs a 3-step recovery:
  1. Quick check if `kilocode` is already working (fast path for clouds where postinstall succeeds)
  2. Re-runs the postinstall from the npm package directory explicitly
  3. As a last resort, searches for the native binary in the package dir and symlinks it to PATH
- Version bump: 0.20.7 -> 0.20.8

## Test plan

- [x] `bunx @biomejs/biome check src/` passes with zero errors
- [x] `bun test` passes (1428 tests, 0 failures)
- [ ] E2E: deploy kilocode on GCP and verify binary is found after install

Fixes #2706

-- refactor/code-health