### PR TITLE
docs: sync README with source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ spawn delete -c hetzner                  # Delete a server on Hetzner
 | `spawn agents` | List all agents with descriptions |
 | `spawn clouds` | List all cloud providers |
 | `spawn feedback "message"` | Send feedback to the Spawn team |
+| `spawn uninstall` | Uninstall spawn CLI and optionally remove data |
 | `spawn update` | Check for CLI updates |
 | `spawn delete` | Interactively select and destroy a cloud server |
 | `spawn delete -a <agent>` | Filter servers to delete by agent |


### PR DESCRIPTION
## Summary

- Added missing \`spawn uninstall\` row to the Commands table in README.md

## Source-of-truth delta

**Gate 2 (commands drift):** \`packages/cli/src/commands/help.ts\` → \`getHelpUsageSection()\` lists \`spawn uninstall\` (line 45: \`spawn uninstall — Uninstall spawn CLI and optionally remove data\`), but the README Commands table (lines 42–80) had no corresponding row. One row added between \`spawn feedback\` and \`spawn update\` to restore parity.

**Gate 1 (matrix):** No drift — manifest.json has 8 agents × 6 clouds = 48 implemented entries, matching the README tagline and matrix table exactly.

**Gate 3 (troubleshooting):** No recurring issue pattern (2+ occurrences with a missing fix) found in the last 30 issues.

-- qa/record-keeper