### PR TITLE
fix(e2e): use aggressive pre-run cleanup threshold to prevent DO quota exhaustion

### DIFF
--- a/sh/e2e/e2e.sh
+++ b/sh/e2e/e2e.sh
@@ -314,11 +314,11 @@ run_agents_for_cloud() {
   local cloud_failed=""
 
   # Pre-run stale cleanup: remove orphaned e2e instances from previous
-  # interrupted runs before starting new agents. This prevents "quota exceeded"
-  # failures caused by leftover instances that are under the post-run cleanup
-  # max_age threshold (30 min) but still consuming account capacity.
+  # interrupted runs before starting new agents. Uses a shorter max_age (5 min)
+  # than the default (30 min) so that orphans from recently-failed runs are
+  # cleaned before they can exhaust the account's instance quota (#2793).
   if [ "${SKIP_CLEANUP}" -eq 0 ]; then
-    cloud_cleanup_stale || log_warn "Pre-run stale cleanup encountered errors"
+    _CLEANUP_MAX_AGE=300 cloud_cleanup_stale || log_warn "Pre-run stale cleanup encountered errors"
   fi
 
   # Resolve effective parallelism (respect per-cloud cap)

--- a/sh/e2e/lib/clouds/aws.sh
+++ b/sh/e2e/lib/clouds/aws.sh
@@ -212,7 +212,7 @@ _aws_cleanup_stale() {
   local region="${AWS_REGION:-us-east-1}"
   local now
   now=$(date +%s)
-  local max_age=1800  # 30 minutes in seconds
+  local max_age="${_CLEANUP_MAX_AGE:-1800}"  # default 30 min; pre-run uses shorter
 
   # List all instances
   local instances_json

--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -287,7 +287,7 @@ _digitalocean_cleanup_stale() {
 
   local now
   now=$(date +%s)
-  local max_age=1800  # 30 minutes in seconds
+  local max_age="${_CLEANUP_MAX_AGE:-1800}"  # default 30 min; pre-run uses shorter
 
   local droplets_json
   droplets_json=$(_do_curl_auth -sf \

--- a/sh/e2e/lib/clouds/gcp.sh
+++ b/sh/e2e/lib/clouds/gcp.sh
@@ -243,7 +243,7 @@ _gcp_cleanup_stale() {
   local project="${GCP_PROJECT:-}"
   local now
   now=$(date +%s)
-  local max_age=1800  # 30 minutes in seconds
+  local max_age="${_CLEANUP_MAX_AGE:-1800}"  # default 30 min; pre-run uses shorter
 
   if [ -z "${project}" ]; then
     log_warn "GCP_PROJECT not set — skipping stale cleanup"

--- a/sh/e2e/lib/clouds/hetzner.sh
+++ b/sh/e2e/lib/clouds/hetzner.sh
@@ -229,7 +229,7 @@ _hetzner_teardown() {
 _hetzner_cleanup_stale() {
   local now
   now=$(date +%s)
-  local max_age=1800  # 30 minutes
+  local max_age="${_CLEANUP_MAX_AGE:-1800}"  # default 30 min; pre-run uses shorter
 
   local response
   response=$(_hetzner_curl_auth -sf \

--- a/sh/e2e/lib/clouds/sprite.sh
+++ b/sh/e2e/lib/clouds/sprite.sh
@@ -254,7 +254,7 @@ _sprite_teardown() {
 _sprite_cleanup_stale() {
   local now
   now=$(date +%s)
-  local max_age=1800  # 30 minutes in seconds
+  local max_age="${_CLEANUP_MAX_AGE:-1800}"  # default 30 min; pre-run uses shorter
 
   # List all sprites
   local sprite_output


### PR DESCRIPTION
**Why:** DigitalOcean E2E tests fail because orphaned droplets from recently-failed runs (< 30 min old) exhaust the account droplet limit (422 unprocessable_entity). The pre-run cleanup added in #2789 uses the same 30-minute max_age as post-run, so recent orphans survive.

**What:** Pre-run cleanup now uses `_CLEANUP_MAX_AGE=300` (5 min) to aggressively reclaim orphaned `e2e-*` instances before provisioning new ones. All 5 cloud drivers (`digitalocean`, `aws`, `hetzner`, `gcp`, `sprite`) read `_CLEANUP_MAX_AGE` with a default of 1800 (30 min), so post-run behavior is unchanged.

**Changes:**
- `sh/e2e/e2e.sh` — set `_CLEANUP_MAX_AGE=300` on the pre-run `cloud_cleanup_stale` call
- `sh/e2e/lib/clouds/{digitalocean,aws,hetzner,gcp,sprite}.sh` — read `_CLEANUP_MAX_AGE` env var instead of hardcoding 1800

Fixes #2793

-- refactor/code-health