### PR TITLE
fix(tarball): validate remote VM arch for single-arch releases

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/agent-tarball.test.ts
+++ b/packages/cli/src/__tests__/agent-tarball.test.ts
@@ -78,7 +78,7 @@ describe("tryTarballInstall", () => {
     expect(getUrl()).toContain("/releases/tags/agent-openclaw-latest");
   });
 
-  it("runs curl | tar xz -C / on the remote VM", async () => {
+  it("runs curl | tar xz -C / on the remote VM with arch check for x86_64-only release", async () => {
     const fetchFn = mockFetch(new Response(JSON.stringify(RELEASE_PAYLOAD)));
     const runner = createMockRunner();
 
@@ -91,8 +91,61 @@ describe("tryTarballInstall", () => {
     expect(cmd).toContain("curl -fsSL");
     expect(cmd).toContain("tar xz -C /");
     expect(cmd).toContain(".spawn-tarball");
+    // Must include arch validation even with single-arch release
+    expect(cmd).toContain("uname -m");
+    expect(cmd).toContain("exit 1");
     const mirrorCmd = String(runner.runServer.mock.calls[1][0]);
     expect(mirrorCmd).toContain("cp -a");
+  });
+
+  it("includes arch check for arm64-only release", async () => {
+    const armOnlyPayload = {
+      assets: [
+        {
+          name: "spawn-agent-claude-arm64-20260305.tar.gz",
+          browser_download_url:
+            "https://github.com/OpenRouterTeam/spawn/releases/download/agent-claude-latest/spawn-agent-claude-arm64-20260305.tar.gz",
+        },
+      ],
+    };
+    const fetchFn = mockFetch(new Response(JSON.stringify(armOnlyPayload)));
+    const runner = createMockRunner();
+
+    const result = await tryTarballInstall(runner, "claude", fetchFn);
+
+    expect(result).toBe(true);
+    const cmd = String(runner.runServer.mock.calls[0][0]);
+    expect(cmd).toContain("uname -m");
+    expect(cmd).toContain("exit 1");
+    expect(cmd).toContain("Tarball is arm64 but remote is");
+  });
+
+  it("uses arch selection (no exit 1) when both architectures are available", async () => {
+    const dualArchPayload = {
+      assets: [
+        {
+          name: "spawn-agent-claude-x86_64-20260305.tar.gz",
+          browser_download_url:
+            "https://github.com/OpenRouterTeam/spawn/releases/download/agent-claude-latest/spawn-agent-claude-x86_64-20260305.tar.gz",
+        },
+        {
+          name: "spawn-agent-claude-arm64-20260305.tar.gz",
+          browser_download_url:
+            "https://github.com/OpenRouterTeam/spawn/releases/download/agent-claude-latest/spawn-agent-claude-arm64-20260305.tar.gz",
+        },
+      ],
+    };
+    const fetchFn = mockFetch(new Response(JSON.stringify(dualArchPayload)));
+    const runner = createMockRunner();
+
+    const result = await tryTarballInstall(runner, "claude", fetchFn);
+
+    expect(result).toBe(true);
+    const cmd = String(runner.runServer.mock.calls[0][0]);
+    expect(cmd).toContain("uname -m");
+    // Dual-arch uses _url variable selection, not exit 1
+    expect(cmd).toContain("_url=");
+    expect(cmd).not.toContain("exit 1");
   });
 
   it("returns false when release does not exist (404)", async () => {

--- a/packages/cli/src/shared/agent-tarball.ts
+++ b/packages/cli/src/shared/agent-tarball.ts
@@ -70,7 +70,6 @@ export async function tryTarballInstall(
     return {
       x86Url: x86Asset?.browser_download_url || "",
       armUrl: armAsset?.browser_download_url || "",
-      url: x86Asset?.browser_download_url || armAsset?.browser_download_url || "",
     };
   });
   if (!metaResult.ok) {
@@ -81,7 +80,7 @@ export async function tryTarballInstall(
   if (!metaResult.data) {
     return false;
   }
-  const { x86Url, armUrl, url } = metaResult.data;
+  const { x86Url, armUrl } = metaResult.data;
 
   // Phase 2: URL validation + command building (deterministic — no try/catch needed)
   // SECURITY: Validate URLs match expected GitHub releases pattern.
@@ -100,13 +99,26 @@ export async function tryTarballInstall(
   const sudo = '$([ "$(id -u)" != "0" ] && echo sudo || echo "")';
   let downloadCmd: string;
   if (x86Url && armUrl) {
+    // Both architectures available — let the remote VM pick the right one
     downloadCmd =
       "_arch=$(uname -m); " +
       `if [ "$_arch" = "aarch64" ] || [ "$_arch" = "arm64" ]; then ` +
       `_url='${armUrl}'; else _url='${x86Url}'; fi; ` +
       `curl -fsSL --connect-timeout 10 --max-time 120 "$_url" | ${sudo} tar xz -C / && ${sudo} test -f /root/.spawn-tarball`;
+  } else if (x86Url) {
+    // Only x86_64 available — verify remote arch matches before installing
+    downloadCmd =
+      "_arch=$(uname -m); " +
+      'if [ "$_arch" = "aarch64" ] || [ "$_arch" = "arm64" ]; then ' +
+      'echo "Tarball is x86_64 but remote is $_arch" >&2; exit 1; fi; ' +
+      `curl -fsSL --connect-timeout 10 --max-time 120 '${x86Url}' | ${sudo} tar xz -C / && ${sudo} test -f /root/.spawn-tarball`;
   } else {
-    downloadCmd = `curl -fsSL --connect-timeout 10 --max-time 120 '${url}' | ${sudo} tar xz -C / && ${sudo} test -f /root/.spawn-tarball`;
+    // Only arm64 available — verify remote arch matches before installing
+    downloadCmd =
+      "_arch=$(uname -m); " +
+      'if [ "$_arch" != "aarch64" ] && [ "$_arch" != "arm64" ]; then ' +
+      'echo "Tarball is arm64 but remote is $_arch" >&2; exit 1; fi; ' +
+      `curl -fsSL --connect-timeout 10 --max-time 120 '${armUrl}' | ${sudo} tar xz -C / && ${sudo} test -f /root/.spawn-tarball`;
   }
 
   // Phase 3: Remote execution — catch-all because any failure means "fall back to live install"


### PR DESCRIPTION
## Summary
- When a GitHub Release has only one architecture's tarball (x86_64 or arm64), the remote download command now checks `uname -m` and exits with error if the arch doesn't match
- Prevents installing x86_64 tarballs on ARM VMs (or vice versa) which causes "Exec format error" at runtime and skips the live install fallback
- Adds tests for x86_64-only, arm64-only, and dual-arch release scenarios

## Test plan
- [x] Existing tests pass (11/11)
- [x] New test: x86_64-only release includes `uname -m` check and `exit 1`
- [x] New test: arm64-only release includes `uname -m` check and `exit 1`
- [x] New test: dual-arch release uses `_url=` selection without `exit 1`
- [x] Biome lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)