### PR TITLE
feat: systemd auto-update service for agents on cloud VMs

### DIFF
--- a/packages/cli/src/__tests__/auto-update.test.ts
+++ b/packages/cli/src/__tests__/auto-update.test.ts
@@ -1,0 +1,331 @@
+/**
+ * auto-update.test.ts — Tests for the agent auto-update systemd service setup.
+ *
+ * Verifies that setupAutoUpdate generates the correct systemd units and
+ * wrapper script, and that the orchestration pipeline calls it for cloud
+ * VMs but skips it for local execution and agents without updateCmd.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { asyncTryCatch, isNumber, isString, tryCatch } from "@openrouter/spawn-shared";
+
+const mockGetOrPromptApiKey = mock(() => Promise.resolve("sk-or-v1-test-key"));
+const mockTryTarballInstall = mock(() => Promise.resolve(false));
+
+import type { AgentConfig } from "../shared/agents";
+import type { CloudOrchestrator, OrchestrationOptions } from "../shared/orchestrate";
+
+import { setupAutoUpdate } from "../shared/agent-setup";
+import { runOrchestration } from "../shared/orchestrate";
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function createMockCloud(overrides: Partial<CloudOrchestrator> = {}): CloudOrchestrator {
+  const mockRunner = {
+    runServer: mock(() => Promise.resolve()),
+    uploadFile: mock(() => Promise.resolve()),
+    downloadFile: mock(() => Promise.resolve()),
+  };
+  return {
+    cloudName: "testcloud",
+    cloudLabel: "Test Cloud",
+    runner: mockRunner,
+    authenticate: mock(() => Promise.resolve()),
+    promptSize: mock(() => Promise.resolve()),
+    createServer: mock(() =>
+      Promise.resolve({
+        ip: "10.0.0.1",
+        user: "root",
+        server_name: "test-server-1",
+        cloud: "testcloud",
+      }),
+    ),
+    getServerName: mock(() => Promise.resolve("test-server-1")),
+    waitForReady: mock(() => Promise.resolve()),
+    interactiveSession: mock(() => Promise.resolve(0)),
+    ...overrides,
+  };
+}
+
+function createMockAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    name: "TestAgent",
+    install: mock(() => Promise.resolve()),
+    envVars: mock((key: string) => [
+      `OPENROUTER_API_KEY=${key}`,
+    ]),
+    launchCmd: mock(() => "test-agent --start"),
+    ...overrides,
+  };
+}
+
+const defaultOpts: OrchestrationOptions = {
+  tryTarball: mockTryTarballInstall,
+  getApiKey: mockGetOrPromptApiKey,
+};
+
+async function runOrchestrationSafe(
+  cloud: CloudOrchestrator,
+  agent: AgentConfig,
+  agentName: string,
+  opts: OrchestrationOptions = defaultOpts,
+): Promise<void> {
+  const r = await asyncTryCatch(async () => runOrchestration(cloud, agent, agentName, opts));
+  if (!r.ok) {
+    if (r.error.message.startsWith("__EXIT_")) {
+      return;
+    }
+    throw r.error;
+  }
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────
+
+describe("auto-update service", () => {
+  let exitSpy: ReturnType<typeof spyOn>;
+  let stderrSpy: ReturnType<typeof spyOn>;
+  let testDir: string;
+  let savedSpawnHome: string | undefined;
+  let savedEnabledSteps: string | undefined;
+
+  beforeEach(() => {
+    testDir = join(process.env.HOME ?? "", `.spawn-test-autoupdate-${Date.now()}-${Math.random()}`);
+    mkdirSync(testDir, {
+      recursive: true,
+    });
+    savedSpawnHome = process.env.SPAWN_HOME;
+    savedEnabledSteps = process.env.SPAWN_ENABLED_STEPS;
+    process.env.SPAWN_HOME = testDir;
+    process.env.SPAWN_SKIP_GITHUB_AUTH = "1";
+    delete process.env.SPAWN_ENABLED_STEPS;
+    delete process.env.SPAWN_BETA;
+    stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+    exitSpy = spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`__EXIT_${isNumber(code) ? code : 0}__`);
+    });
+    mockGetOrPromptApiKey.mockClear();
+    mockGetOrPromptApiKey.mockImplementation(() => Promise.resolve("sk-or-v1-test-key"));
+    mockTryTarballInstall.mockClear();
+    mockTryTarballInstall.mockImplementation(() => Promise.resolve(false));
+  });
+
+  afterEach(() => {
+    if (savedSpawnHome !== undefined) {
+      process.env.SPAWN_HOME = savedSpawnHome;
+    } else {
+      delete process.env.SPAWN_HOME;
+    }
+    if (savedEnabledSteps !== undefined) {
+      process.env.SPAWN_ENABLED_STEPS = savedEnabledSteps;
+    } else {
+      delete process.env.SPAWN_ENABLED_STEPS;
+    }
+    tryCatch(() =>
+      rmSync(testDir, {
+        recursive: true,
+        force: true,
+      }),
+    );
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  describe("setupAutoUpdate direct", () => {
+    it("calls runServer with systemd unit setup script", async () => {
+      const runServer = mock(() => Promise.resolve());
+      const runner = {
+        runServer,
+        uploadFile: mock(() => Promise.resolve()),
+        downloadFile: mock(() => Promise.resolve()),
+      };
+
+      await setupAutoUpdate(runner, "claude", "npm install -g @anthropic-ai/claude-code@latest");
+
+      expect(runServer).toHaveBeenCalledTimes(1);
+      const script = runServer.mock.calls[0][0];
+      expect(script).toContain("command -v systemctl");
+      expect(script).toContain("/usr/local/bin/spawn-auto-update");
+      expect(script).toContain("spawn-auto-update.service");
+      expect(script).toContain("spawn-auto-update.timer");
+      expect(script).toContain("systemctl enable spawn-auto-update.timer");
+      expect(script).toContain("systemctl start spawn-auto-update.timer");
+      expect(script).toContain("systemctl daemon-reload");
+    });
+
+    it("uses base64-encoded wrapper containing the update command", async () => {
+      const runServer = mock(() => Promise.resolve());
+      const runner = {
+        runServer,
+        uploadFile: mock(() => Promise.resolve()),
+        downloadFile: mock(() => Promise.resolve()),
+      };
+
+      await setupAutoUpdate(runner, "codex", "npm install -g @openai/codex@latest");
+
+      const script = runServer.mock.calls[0][0];
+      const wrapperMatch =
+        /printf '%s' '([A-Za-z0-9+/=]+)' \| base64 -d \| \$_sudo tee \/usr\/local\/bin\/spawn-auto-update/.exec(script);
+      expect(wrapperMatch).toBeTruthy();
+      const decoded = Buffer.from(wrapperMatch![1], "base64").toString("utf-8");
+      expect(decoded).toContain("npm install -g @openai/codex@latest");
+      expect(decoded).toContain("source");
+      expect(decoded).toContain(".spawnrc");
+      expect(decoded).toContain("flock -n 9");
+      expect(decoded).toContain("LOCKFILE");
+    });
+
+    it("includes system updates with dpkg lock coordination", async () => {
+      const runServer = mock(() => Promise.resolve());
+      const runner = {
+        runServer,
+        uploadFile: mock(() => Promise.resolve()),
+        downloadFile: mock(() => Promise.resolve()),
+      };
+
+      await setupAutoUpdate(runner, "claude", "npm install -g @anthropic-ai/claude-code@latest");
+
+      const script = runServer.mock.calls[0][0];
+      const allB64Matches = script.matchAll(/printf '%s' '([A-Za-z0-9+/=]+)'/g);
+      let wrapperContent = "";
+      for (const m of allB64Matches) {
+        const decoded = Buffer.from(m[1], "base64").toString("utf-8");
+        if (decoded.includes("apt-get")) {
+          wrapperContent = decoded;
+          break;
+        }
+      }
+      expect(wrapperContent).not.toBe("");
+      expect(wrapperContent).toContain("apt-get update");
+      expect(wrapperContent).toContain("apt-get upgrade");
+      expect(wrapperContent).toContain("DEBIAN_FRONTEND=noninteractive");
+      expect(wrapperContent).toContain("force-confdef");
+      expect(wrapperContent).toContain("flock -w 300 /var/lib/dpkg/lock-frontend");
+      expect(wrapperContent).toContain("unattended-upgrades");
+    });
+
+    it("timer unit has correct schedule", async () => {
+      const runServer = mock(() => Promise.resolve());
+      const runner = {
+        runServer,
+        uploadFile: mock(() => Promise.resolve()),
+        downloadFile: mock(() => Promise.resolve()),
+      };
+
+      await setupAutoUpdate(runner, "openclaw", "npm install -g openclaw@latest");
+
+      const script = runServer.mock.calls[0][0];
+      const allB64Matches = script.matchAll(/printf '%s' '([A-Za-z0-9+/=]+)'/g);
+      let timerContent = "";
+      for (const m of allB64Matches) {
+        const decoded = Buffer.from(m[1], "base64").toString("utf-8");
+        if (decoded.includes("OnUnitActiveSec")) {
+          timerContent = decoded;
+          break;
+        }
+      }
+      expect(timerContent).not.toBe("");
+      expect(timerContent).toContain("OnBootSec=15min");
+      expect(timerContent).toContain("OnUnitActiveSec=6h");
+      expect(timerContent).toContain("RandomizedDelaySec=30min");
+      expect(timerContent).toContain("Persistent=true");
+    });
+
+    it("does not throw on runServer failure (non-fatal)", async () => {
+      const runServer = mock(() => Promise.reject(new Error("SSH connection refused")));
+      const runner = {
+        runServer,
+        uploadFile: mock(() => Promise.resolve()),
+        downloadFile: mock(() => Promise.resolve()),
+      };
+
+      await setupAutoUpdate(runner, "claude", "npm install -g @anthropic-ai/claude-code@latest");
+    });
+  });
+
+  describe("orchestration integration", () => {
+    it("calls setupAutoUpdate for cloud VMs when agent has updateCmd", async () => {
+      const runServer = mock(() => Promise.resolve());
+      const cloud = createMockCloud({
+        cloudName: "digitalocean",
+        runner: {
+          runServer,
+          uploadFile: mock(() => Promise.resolve()),
+          downloadFile: mock(() => Promise.resolve()),
+        },
+      });
+      const agent = createMockAgent({
+        updateCmd: "npm install -g test-agent@latest",
+      });
+
+      await runOrchestrationSafe(cloud, agent, "testagent");
+
+      const calls = runServer.mock.calls.map((c) => c[0]);
+      const autoUpdateCall = calls.find((cmd: string) => isString(cmd) && cmd.includes("spawn-auto-update"));
+      expect(autoUpdateCall).toBeTruthy();
+    });
+
+    it("skips setupAutoUpdate for local cloud", async () => {
+      const runServer = mock(() => Promise.resolve());
+      const cloud = createMockCloud({
+        cloudName: "local",
+        runner: {
+          runServer,
+          uploadFile: mock(() => Promise.resolve()),
+          downloadFile: mock(() => Promise.resolve()),
+        },
+      });
+      const agent = createMockAgent({
+        updateCmd: "npm install -g test-agent@latest",
+      });
+
+      await runOrchestrationSafe(cloud, agent, "testagent");
+
+      const calls = runServer.mock.calls.map((c) => c[0]);
+      const autoUpdateCall = calls.find((cmd: string) => isString(cmd) && cmd.includes("spawn-auto-update"));
+      expect(autoUpdateCall).toBeUndefined();
+    });
+
+    it("skips setupAutoUpdate when auto-update step is disabled", async () => {
+      process.env.SPAWN_ENABLED_STEPS = "github";
+      const runServer = mock(() => Promise.resolve());
+      const cloud = createMockCloud({
+        cloudName: "digitalocean",
+        runner: {
+          runServer,
+          uploadFile: mock(() => Promise.resolve()),
+          downloadFile: mock(() => Promise.resolve()),
+        },
+      });
+      const agent = createMockAgent({
+        updateCmd: "npm install -g test-agent@latest",
+      });
+
+      await runOrchestrationSafe(cloud, agent, "testagent");
+
+      const calls = runServer.mock.calls.map((c) => c[0]);
+      const autoUpdateCall = calls.find((cmd: string) => isString(cmd) && cmd.includes("spawn-auto-update"));
+      expect(autoUpdateCall).toBeUndefined();
+    });
+
+    it("skips setupAutoUpdate when agent has no updateCmd", async () => {
+      const runServer = mock(() => Promise.resolve());
+      const cloud = createMockCloud({
+        cloudName: "digitalocean",
+        runner: {
+          runServer,
+          uploadFile: mock(() => Promise.resolve()),
+          downloadFile: mock(() => Promise.resolve()),
+        },
+      });
+      const agent = createMockAgent();
+
+      await runOrchestrationSafe(cloud, agent, "testagent");
+
+      const calls = runServer.mock.calls.map((c) => c[0]);
+      const autoUpdateCall = calls.find((cmd: string) => isString(cmd) && cmd.includes("spawn-auto-update"));
+      expect(autoUpdateCall).toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -714,6 +714,132 @@ const KILOCODE_BINARY_VERIFY =
   '{ echo "WARNING: kilocode binary still not found after recovery attempts"; }; ' +
   "}";
 
+// ─── Auto-Update Service ─────────────────────────────────────────────────────
+
+/**
+ * Install a systemd timer + service that periodically updates the agent
+ * binary and system packages without disrupting running instances.
+ *
+ * Safety for running instances:
+ * - Binary agents (Go, Rust): Linux keeps old inode in memory; replacement on disk is safe
+ * - npm agents: Node.js caches all loaded modules in memory at startup. npm install -g
+ *   replaces files on disk via a staging dir. Running processes are unaffected since
+ *   CLI agents load everything at startup (no lazy imports after the swap).
+ *
+ * The new version takes effect on next restart via the existing restart loop.
+ * Skipped for local cloud and non-systemd systems.
+ */
+export async function setupAutoUpdate(runner: CloudRunner, agentName: string, updateCmd: string): Promise<void> {
+  logStep("Setting up agent auto-update service...");
+
+  const wrapperScript = [
+    "#!/bin/bash",
+    "set -eo pipefail",
+    'LOGFILE="/var/log/spawn-auto-update.log"',
+    'LOCKFILE="/var/lock/spawn-auto-update.lock"',
+    "",
+    'log() { printf "[%s] %s\\n" "$(date -u +\'%Y-%m-%dT%H:%M:%SZ\')" "$*" >> "$LOGFILE"; }',
+    "",
+    "# Exclusive lock — skip if another update is already running",
+    'exec 9>"$LOCKFILE"',
+    "if ! flock -n 9; then",
+    '  log "Another update is already running, skipping"',
+    "  exit 0",
+    "fi",
+    "",
+    '[ -f "$HOME/.spawnrc" ] && source "$HOME/.spawnrc" 2>/dev/null',
+    'export PATH="$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.claude/local/bin:$PATH"',
+    "",
+    "# ── Phase 1: System package updates ──",
+    'log "Updating system packages"',
+    "if command -v apt-get >/dev/null 2>&1; then",
+    "  _sudo_sys=''",
+    '  [ "$(id -u)" != "0" ] && _sudo_sys="sudo"',
+    "  export DEBIAN_FRONTEND=noninteractive",
+    "  # Disable Ubuntu's unattended-upgrades to avoid dpkg lock contention.",
+    "  # We handle all updates here — running both causes lock conflicts.",
+    "  if $_sudo_sys systemctl is-active --quiet unattended-upgrades 2>/dev/null; then",
+    "    $_sudo_sys systemctl disable --now unattended-upgrades 2>/dev/null || true",
+    '    log "Disabled unattended-upgrades (spawn handles updates)"',
+    "  fi",
+    "  # Wait up to 5 min for any in-progress dpkg/apt operation to finish",
+    '  $_sudo_sys flock -w 300 /var/lib/dpkg/lock-frontend apt-get update -qq >> "$LOGFILE" 2>&1 || log "apt-get update failed (non-fatal)"',
+    '  $_sudo_sys flock -w 300 /var/lib/dpkg/lock-frontend apt-get upgrade -y -qq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" >> "$LOGFILE" 2>&1 || log "apt-get upgrade failed (non-fatal)"',
+    '  $_sudo_sys apt-get autoremove -y -qq >> "$LOGFILE" 2>&1 || true',
+    '  log "System packages updated"',
+    "fi",
+    "",
+    "# ── Phase 2: Agent update ──",
+    `log "Starting ${agentName} update"`,
+    updateCmd + ' >> "$LOGFILE" 2>&1',
+    "_exit=$?",
+    'if [ "$_exit" -eq 0 ]; then',
+    `  log "${agentName} update completed successfully"`,
+    "else",
+    `  log "${agentName} update failed (exit code $_exit)"`,
+    "fi",
+    'exit "$_exit"',
+  ].join("\n");
+
+  // __USER__ and __HOME__ are sed-substituted at deploy time
+  const unitFile = [
+    "[Unit]",
+    `Description=Spawn auto-update for ${agentName}`,
+    "After=network-online.target",
+    "Wants=network-online.target",
+    "",
+    "[Service]",
+    "Type=oneshot",
+    "ExecStart=/usr/local/bin/spawn-auto-update",
+    "User=__USER__",
+    "Environment=HOME=__HOME__",
+    "TimeoutStartSec=1800",
+    "",
+    "[Install]",
+    "WantedBy=multi-user.target",
+  ].join("\n");
+
+  const timerFile = [
+    "[Unit]",
+    `Description=Run spawn auto-update for ${agentName} every 6 hours`,
+    "",
+    "[Timer]",
+    "OnBootSec=15min",
+    "OnUnitActiveSec=6h",
+    "RandomizedDelaySec=30min",
+    "Persistent=true",
+    "",
+    "[Install]",
+    "WantedBy=timers.target",
+  ].join("\n");
+
+  const wrapperB64 = Buffer.from(wrapperScript).toString("base64");
+  const unitB64 = Buffer.from(unitFile).toString("base64");
+  const timerB64 = Buffer.from(timerFile).toString("base64");
+
+  const script = [
+    "if ! command -v systemctl >/dev/null 2>&1; then exit 0; fi",
+    '_sudo=""',
+    '[ "$(id -u)" != "0" ] && _sudo="sudo"',
+    "printf '%s' '" + wrapperB64 + "' | base64 -d | $_sudo tee /usr/local/bin/spawn-auto-update > /dev/null",
+    "$_sudo chmod +x /usr/local/bin/spawn-auto-update",
+    "printf '%s' '" + unitB64 + "' | base64 -d > /tmp/spawn-auto-update.service.tmp",
+    'sed -i "s|__USER__|$(whoami)|;s|__HOME__|$HOME|" /tmp/spawn-auto-update.service.tmp',
+    "$_sudo mv /tmp/spawn-auto-update.service.tmp /etc/systemd/system/spawn-auto-update.service",
+    "printf '%s' '" + timerB64 + "' | base64 -d | $_sudo tee /etc/systemd/system/spawn-auto-update.timer > /dev/null",
+    "$_sudo systemctl daemon-reload",
+    "$_sudo systemctl enable spawn-auto-update.timer 2>/dev/null",
+    "$_sudo systemctl start spawn-auto-update.timer",
+  ].join("\n");
+
+  const result = await asyncTryCatch(() => runner.runServer(script));
+  if (result.ok) {
+    logInfo("Agent auto-update service installed (runs every 6 hours)");
+  } else {
+    logWarn("Auto-update setup failed (non-fatal, agent still works)");
+  }
+}
+
 // ─── Default Agent Definitions ───────────────────────────────────────────────
 
 // Last zeroclaw release that shipped Linux prebuilt binaries (v0.1.9a has none).
