### PR TITLE
fix(do): skip restart loop in headless mode to prevent droplet quota exhaustion

### DIFF
--- a/sh/digitalocean/claude.sh
+++ b/sh/digitalocean/claude.sh
@@ -21,6 +21,14 @@ _ensure_bun() {
 # bun from the foreground process group and broke @clack/prompts multiselect.
 # Now SIGTERM is detected from exit code 143 (128 + 15) after the child exits.
 _run_with_restart() {
+    # In headless mode (E2E / --headless), skip the restart loop entirely.
+    # Restarting in headless mode creates duplicate droplets, exhausting the
+    # account's droplet quota and causing all subsequent agents to fail.
+    if [ "${SPAWN_HEADLESS:-}" = "1" ]; then
+        "$@"
+        return $?
+    fi
+
     local attempt=0
     local backoff=2
     while [ "$attempt" -lt "$_MAX_RETRIES" ]; do

--- a/sh/digitalocean/codex.sh
+++ b/sh/digitalocean/codex.sh
@@ -21,6 +21,14 @@ _ensure_bun() {
 # bun from the foreground process group and broke @clack/prompts multiselect.
 # Now SIGTERM is detected from exit code 143 (128 + 15) after the child exits.
 _run_with_restart() {
+    # In headless mode (E2E / --headless), skip the restart loop entirely.
+    # Restarting in headless mode creates duplicate droplets, exhausting the
+    # account's droplet quota and causing all subsequent agents to fail.
+    if [ "${SPAWN_HEADLESS:-}" = "1" ]; then
+        "$@"
+        return $?
+    fi
+
     local attempt=0
     local backoff=2
     while [ "$attempt" -lt "$_MAX_RETRIES" ]; do

--- a/sh/digitalocean/hermes.sh
+++ b/sh/digitalocean/hermes.sh
@@ -21,6 +21,14 @@ _ensure_bun() {
 # bun from the foreground process group and broke @clack/prompts multiselect.
 # Now SIGTERM is detected from exit code 143 (128 + 15) after the child exits.
 _run_with_restart() {
+    # In headless mode (E2E / --headless), skip the restart loop entirely.
+    # Restarting in headless mode creates duplicate droplets, exhausting the
+    # account's droplet quota and causing all subsequent agents to fail.
+    if [ "${SPAWN_HEADLESS:-}" = "1" ]; then
+        "$@"
+        return $?
+    fi
+
     local attempt=0
     local backoff=2
     while [ "$attempt" -lt "$_MAX_RETRIES" ]; do

--- a/sh/digitalocean/junie.sh
+++ b/sh/digitalocean/junie.sh
@@ -21,6 +21,14 @@ _ensure_bun() {
 # bun from the foreground process group and broke @clack/prompts multiselect.
 # Now SIGTERM is detected from exit code 143 (128 + 15) after the child exits.
 _run_with_restart() {
+    # In headless mode (E2E / --headless), skip the restart loop entirely.
+    # Restarting in headless mode creates duplicate droplets, exhausting the
+    # account's droplet quota and causing all subsequent agents to fail.
+    if [ "${SPAWN_HEADLESS:-}" = "1" ]; then
+        "$@"
+        return $?
+    fi
+
     local attempt=0
     local backoff=2
     while [ "$attempt" -lt "$_MAX_RETRIES" ]; do

--- a/sh/digitalocean/kilocode.sh
+++ b/sh/digitalocean/kilocode.sh
@@ -21,6 +21,14 @@ _ensure_bun() {
 # bun from the foreground process group and broke @clack/prompts multiselect.
 # Now SIGTERM is detected from exit code 143 (128 + 15) after the child exits.
 _run_with_restart() {
+    # In headless mode (E2E / --headless), skip the restart loop entirely.
+    # Restarting in headless mode creates duplicate droplets, exhausting the
+    # account's droplet quota and causing all subsequent agents to fail.
+    if [ "${SPAWN_HEADLESS:-}" = "1" ]; then
+        "$@"
+        return $?
+    fi
+
     local attempt=0
     local backoff=2
     while [ "$attempt" -lt "$_MAX_RETRIES" ]; do

--- a/sh/digitalocean/openclaw.sh
+++ b/sh/digitalocean/openclaw.sh
@@ -21,6 +21,14 @@ _ensure_bun() {
 # bun from the foreground process group and broke @clack/prompts multiselect.
 # Now SIGTERM is detected from exit code 143 (128 + 15) after the child exits.
 _run_with_restart() {
+    # In headless mode (E2E / --headless), skip the restart loop entirely.
+    # Restarting in headless mode creates duplicate droplets, exhausting the
+    # account's droplet quota and causing all subsequent agents to fail.
+    if [ "${SPAWN_HEADLESS:-}" = "1" ]; then
+        "$@"
+        return $?
+    fi
+
     local attempt=0
     local backoff=2
     while [ "$attempt" -lt "$_MAX_RETRIES" ]; do

--- a/sh/digitalocean/opencode.sh
+++ b/sh/digitalocean/opencode.sh
@@ -21,6 +21,14 @@ _ensure_bun() {
 # bun from the foreground process group and broke @clack/prompts multiselect.
 # Now SIGTERM is detected from exit code 143 (128 + 15) after the child exits.
 _run_with_restart() {
+    # In headless mode (E2E / --headless), skip the restart loop entirely.
+    # Restarting in headless mode creates duplicate droplets, exhausting the
+    # account's droplet quota and causing all subsequent agents to fail.
+    if [ "${SPAWN_HEADLESS:-}" = "1" ]; then
+        "$@"
+        return $?
+    fi
+
     local attempt=0
     local backoff=2
     while [ "$attempt" -lt "$_MAX_RETRIES" ]; do

--- a/sh/digitalocean/zeroclaw.sh
+++ b/sh/digitalocean/zeroclaw.sh
@@ -21,6 +21,14 @@ _ensure_bun() {
 # bun from the foreground process group and broke @clack/prompts multiselect.
 # Now SIGTERM is detected from exit code 143 (128 + 15) after the child exits.
 _run_with_restart() {
+    # In headless mode (E2E / --headless), skip the restart loop entirely.
+    # Restarting in headless mode creates duplicate droplets, exhausting the
+    # account's droplet quota and causing all subsequent agents to fail.
+    if [ "${SPAWN_HEADLESS:-}" = "1" ]; then
+        "$@"
+        return $?
+    fi
+
     local attempt=0
     local backoff=2
     while [ "$attempt" -lt "$_MAX_RETRIES" ]; do


### PR DESCRIPTION
**Why:** Prevents DO E2E runs from creating duplicate droplets (up to 3x per agent) when the provision timeout kills the process, which exhausts the account's droplet quota and causes all subsequent agents to fail.

## Root cause

All 8 DigitalOcean agent scripts (`sh/digitalocean/*.sh`) have a `_run_with_restart` wrapper that catches SIGTERM (143) and SIGKILL (137) exit codes and retries the orchestration up to 3 times with exponential backoff. This is useful for interactive sessions where the user's SSH connection drops.

However, when running in headless mode (E2E tests via `--headless`), the provision timeout in `provision.sh` kills the process tree after `PROVISION_TIMEOUT` seconds. The `_run_with_restart` wrapper survives the kill (it's a shell function, not a child process), catches the exit code, and restarts `bun run digitalocean/main.ts` — which creates a **new duplicate droplet**. With `_MAX_RETRIES=3`, a single agent test could create up to 3 droplets instead of 1.

With 5 DO agents running in the E2E, this means up to 15 droplets instead of 5, exhausting the account's droplet limit and causing all agents to fail with quota errors.

## Fix

Added an early return in `_run_with_restart()` that checks `SPAWN_HEADLESS=1` (set by `runScriptHeadless` in `packages/cli/src/commands/run.ts`). When headless, the function runs the command once without retries and returns the exit code directly.

Applied to all 8 DO agent scripts: claude, codex, openclaw, zeroclaw, opencode, kilocode, hermes, junie.

Fixes #2794

-- refactor/code-health