### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/__tests__/README.md
+++ b/packages/cli/src/__tests__/README.md
@@ -63,8 +63,11 @@ bun test src/__tests__/manifest.test.ts
 - `paths.test.ts` — `getSpawnDir`, `getCacheDir`, `getHistoryPath`, `getSshDir`, path resolution
 - `ssh-keys.test.ts` — SSH key discovery, generation, fingerprinting
 - `update-check.test.ts` — Auto-update check logic
+- `auto-update.test.ts` — `setupAutoUpdate`: systemd service unit generation and orchestration integration
+- `kill-with-timeout.test.ts` — `killWithTimeout`: SIGKILL after grace period, already-exited process handling
 - `with-retry-result.test.ts` — `withRetry`, `wrapSshCall`, Result constructors
 - `orchestrate.test.ts` — `runOrchestration`
+- `shell.test.ts` — `getLocalShell`, `isWindows`, `getInstallCmd`, `getWhichCommand`, `getInstallScriptUrl`: platform-aware shell detection
 - `fs-sandbox.test.ts` — Guardrail: verifies test preload sandbox isolates filesystem writes
 
 ### Parsing and type utilities
@@ -87,8 +90,10 @@ bun test src/__tests__/manifest.test.ts
 - `check-entity.test.ts` / `check-entity-messages.test.ts` — Entity validation
 - `agent-tarball.test.ts` — `tryTarballInstall`: GitHub Release tarball install, fallback, URL validation
 - `gateway-resilience.test.ts` — `startGateway` systemd unit with auto-restart and cron heartbeat
+- `digitalocean-token.test.ts` — DigitalOcean token storage, retrieval, and API client helpers
 - `do-payment-warning.test.ts` — `ensureDoToken` proactive payment method reminder for first-time DigitalOcean users
 - `do-snapshot.test.ts` — `findSpawnSnapshot`: DigitalOcean snapshot lookup, filtering, error handling
+- `hetzner-pagination.test.ts` — Hetzner API pagination: multi-page server listing and cursor handling
 - `sprite-keep-alive.test.ts` — `installSpriteKeepAlive` download/install, graceful failure, session script wrapping
 - `ui-utils.test.ts` — `validateServerName`, `validateRegionName`, `toKebabCase`, `sanitizeTermValue`, `jsonEscape`
 - `gcp-shellquote.test.ts` — `shellQuote` GCP-specific quoting edge cases


### PR DESCRIPTION
## Summary

Comprehensive dead code and stale reference scan across `packages/cli/src/` and `sh/`. No actual dead code, stale references, Python usage, or banned patterns were found in production code — the codebase is clean. One documentation gap was discovered and fixed:

- **5 undocumented test files** added to `packages/cli/src/__tests__/README.md`: `auto-update.test.ts`, `kill-with-timeout.test.ts`, `shell.test.ts`, `digitalocean-token.test.ts`, `hetzner-pagination.test.ts`

## Scan Results by Category

**a) Dead code** — None found. All exported functions in `shared/`, cloud modules, and utility files have verified callers.

**b) Stale references** — None found. All cloud driver functions (`_validate_env`, `_headless_env`, `_provision_verify`, `_exec`, `_teardown`, `_cleanup_stale`) are implemented across all 5 cloud drivers. All TypeScript imports resolve to existing files.

**c) Python usage** — None found. No `python3 -c` or `python -c` calls in any shell scripts.

**d) Duplicate utilities** — None found. `getConnectionInfo`, `promptSpawnName`, `getServerName`, etc. are cloud-specific wrappers over shared helpers, not duplicates.

**e) Stale comments** — None found. Shell script comments referencing `BASH_SOURCE` and `source` in e2e scripts are correctly documented as intentional (e2e runs from disk, not curl|bash).

## Test plan

- [x] `bun test` — 1467 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` — no errors
- [x] `bash -n` on all 63 shell scripts — no syntax errors

-- qa/code-quality