### PR TITLE
fix: correct jq cross-product syntax in packer workflow

### DIFF
--- a/.github/workflows/packer-snapshots.yml
+++ b/.github/workflows/packer-snapshots.yml
@@ -49,7 +49,7 @@ jobs:
 
           # Build a flat include array: [{agent, cloud}, ...]
           INCLUDE=$(jq -nc --argjson agents "$AGENTS" --argjson clouds "$CLOUDS" \
-            '[($agents[] | . as $a) | ($clouds[] | {agent: $a, cloud: .})]')
+            '[$agents[] as $a | $clouds[] as $c | {agent: $a, cloud: $c}]')
           echo "include=${INCLUDE}" >> "$GITHUB_OUTPUT"
         env:
           SINGLE_AGENT_INPUT: ${{ inputs.agent }}


### PR DESCRIPTION
## Summary
- Fixes invalid jq syntax in the packer-snapshots workflow matrix generation
- `[($agents[] | . as $a) | ...]` is not valid jq — use `[$agents[] as $a | $clouds[] as $c | ...]`

## Test plan
- [ ] Workflow dispatch succeeds (matrix step no longer errors with jq compile error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)