### PR TITLE
fix(aws): wait for public IP before returning from waitForInstance

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1004,7 +1004,7 @@ async function waitForInstance(maxAttempts = 60): Promise<VMConnection> {
     const state = infoResult.ok ? infoResult.data.state : "";
     const ip = infoResult.ok ? infoResult.data.ip : "";
 
-    if (state === "running") {
+    if (state === "running" && ip.trim()) {
       _state.instanceIp = ip.trim();
       logStepDone();
       logInfo(`Instance running: IP=${_state.instanceIp}`);
@@ -1017,7 +1017,8 @@ async function waitForInstance(maxAttempts = 60): Promise<VMConnection> {
       };
     }
 
-    logStepInline(`Instance state: ${state || "pending"} (${attempt}/${maxAttempts})`);
+    const detail = state === "running" ? "running, waiting for IP" : state || "pending";
+    logStepInline(`Instance state: ${detail} (${attempt}/${maxAttempts})`);
     await sleep(pollDelay);
   }
 


### PR DESCRIPTION
## Summary
- Lightsail can report `state=running` before assigning a public IP address
- `waitForInstance` now continues polling until both state is running **and** IP is non-empty
- Adds a more descriptive status message ("running, waiting for IP") during the gap

## Test plan
- [x] `bunx @biomejs/biome check` passes
- [x] `bun test` — 1455 tests pass, 0 failures
- [ ] Deploy an AWS Lightsail instance and confirm IP is populated before SSH begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)