### PR TITLE
fix: restore packages/cli/bunfig.toml for preload resolution

### DIFF
--- a/packages/cli/bunfig.toml
+++ b/packages/cli/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/__tests__/preload.ts"]


### PR DESCRIPTION
## Summary
- Restore `packages/cli/bunfig.toml` with just the preload directive — needed when running `bun test` from `packages/cli/` (pre-merge hook, local dev)
- The root `bunfig.toml` handles coverage thresholds workspace-wide; the CLI-local one ensures the test sandbox preload resolves

## Test plan
- [x] `cd packages/cli && bun test` — 2090 pass, 0 fail
- [x] `bun test` from repo root — 2149 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)