### PR TITLE
fix(types): resolve TypeScript strict mode errors in production code

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -196,7 +196,7 @@ async function promptSetupOptions(agentName: string): Promise<Set<string> | unde
       message: "Model ID",
       placeholder: "provider/model-name",
       validate: (val) => {
-        if (!val.trim()) {
+        if (!val?.trim()) {
           return "Model ID is required";
         }
         if (!validateModelId(val.trim())) {

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -585,7 +585,7 @@ export async function handleRecordAction(
   }
 
   if (action === "enter") {
-    const enterResult = await asyncTryCatch(() => cmdEnterAgent(selected.connection, selected.agent, manifest));
+    const enterResult = await asyncTryCatch(() => cmdEnterAgent(conn, selected.agent, manifest));
     if (!enterResult.ok) {
       p.log.error(`Connection failed: ${getErrorMessage(enterResult.error)}`);
 
@@ -597,7 +597,7 @@ export async function handleRecordAction(
   }
 
   if (action === "dashboard") {
-    const dashResult = await asyncTryCatch(() => cmdOpenDashboard(selected.connection));
+    const dashResult = await asyncTryCatch(() => cmdOpenDashboard(conn));
     if (!dashResult.ok) {
       p.log.error(`Dashboard failed: ${getErrorMessage(dashResult.error)}`);
     }
@@ -605,7 +605,7 @@ export async function handleRecordAction(
   }
 
   if (action === "reconnect") {
-    const reconnectResult = await asyncTryCatch(() => cmdConnect(selected.connection));
+    const reconnectResult = await asyncTryCatch(() => cmdConnect(conn));
     if (!reconnectResult.ok) {
       p.log.error(`Connection failed: ${getErrorMessage(reconnectResult.error)}`);
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -114,7 +114,7 @@ function buildCloudLines(cloudInfo: {
   name: string;
   price: string;
   description: string;
-  defaults?: Record<string, string>;
+  defaults?: Record<string, unknown>;
 }): string[] {
   const lines = [
     `  Name:        ${cloudInfo.name}`,
@@ -123,8 +123,8 @@ function buildCloudLines(cloudInfo: {
   ];
   if (cloudInfo.defaults) {
     lines.push("  Defaults:");
-    for (const [k, v] of Object.entries(cloudInfo.defaults)) {
-      lines.push(`    ${k}: ${v}`);
+    for (const [k, val] of Object.entries(cloudInfo.defaults)) {
+      lines.push(`    ${k}: ${String(val)}`);
     }
   }
   return lines;

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -653,10 +653,11 @@ async function tryDoOAuth(): Promise<string | null> {
 
   // Exchange code for token
   logStep("Exchanging authorization code for access token...");
+  const code = oauthCode; // capture for closure (TS can't narrow `let` across async boundaries)
   const exchangeResult = await asyncTryCatch(async () => {
     const body = new URLSearchParams({
       grant_type: "authorization_code",
-      code: oauthCode,
+      code,
       client_id: DO_CLIENT_ID,
       client_secret: DO_CLIENT_SECRET,
       redirect_uri: redirectUri,
@@ -1069,8 +1070,9 @@ export async function createServer(
         logStep("Retrying droplet creation...");
         const retryText = await doApi("POST", "/droplets", body);
         const retryData = parseJsonObj(retryText);
-        if (retryData?.droplet?.id) {
-          _state.dropletId = String(retryData.droplet.id);
+        const retryDroplet = toRecord(retryData?.droplet);
+        if (retryDroplet?.id) {
+          _state.dropletId = String(retryDroplet.id);
           logInfo(`Droplet created: ID=${_state.dropletId}`);
           await waitForDropletActive(_state.dropletId);
           return {
@@ -1099,8 +1101,9 @@ export async function createServer(
   }
 
   const createData = parseJsonObj(createApiResult.data);
+  const createdDroplet = toRecord(createData?.droplet);
 
-  if (!createData?.droplet?.id) {
+  if (!createdDroplet?.id) {
     logError("Failed to create DigitalOcean droplet: unexpected API response");
     showNonBillingError(digitaloceanBilling, [
       "Region/size unavailable (try different DO_REGION or DO_DROPLET_SIZE)",
@@ -1109,7 +1112,7 @@ export async function createServer(
     throw new Error("Droplet creation failed");
   }
 
-  _state.dropletId = String(createData.droplet.id);
+  _state.dropletId = String(createdDroplet.id);
   logInfo(`Droplet created: ID=${_state.dropletId}`);
 
   // Wait for droplet to become active and get IP
@@ -1142,10 +1145,12 @@ async function waitForDropletActive(dropletId: string, maxAttempts = 60): Promis
       throw r.error;
     }
     const data = parseJsonObj(r.data);
-    const status = data?.droplet?.status;
+    const droplet = toRecord(data?.droplet);
+    const status = droplet?.status;
 
     if (status === "active") {
-      const v4Networks = toObjectArray(data?.droplet?.networks?.v4);
+      const networks = toRecord(droplet?.networks);
+      const v4Networks = toObjectArray(networks?.v4);
       const publicNet = v4Networks.find((n) => n.type === "public");
       if (publicNet?.ip_address) {
         _state.serverIp = isString(publicNet.ip_address) ? publicNet.ip_address : "";
@@ -1527,7 +1532,9 @@ export async function getServerIp(dropletId: string): Promise<string | null> {
     throw r.error;
   }
   const data = parseJsonObj(r.data);
-  const v4Networks = toObjectArray(data?.droplet?.networks?.v4);
+  const droplet = toRecord(data?.droplet);
+  const networks = toRecord(droplet?.networks);
+  const v4Networks = toObjectArray(networks?.v4);
   const publicNet = v4Networks.find((n) => n.type === "public");
   return publicNet?.ip_address && isString(publicNet.ip_address) ? publicNet.ip_address : null;
 }
@@ -1537,7 +1544,8 @@ export async function listServers(): Promise<CloudInstance[]> {
   const droplets = await doGetAll("/droplets", "droplets");
   const results: CloudInstance[] = [];
   for (const d of droplets) {
-    const v4Networks = toObjectArray(d?.networks?.v4);
+    const networks = toRecord(d.networks);
+    const v4Networks = toObjectArray(networks?.v4);
     const publicNet = v4Networks.find((n) => n.type === "public");
     const ip = publicNet?.ip_address && isString(publicNet.ip_address) ? publicNet.ip_address : "";
     results.push({

--- a/packages/cli/src/history.ts
+++ b/packages/cli/src/history.ts
@@ -317,29 +317,50 @@ function recoverFromArchives(): SpawnRecord[] {
   return result.ok ? result.data : [];
 }
 
+/** Backfill missing `id` field on parsed records (pre-migration records lack it). */
+function backfillRecordIds(records: v.InferOutput<typeof SpawnRecordSchema>[]): SpawnRecord[] {
+  return records.map((r) => ({
+    ...r,
+    id: r.id ?? generateSpawnId(),
+  }));
+}
+
 /** Parse raw JSON into SpawnRecord[], handling all format versions. */
 function parseHistoryData(raw: unknown): SpawnRecord[] | null {
   // v1 format: { version: 1, records: [...] } — strict check
   const v1 = v.safeParse(HistoryFileV1Schema, raw);
   if (v1.success) {
-    return v1.output.records;
+    return backfillRecordIds(v1.output.records);
   }
 
   // Loose v1: version=1 but some individual records are malformed
   const v1Loose = v.safeParse(HistoryFileV1LooseSchema, raw);
   if (v1Loose.success) {
     const allRecords = v1Loose.output.records;
-    const valid = allRecords.filter((el) => v.safeParse(SpawnRecordSchema, el).success);
+    const valid: v.InferOutput<typeof SpawnRecordSchema>[] = [];
+    for (const el of allRecords) {
+      const result = v.safeParse(SpawnRecordSchema, el);
+      if (result.success) {
+        valid.push(result.output);
+      }
+    }
     const dropped = allRecords.length - valid.length;
     if (dropped > 0) {
       console.error(`Warning: Dropped ${dropped} malformed record(s) from history.`);
     }
-    return valid;
+    return backfillRecordIds(valid);
   }
 
   // v0 format: bare array (pre-versioning; migrated to v1 on next write)
   if (Array.isArray(raw)) {
-    return raw.filter((el) => v.safeParse(SpawnRecordSchema, el).success);
+    const valid: v.InferOutput<typeof SpawnRecordSchema>[] = [];
+    for (const el of raw) {
+      const result = v.safeParse(SpawnRecordSchema, el);
+      if (result.success) {
+        valid.push(result.output);
+      }
+    }
+    return backfillRecordIds(valid);
   }
 
   // Unrecognized format

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+import type { Manifest } from "./manifest.js";
+
 import { getErrorMessage, isString, toRecord } from "@openrouter/spawn-shared";
 import pc from "picocolors";
 import pkg from "../package.json" with { type: "json" };
@@ -148,23 +150,7 @@ function checkUnknownFlags(args: string[]): void {
 }
 
 /** Show info for a name that could be an agent or cloud, or show an error with suggestions */
-function showUnknownCommandError(
-  name: string,
-  manifest: {
-    agents: Record<
-      string,
-      {
-        name: string;
-      }
-    >;
-    clouds: Record<
-      string,
-      {
-        name: string;
-      }
-    >;
-  },
-): never {
+function showUnknownCommandError(name: string, manifest: Manifest): never {
   const agentMatch = findClosestKeyByNameOrKey(name, agentKeys(manifest), (k) => manifest.agents[k].name);
   const cloudMatch = findClosestKeyByNameOrKey(name, cloudKeys(manifest), (k) => manifest.clouds[k].name);
 

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -441,18 +441,20 @@ async function postInstall(
   // SSH tunnel for web dashboard
   let tunnelHandle: SshTunnelHandle | undefined;
   if (agent.tunnel) {
+    const tunnelCfg = agent.tunnel; // capture for closure (TS can't narrow across async boundaries)
     if (cloud.getConnectionInfo) {
+      const getConnInfo = cloud.getConnectionInfo; // capture for closure
       const tunnelResult = await asyncTryCatchIf(isOperationalError, async () => {
-        const conn = cloud.getConnectionInfo();
+        const conn = getConnInfo();
         const keys = await ensureSshKeys();
         tunnelHandle = await startSshTunnel({
           host: conn.host,
           user: conn.user,
-          remotePort: agent.tunnel.remotePort,
+          remotePort: tunnelCfg.remotePort,
           sshKeyOpts: getSshKeyOpts(keys),
         });
-        if (agent.tunnel.browserUrl) {
-          const url = agent.tunnel.browserUrl(tunnelHandle.localPort);
+        if (tunnelCfg.browserUrl) {
+          const url = tunnelCfg.browserUrl(tunnelHandle.localPort);
           if (url) {
             openBrowser(url);
           }


### PR DESCRIPTION
**Why:** Fixes ~24 TypeScript strict mode type errors in production code that could lead to runtime crashes (undefined access, type mismatches). Fixes #2821

## Changes

**7 production files fixed:**

- **`commands/interactive.ts`** — Guard against `undefined` val in `@clack/prompts` validate callback using optional chaining (`val?.trim()`)
- **`commands/list.ts`** — Use already-narrowed `conn` const instead of `selected.connection` (which TS cannot narrow across async boundaries)
- **`commands/run.ts`** — Widen `buildCloudLines` defaults parameter from `Record<string, string>` to `Record<string, unknown>` to match `CloudDef`
- **`digitalocean/digitalocean.ts`** — Use `toRecord()` to safely drill into nested API response objects (`droplet.id`, `droplet.networks.v4`, etc.); capture narrowed `oauthCode` in a const for async closure
- **`history.ts`** — Add `backfillRecordIds()` helper to ensure parsed records always have `id: string`; collect `v.safeParse` outputs directly to get properly typed arrays
- **`index.ts`** — Replace inline manifest type with `Manifest` import so `agentKeys()`/`cloudKeys()` accept the parameter
- **`shared/orchestrate.ts`** — Capture narrowed `agent.tunnel` and `cloud.getConnectionInfo` in const variables before async closures (TS loses narrowing across async boundaries)

## Approach

All fixes use proper TypeScript patterns (no `as` casts):
- Optional chaining + null checks
- Const captures for closure narrowing
- `toRecord()` for safe nested property access on `Record<string, unknown>`
- Valibot `safeParse` output typing

## Verification

- `bunx tsc --noEmit` — 0 production errors (down from 24)
- `bunx @biomejs/biome check src/` — 0 errors
- `bun test` — 2095 tests pass, 0 failures
- Version bumped: 0.25.2 → 0.25.3

-- refactor/code-health