### PR TITLE
feat(hetzner): add snapshot support + Packer image builds

### DIFF
--- a/.github/workflows/packer-snapshots.yml
+++ b/.github/workflows/packer-snapshots.yml
@@ -1,4 +1,4 @@
-name: Packer DO Snapshots
+name: Packer Snapshots
 
 on:
   schedule:
@@ -10,6 +10,14 @@ on:
         description: "Single agent to build (leave empty for all)"
         required: false
         type: string
+      cloud:
+        description: "Cloud to build for (leave empty for all)"
+        required: false
+        type: choice
+        options:
+          - ""
+          - digitalocean
+          - hetzner
 
 permissions:
   contents: read
@@ -19,29 +27,42 @@ jobs:
     name: Generate matrix
     runs-on: ubuntu-latest
     outputs:
-      agents: ${{ steps.set.outputs.agents }}
+      include: ${{ steps.set.outputs.include }}
     steps:
       - uses: actions/checkout@v4
       - id: set
         run: |
           SINGLE_AGENT="${SINGLE_AGENT_INPUT}"
+          SINGLE_CLOUD="${SINGLE_CLOUD_INPUT}"
+
           if [ -n "$SINGLE_AGENT" ]; then
-            echo "agents=[\"${SINGLE_AGENT}\"]" >> "$GITHUB_OUTPUT"
+            AGENTS="[\"${SINGLE_AGENT}\"]"
           else
             AGENTS=$(jq -c 'keys' packer/agents.json)
-            echo "agents=${AGENTS}" >> "$GITHUB_OUTPUT"
           fi
+
+          if [ -n "$SINGLE_CLOUD" ]; then
+            CLOUDS="[\"${SINGLE_CLOUD}\"]"
+          else
+            CLOUDS='["digitalocean","hetzner"]'
+          fi
+
+          # Build a flat include array: [{agent, cloud}, ...]
+          INCLUDE=$(jq -nc --argjson agents "$AGENTS" --argjson clouds "$CLOUDS" \
+            '[($agents[] | . as $a) | ($clouds[] | {agent: $a, cloud: .})]')
+          echo "include=${INCLUDE}" >> "$GITHUB_OUTPUT"
         env:
           SINGLE_AGENT_INPUT: ${{ inputs.agent }}
+          SINGLE_CLOUD_INPUT: ${{ inputs.cloud }}
 
   build:
-    name: "Build ${{ matrix.agent }}"
+    name: "${{ matrix.cloud }}/${{ matrix.agent }}"
     needs: matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        agent: ${{ fromJson(needs.matrix.outputs.agents) }}
