### PR TITLE
fix(security): escape newlines in safe_substitute to prevent sed injection

### DIFF
--- a/.claude/skills/setup-agent-team/discovery.sh
+++ b/.claude/skills/setup-agent-team/discovery.sh
@@ -36,12 +36,15 @@ log_error() { printf "${RED}[discovery]${NC} %s\n" "$1"; echo "[$(date +'%Y-%m-%
 
 # --- Safe sed substitution (escapes sed metacharacters in replacement) ---
 # Usage: safe_substitute PLACEHOLDER VALUE FILE
+# Escapes \, &, |, and newlines in VALUE to prevent sed injection.
 safe_substitute() {
     local placeholder="$1"
     local value="$2"
     local file="$3"
     local escaped
     escaped=$(printf '%s' "$value" | sed -e 's/[\\]/\\&/g' -e 's/[&]/\\&/g' -e 's/[|]/\\|/g')
+    # Escape literal newlines for sed replacement (backslash + newline)
+    escaped="${escaped//$'\n'/\\$'\n'}"
     sed -i.bak "s|${placeholder}|${escaped}|g" "$file"
     rm -f "${file}.bak"
 }

--- a/.claude/skills/setup-agent-team/qa.sh
+++ b/.claude/skills/setup-agent-team/qa.sh
@@ -77,6 +77,8 @@ safe_substitute() {
     # Escape backslashes first, then &, then the delimiter |
     local escaped
     escaped=$(printf '%s' "$value" | sed -e 's/[\\]/\\&/g' -e 's/[&]/\\&/g' -e 's/[|]/\\|/g')
+    # Escape literal newlines for sed replacement (backslash + newline)
+    escaped="${escaped//$'\n'/\\$'\n'}"
     sed -i.bak "s|${placeholder}|${escaped}|g" "$file"
     rm -f "${file}.bak"
 }

--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -46,12 +46,15 @@ log() {
 
 # --- Safe sed substitution (escapes sed metacharacters in replacement) ---
 # Usage: safe_substitute PLACEHOLDER VALUE FILE
+# Escapes \, &, |, and newlines in VALUE to prevent sed injection.
 safe_substitute() {
     local placeholder="$1"
     local value="$2"
     local file="$3"
     local escaped
     escaped=$(printf '%s' "$value" | sed -e 's/[\\]/\\&/g' -e 's/[&]/\\&/g' -e 's/[|]/\\|/g')
+    # Escape literal newlines for sed replacement (backslash + newline)
+    escaped="${escaped//$'\n'/\\$'\n'}"
     sed -i.bak "s|${placeholder}|${escaped}|g" "$file"
     rm -f "${file}.bak"
 }

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -93,12 +93,15 @@ log() {
 
 # --- Safe sed substitution (escapes sed metacharacters in replacement) ---
 # Usage: safe_substitute PLACEHOLDER VALUE FILE
+# Escapes \, &, |, and newlines in VALUE to prevent sed injection.
 safe_substitute() {
     local placeholder="$1"
     local value="$2"
     local file="$3"
     local escaped
     escaped=$(printf '%s' "$value" | sed -e 's/[\\]/\\&/g' -e 's/[&]/\\&/g' -e 's/[|]/\\|/g')
+    # Escape literal newlines for sed replacement (backslash + newline)
+    escaped="${escaped//$'\n'/\\$'\n'}"
     sed -i.bak "s|${placeholder}|${escaped}|g" "$file"
     rm -f "${file}.bak"
 }


### PR DESCRIPTION
**Why:** `safe_substitute()` passes user-controlled values directly to sed without escaping newlines, allowing sed command injection via multiline input. The function escaped `\`, `&`, and `|` but not newlines — a newline in the replacement value breaks the sed `s` command syntax.

Fixes #2702

## Changes
- Escape newlines in `safe_substitute()` after existing metacharacter escaping, using `${escaped//$'\n'/\\$'\n'}` (backslash + literal newline — the standard sed replacement encoding)
- Applied to all 4 copies: `discovery.sh`, `qa.sh`, `refactor.sh`, `security.sh`

## Test plan
- [x] `bash -n` syntax check passes on all 4 modified files
- [x] Manual functional tests: simple values, multiline values, special chars + newlines, injection attempts — all pass
- [x] `bun test` — 1428 tests pass, 0 failures
- [x] `biome check` — 127 files, no issues

-- refactor/security-auditor