### PR TITLE
security: base64-encode cmd in _sprite_exec to prevent injection

### DIFF
--- a/sh/e2e/lib/clouds/sprite.sh
+++ b/sh/e2e/lib/clouds/sprite.sh
@@ -193,11 +193,23 @@ _sprite_exec() {
   local _stderr_tmp
   _stderr_tmp=$(mktemp /tmp/sprite-exec-err.XXXXXX) || return 1
 
+  # Base64-encode the command to prevent shell injection when passed to the
+  # remote bash. The encoded string contains only [A-Za-z0-9+/=] characters,
+  # making it safe to pipe through the sprite CLI exec interface.
+  local encoded_cmd
+  encoded_cmd=$(printf '%s' "${cmd}" | base64 | tr -d '\n')
+
+  # Validate base64 output contains only safe characters (defense-in-depth).
+  if ! printf '%s' "${encoded_cmd}" | grep -qE '^[A-Za-z0-9+/=]+$'; then
+    rm -f "${_stderr_tmp}"
+    return 1
+  fi
+
   while [ "${_attempt}" -lt "${_max}" ]; do
     _sprite_fix_config
-    # Pipe the command via stdin to avoid interpolating it into the remote
-    # command string — eliminates shell injection risk.
-    printf '%s' "${cmd}" | _sprite_cmd exec -s "${app}" -- bash 2>"${_stderr_tmp}"
+    # Decode and execute on the remote side — the encoded payload is safe
+    # against shell metacharacters (;, |, $(), backticks).
+    printf '%s' "${encoded_cmd}" | _sprite_cmd exec -s "${app}" -- bash -c 'base64 -d | bash' 2>"${_stderr_tmp}"
     local _rc=$?
     if [ "${_rc}" -eq 0 ]; then
       rm -f "${_stderr_tmp}"


### PR DESCRIPTION
**Why:** `_sprite_exec` pipes the command string directly to `bash` on the remote side. While stdin piping is safer than argument interpolation, all other cloud drivers (aws, hetzner, digitalocean, gcp) use base64 encoding as defense-in-depth. This PR brings Sprite's `_sprite_exec` in line with that standard.

Fixes #2800

-- refactor/security-auditor

## Summary
- Base64-encode the command locally before piping through `sprite exec`
- Validate the encoded string contains only safe characters `[A-Za-z0-9+/=]` (defense-in-depth)
- Decode and execute on the remote side via `base64 -d | bash`
- Mirrors the pattern already used by `_aws_exec`, `_hetzner_exec`, `_digitalocean_exec`, `_gcp_exec`

## Test plan
- [x] `bash -n sh/e2e/lib/clouds/sprite.sh` — syntax clean
- [ ] E2E run on Sprite cloud to verify commands still execute correctly