### PR TITLE
test: remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/credential-hints.test.ts
+++ b/packages/cli/src/__tests__/credential-hints.test.ts
@@ -128,23 +128,4 @@ describe("credentialHints", () => {
       expect(joined).not.toContain("OPENROUTER_API_KEY -- not set");
     });
   });
-
-  describe("integration with getScriptFailureGuidance", () => {
-    it("always includes setup instructions regardless of env state", () => {
-      const hints = credentialHints("digitalocean", "DO_API_TOKEN");
-      const joined = hints.join("\n");
-      expect(joined).toContain("setup instructions");
-    });
-
-    it("always returns at least one line", () => {
-      const hints = credentialHints("sprite");
-      expect(hints.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it("returns more lines when authHint is provided", () => {
-      const withHint = credentialHints("hetzner", "HCLOUD_TOKEN");
-      const withoutHint = credentialHints("hetzner");
-      expect(withHint.length).toBeGreaterThan(withoutHint.length);
-    });
-  });
 });


### PR DESCRIPTION
## Summary

- Removed 3 theatrical tests from `credential-hints.test.ts` in an `"integration with getScriptFailureGuidance"` describe block
- All removed tests were redundant with existing, more specific tests in the same file

### Removed tests and why

| Test | Why removed |
|---|---|
| "always includes setup instructions regardless of env state" | Checked for vague string `"setup instructions"` — already verified with concrete assertions in the `"when all required env vars are missing"` describe block (line 66) |
| "always returns at least one line" | Pure existence check (`length >= 1`) — already proven by `"when no authHint is provided"` which asserts exact length of 1 |
| "returns more lines when authHint is provided" | Tests implementation detail (line count delta) not behavior — the actual behavior is fully covered by per-scenario describe blocks |

### Scan findings (no other action needed)

Scanned all 73 test files (1467 tests) for:
- **Duplicate describe blocks** across files: all duplicated names are nested within different parent contexts — no true duplicates
- **Bash-grep tests** (`type FUNCTION_NAME`): none found
- **Always-pass patterns** (`if (cond) { expect } else { /* skip */ }`): all conditional blocks are guard clauses (re-throw or setup), not skipping asserts
- **Excessive subprocess spawning**: only `fs-sandbox.test.ts` uses real `Bun.spawnSync` (legitimate sandbox guardrail); all other uses are properly mocked via `spyOn`

## Test plan

- [x] `bun test` passes: 1464/1464 (removed 3 tests)
- [x] `bunx @biomejs/biome check src/` passes: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
-- qa/dedup-scanner