### PR TITLE
fix(cli): validate agent key in fix command before manifest lookup

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/cmd-fix.test.ts
+++ b/packages/cli/src/__tests__/cmd-fix.test.ts
@@ -151,6 +151,18 @@ describe("buildFixScript", () => {
     expect(() => buildFixScript(mockManifest, "unknown-agent")).toThrow("Unknown agent: unknown-agent");
   });
 
+  it("throws for agent key with shell metacharacters", () => {
+    expect(() => buildFixScript(mockManifest, "claude;rm -rf /")).toThrow("can only contain");
+  });
+
+  it("throws for agent key with path traversal", () => {
+    expect(() => buildFixScript(mockManifest, "../etc/passwd")).toThrow("can only contain");
+  });
+
+  it("throws for agent key with command substitution", () => {
+    expect(() => buildFixScript(mockManifest, "claude$(whoami)")).toThrow("can only contain");
+  });
+
   it("shell-escapes single quotes in env var values", () => {
     const manifest = {
       ...mockManifest,
@@ -220,6 +232,14 @@ describe("fixSpawn", () => {
     });
     await fixSpawn(record, mockManifest);
     expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("Unknown agent"));
+  });
+
+  it("shows security error for agent name with shell metacharacters", async () => {
+    const record = makeRecord({
+      agent: "claude;rm -rf /",
+    });
+    await fixSpawn(record, mockManifest);
+    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("Security validation failed"));
   });
 
   it("calls the script runner with correct args on success", async () => {

--- a/packages/cli/src/commands/fix.ts
+++ b/packages/cli/src/commands/fix.ts
@@ -7,7 +7,7 @@ import { isString } from "@openrouter/spawn-shared";
 import pc from "picocolors";
 import { getActiveServers } from "../history.js";
 import { loadManifest } from "../manifest.js";
-import { validateConnectionIP, validateServerIdentifier, validateUsername } from "../security.js";
+import { validateConnectionIP, validateIdentifier, validateServerIdentifier, validateUsername } from "../security.js";
 import { getHistoryPath } from "../shared/paths.js";
 import { asyncTryCatch, tryCatch } from "../shared/result.js";
 import { SSH_INTERACTIVE_OPTS } from "../shared/ssh.js";
@@ -31,6 +31,9 @@ function resolveEnvTemplate(template: string): string {
 
 /** Build a bash script to re-inject env vars and reinstall the agent remotely. */
 export function buildFixScript(manifest: Manifest, agentKey: string): string {
+  // SECURITY: validate agentKey before using it to index the manifest
+  validateIdentifier(agentKey, "Agent name");
+
   const agentDef = manifest.agents[agentKey];
   if (!agentDef) {
     throw new Error(`Unknown agent: ${agentKey}`);
@@ -137,6 +140,7 @@ export async function fixSpawn(record: SpawnRecord, manifest: Manifest | null, o
 
   // SECURITY: validate all connection fields before use
   const validationResult = tryCatch(() => {
+    validateIdentifier(record.agent, "Agent name");
     validateConnectionIP(conn.ip);
     validateUsername(conn.user);
     if (conn.server_name) {


### PR DESCRIPTION
**Why:** `buildFixScript()` and `fixSpawn()` in `fix.ts` use `agentKey` from spawn history to index `manifest.agents` without first validating it matches the safe identifier pattern. A tampered `~/.spawn/history.json` could inject keys like `__proto__` or shell metacharacters, causing unexpected behavior.

## Changes

- Add `validateIdentifier(agentKey, "Agent name")` at the top of `buildFixScript()` before the manifest lookup
- Add `validateIdentifier(record.agent, "Agent name")` inside `fixSpawn()`'s existing security validation block (alongside IP, username, and server ID validation)
- Add 4 new test cases: shell metacharacters, path traversal, and command substitution in `buildFixScript`, plus a `fixSpawn` integration test for invalid agent names
- Bump CLI version to 0.23.3

## Test plan

- [x] `bunx @biomejs/biome check src/` passes with zero errors
- [x] `bun test src/__tests__/cmd-fix.test.ts` — 25 tests pass (4 new)
- [x] All existing tests continue to pass (no regressions)

Fixes #2791

-- refactor/security-auditor