@@ -738,6 +864,10 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       configure: (apiKey) => setupClaudeCodeConfig(runner, apiKey),
       launchCmd: () =>
         "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude",
+      updateCmd:
+        'export PATH="$HOME/.claude/local/bin:$HOME/.npm-global/bin:$HOME/.local/bin:$HOME/.bun/bin:$HOME/.n/bin:$PATH"; ' +
+        "npm install -g @anthropic-ai/claude-code@latest 2>/dev/null || " +
+        "curl --proto '=https' -fsSL https://claude.ai/install.sh | bash",
     },
 
     codex: {
@@ -755,6 +885,9 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       ],
       configure: () => setupCodexConfig(runner),
       launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex",
+      updateCmd:
+        'export PATH="$HOME/.npm-global/bin:$HOME/.bun/bin:$PATH"; ' +
+        "npm install -g ${_NPM_G_FLAGS:-} @openai/codex@latest",
     },
 
     openclaw: (() => {
@@ -786,6 +919,9 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
           remotePort: 18789,
           browserUrl: (localPort: number) => `http://localhost:${localPort}/#token=${dashboardToken}`,
         },
+        updateCmd:
+          'export PATH="$HOME/.npm-global/bin:$HOME/.bun/bin:$PATH"; ' +
+          "npm install -g ${_NPM_G_FLAGS:-} openclaw@latest",
       };
     })(),
 