+        include: ${{ fromJson(needs.matrix.outputs.include) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -61,9 +82,10 @@ jobs:
           version: latest
 
       - name: Init Packer plugins
-        run: packer init packer/digitalocean.pkr.hcl
+        run: packer init packer/${{ matrix.cloud }}.pkr.hcl
 
-      - name: Generate variables file
+      - name: Generate variables file (DigitalOcean)
+        if: matrix.cloud == 'digitalocean'
         run: |
           jq -n \
             --arg token "$DO_API_TOKEN" \
@@ -82,13 +104,32 @@ jobs:
           TIER: ${{ steps.config.outputs.tier }}
           INSTALL_COMMANDS: ${{ steps.config.outputs.install }}
 
-      - name: Build snapshot
-        run: packer build -var-file=packer/auto.pkrvars.json packer/digitalocean.pkr.hcl
-
-      - name: Cleanup old snapshots
-        if: success()
+      - name: Generate variables file (Hetzner)
+        if: matrix.cloud == 'hetzner'
         run: |
-          # DO snapshots don't support tags — filter by name prefix instead
+          jq -n \
+            --arg token "$HCLOUD_TOKEN" \
+            --arg agent "$AGENT_NAME" \
+            --arg tier "$TIER" \
+            --argjson install "$INSTALL_COMMANDS" \
+            '{
+              hcloud_token: $token,
+              agent_name: $agent,
+              cloud_init_tier: $tier,
+              install_commands: $install
+            }' > packer/auto.pkrvars.json
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          AGENT_NAME: ${{ matrix.agent }}
+          TIER: ${{ steps.config.outputs.tier }}
+          INSTALL_COMMANDS: ${{ steps.config.outputs.install }}
+
+      - name: Build snapshot
+        run: packer build -var-file=packer/auto.pkrvars.json packer/${{ matrix.cloud }}.pkr.hcl
+
+      - name: Cleanup old DO snapshots
+        if: success() && matrix.cloud == 'digitalocean'
+        run: |
           PREFIX="spawn-${AGENT_NAME}-"
           SNAPSHOTS=$(curl -s -H "Authorization: Bearer ${DO_API_TOKEN}" \
             "https://api.digitalocean.com/v2/images?private=true&per_page=100" \
@@ -104,8 +145,27 @@ jobs:
           DO_API_TOKEN: ${{ secrets.DO_API_TOKEN }}
           AGENT_NAME: ${{ matrix.agent }}
 
+      - name: Cleanup old Hetzner snapshots
+        if: success() && matrix.cloud == 'hetzner'
+        run: |
+          PREFIX="spawn-${AGENT_NAME}-"
+          # Hetzner Packer sets snapshot_name → description field in the API
+          SNAPSHOTS=$(curl -s -H "Authorization: Bearer ${HCLOUD_TOKEN}" \
+            "https://api.hetzner.cloud/v1/images?type=snapshot&per_page=100" \
+            | jq -r --arg prefix "$PREFIX" \
+              '[.images[] | select(.description | startswith($prefix))] | sort_by(.created) | reverse | .[1:] | .[].id')
+
+          for ID in $SNAPSHOTS; do
+            echo "Deleting old snapshot: ${ID}"
+            curl -s -X DELETE -H "Authorization: Bearer ${HCLOUD_TOKEN}" \
+              "https://api.hetzner.cloud/v1/images/${ID}" || true
+          done
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          AGENT_NAME: ${{ matrix.agent }}
+
       - name: Submit to DO Marketplace
-        if: success()
+        if: success() && matrix.cloud == 'digitalocean'
         run: |
           # Skip if no marketplace app IDs configured
           if [ -z "$MARKETPLACE_APP_IDS" ]; then

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -470,6 +470,53 @@ export async function promptLocation(excludeLocations?: string[]): Promise<strin
   return selectFromList(items, "Hetzner location", defaultLoc);
 }
 
+// ─── Snapshot Lookup ─────────────────────────────────────────────────────────
+
+export async function findSpawnSnapshot(agentName: string): Promise<string | null> {
+  const r = await asyncTryCatch(async () => {
+    const prefix = `spawn-${agentName}-`;
+    const text = await hetznerApi("GET", "/images?type=snapshot&per_page=100", undefined, 1);
+    const data = parseJsonObj(text);
+    const allImages = toObjectArray(data?.images);
+    // Hetzner Packer sets snapshot_name → description field in the API
+    const images = allImages.filter((img) => isString(img.description) && img.description.startsWith(prefix));
+    if (images.length === 0) {
+      return null;
+    }
+
+    // Sort by created descending to get the latest snapshot
+    images.sort((a, b) => {
+      const aDate = isString(a.created) ? a.created : "";
+      const bDate = isString(b.created) ? b.created : "";
+      return bDate.localeCompare(aDate);
+    });
+
+    const latestId = images[0].id;
+    if (!isNumber(latestId) || latestId <= 0) {
+      return null;
+    }
+
+    logInfo(`Found pre-built snapshot for ${agentName} (ID: ${latestId})`);
+    return String(latestId);
+  });
+  return r.ok ? r.data : null;
+}
+
+// ─── SSH-Only Wait (for snapshot boots) ──────────────────────────────────────
+
+export async function waitForSshOnly(ip?: string): Promise<void> {
+  const serverIp = ip || _state.serverIp;
+  const selectedKeys = await ensureSshKeys();
+  const keyOpts = getSshKeyOpts(selectedKeys);
+  await sharedWaitForSsh({
+    host: serverIp,
+    user: "root",
+    maxAttempts: 36,
+    extraSshOpts: keyOpts,
+  });
+  logInfo("SSH available (snapshot boot — skipping cloud-init)");
+}
+
 // ─── Provisioning ────────────────────────────────────────────────────────────
 
 /** Check if a Hetzner API error indicates a location is unavailable (HTTP 412 resource_unavailable). */
@@ -482,10 +529,12 @@ export async function createServer(
   serverType?: string,
   location?: string,
   tier?: CloudInitTier,
+  snapshotId?: string,
 ): Promise<VMConnection> {
   const sType = serverType || process.env.HETZNER_SERVER_TYPE || DEFAULT_SERVER_TYPE;
   let loc = location || process.env.HETZNER_LOCATION || DEFAULT_LOCATION;
-  const image = "ubuntu-24.04";
+  const image = snapshotId ? Number(snapshotId) : "ubuntu-24.04";
+  const imageLabel = snapshotId ? `snapshot:${snapshotId}` : "ubuntu-24.04";
 
   if (!validateRegionName(loc)) {
     logError("Invalid HETZNER_LOCATION");
@@ -495,14 +544,15 @@ export async function createServer(
   // Get all SSH key IDs once (paginated to avoid missing keys beyond page 1)
   const allKeys = await hetznerGetAll("/ssh_keys", "ssh_keys");
   const sshKeyIds: number[] = allKeys.map((k) => (isNumber(k.id) ? k.id : 0)).filter(Boolean);
-  const userdata = getCloudInitUserdata(tier);
+  // Skip cloud-init when booting from a pre-baked snapshot
+  const userdata = snapshotId ? undefined : getCloudInitUserdata(tier);
 
   // Track locations that failed so the user isn't offered them again
   const failedLocations: string[] = [];
   const maxLocationRetries = 3;
 
   for (let attempt = 0; attempt <= maxLocationRetries; attempt++) {
-    logStep(`Creating Hetzner server '${name}' (type: ${sType}, location: ${loc})...`);
+    logStep(`Creating Hetzner server '${name}' (type: ${sType}, location: ${loc}, image: ${imageLabel})...`);
 
     const body = JSON.stringify({
       name,

--- a/packages/cli/src/hetzner/main.ts
+++ b/packages/cli/src/hetzner/main.ts
@@ -12,6 +12,7 @@ import {
   downloadFile,
   ensureHcloudToken,
   ensureSshKey,
+  findSpawnSnapshot,
   getConnectionInfo,
   getServerName,
   interactiveSession,
@@ -21,6 +22,7 @@ import {
   runServer,
   uploadFile,
   waitForCloudInit,
+  waitForSshOnly,
 } from "./hetzner";
 
 async function main() {
@@ -35,10 +37,12 @@ async function main() {
 
   let serverType = "";
   let location = "";
+  let snapshotId: string | null = null;
 
   const cloud: CloudOrchestrator = {
     cloudName: "hetzner",
     cloudLabel: "Hetzner Cloud",
+    skipAgentInstall: false,
     runner: {
       runServer,
       uploadFile,
@@ -54,11 +58,20 @@ async function main() {
       location = await promptLocation();
     },
     async createServer(name: string) {
-      return await createHetznerServer(name, serverType, location, agent.cloudInitTier);
+      // Check for a pre-built snapshot before provisioning
+      snapshotId = await findSpawnSnapshot(agentName);
+      if (snapshotId) {
+        cloud.skipAgentInstall = true;
+      }
+      return await createHetznerServer(name, serverType, location, agent.cloudInitTier, snapshotId ?? undefined);
     },
     getServerName,
     async waitForReady() {
-      await waitForCloudInit();
+      if (snapshotId) {
+        await waitForSshOnly();
+      } else {
+        await waitForCloudInit();
+      }
     },
     interactiveSession,
     getConnectionInfo,

--- a/packer/hetzner.pkr.hcl
+++ b/packer/hetzner.pkr.hcl
@@ -1,0 +1,165 @@
+packer {
+  required_plugins {
+    hcloud = {
+      version = ">= 1.6.0"
+      source  = "github.com/hetznercloud/hcloud"
+    }
+  }
+}
+
+variable "hcloud_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "agent_name" {
+  type = string
+}
+
+variable "cloud_init_tier" {
+  type    = string
+  default = "minimal"
+}
+
+variable "install_commands" {
+  type    = list(string)
+  default = []
+}
+
+locals {
+  timestamp  = formatdate("YYYYMMDD-hhmm", timestamp())
+  image_name = "spawn-${var.agent_name}-${local.timestamp}"
+}
+
+source "hcloud" "spawn" {
+  token        = var.hcloud_token
+  image        = "ubuntu-24.04"
+  location     = "fsn1"
+  # 4 GB RAM — Claude's native installer and zeroclaw's Rust build
+  # get OOM-killed on smaller instances. Snapshots built here work on all sizes.
+  server_type  = "cx23"
+  ssh_username = "root"
+
+  snapshot_name = local.image_name
+  snapshot_labels = {
+    managed-by = "packer"
+    project    = "spawn"
+    agent      = var.agent_name
+  }
+}
+
+build {
+  sources = ["source.hcloud.spawn"]
+
+  # Wait for cloud-init to finish (Hetzner base images run it on first boot)
+  provisioner "shell" {
+    inline = [
+      "cloud-init status --wait || true",
+    ]
+  }
+
+  # Wait for any apt locks to be released (cloud-init may hold them)
+  provisioner "shell" {
+    inline = [
+      "for i in $(seq 1 30); do fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || break; echo 'Waiting for apt lock...'; sleep 2; done",
+    ]
+  }
+
+  # Run the tier script (installs base packages: curl, git, node, bun, etc.)
+  provisioner "shell" {
+    script = "packer/scripts/tier-${var.cloud_init_tier}.sh"
+  }
+
+  # Install the agent
+  provisioner "shell" {
+    inline = var.install_commands
+    environment_vars = [
+      "HOME=/root",
+      "DEBIAN_FRONTEND=noninteractive",
+      "PATH=/root/.local/bin:/root/.bun/bin:/root/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    ]
+  }
+
+  # Leave a marker so the CLI knows this is a pre-baked snapshot
+  provisioner "shell" {
+    inline = [
+      "echo 'spawn-${var.agent_name}' > /root/.spawn-snapshot",
+      "date -u '+%Y-%m-%dT%H:%M:%SZ' >> /root/.spawn-snapshot",
+      "touch /root/.cloud-init-complete",
+    ]
+    environment_vars = [
+      "HOME=/root",
+      "PATH=/root/.local/bin:/root/.bun/bin:/root/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    ]
+  }
+
+  # Install security updates and clean up
+  provisioner "shell" {
+    inline = [
+      "apt-get update -y",
+      "apt-get -o Dpkg::Options::='--force-confold' dist-upgrade -y",
+      "apt-get -y autoremove",
+      "apt-get -y autoclean",
+    ]
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive",
+    ]
+  }
+
+  # Cleanup — clear secrets, keys, history, logs so each server gets a fresh identity.
+  # cloud-init re-runs on first boot to re-inject SSH keys.
+  provisioner "shell" {
+    inline = [
+      # Ensure /tmp exists with correct permissions
+      "mkdir -p /tmp",
+      "chmod 1777 /tmp",
+
+      # Remove SSH authorized keys (cloud-init re-injects on first boot)
+      "rm -f /root/.ssh/authorized_keys",
+      "find /home -name authorized_keys -delete",
+
+      # Remove SSH host keys (regenerated on first boot)
+      "rm -f /etc/ssh/ssh_host_*",
+      "touch /etc/ssh/revoked_keys",
+      "chmod 600 /etc/ssh/revoked_keys",
+
+      # Clear bash history
+      "rm -f /root/.bash_history",
+      "find /home -name .bash_history -delete",
+
+      # Truncate recent log files and remove archived logs
+      "find /var/log -mtime -1 -type f -exec truncate -s 0 {} \\;",
+      "rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????",
+
+      # Clear apt cache
+      "apt-get clean",
+      "rm -rf /var/lib/apt/lists/*",
+
+      # Clear tmp
+      "rm -rf /tmp/* /var/tmp/*",
+
+      # Remove cloud-init instance data so it re-runs on first boot
+      "rm -rf /var/lib/cloud/instances/*",
+
+      # Remove machine-id so each server gets a unique one
+      "truncate -s 0 /etc/machine-id",
+      "rm -f /var/lib/dbus/machine-id",
+      "ln -sf /etc/machine-id /var/lib/dbus/machine-id",
+
+      # Reset cloud-init so it runs again on first boot
+      "cloud-init clean --logs",
+
+      # Zero-fill free disk space to reduce snapshot size
+      "dd if=/dev/zero of=/zerofile bs=4096 || true",
+      "rm -f /zerofile",
+
+      "sync",
+    ]
+  }
+
+  # Write Packer manifest for CI
+  post-processor "manifest" {
+    output     = "packer/manifest.json"
+    strip_path = true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `findSpawnSnapshot()` to query Hetzner `/images?type=snapshot` API for pre-built `spawn-{agent}-*` images
- Adds `waitForSshOnly()` for snapshot boots (skips cloud-init polling)
- Updates `createServer()` to accept optional `snapshotId` — boots from snapshot, skips cloud-init userdata
- Wires up orchestrator in `main.ts` with `skipAgentInstall` flag, mirroring DigitalOcean
- Adds `packer/hetzner.pkr.hcl` using the `hcloud` plugin (same structure as DO template)
- Unifies `packer-snapshots.yml` to build both DO and Hetzner in a single workflow with `cloud×agent` matrix

## How it works
1. Before provisioning, CLI checks for Hetzner snapshots matching `spawn-{agentName}-*` by description
2. If found, boots from the latest snapshot and skips both cloud-init and agent installation
3. If no snapshot exists, falls back to the current ubuntu + cloud-init flow (no behavior change)
4. Packer workflow builds snapshots nightly for both clouds, with per-cloud cleanup

## To activate
Add a `HCLOUD_TOKEN` secret to GitHub Actions. The nightly build will then produce Hetzner snapshots for all agents.

## Test plan
- [ ] Verify existing Hetzner provisioning still works (no snapshot = same behavior)
- [ ] Create a manual Hetzner snapshot with description `spawn-claude-test` and verify detection
- [ ] Confirm `skipAgentInstall` is set when booting from snapshot
- [ ] Verify workflow dispatches correctly for both clouds

🤖 Generated with [Claude Code](https://claude.com/claude-code)