### PR TITLE
feat(hermes): enable HERMES_YOLO_MODE for cloud VMs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.20.8",
+  "version": "0.20.9",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -170,6 +170,8 @@ async function promptSetupOptions(agentName: string): Promise<Set<string> | unde
     return undefined;
   }
 
+  const defaultOnValues = filteredSteps.filter((s) => s.defaultOn).map((s) => s.value);
+
   const selected = await p.multiselect({
     message: "Setup options (↑/↓ navigate, space=toggle, a=all, enter=confirm)",
     options: filteredSteps.map((s) => ({
@@ -177,6 +179,7 @@ async function promptSetupOptions(agentName: string): Promise<Set<string> | unde
       label: s.label,
       hint: s.hint,
     })),
+    initialValues: defaultOnValues.length > 0 ? defaultOnValues : undefined,
     required: false,
   });
 

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -866,7 +866,16 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         `OPENROUTER_API_KEY=${apiKey}`,
         "OPENAI_BASE_URL=https://openrouter.ai/api/v1",
         `OPENAI_API_KEY=${apiKey}`,
+        "HERMES_YOLO_MODE=1",
       ],
+      configure: async (_apiKey, _modelId, enabledSteps) => {
+        // YOLO mode is on by default (in envVars above). If the user explicitly
+        // unchecked it in setup options, remove it from .spawnrc.
+        if (enabledSteps && !enabledSteps.has("yolo-mode")) {
+          await runner.runServer("sed -i '/HERMES_YOLO_MODE/d' ~/.spawnrc");
+          logInfo("YOLO mode disabled — Hermes will prompt before installing tools");
+        }
+      },
       launchCmd: () =>
         "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.local/bin:$HOME/.hermes/hermes-agent/venv/bin:$PATH; hermes",
     },

--- a/packages/cli/src/shared/agents.ts
+++ b/packages/cli/src/shared/agents.ts
@@ -16,6 +16,8 @@ export interface OptionalStep {
   dataEnvVar?: string;
   /** When true, step requires interactive input (e.g. QR scan) — skipped in headless. */
   interactive?: boolean;
+  /** When true, step is pre-selected in the multiselect (user can uncheck). */
+  defaultOn?: boolean;
 }
 
 export interface AgentConfig {
@@ -56,6 +58,14 @@ export interface TunnelConfig {
 
 /** Extra setup steps for specific agents (merged with COMMON_STEPS). */
 const AGENT_EXTRA_STEPS: Record<string, OptionalStep[]> = {
+  hermes: [
+    {
+      value: "yolo-mode",
+      label: "YOLO mode",
+      hint: "let Hermes install tools without approval prompts",
+      defaultOn: true,
+    },
+  ],
   openclaw: [
     {
       value: "browser",


### PR DESCRIPTION
## Summary
- Sets `HERMES_YOLO_MODE=1` env var for Hermes Agent on cloud VMs
- Disables Hermes's security approval prompts so it can self-install skill dependencies (e.g. himalaya for email) at runtime
- Without this, Hermes blocks `curl | sh` installs on VMs that were themselves provisioned via `curl | sh`

## Test plan
- [ ] Deploy Hermes on DigitalOcean, ask it to use a skill requiring a dependency install
- [ ] Verify the install succeeds without "security filter blocked" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)