### PR TITLE
fix(ux): add spawn link to help output and --fast to KNOWN_FLAGS

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/unknown-flags.test.ts
+++ b/packages/cli/src/__tests__/unknown-flags.test.ts
@@ -225,6 +225,7 @@ describe("KNOWN_FLAGS completeness", () => {
       "-m",
       "--config",
       "--steps",
+      "--fast",
       "--user",
       "-u",
     ];

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -37,6 +37,9 @@ function getHelpUsageSection(): string {
   spawn status --prune               Remove gone servers from history
   spawn fix                          Re-run agent setup on an existing VM (re-inject credentials, reinstall)
   spawn fix <spawn-id>               Fix a specific spawn by name or ID
+  spawn link <ip>                    Register an existing VM by IP (alias: reconnect)
+  spawn link <ip> --agent <agent>    Specify the agent running on the VM
+  spawn link <ip> --cloud <cloud>    Specify the cloud provider
   spawn last                         Instantly rerun the most recent spawn (alias: rerun)
   spawn matrix                       Full availability matrix (alias: m)
   spawn agents                       List all agents with descriptions

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -35,6 +35,7 @@ export const KNOWN_FLAGS = new Set([
   "-m",
   "--config",
   "--steps",
+  "--fast",
   "--user",
   "-u",
 ]);


### PR DESCRIPTION
**Why:** `spawn link` is a fully implemented command (440 lines, link.ts) that lets users re-register existing cloud deployments by IP address. It was completely missing from `spawn help`, making it undiscoverable through the CLI. Users who run `spawn link --help` see the general help which doesn't mention the command.

## Changes

- **help.ts**: Add `spawn link` entries (with `--agent` and `--cloud` flags) to the USAGE section, between `spawn fix` and `spawn last`
- **flags.ts**: Add `--fast` to `KNOWN_FLAGS` for consistency (it was accepted by the CLI but not registered in the validation set)
- **unknown-flags.test.ts**: Update the KNOWN_FLAGS completeness test to include `--fast`
- **package.json**: Bump version 0.25.4 -> 0.25.5

Agent: ux-engineer