@@ -798,6 +934,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         `OPENROUTER_API_KEY=${apiKey}`,
       ],
       launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode",
+      updateCmd: openCodeInstallCmd(),
     },
 
     kilocode: {
@@ -817,6 +954,9 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         `KILO_OPEN_ROUTER_API_KEY=${apiKey}`,
       ],
       launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode",
+      updateCmd:
+        'export PATH="$HOME/.npm-global/bin:$HOME/.bun/bin:$PATH"; ' +
+        "npm install -g ${_NPM_G_FLAGS:-} @kilocode/cli@latest",
     },
 
     zeroclaw: {
@@ -848,6 +988,18 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       configure: (apiKey) => setupZeroclawConfig(runner, apiKey),
       launchCmd: () =>
         "export PATH=$HOME/.local/bin:$HOME/.cargo/bin:$PATH; source ~/.spawnrc 2>/dev/null; zeroclaw agent",
+      updateCmd:
+        'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; ' +
+        `_ZC_ARCH="$(uname -m)"; ` +
+        `if [ "$_ZC_ARCH" = "x86_64" ]; then _ZC_TARGET="x86_64-unknown-linux-gnu"; ` +
+        `elif [ "$_ZC_ARCH" = "aarch64" ] || [ "$_ZC_ARCH" = "arm64" ]; then _ZC_TARGET="aarch64-unknown-linux-gnu"; ` +
+        "else exit 1; fi; " +
+        `_ZC_URL="https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/zeroclaw-\${_ZC_TARGET}.tar.gz"; ` +
+        `_ZC_TMP="$(mktemp -d)"; ` +
+        `curl --proto '=https' -fsSL "$_ZC_URL" -o "$_ZC_TMP/zeroclaw.tar.gz" && ` +
+        `tar -xzf "$_ZC_TMP/zeroclaw.tar.gz" -C "$_ZC_TMP" && ` +
+        `install -m 755 "$_ZC_TMP/zeroclaw" "$HOME/.local/bin/zeroclaw" && ` +
+        `rm -rf "$_ZC_TMP"`,
     },
 
     hermes: {
@@ -878,6 +1030,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       },
       launchCmd: () =>
         "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.local/bin:$HOME/.hermes/hermes-agent/venv/bin:$PATH; hermes",
