### PR TITLE
fix(digitalocean): use s-2vcpu-4gb-intel for openclaw to support nyc3 region

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -862,8 +862,8 @@ const DROPLET_SIZES: DropletSize[] = [
     label: "2 vCPU \u00b7 2 GB RAM \u00b7 $18/mo",
   },
   {
-    id: "s-2vcpu-4gb",
-    label: "2 vCPU \u00b7 4 GB RAM \u00b7 $24/mo",
+    id: "s-2vcpu-4gb-intel",
+    label: "2 vCPU \u00b7 4 GB RAM \u00b7 $28/mo (Intel, available in all regions)",
   },
   {
     id: "s-4vcpu-8gb",

--- a/packages/cli/src/digitalocean/main.ts
+++ b/packages/cli/src/digitalocean/main.ts
@@ -28,7 +28,9 @@ import {
 
 /** Agents that need more than the default 2GB RAM (e.g. openclaw-plugins OOMs on 2GB) */
 const AGENT_MIN_SIZE: Record<string, string> = {
-  openclaw: "s-2vcpu-4gb",
+  // s-2vcpu-4gb-intel is used instead of s-2vcpu-4gb because the non-intel variant
+  // is not available in nyc3 (the default E2E region). Both offer 2 vCPUs and 4GB RAM.
+  openclaw: "s-2vcpu-4gb-intel",
 };
 
 /** DO marketplace image slugs — hardcoded from vendor portal (approved 2026-03-13) */


### PR DESCRIPTION
## Summary

- `s-2vcpu-4gb` is not available in `nyc3` (the default E2E test region), causing openclaw provisioning to fail with 422 "Size is not available in this region"
- Changed `AGENT_MIN_SIZE` for openclaw in `digitalocean/main.ts` from `s-2vcpu-4gb` to `s-2vcpu-4gb-intel`
- `s-2vcpu-4gb-intel` offers the same specs (2 vCPU, 4 GB RAM) and is available in `nyc3`, `nyc1`, `nyc2`, and all regions
- Updated the size picker list in `digitalocean.ts` to display the intel variant with corrected pricing ($28/mo)

This is a rebased version of #2768 which had a merge conflict due to version bump.
Closes #2768.

-- qa/e2e-tester