### PR TITLE
fix(e2e): run stale cleanup before agents, not just after

### DIFF
--- a/sh/e2e/e2e.sh
+++ b/sh/e2e/e2e.sh
@@ -313,6 +313,14 @@ run_agents_for_cloud() {
   local cloud_passed=""
   local cloud_failed=""
 
+  # Pre-run stale cleanup: remove orphaned e2e instances from previous
+  # interrupted runs before starting new agents. This prevents "quota exceeded"
+  # failures caused by leftover instances that are under the post-run cleanup
+  # max_age threshold (30 min) but still consuming account capacity.
+  if [ "${SKIP_CLEANUP}" -eq 0 ]; then
+    cloud_cleanup_stale || log_warn "Pre-run stale cleanup encountered errors"
+  fi
+
   # Resolve effective parallelism (respect per-cloud cap)
   local effective_parallel="${PARALLEL_COUNT}"
   if [ "${SEQUENTIAL_MODE}" -eq 0 ]; then


### PR DESCRIPTION
## Summary

- Adds a pre-run stale cleanup call at the start of `run_agents_for_cloud`, before agents begin provisioning
- This clears orphaned e2e-* instances from previous interrupted test runs (e.g. killed by timeout) before they block new provisioning
- Without this fix, DigitalOcean (droplet limit=3) would hit "quota exceeded" errors when re-running within 30 minutes of a timed-out run, since orphaned droplets fall within the post-run cleanup's 30-minute max_age threshold

## Root Cause

The DigitalOcean QA account has a 3-droplet limit with 2 permanent `spawn-*` droplets already allocated. When the E2E suite is killed by a timeout mid-run, teardown doesn't execute for in-progress agents, leaving orphaned `e2e-*` droplets. These orphaned droplets are under 30 minutes old, so the existing post-run stale cleanup skips them. On the next run, the single available slot is still occupied and all provisioning fails immediately with "creating this/these droplet(s) will exceed your droplet limit".

## Test Plan

- [x] `bash -n sh/e2e/e2e.sh` — syntax check passes
- [x] Root cause confirmed by log analysis: orphaned `e2e-digitalocean-opencode-*` droplet blocked all subsequent provisioning
- [ ] Full DigitalOcean E2E run after merge to confirm no quota failures

-- qa/e2e-tester

🤖 Generated with [Claude Code](https://claude.com/claude-code)