### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/cmd-listing-output.test.ts
+++ b/packages/cli/src/__tests__/cmd-listing-output.test.ts
@@ -214,216 +214,78 @@ describe("cmdMatrix output", () => {
   });
 
   describe("grid view (wide terminal)", () => {
-    it("should display cloud names in header row", async () => {
-      await setManifest(smallManifest);
+    let origColumns: number;
 
-      // Force wide terminal for grid view
-      const origColumns = process.stdout.columns;
+    beforeEach(() => {
+      origColumns = process.stdout.columns;
       Object.defineProperty(process.stdout, "columns", {
         value: 200,
         configurable: true,
       });
+    });
 
-      await cmdMatrix();
-
+    afterEach(() => {
       Object.defineProperty(process.stdout, "columns", {
         value: origColumns,
         configurable: true,
       });
+    });
+
+    it("should display headers, icons, and legend", async () => {
+      await setManifest(smallManifest);
+      await cmdMatrix();
 
       const output = captureOutput(consoleMocks.log);
+      // Cloud names in header row
       expect(output).toContain("Sprite");
       expect(output).toContain("Hetzner Cloud");
-    });
-
-    it("should display agent names in row labels", async () => {
-      await setManifest(smallManifest);
-
-      const origColumns = process.stdout.columns;
-      Object.defineProperty(process.stdout, "columns", {
-        value: 200,
-        configurable: true,
-      });
-
-      await cmdMatrix();
-
-      Object.defineProperty(process.stdout, "columns", {
-        value: origColumns,
-        configurable: true,
-      });
-
-      const output = captureOutput(consoleMocks.log);
+      // Agent names in row labels
       expect(output).toContain("Claude Code");
       expect(output).toContain("Codex");
-    });
-
-    it("should use + icon for implemented combinations", async () => {
-      await setManifest(smallManifest);
-
-      const origColumns = process.stdout.columns;
-      Object.defineProperty(process.stdout, "columns", {
-        value: 200,
-        configurable: true,
-      });
-
-      await cmdMatrix();
-
-      Object.defineProperty(process.stdout, "columns", {
-        value: origColumns,
-        configurable: true,
-      });
-
-      const output = captureOutput(consoleMocks.log);
+      // Icons for implemented (+) and missing (-)
       expect(output).toContain("+");
-    });
-
-    it("should use - icon for missing combinations", async () => {
-      await setManifest(smallManifest);
-
-      const origColumns = process.stdout.columns;
-      Object.defineProperty(process.stdout, "columns", {
-        value: 200,
-        configurable: true,
-      });
-
-      await cmdMatrix();
-
-      Object.defineProperty(process.stdout, "columns", {
-        value: origColumns,
-        configurable: true,
-      });
-
-      const output = captureOutput(consoleMocks.log);
       expect(output).toContain("-");
-    });
-
-    it("should display grid legend in footer", async () => {
-      await setManifest(smallManifest);
-
-      const origColumns = process.stdout.columns;
-      Object.defineProperty(process.stdout, "columns", {
-        value: 200,
-        configurable: true,
-      });
-
-      await cmdMatrix();
-
-      Object.defineProperty(process.stdout, "columns", {
-        value: origColumns,
-        configurable: true,
-      });
-
-      const output = captureOutput(consoleMocks.log);
+      // Legend in footer
       expect(output).toContain("implemented");
       expect(output).toContain("not yet available");
     });
   });
 
   describe("compact view (narrow terminal)", () => {
-    it("should display compact view when terminal is narrow", async () => {
-      await setManifest(smallManifest);
+    let origColumns: number;
 
-      const origColumns = process.stdout.columns;
+    beforeEach(() => {
+      origColumns = process.stdout.columns;
       // Force very narrow terminal to trigger compact view
       Object.defineProperty(process.stdout, "columns", {
         value: 40,
         configurable: true,
       });
+    });
 
-      await cmdMatrix();
-
+    afterEach(() => {
       Object.defineProperty(process.stdout, "columns", {
         value: origColumns,
         configurable: true,
       });
+    });
+
+    it("should display agent/cloud counts, support status, and legend", async () => {
+      await setManifest(smallManifest);
+      await cmdMatrix();
 
       const output = captureOutput(consoleMocks.log);
       // Compact view shows "Agent" header and "Clouds" count column
       expect(output).toContain("Agent");
       expect(output).toContain("Clouds");
-    });
-
-    it("should show count/total for each agent in compact view", async () => {
-      await setManifest(smallManifest);
-
-      const origColumns = process.stdout.columns;
-      Object.defineProperty(process.stdout, "columns", {
-        value: 40,
-        configurable: true,
-      });
-
-      await cmdMatrix();
-
-      Object.defineProperty(process.stdout, "columns", {
-        value: origColumns,
-        configurable: true,
-      });
-
-      const output = captureOutput(consoleMocks.log);
       // claude: 2/2, codex: 1/2
       expect(output).toContain("2/2");
       expect(output).toContain("1/2");
-    });
-
-    it("should show 'all clouds supported' for fully implemented agent", async () => {
-      await setManifest(smallManifest);
-
-      const origColumns = process.stdout.columns;
-      Object.defineProperty(process.stdout, "columns", {
-        value: 40,
-        configurable: true,
-      });
-
-      await cmdMatrix();
-
-      Object.defineProperty(process.stdout, "columns", {
-        value: origColumns,
-        configurable: true,
-      });
-
-      const output = captureOutput(consoleMocks.log);
       // claude is implemented on both clouds
       expect(output).toContain("all clouds supported");
-    });
-
-    it("should show missing cloud names for partially implemented agent", async () => {
-      await setManifest(smallManifest);
-
-      const origColumns = process.stdout.columns;
-      Object.defineProperty(process.stdout, "columns", {
-        value: 40,
-        configurable: true,
-      });
-
-      await cmdMatrix();
-
-      Object.defineProperty(process.stdout, "columns", {
-        value: origColumns,
-        configurable: true,
-      });
-
-      const output = captureOutput(consoleMocks.log);
       // codex is missing on hetzner
       expect(output).toContain("Hetzner Cloud");
-    });
-
-    it("should show compact legend in footer", async () => {
-      await setManifest(smallManifest);
-
-      const origColumns = process.stdout.columns;
-      Object.defineProperty(process.stdout, "columns", {
-        value: 40,
-        configurable: true,
-      });
-
-      await cmdMatrix();
-
-      Object.defineProperty(process.stdout, "columns", {
-        value: origColumns,
-        configurable: true,
-      });
-
-      const output = captureOutput(consoleMocks.log);
+      // Legend uses color names
       expect(output).toContain("green");
       expect(output).toContain("yellow");
     });
@@ -669,8 +531,24 @@ describe("cmdClouds output", () => {
     });
 
     it("should display auth hints for clouds with env var auth", async () => {
+      // Clear cloud tokens so the output always shows "needs" regardless of the host environment.
+      // Saved values are restored in afterEach via consoleMocks/fetch restore, but env vars
+      // need their own save/restore since afterEach doesn't handle them.
+      const savedSprite = process.env.SPRITE_TOKEN;
+      const savedHcloud = process.env.HCLOUD_TOKEN;
+      delete process.env.SPRITE_TOKEN;
+      delete process.env.HCLOUD_TOKEN;
+
       await setManifest(smallManifest);
       await cmdClouds();
+
+      // Restore before asserting so a failure doesn't leak env state
+      if (savedSprite !== undefined) {
+        process.env.SPRITE_TOKEN = savedSprite;
+      }
+      if (savedHcloud !== undefined) {
+        process.env.HCLOUD_TOKEN = savedHcloud;
+      }
 
       const output = captureOutput(consoleMocks.log);
       expect(output).toContain("needs");


### PR DESCRIPTION
## Summary

- Consolidated 10 single-assertion `cmdMatrix` tests that each ran the full command just to check one output property into 2 comprehensive tests using `beforeEach`/`afterEach` for terminal-width setup
- Fixed a pre-existing environment-dependent test failure where `HCLOUD_TOKEN` being set on the host machine caused `cmdClouds` auth-hint test to show "ready" instead of "needs"

## What was found

**Excessive command re-execution for trivially different assertions** in `cmd-listing-output.test.ts`:

The "grid view (wide terminal)" and "compact view (narrow terminal)" describe blocks each had 5 separate tests with identical boilerplate:
1. Set manifest
2. Manually set `process.stdout.columns`
3. Call `cmdMatrix()`
4. Reset `process.stdout.columns`
5. Assert **one** thing

This meant `cmdMatrix()` was called 10 times for assertions that could share a single invocation. Consolidated into 2 tests with `beforeEach`/`afterEach` managing terminal width.

**Pre-existing environment-dependent failure**: `should display auth hints for clouds with env var auth` was asserting `HCLOUD_TOKEN` in the output, but this machine has `HCLOUD_TOKEN` set as a real environment variable, so the cloud showed "ready" instead of "needs". Fixed by clearing the env vars before the test and restoring them after.

## Test results

- Before: 1428 pass, 1 fail (environment-dependent)
- After: 1420 pass, 0 fail (8 tests consolidated into 2, 1 failure fixed)

-- qa/dedup-scanner