### PR TITLE
fix: prevent grep pipefail from killing tarball release uploads

### DIFF
--- a/.github/workflows/agent-tarballs.yml
+++ b/.github/workflows/agent-tarballs.yml
@@ -163,8 +163,9 @@ jobs:
           # Delete stale asset for this arch if present (from a previous build today)
           gh release delete-asset "${TAG}" "${TARBALL}" --yes 2>/dev/null || true
           # Also clean up any older-dated tarball for this arch
+          # grep returns exit 1 when no matches — pipe through cat to avoid pipefail killing the step
           gh release view "${TAG}" --json assets --jq ".assets[].name" 2>/dev/null \
-            | grep "spawn-agent-${AGENT_NAME}-${ARCH}-" \
+            | { grep "spawn-agent-${AGENT_NAME}-${ARCH}-" || true; } \
             | while IFS= read -r old; do
                 gh release delete-asset "${TAG}" "${old}" --yes 2>/dev/null || true
               done


### PR DESCRIPTION
## Summary
- Wraps `grep` in `{ grep ... || true; }` in the old-asset cleanup pipeline
- `grep` returns exit 1 when no matches are found, which with `set -eo pipefail` kills the entire release step before `gh release upload` runs

## Root cause
The cleanup step deletes stale tarballs before uploading the new one:
```bash
gh release view ... | grep "spawn-agent-NAME-ARCH-" | while read old; do delete; done
```
When there are no old assets to clean up, `grep` exits 1 → `pipefail` kills the step → tarball never uploads.

This has caused **all arm64 builds** to fail nightly (5 consecutive days of failures).

## Test plan
- [ ] Trigger agent-tarballs workflow after merge — all jobs should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)