### PR TITLE
fix(cli): handle --help/--version flags after positional args

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -591,6 +591,17 @@ function hasTrailingHelpFlag(args: string[]): boolean {
   return args.slice(1).some((a) => HELP_FLAGS.includes(a));
 }
 
+const VERSION_FLAGS = [
+  "--version",
+  "-v",
+  "-V",
+];
+
+/** Check if trailing args contain a version flag */
+function hasTrailingVersionFlag(args: string[]): boolean {
+  return args.slice(1).some((a) => VERSION_FLAGS.includes(a));
+}
+
 /** Handle list/ls/history commands with filters and --clear */
 async function dispatchListCommand(filteredArgs: string[]): Promise<void> {
   if (hasTrailingHelpFlag(filteredArgs)) {
@@ -664,6 +675,14 @@ async function dispatchVerbAlias(
   headless: boolean,
   outputFormat?: string,
 ): Promise<void> {
+  if (hasTrailingHelpFlag(filteredArgs)) {
+    cmdHelp();
+    return;
+  }
+  if (hasTrailingVersionFlag(filteredArgs)) {
+    showVersion();
+    return;
+  }
   if (filteredArgs.length > 1) {
     const remaining = filteredArgs.slice(1);
     warnExtraArgs(remaining, 2);
@@ -756,6 +775,15 @@ async function dispatchCommand(
     if (await dispatchSlashNotation(cmd, prompt, dryRun, debug, headless, outputFormat)) {
       return;
     }
+  }
+
+  if (hasTrailingHelpFlag(filteredArgs)) {
+    cmdHelp();
+    return;
+  }
+  if (hasTrailingVersionFlag(filteredArgs)) {
+    showVersion();
+    return;
   }
 
   warnExtraArgs(filteredArgs, 2);


### PR DESCRIPTION
## Summary
- `spawn claude sprite --help` no longer warns about extra args and provisions a server — it now shows help
- `spawn claude sprite --version` now shows version info instead of proceeding to provision
- Same fix applied to verb alias path (`spawn run claude sprite --help`)

## What changed
- Added `VERSION_FLAGS` constant and `hasTrailingVersionFlag()` helper (mirrors existing `hasTrailingHelpFlag()`)
- Added trailing help/version checks in `dispatchCommand()` before the default `warnExtraArgs` + `handleDefaultCommand` fallthrough
- Added trailing help/version checks in `dispatchVerbAlias()` before routing to `handleDefaultCommand`
- Bumped CLI version to 0.21.5

## Test plan
- [x] `bun test` — 1455 tests pass, 0 failures
- [x] `biome check` — 0 errors on changed file
- [ ] Manual: `spawn claude sprite --help` shows help
- [ ] Manual: `spawn claude sprite -v` shows version
- [ ] Manual: `spawn run claude sprite --help` shows help

🤖 Generated with [Claude Code](https://claude.com/claude-code)