### PR TITLE
fix(ui): propagate Ctrl+C/Esc cancellation instead of returning empty string

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/ui.ts
+++ b/packages/cli/src/shared/ui.ts
@@ -87,7 +87,11 @@ export async function prompt(question: string): Promise<string> {
   if (!r.ok) {
     throw r.error;
   }
-  return p.isCancel(r.data) ? "" : (r.data || "").trim();
+  if (p.isCancel(r.data)) {
+    process.stderr.write("\n");
+    process.exit(0);
+  }
+  return (r.data || "").trim();
 }
 
 /**
@@ -125,7 +129,8 @@ export async function selectFromList(items: string[], promptText: string, defaul
   });
 
   if (p.isCancel(result)) {
-    return "";
+    process.stderr.write("\n");
+    process.exit(0);
   }
   return isString(result) ? result : String(result);
 }


### PR DESCRIPTION
**Why:** `p.isCancel()` returns are silently converted to `""` causing infinite retry loops in billing, silent fallthrough in oauth key entry, and unintended defaults in name prompts. Fixes by calling `process.exit(0)` on cancel.

Fixes #2745

- `prompt()`: call `process.exit(0)` when `p.isCancel(result)` is true
- `selectFromList()`: same fix
- Reviewed all callers (billing-guidance, oauth, gcp, hetzner, digitalocean, aws, orchestrate, agent-setup) — no workarounds needed removal

-- refactor/ux-engineer