+      updateCmd:
+        "curl --proto '=https' -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
     },
 
     junie: {
@@ -896,6 +1050,9 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         `OPENROUTER_API_KEY=${apiKey}`,
       ],
       launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; junie",
+      updateCmd:
+        'export PATH="$HOME/.npm-global/bin:$HOME/.bun/bin:$PATH"; ' +
+        "npm install -g ${_NPM_G_FLAGS:-} @jetbrains/junie-cli@latest",
     },
   };
 }

--- a/packages/cli/src/shared/agents.ts
+++ b/packages/cli/src/shared/agents.ts
@@ -46,6 +46,8 @@ export interface AgentConfig {
   skipTarball?: boolean;
   /** SSH tunnel config for web dashboards. */
   tunnel?: TunnelConfig;
+  /** Shell command to update the agent to its latest version (used by auto-update timer). */
+  updateCmd?: string;
 }
 
 /** Configuration for SSH-tunneling a remote port to localhost. */
@@ -127,6 +129,12 @@ const COMMON_STEPS: OptionalStep[] = [
     value: "custom-model",
     label: "Custom model",
     hint: "enter an OpenRouter model ID manually",
+  },
+  {
+    value: "auto-update",
+    label: "Auto-update",
+    hint: "keep agent + system packages up to date (every 6h)",
+    defaultOn: true,
   },
 ];
 

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -10,7 +10,7 @@ import { readFileSync } from "node:fs";
 import { getErrorMessage } from "@openrouter/spawn-shared";
 import * as v from "valibot";
 import { generateSpawnId, saveLaunchCmd, saveMetadata, saveSpawnRecord } from "../history.js";
