### PR TITLE
feat: add --beta parallel for concurrent tarball download + server boot

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.23.3",
+  "version": "0.24.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -856,14 +856,16 @@ async function main(): Promise<void> {
   const VALID_BETA_FEATURES = new Set([
     "tarball",
     "images",
+    "parallel",
   ]);
-  const betaFeatures = extractAllFlagValues(filteredArgs, "--beta", "spawn <agent> <cloud> --beta images");
+  const betaFeatures = extractAllFlagValues(filteredArgs, "--beta", "spawn <agent> <cloud> --beta parallel");
   for (const flag of betaFeatures) {
     if (!VALID_BETA_FEATURES.has(flag)) {
       console.error(pc.red(`Unknown beta feature: ${pc.bold(flag)}`));
       console.error("\nAvailable beta features:");
-      console.error(`  ${pc.cyan("tarball")}  Use pre-built tarball for agent installation`);
-      console.error(`  ${pc.cyan("images")}   Use pre-built DO marketplace images (faster boot)`);
+      console.error(`  ${pc.cyan("tarball")}   Use pre-built tarball for agent installation`);
+      console.error(`  ${pc.cyan("images")}    Use pre-built DO marketplace images (faster boot)`);
+      console.error(`  ${pc.cyan("parallel")}  Download tarball while server boots (implies tarball)`);
       process.exit(1);
     }
   }

--- a/packages/cli/src/shared/agent-tarball.ts
+++ b/packages/cli/src/shared/agent-tarball.ts
@@ -4,9 +4,12 @@
 
 import type { CloudRunner } from "./agent-setup";
 
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { getErrorMessage } from "@openrouter/spawn-shared";
 import * as v from "valibot";
-import { asyncTryCatch } from "./result";
+import { asyncTryCatch, tryCatch } from "./result";
 import { logDebug, logInfo, logStep, logWarn } from "./ui";
 
 const REPO = "OpenRouterTeam/spawn";
@@ -152,5 +155,163 @@ export async function tryTarballInstall(
   }
 
   logInfo("Agent installed from pre-built tarball");
