### PR TITLE
fix(security): resolve symlinks in prompt file path validation

### DIFF
--- a/packages/cli/src/__tests__/prompt-file-security.test.ts
+++ b/packages/cli/src/__tests__/prompt-file-security.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { validatePromptFilePath, validatePromptFileStats } from "../security.js";
 
 describe("validatePromptFilePath", () => {
@@ -113,6 +115,48 @@ describe("validatePromptFilePath", () => {
     expect(() => validatePromptFilePath("/backup/id_ed25519")).toThrow("SSH key");
     expect(() => validatePromptFilePath("id_ecdsa")).toThrow("SSH key");
     expect(() => validatePromptFilePath("/tmp/id_rsa.pub")).toThrow("SSH key");
+  });
+
+  describe("symlink bypass protection", () => {
+    const home = process.env.HOME ?? "";
+    const testDir = join(home, ".spawn-test-symlinks");
+    const sshDir = join(testDir, ".ssh");
+    const envFile = join(testDir, ".env");
+
+    beforeEach(() => {
+      mkdirSync(sshDir, {
+        recursive: true,
+      });
+      writeFileSync(join(sshDir, "id_rsa"), "fake-key");
+      writeFileSync(envFile, "SECRET=value");
+    });
+
+    afterEach(() => {
+      rmSync(testDir, {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    it("should reject symlinks pointing to sensitive SSH files", () => {
+      const symlink = join(testDir, "innocent.txt");
+      symlinkSync(join(sshDir, "id_rsa"), symlink);
+      expect(() => validatePromptFilePath(symlink)).toThrow("SSH");
+    });
+
+    it("should reject symlinks pointing to .env files", () => {
+      const symlink = join(testDir, "notes.txt");
+      symlinkSync(envFile, symlink);
+      expect(() => validatePromptFilePath(symlink)).toThrow("environment file");
+    });
+
+    it("should accept symlinks pointing to non-sensitive files", () => {
+      const safeFile = join(testDir, "safe.txt");
+      writeFileSync(safeFile, "hello");
+      const symlink = join(testDir, "link.txt");
+      symlinkSync(safeFile, symlink);
+      expect(() => validatePromptFilePath(symlink)).not.toThrow();
+    });
   });
 });
 

--- a/packages/cli/src/security.ts
+++ b/packages/cli/src/security.ts
@@ -3,6 +3,7 @@
  * SECURITY-CRITICAL: These functions protect against injection attacks
  */
 
+import { existsSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 
 // Allowlist pattern for agent and cloud identifiers
@@ -631,8 +632,15 @@ export function validatePromptFilePath(filePath: string): void {
     );
   }
 
-  // Normalize the path to resolve .. and symlink-like textual tricks
-  const resolved = resolve(filePath);
+  // Normalize the path to resolve .. and textual tricks
+  let resolved = resolve(filePath);
+
+  // Follow symlinks to validate the real target path, not the symlink name.
+  // Without this, a symlink like `innocent.txt -> ~/.ssh/id_rsa` would bypass
+  // sensitive path checks because the resolved string wouldn't match patterns.
+  if (existsSync(resolved)) {
+    resolved = realpathSync(resolved);
+  }
 
   // Check against sensitive path patterns
   for (const { pattern, description } of SENSITIVE_PATH_PATTERNS) {


### PR DESCRIPTION
## Summary
- **Fix symlink bypass** in `validatePromptFilePath`: uses `realpathSync()` to canonicalize paths before checking against sensitive patterns, preventing attackers from using symlinks (e.g., `innocent.txt -> ~/.ssh/id_rsa`) to exfiltrate credentials
- **Add symlink bypass tests**: 3 new tests covering symlinks to SSH keys, `.env` files, and safe files
- Version bump: 0.21.3 → 0.21.4

## Test plan
- [x] New symlink bypass tests pass (3 tests)
- [x] All existing prompt-file-security tests still pass (13 total)
- [x] Full test suite passes (1456 tests, 0 failures)
- [x] Biome lint passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)