-import { offerGithubAuth, wrapSshCall } from "./agent-setup";
+import { offerGithubAuth, setupAutoUpdate, wrapSshCall } from "./agent-setup";
 import { tryTarballInstall } from "./agent-tarball";
 import { generateEnvConfig } from "./agents";
 import { getOrPromptApiKey } from "./oauth";
@@ -252,6 +252,11 @@ export async function runOrchestration(
     // Pass explicitlyRequested=true when user opted in via setup options so the
     // step always runs even if no local gh token was found during detectGithubAuth.
     await offerGithubAuth(cloud.runner, enabledSteps?.has("github"));
+  }
+
+  // 10c. Auto-update service (systemd timer — cloud VMs only, default on)
+  if (cloud.cloudName !== "local" && agent.updateCmd && (!enabledSteps || enabledSteps.has("auto-update"))) {
+    await setupAutoUpdate(cloud.runner, agentName, agent.updateCmd);
   }
 
   // 11. Pre-launch hooks (e.g. OpenClaw gateway)


### PR DESCRIPTION
## Summary

- Adds a **systemd timer + oneshot service** that updates agent binaries and system packages every 6 hours on cloud VMs — without disrupting running instances
- New **"Auto-update"** option in the setup multiselect (default on, user can uncheck or disable via `--steps`)
- Covers all 8 agents with tailored update commands (npm, binary download, curl installer)

