### PR TITLE
fix(gcp): add /usr/local/bin to PATH for kilocode binary detection

### DIFF
--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -535,7 +535,7 @@ verify_codex() {
 
   # Binary check
   log_step "Checking codex binary..."
-  if cloud_exec "${app}" "PATH=\$HOME/.npm-global/bin:\$HOME/.bun/bin:\$HOME/.local/bin:\$PATH command -v codex" >/dev/null 2>&1; then
+  if cloud_exec "${app}" "PATH=\$HOME/.npm-global/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/usr/local/bin:\$PATH command -v codex" >/dev/null 2>&1; then
     log_ok "codex binary found"
   else
     log_err "codex binary not found"
@@ -594,7 +594,7 @@ verify_kilocode() {
 
   # Binary check
   log_step "Checking kilocode binary..."
-  if cloud_exec "${app}" "PATH=\$HOME/.npm-global/bin:\$HOME/.bun/bin:\$HOME/.local/bin:\$PATH command -v kilocode" >/dev/null 2>&1; then
+  if cloud_exec "${app}" "PATH=\$HOME/.npm-global/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/usr/local/bin:\$PATH command -v kilocode" >/dev/null 2>&1; then
     log_ok "kilocode binary found"
   else
     log_err "kilocode binary not found"


### PR DESCRIPTION
**Why:** Fixes kilocode FAILED on GCP — npm installs to /usr/local/bin when running as root but the E2E verify PATH check doesn't include /usr/local/bin, causing binary not found despite successful install.

## Summary

- Added `/usr/local/bin` to the PATH in `verify_kilocode` binary check in `sh/e2e/lib/verify.sh`
- Also fixed the same latent issue in `verify_codex` (same missing path)
- This aligns both verify functions with `verify_openclaw` and `verify_junie` which already include `/usr/local/bin`
- The `.spawnrc` PATH (generated by `generateEnvConfig` in `agents.ts`) already includes `/usr/local/bin` — the E2E verify was the only place that omitted it

**Root cause:** On GCP, `npm prefix -g` returns `/usr/local` (writable by root), so `npm install -g @kilocode/cli` installs to `/usr/local/bin/kilocode`. The `NPM_PREFIX_SETUP` correctly skips the `--prefix ~/.npm-global` override when `/usr/local` is writable and in PATH. But the E2E binary verify used a hardcoded PATH (`$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH`) that relied on `$PATH` expansion in the non-login SSH context, where `/usr/local/bin` may not be present.

Fixes #2823

-- refactor/code-health