### PR TITLE
fix(security): credential files created world-readable due to Bun.write ignoring mode

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -4,7 +4,7 @@ import type { CloudInstance, VMConnection } from "../history.js";
 import type { CloudInitTier } from "../shared/agents";
 
 import { createHash, createHmac } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { normalize } from "node:path";
 import { getErrorMessage } from "@openrouter/spawn-shared";
 import * as v from "valibot";
@@ -66,7 +66,7 @@ export async function saveCredsToConfig(accessKeyId: string, secretAccessKey: st
     mode: 0o700,
   });
   const payload = `{\n  "accessKeyId": ${jsonEscape(accessKeyId)},\n  "secretAccessKey": ${jsonEscape(secretAccessKey)},\n  "region": ${jsonEscape(region)}\n}\n`;
-  await Bun.write(configPath, payload, {
+  writeFileSync(configPath, payload, {
     mode: 0o600,
   });
 }

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -3,7 +3,7 @@
 import type { CloudInstance, VMConnection } from "../history.js";
 import type { CloudInitTier } from "../shared/agents";
 
-import { mkdirSync, readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { normalize } from "node:path";
 import * as p from "@clack/prompts";
 import { getErrorMessage, isNumber, isString, toObjectArray, toRecord } from "@openrouter/spawn-shared";
@@ -239,7 +239,7 @@ async function saveConfig(values: Record<string, unknown>): Promise<void> {
     recursive: true,
     mode: 0o700,
   });
-  await Bun.write(configPath, JSON.stringify(values, null, 2) + "\n", {
+  writeFileSync(configPath, JSON.stringify(values, null, 2) + "\n", {
     mode: 0o600,
   });
 }

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -3,7 +3,7 @@
 import type { CloudInstance, VMConnection } from "../history.js";
 import type { CloudInitTier } from "../shared/agents";
 
-import { mkdirSync, readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { normalize } from "node:path";
 import { getErrorMessage, isNumber, isString, toObjectArray, toRecord } from "@openrouter/spawn-shared";
 import { handleBillingError, isBillingError, showNonBillingError } from "../shared/billing-guidance";
@@ -130,7 +130,7 @@ async function saveTokenToConfig(token: string): Promise<void> {
     mode: 0o700,
   });
   const escaped = jsonEscape(token);
-  await Bun.write(configPath, `{\n  "api_key": ${escaped},\n  "token": ${escaped}\n}\n`, {
+  writeFileSync(configPath, `{\n  "api_key": ${escaped},\n  "token": ${escaped}\n}\n`, {
     mode: 0o600,
   });
 }

--- a/packages/cli/src/shared/oauth.ts
+++ b/packages/cli/src/shared/oauth.ts
@@ -1,6 +1,6 @@
 // shared/oauth.ts — OpenRouter OAuth flow + API key management
 
-import { mkdirSync, readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { getErrorMessage, isString } from "@openrouter/spawn-shared";
 import * as v from "valibot";
@@ -259,7 +259,7 @@ async function saveOpenRouterKey(key: string): Promise<void> {
       recursive: true,
       mode: 0o700,
     });
-    await Bun.write(
+    writeFileSync(
       configPath,
       JSON.stringify(
         {


### PR DESCRIPTION
## Summary

- `Bun.write(path, data, { mode: 0o600 })` silently ignores the `mode` option — files get default `0644` permissions
- All 4 credential-saving functions (Hetzner, DigitalOcean, AWS, OpenRouter) used this pattern, leaving API tokens readable by all local users
- Replaced `Bun.write` with `writeFileSync` from `node:fs`, which correctly applies `0o600` permissions

Verified with a repro script:
```
Bun.write  + { mode: 0o600 } → actual: 0o664 (world-readable)
writeFileSync + { mode: 0o600 } → actual: 0o600 (owner-only)
```

## Files changed

- `packages/cli/src/hetzner/hetzner.ts` — Hetzner API token
- `packages/cli/src/digitalocean/digitalocean.ts` — DigitalOcean OAuth token
- `packages/cli/src/aws/aws.ts` — AWS access keys
- `packages/cli/src/shared/oauth.ts` — OpenRouter API key
- `packages/cli/package.json` — version bump 0.21.2 → 0.21.3

## Test plan

- [x] Verified `Bun.write` ignores mode via repro script
- [x] Verified `writeFileSync` applies mode correctly
- [x] Bun docs confirm `Bun.write` has no `mode` parameter in its API signature
- [x] All 1453 tests pass
- [x] Biome lint: zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)