### How it works

1. During provisioning, `setupAutoUpdate()` deploys 3 files to the VM via SSH:
   - `/usr/local/bin/spawn-auto-update` — wrapper script (sources `.spawnrc`, flock guard, two-phase update)
   - `/etc/systemd/system/spawn-auto-update.service` — oneshot service
   - `/etc/systemd/system/spawn-auto-update.timer` — fires 15min after boot, then every 6h with 30min jitter
2. **Phase 1**: System packages — `apt-get update && apt-get upgrade` with `DEBIAN_FRONTEND=noninteractive` and `--force-confdef`/`--force-confold`
3. **Phase 2**: Agent-specific update command (e.g. `npm install -g @anthropic-ai/claude-code@latest`)
4. Running processes are unaffected — new version takes effect on next restart via the existing restart loop

### Safety

- **Binary agents** (OpenCode, ZeroClaw): Linux keeps old inode in memory; disk replacement is safe
- **npm agents** (Claude, Codex, OpenClaw, Kilo, Junie): Node.js caches modules at startup; no lazy imports in CLI agents
- **Disables `unattended-upgrades`** on first run to prevent dpkg lock contention
- **`flock -w 300`** on `/var/lib/dpkg/lock-frontend` to wait for any in-progress apt operations
- **Exclusive flock** on wrapper script prevents concurrent update runs
- **Non-fatal**: setup failure doesn't block agent launch
- Skipped for `local` cloud and non-systemd systems

### Files changed

| File | Change |
|------|--------|
| `packages/cli/src/shared/agents.ts` | Add `updateCmd` to `AgentConfig`, add `auto-update` to `COMMON_STEPS` with `defaultOn: true` |
| `packages/cli/src/shared/agent-setup.ts` | Add `setupAutoUpdate()` function + `updateCmd` on all 8 agents |
| `packages/cli/src/shared/orchestrate.ts` | Wire auto-update into pipeline (step 10c), gated on `enabledSteps` |
| `packages/cli/src/__tests__/auto-update.test.ts` | 9 new tests (direct + orchestration integration) |
| `packages/cli/package.json` | `0.20.11` → `0.21.0` |

## Test plan

- [x] `bunx @biomejs/biome check src/` — 0 errors (132 files)
- [x] `bun test` — 1453 pass, 0 fail (71 files)
- [x] Rebased on latest upstream/main (includes Windows PowerShell + `spawn uninstall`)
- [ ] Manual test: provision a DO droplet, verify timer is active (`systemctl list-timers`)
- [ ] Manual test: verify `/var/log/spawn-auto-update.log` shows successful update after 15min
- [ ] Manual test: verify running agent session is not disrupted during update

🤖 Generated with [Claude Code](https://claude.com/claude-code)