### PR TITLE
fix(cli): exit with code 1 on spawn fix error paths

### DIFF
--- a/packages/cli/src/__tests__/cmd-fix.test.ts
+++ b/packages/cli/src/__tests__/cmd-fix.test.ts
@@ -412,8 +412,9 @@ describe("cmdFix", () => {
     await loadManifest(true);
     global.fetch = savedFetch;
 
-    await cmdFix("nonexistent-id");
+    await expect(cmdFix("nonexistent-id")).rejects.toThrow("process.exit");
 
+    expect(processExitSpy).toHaveBeenCalledWith(1);
     expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("not found"));
   });
 

--- a/packages/cli/src/commands/fix.ts
+++ b/packages/cli/src/commands/fix.ts
@@ -226,7 +226,7 @@ export async function cmdFix(spawnId?: string, options?: FixOptions): Promise<vo
     if (!record) {
       p.log.error(`Spawn not found: ${pc.bold(spawnId)}`);
       p.log.info(`Run ${pc.cyan("spawn list")} to see your active spawns.`);
-      return;
+      process.exit(1);
     }
     await fixSpawn(record, manifest, options);
     return;
@@ -242,7 +242,7 @@ export async function cmdFix(spawnId?: string, options?: FixOptions): Promise<vo
   if (!isInteractiveTTY()) {
     p.log.error("spawn fix requires an interactive terminal or a spawn name/ID.");
     p.log.info(`Usage: ${pc.cyan("spawn fix <spawn-id>")}`);
-    return;
+    process.exit(1);
   }
 
   // Interactive picker: show active servers and let user choose
@@ -264,7 +264,7 @@ export async function cmdFix(spawnId?: string, options?: FixOptions): Promise<vo
   const record = servers.find((r) => (r.id || r.timestamp) === selected);
   if (!record) {
     p.log.error("Spawn not found.");
-    return;
+    process.exit(1);
   }
 
   await fixSpawn(record, manifest, options);


### PR DESCRIPTION
## Summary
- `spawn fix <nonexistent-id>` and `spawn fix` (non-interactive, multiple servers) now exit with code 1 instead of 0
- `fixSpawn()` is unchanged since it's also called from the list picker where returning to loop is correct

## User-facing impact
- **Before:** `spawn fix bad-id && echo ok` prints error but also prints "ok" (exit 0)
- **After:** `spawn fix bad-id && echo ok` prints error and stops (exit 1)

## Test plan
- [x] Updated `cmd-fix.test.ts` to expect `process.exit(1)` on not-found path
- [x] All 1453 tests pass
- [x] Biome check clean

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>