### PR TITLE
test: add SPAWN_FAST fast-mode coverage to orchestrate

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/orchestrate.test.ts
+++ b/packages/cli/src/__tests__/orchestrate.test.ts
@@ -662,4 +662,141 @@ describe("runOrchestration", () => {
     stderrSpy.mockRestore();
     exitSpy.mockRestore();
   });
+
+  // ── Fast mode (SPAWN_FAST=1) ──────────────────────────────────────
+
+  describe("fast mode (SPAWN_FAST=1)", () => {
+    let savedSpawnFast: string | undefined;
+
+    beforeEach(() => {
+      savedSpawnFast = process.env.SPAWN_FAST;
+      process.env.SPAWN_FAST = "1";
+    });
+
+    afterEach(() => {
+      if (savedSpawnFast !== undefined) {
+        process.env.SPAWN_FAST = savedSpawnFast;
+      } else {
+        delete process.env.SPAWN_FAST;
+      }
+    });
+
+    it("calls createServer and getApiKey for non-local cloud", async () => {
+      const cloud = createMockCloud({
+        cloudName: "hetzner",
+      });
+      const agent = createMockAgent();
+
+      await runOrchestrationSafe(cloud, agent, "testagent");
+
+      expect(cloud.createServer).toHaveBeenCalledTimes(1);
+      expect(mockGetOrPromptApiKey).toHaveBeenCalledTimes(1);
+      expect(cloud.interactiveSession).toHaveBeenCalledTimes(1);
+      stderrSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+
+    it("throws when createServer rejects", async () => {
+      const cloud = createMockCloud({
+        cloudName: "hetzner",
+        createServer: mock(() => Promise.reject(new Error("server boot failed"))),
+      });
+      const agent = createMockAgent();
+
+      const result = await asyncTryCatch(() => runOrchestration(cloud, agent, "testagent", defaultOpts));
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toBe("server boot failed");
+      }
+      stderrSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+
+    it("throws when getApiKey rejects", async () => {
+      const cloud = createMockCloud({
+        cloudName: "hetzner",
+      });
+      const agent = createMockAgent();
+      const failingGetApiKey = mock(() => Promise.reject(new Error("api key failed")));
+
+      const result = await asyncTryCatch(() =>
+        runOrchestration(cloud, agent, "testagent", {
+          ...defaultOpts,
+          getApiKey: failingGetApiKey,
+        }),
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toBe("api key failed");
+      }
+      stderrSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+
+    it("falls back to agent.install when no tarball available", async () => {
+      const install = mock(() => Promise.resolve());
+      const cloud = createMockCloud({
+        cloudName: "hetzner",
+      });
+      const agent = createMockAgent({
+        install,
+      });
+
+      await runOrchestrationSafe(cloud, agent, "testagent");
+
+      // downloadTarballLocally returns null (mocked globally), no local tarball
+      // tryTarball also returns false → falls through to agent.install
+      expect(install).toHaveBeenCalledTimes(1);
+      stderrSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+
+    it("uses sequential path for local cloud even with SPAWN_FAST=1", async () => {
+      const callOrder: string[] = [];
+      mockGetOrPromptApiKey.mockImplementation(async () => {
+        callOrder.push("getApiKey");
+        return "sk-or-v1-test-key";
+      });
+      const cloud = createMockCloud({
+        cloudName: "local",
+        createServer: mock(async () => {
+          callOrder.push("createServer");
+          return {
+            ip: "127.0.0.1",
+            user: "root",
+            server_name: "local",
+            cloud: "local",
+          };
+        }),
+      });
+      const agent = createMockAgent();
+
+      await runOrchestrationSafe(cloud, agent, "testagent");
+
+      // In sequential mode, getApiKey runs before createServer
+      expect(callOrder.indexOf("getApiKey")).toBeLessThan(callOrder.indexOf("createServer"));
+      stderrSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+
+    it("continues when preProvision and checkAccountReady fail (non-fatal)", async () => {
+      const cloud = createMockCloud({
+        cloudName: "hetzner",
+        checkAccountReady: mock(() => Promise.reject(new Error("account check failed"))),
+      });
+      const agent = createMockAgent({
+        preProvision: mock(() => Promise.reject(new Error("pre-provision failed"))),
+      });
+
+      await runOrchestrationSafe(cloud, agent, "testagent");
+
+      // Orchestration should complete despite non-fatal failures
+      expect(cloud.createServer).toHaveBeenCalledTimes(1);
+      expect(cloud.interactiveSession).toHaveBeenCalledTimes(1);
+      stderrSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
**Why:** SPAWN_FAST parallel orchestration path (Promise.allSettled over 5 concurrent tasks) added in #2796 has zero test coverage. Tests verify fast-mode is taken for non-local clouds and that errors from server boot and API key fetch propagate correctly.

-- refactor/test-engineer

## Summary

- Add 6 test cases in a new `describe("fast mode (SPAWN_FAST=1)")` block to `orchestrate.test.ts`
- Happy path: verifies `createServer` and `getApiKey` are both called for non-local clouds
- Server boot failure: verifies `createServer` rejection propagates as thrown error
- API key failure: verifies `getApiKey` rejection propagates as thrown error
- Tarball fallback: verifies `agent.install` is called when no tarball available
- Local cloud exclusion: verifies sequential path is used for local cloud even with `SPAWN_FAST=1`
- Non-fatal failures: verifies `preProvision` and `checkAccountReady` rejections don't abort orchestration
- Patch version bump: 0.24.0 -> 0.24.1

## Test plan

- [x] `bun test packages/cli/src/__tests__/orchestrate.test.ts` — 35 tests pass (29 existing + 6 new)
- [x] `bun test` — full suite 1463 tests pass, 0 failures
- [x] `bunx @biomejs/biome check src/` — 0 errors