+  return true;
+}
+
+// ─── Parallel tarball: local download + SCP upload ──────────────────────────
+
+interface TarballMeta {
+  x86Url: string;
+  armUrl: string;
+  url: string;
+}
+
+/** Fetch tarball metadata from GitHub Releases. Shared by both install paths. */
+async function fetchTarballMeta(agentName: string, fetchFn: typeof fetch = fetch): Promise<TarballMeta | null> {
+  const tag = `agent-${agentName}-latest`;
+  const resp = await fetchFn(`https://api.github.com/repos/${REPO}/releases/tags/${tag}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!resp.ok) {
+    return null;
+  }
+
+  const json: unknown = await resp.json();
+  const parsed = v.safeParse(ReleaseSchema, json);
+  if (!parsed.success) {
+    return null;
+  }
+
+  const x86Asset = parsed.output.assets.find((a) => a.name.includes("-x86_64-") && a.name.endsWith(".tar.gz"));
+  const armAsset = parsed.output.assets.find((a) => a.name.includes("-arm64-") && a.name.endsWith(".tar.gz"));
+
+  if (!x86Asset && !armAsset) {
+    return null;
+  }
+
+  return {
+    x86Url: x86Asset?.browser_download_url || "",
+    armUrl: armAsset?.browser_download_url || "",
+    url: x86Asset?.browser_download_url || armAsset?.browser_download_url || "",
+  };
+}
+
+/** Validate a tarball URL matches the expected GitHub releases pattern. */
+function isValidTarballUrl(url: string): boolean {
+  return /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/releases\/download\/[^\s'"`;|&$()]+$/.test(url);
+}
+
+export interface LocalTarball {
+  localPath: string;
+  cleanup: () => void;
+}
+
+/**
+ * Download the agent tarball to a local temp file (for parallel boot + download).
+ * Returns the local path and cleanup function, or null on failure.
+ * Always downloads x86_64 (all current cloud VMs are x86_64).
+ */
+export async function downloadTarballLocally(
+  agentName: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<LocalTarball | null> {
+  logStep("Downloading tarball locally (parallel)...");
+
+  const r = await asyncTryCatch(async () => {
+    const meta = await fetchTarballMeta(agentName, fetchFn);
+    if (!meta) {
+      logWarn("No pre-built tarball available");
+      return null;
+    }
+
+    // Prefer x86_64 (all current cloud VMs default to x86_64)
+    const downloadUrl = meta.x86Url || meta.url;
+    if (!downloadUrl || !isValidTarballUrl(downloadUrl)) {
+      logWarn("Tarball URL failed safety validation");
+      return null;
+    }
+
+    const resp = await fetchFn(downloadUrl, {
+      signal: AbortSignal.timeout(120_000),
+      redirect: "follow",
+    });
+    if (!resp.ok || !resp.body) {
+      logWarn("Tarball download failed");
+      return null;
+    }
+
+    const localPath = join(tmpdir(), `spawn-agent-${agentName}-${Date.now()}.tar.gz`);
+    await Bun.write(localPath, resp);
+
+    logInfo("Tarball downloaded locally");
+    return {
+      localPath,
+      cleanup: () => {
+        tryCatch(() => unlinkSync(localPath));
+      },
+    };
+  });
+
+  if (!r.ok) {
+    logWarn("Local tarball download failed");
+    logDebug(getErrorMessage(r.error));
+    return null;
+  }
+  return r.data;
+}
+
+/**
+ * Upload a locally-downloaded tarball to the remote VM and extract it.
+ * Returns true on success, false on failure.
+ */
+export async function uploadAndExtractTarball(runner: CloudRunner, localPath: string): Promise<boolean> {
+  logStep("Uploading tarball to server...");
+  const remotePath = "/tmp/spawn-agent-parallel.tar.gz";
+  const sudo = '$([ "$(id -u)" != "0" ] && echo sudo || echo "")';
+
+  const uploadResult = await asyncTryCatch(() => runner.uploadFile(localPath, remotePath));
+  if (!uploadResult.ok) {
+    logWarn("Tarball upload failed");
+    logDebug(getErrorMessage(uploadResult.error));
+    return false;
+  }
+
+  const extractResult = await asyncTryCatch(() =>
+    runner.runServer(
+      `${sudo} tar xz -C / -f ${remotePath} && ${sudo} test -f /root/.spawn-tarball && rm -f ${remotePath}`,
+      150,
+    ),
+  );
+  if (!extractResult.ok) {
+    logWarn("Tarball extraction failed on remote VM");
+    logDebug(getErrorMessage(extractResult.error));
+    return false;
+  }
+
+  // Mirror /root/ files for non-root SSH users
+  const mirrorCmd = [
+    'if [ "$(id -u)" != "0" ]; then',
+    "  for _d in .claude .local .npm-global .cargo .opencode .hermes .bun; do",
+    '    if [ -d "/root/$_d" ]; then',
+    '      mkdir -p "$HOME/$_d"',
+    '      cp -a "/root/$_d/." "$HOME/$_d/" 2>/dev/null || true',
+    "    fi",
+    "  done",
+    '  cp /root/.spawn-tarball "$HOME/.spawn-tarball" 2>/dev/null || true',
+    '  chown -R "$(id -u):$(id -g)" "$HOME/.spawn-tarball" 2>/dev/null || true',
+    "  for _d in .claude .local .npm-global .cargo .opencode .hermes .bun; do",
+    '    if [ -d "$HOME/$_d" ]; then',
+    '      chown -R "$(id -u):$(id -g)" "$HOME/$_d" 2>/dev/null || true',
+    "    fi",
+    "  done",
+    "fi",
+  ].join("\n");
+  await asyncTryCatch(() => runner.runServer(mirrorCmd, 30));
+
+  logInfo("Agent installed from pre-built tarball (parallel upload)");
   return true;
 }

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -11,7 +11,7 @@ import { getErrorMessage } from "@openrouter/spawn-shared";
 import * as v from "valibot";
 import { generateSpawnId, saveLaunchCmd, saveMetadata, saveSpawnRecord } from "../history.js";
 import { offerGithubAuth, setupAutoUpdate, wrapSshCall } from "./agent-setup";
-import { tryTarballInstall } from "./agent-tarball";
+import { downloadTarballLocally, tryTarballInstall, uploadAndExtractTarball } from "./agent-tarball";
 import { generateEnvConfig } from "./agents";
 import { getOrPromptApiKey } from "./oauth";
 import { getSpawnPreferencesPath } from "./paths";
@@ -172,8 +172,33 @@ export async function runOrchestration(
     connection,
   });
 
