### PR TITLE
fix: rename duplicate providers variable in key-server.ts

### DIFF
--- a/.claude/skills/setup-agent-team/key-server.ts
+++ b/.claude/skills/setup-agent-team/key-server.ts
@@ -447,7 +447,7 @@ const server = Bun.serve({
 
       const batchId = randomUUID();
       const exp = now + day;
-      const providers: ProviderRequest[] = requested.map((k) => {
+      const providerRequests: ProviderRequest[] = requested.map((k) => {
         const info = clouds.get(k);
         return {
           provider: k,
@@ -462,7 +462,7 @@ const server = Bun.serve({
 
       const batch: KeyBatch = {
         batchId,
-        providers,
+        providers: providerRequests,
         emailedAt: now,
         expiresAt: exp,
       };


### PR DESCRIPTION
## Summary
- Renames the second `const providers` declaration to `providerRequests` in `key-server.ts`
- Fixes a parse error (`"providers" has already been declared`) that crashed the key server on startup

Closes #2808

## Test plan
- [ ] Verify `bun build --no-bundle` parses key-server.ts without errors
- [ ] Verify key server starts without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)