### PR TITLE
fix(e2e): replace counting loops with wc -w in e2e.sh

### DIFF
--- a/sh/e2e/e2e.sh
+++ b/sh/e2e/e2e.sh
@@ -173,8 +173,7 @@ fi
 # ---------------------------------------------------------------------------
 # Count clouds to decide single vs multi-cloud mode
 # ---------------------------------------------------------------------------
-cloud_count=0
-for _ in ${CLOUDS}; do cloud_count=$((cloud_count + 1)); done
+cloud_count=$(printf '%s\n' "${CLOUDS}" | wc -w | tr -d ' ')
 
 # ---------------------------------------------------------------------------
 # run_single_agent AGENT
@@ -420,8 +419,8 @@ run_agents_for_cloud() {
 
   local pass_count=0
   local fail_count=0
-  for _ in ${cloud_passed}; do pass_count=$((pass_count + 1)); done
-  for _ in ${cloud_failed}; do fail_count=$((fail_count + 1)); done
+  if [ -n "${cloud_passed}" ]; then pass_count=$(printf '%s\n' "${cloud_passed}" | wc -w | tr -d ' '); fi
+  if [ -n "${cloud_failed}" ]; then fail_count=$(printf '%s\n' "${cloud_failed}" | wc -w | tr -d ' '); fi
 
   printf '%s %s %s %s %s' "${pass_count}" "${fail_count}" "${cloud_duration_str}" "${cloud_passed}" "|${cloud_failed}" \
     > "${log_dir}/${cloud}.summary"


### PR DESCRIPTION
## Summary

Fixes #2776

Replaces `for _ in ${VAR}; do count=$((count+1)); done` counting patterns in `sh/e2e/e2e.sh` with `printf '%s\n' "${VAR}" | wc -w | tr -d ' '`:

- **Line 176**: `cloud_count` — replaced 2-line loop with single `wc -w` expression
- **Lines 422-423**: `pass_count` / `fail_count` — replaced 2 counting loops with 2 `wc -w` expressions (with empty-string guard to avoid passing blank to `wc`)

The `wc -w` approach counts whitespace-separated words, which is exactly what these variables hold (space-separated lists of cloud/agent names). This eliminates the unquoted loop variable patterns flagged in the issue, while being portable to bash 3.2/macOS.

## Test plan

- [x] \`bash -n sh/e2e/e2e.sh\` passes (syntax check)
- [x] Logic unchanged: empty list → 0, single item → 1, multiple items → N
- [ ] Manual smoke: \`wc -w\` counting works correctly for all list sizes

-- refactor/issue-fixer