### PR TITLE
feat(hetzner): default region nbg1 + location fallback

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -302,7 +302,7 @@
       "interactive_method": "ssh -t root@IP",
       "defaults": {
         "server_type": "cx23",
-        "location": "fsn1",
+        "location": "nbg1",
         "image": "ubuntu-24.04"
       },
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/clouds/hetzner.png"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.11.25",
+  "version": "0.11.26",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -411,14 +411,75 @@ export async function createServer(
     start_after_create: true,
   });
 
-  const resp = await hetznerApi("POST", "/servers", body);
-  const data = parseJsonObj(resp);
+  let currentLoc = loc;
+  let currentBody = body;
 
-  // Hetzner success responses contain "error": null in action objects,
-  // so check for presence of .server object, not absence of "error" string.
-  const server = toRecord(data?.server);
-  if (!server) {
-    const errMsg = toRecord(data?.error)?.message || "Unknown error";
+  // Retry loop for location fallback
+  for (let locationAttempt = 0; locationAttempt < 2; locationAttempt++) {
+    const resp = await hetznerApi("POST", "/servers", currentBody);
+    const data = parseJsonObj(resp);
+
+    // Hetzner success responses contain "error": null in action objects,
+    // so check for presence of .server object, not absence of "error" string.
+    const server = toRecord(data?.server);
+    if (server) {
+      // Success — extract server info below
+      hetznerServerId = String(server.id);
+      const publicNet = toRecord(server.public_net);
+      const ipv4 = toRecord(publicNet?.ipv4);
+      hetznerServerIp = isString(ipv4?.ip) ? ipv4.ip : "";
+
+      if (!hetznerServerId || hetznerServerId === "null") {
+        logError("Failed to extract server ID from API response");
+        throw new Error("No server ID");
+      }
+      if (!hetznerServerIp || hetznerServerIp === "null") {
+        logError("Failed to extract server IP from API response");
+        throw new Error("No server IP");
+      }
+
+      logInfo(`Server created: ID=${hetznerServerId}, IP=${hetznerServerIp}`);
+      saveVmConnection(hetznerServerIp, "root", hetznerServerId, name, "hetzner");
+      return;
+    }
+
+    const errObj = toRecord(data?.error);
+    const errMsg = isString(errObj?.message) ? errObj.message : "Unknown error";
+    const errCode = isString(errObj?.code) ? errObj.code : "";
+
+    // Location unavailable — offer fallback to user-selected location
+    if (
+      locationAttempt === 0 &&
+      (errCode === "resource_unavailable" || /location.*disabled/i.test(errMsg)) &&
+      process.env.SPAWN_NON_INTERACTIVE !== "1"
+    ) {
+      logWarn(`Location '${currentLoc}' is unavailable: ${errMsg}`);
+      logWarn("Please choose a different location:");
+      process.stderr.write("\n");
+
+      const otherLocations = LOCATIONS.filter((l) => l.id !== currentLoc);
+      const items = otherLocations.map((l) => `${l.id}|${l.label}`);
+      const newLoc = await selectFromList(items, "Hetzner location", otherLocations[0]?.id || "nbg1");
+
+      if (!validateRegionName(newLoc)) {
+        logError("Invalid location selected");
+        throw new Error(`Server creation failed: ${errMsg}`);
+      }
+
+      logStep(`Retrying with location '${newLoc}'...`);
+      currentLoc = newLoc;
+      currentBody = JSON.stringify({
+        name,
+        server_type: sType,
+        location: newLoc,
+        image,
+        ssh_keys: sshKeyIds,
+        user_data: userdata,
+        start_after_create: true,
+      });
+      continue;
+    }
+
     logError(`Failed to create Hetzner server: ${errMsg}`);
     logWarn("Common issues:");
     logWarn("  - Insufficient account balance or payment method required");
@@ -428,22 +489,7 @@ export async function createServer(
     throw new Error(`Server creation failed: ${errMsg}`);
   }
 
-  hetznerServerId = String(server.id);
-  const publicNet = toRecord(server.public_net);
-  const ipv4 = toRecord(publicNet?.ipv4);
-  hetznerServerIp = isString(ipv4?.ip) ? ipv4.ip : "";
-
-  if (!hetznerServerId || hetznerServerId === "null") {
-    logError("Failed to extract server ID from API response");
-    throw new Error("No server ID");
-  }
-  if (!hetznerServerIp || hetznerServerIp === "null") {
-    logError("Failed to extract server IP from API response");
-    throw new Error("No server IP");
-  }
-
-  logInfo(`Server created: ID=${hetznerServerId}, IP=${hetznerServerIp}`);
-  saveVmConnection(hetznerServerIp, "root", hetznerServerId, name, "hetzner");
+  throw new Error("Server creation failed after location fallback");
 }
 
 // ─── SSH Execution ───────────────────────────────────────────────────────────

--- a/sh/e2e/lib/clouds/hetzner.sh
+++ b/sh/e2e/lib/clouds/hetzner.sh
@@ -41,7 +41,7 @@ _hetzner_headless_env() {
 
   printf 'export HETZNER_SERVER_NAME="%s"\n' "${app}"
   printf 'export HETZNER_SERVER_TYPE="%s"\n' "${HETZNER_SERVER_TYPE:-cx23}"
-  printf 'export HETZNER_LOCATION="%s"\n' "${HETZNER_LOCATION:-fsn1}"
+  printf 'export HETZNER_LOCATION="%s"\n' "${HETZNER_LOCATION:-nbg1}"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Changed default Hetzner region from `fsn1` (Falkenstein) to `nbg1` (Nuremberg) — fsn1 is returning HTTP 412 "server location disabled"
- Added location fallback: when server creation fails with `resource_unavailable`, the user is prompted to pick a different location and the creation is retried
- Updated manifest.json and e2e test defaults to match

## Test plan
- [ ] Verify `spawn claude hetzner` provisions in nbg1 by default
- [ ] Manually trigger resource_unavailable by setting `HETZNER_LOCATION=fsn1` to verify fallback prompt appears
- [ ] Run e2e tests on Hetzner

🤖 Generated with [Claude Code](https://claude.com/claude-code)