### PR TITLE
fix(digitalocean): graceful 401 recovery instead of crash

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { _testHelpers } from "../digitalocean/digitalocean";
+
+const { testDoToken, state } = _testHelpers;
+
+describe("testDoToken", () => {
+  const originalFetch = globalThis.fetch;
+  let savedToken: string;
+
+  beforeEach(() => {
+    savedToken = state.token;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    state.token = savedToken;
+  });
+
+  it("returns false when token is empty", async () => {
+    state.token = "";
+    expect(await testDoToken()).toBe(false);
+  });
+
+  it("returns true when API returns valid account JSON", async () => {
+    state.token = "valid-token";
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            account: {
+              uuid: "abc-123",
+            },
+          }),
+        ),
+      ),
+    );
+    expect(await testDoToken()).toBe(true);
+  });
+
+  it("returns false (not throws) when API returns 401", async () => {
+    state.token = "expired-token";
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response("Unauthorized", {
+          status: 401,
+        }),
+      ),
+    );
+    // Before the fix, this would throw: "DigitalOcean API error 401..."
+    // After the fix, asyncTryCatch catches the error and unwrapOr returns false
+    expect(await testDoToken()).toBe(false);
+  });
+
+  it("returns false when API returns 403", async () => {
+    state.token = "forbidden-token";
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response("Forbidden", {
+          status: 403,
+        }),
+      ),
+    );
+    expect(await testDoToken()).toBe(false);
+  });
+
+  it("returns false on network error", async () => {
+    state.token = "some-token";
+    globalThis.fetch = mock(() => Promise.reject(new TypeError("fetch failed")));
+    expect(await testDoToken()).toBe(false);
+  });
+});

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -255,7 +255,7 @@ async function testDoToken(): Promise<boolean> {
     return false;
   }
   return unwrapOr(
-    await asyncTryCatchIf(isNetworkError, async () => {
+    await asyncTryCatch(async () => {
       const text = await doApi("GET", "/account", undefined, 1);
       return text.includes('"uuid"');
     }),
@@ -1510,3 +1510,13 @@ export async function destroyServer(dropletId?: string): Promise<void> {
   await doApi("DELETE", `/droplets/${id}`);
   logInfo(`Droplet ${id} destroyed`);
 }
+
+// ─── Test Helpers ─────────────────────────────────────────────────────────────
+
+/** @internal Exposed for testing only. */
+export const _testHelpers = {
+  testDoToken,
+  get state() {
+    return _state;
+  },
+};


### PR DESCRIPTION
## Summary
- `testDoToken()` used `asyncTryCatchIf(isNetworkError, ...)` which only caught network errors — a 401 HTTP response threw a regular `Error` that escaped the guard, crashing with `Fatal: DigitalOcean API error 401...`
- Changed to `asyncTryCatch(...)` so all errors (including 401) are caught and `testDoToken()` returns `false`, letting `ensureDoToken()` naturally fall through to OAuth recovery
- Bumped CLI version to 0.20.10

## Test plan
- [x] Added `digitalocean-token.test.ts` with 5 tests: empty token, valid response, 401 response, 403 response, network error
- [x] All 1433 tests pass (0 failures)
- [x] Biome lint/format: 0 errors across 128 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)