-  // 7. Wait for readiness
-  await cloud.waitForReady();
+  // 7. Wait for readiness + parallel tarball download
+  const betaFeatures = new Set((process.env.SPAWN_BETA ?? "").split(",").filter(Boolean));
+  const useParallel =
+    betaFeatures.has("parallel") && cloud.cloudName !== "local" && !agent.skipTarball && !cloud.skipAgentInstall;
+
+  let parallelTarball: {
+    localPath: string;
+    cleanup: () => void;
+  } | null = null;
+
+  if (useParallel) {
+    // Download tarball locally while server boots — both run concurrently
+    const [readyResult, downloadResult] = await Promise.allSettled([
+      cloud.waitForReady(),
+      downloadTarballLocally(agentName),
+    ]);
+
+    if (readyResult.status === "rejected") {
+      throw readyResult.reason;
+    }
+
+    if (downloadResult.status === "fulfilled" && downloadResult.value) {
+      parallelTarball = downloadResult.value;
+    }
+  } else {
+    await cloud.waitForReady();
+  }
 
   const envPairs = agent.envVars(apiKey);
   // Inject agent-specific model env var when a custom model is selected
@@ -187,11 +212,24 @@ export async function runOrchestration(
     logInfo("Snapshot boot — skipping agent install");
   } else {
     let installedFromTarball = false;
-    const betaFeatures = new Set((process.env.SPAWN_BETA ?? "").split(",").filter(Boolean));
-    if (cloud.cloudName !== "local" && !agent.skipTarball && betaFeatures.has("tarball")) {
+
+    // Parallel path: upload the locally-downloaded tarball
+    if (parallelTarball) {
+      installedFromTarball = await uploadAndExtractTarball(cloud.runner, parallelTarball.localPath);
+      parallelTarball.cleanup();
+    }
+
+    // Fallback: remote tarball download (--beta tarball or --beta parallel)
+    if (
+      !installedFromTarball &&
+      cloud.cloudName !== "local" &&
+      !agent.skipTarball &&
+      (betaFeatures.has("tarball") || betaFeatures.has("parallel"))
+    ) {
       const tarball = options?.tryTarball ?? tryTarballInstall;
       installedFromTarball = await tarball(cloud.runner, agentName);
     }
+
     if (!installedFromTarball) {
       await agent.install();
     }


### PR DESCRIPTION
## Summary
- Adds `--beta parallel` flag that downloads agent tarballs locally while the server boots
- Once SSH is up, SCPs the pre-downloaded tarball and extracts it
- Falls back to remote tarball download (`--beta tarball` behavior), then live install
- `--beta parallel` implies tarball behavior — no need to also pass `--beta tarball`

## How it works
```
spawn claude hetzner --beta parallel
```

Without parallel:
```
create server → boot → cloud-init → download tarball on server → extract → configure
                ~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~
                      ~90s                      ~15s
```

With parallel:
```
create server → boot → cloud-init ─────────────────────→ SCP + extract → configure
                  ↕ (concurrent)
              download tarball locally (~15s, overlapped)
```

## New functions
- `downloadTarballLocally()` — fetches tarball to local temp file via `fetch()`
- `uploadAndExtractTarball()` — SCPs local file to server, extracts with `tar xz -C /`
- Both return gracefully on failure (no throws) for clean fallback chain

## Test plan
- [ ] `spawn claude hetzner --beta parallel` — verify tarball downloads during boot
- [ ] Kill network during download — verify fallback to remote tarball or live install
- [ ] `spawn claude hetzner --beta tarball` — existing behavior unchanged
- [ ] `spawn claude hetzner` — no change (no beta flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)