### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/manifest-type-contracts.test.ts
+++ b/packages/cli/src/__tests__/manifest-type-contracts.test.ts
@@ -112,15 +112,19 @@ describe("Agent optional field types (when present)", () => {
     }
   });
 
-  it("config_files should be an object with string keys for all agents that have it", () => {
+  it("config_files should be an object with path-like string keys and object values for all agents that have it", () => {
     const agentsWithConfigFiles = allAgents.filter(([, agent]) => agent.config_files !== undefined);
     expect(agentsWithConfigFiles.length).toBeGreaterThan(0);
     for (const [, agent] of agentsWithConfigFiles) {
       expect(typeof agent.config_files).toBe("object");
       expect(agent.config_files).not.toBeNull();
-      for (const filePath of Object.keys(agent.config_files!)) {
+      for (const [filePath, content] of Object.entries(agent.config_files!)) {
         expect(typeof filePath).toBe("string");
         expect(filePath.length).toBeGreaterThan(0);
+        // File paths should contain / or ~ or . indicating a real path
+        expect(filePath).toMatch(/[/~.]/);
+        expect(typeof content).toBe("object");
+        expect(content).not.toBeNull();
       }
     }
   });
@@ -372,23 +376,6 @@ describe("Agent metadata field types", () => {
       for (const tag of agent.tags!) {
         expect(typeof tag, `agent "${key}" tag "${tag}"`).toBe("string");
         expect(tag.length, `agent "${key}" tag "${tag}" length`).toBeGreaterThan(0);
-      }
-    }
-  });
-});
-
-// ── Config files structure ────────────────────────────────────────────────
-
-describe("Config files structure", () => {
-  it("config file paths should look like file paths and values should be objects", () => {
-    const agentsWithConfigFiles = allAgents.filter(([, agent]) => agent.config_files !== undefined);
-    expect(agentsWithConfigFiles.length).toBeGreaterThan(0);
-    for (const [, agent] of agentsWithConfigFiles) {
-      for (const [filePath, content] of Object.entries(agent.config_files!)) {
-        // Should contain / or ~ or . indicating a path
-        expect(filePath).toMatch(/[/~.]/);
-        expect(typeof content).toBe("object");
-        expect(content).not.toBeNull();
       }
     }
   });


### PR DESCRIPTION
## Summary

- Found one genuine duplication in `manifest-type-contracts.test.ts`: two separate describe blocks both iterating over `config_files` data testing overlapping constraints
- Consolidated into a single test under "Agent optional field types" that checks all constraints: key is string, key is non-empty, key matches path regex (`/[/~.]/`), and value is a non-null object
- Removed the now-redundant standalone `"Config files structure"` describe block

## Scan Results

**Duplicates found:** 1 (intra-file within `manifest-type-contracts.test.ts`)

**Tests removed:** 1 (`"config file paths should look like file paths and values should be objects"` in `"Config files structure"` describe)

**Tests rewritten:** 1 (`"config_files should be an object with string keys"` merged with path-shape + value-type checks from the removed duplicate)

**No bash-grep tests found** — no tests used `type FUNCTION_NAME` or shell grep to test existence rather than behavior.

**No always-pass patterns found** — conditional `if (!result.ok) { expect() }` patterns are all preceded by `expect(result.ok).toBe(false)` so the inner branch always executes.

**No excessive subprocess spawning** — only mocked `Bun.spawnSync` via `spyOn` in ssh-keys and sprite-keep-alive tests, plus one legitimate `Bun.spawnSync` in the guardrail `fs-sandbox.test.ts`.

## Test plan

- [x] `bun test` passes: 1462/1462 tests pass (1 duplicate removed from 1463 baseline)
- [x] `bunx @biomejs/biome check src/` passes with 0 errors

-- qa/dedup-scanner