### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/cmd-list-cov.test.ts
+++ b/packages/cli/src/__tests__/cmd-list-cov.test.ts
@@ -1,10 +1,12 @@
 /**
  * cmd-list-cov.test.ts — Coverage tests for commands/list.ts
  *
- * Focuses on uncovered paths: buildRecordLabel, buildRecordSubtitle,
- * resolveListFilters, showEmptyListMessage, cmdListClear, cmdList
- * non-interactive path, cmdLast with no history, handleRecordAction branches.
- * (formatRelativeTime is covered in commands-exported-utils.test.ts)
+ * Focuses on uncovered paths: resolveListFilters, showEmptyListMessage,
+ * cmdList non-interactive path, handleRecordAction branches.
+ * (buildRecordLabel/buildRecordSubtitle covered in cmdlast.test.ts)
+ * (cmdListClear covered in clear-history.test.ts)
+ * (cmdLast covered in cmdlast.test.ts)
+ * (formatRelativeTime covered in commands-exported-utils.test.ts)
  */
 
 import type { SpawnRecord } from "../history.js";
@@ -17,7 +19,7 @@ import { createConsoleMocks, createMockManifest, mockClackPrompts, restoreMocks 
 
 const clack = mockClackPrompts();
 
-const { buildRecordLabel, buildRecordSubtitle, cmdList, cmdListClear, cmdLast } = await import("../commands/index.js");
+const { cmdList } = await import("../commands/index.js");
 const { resolveListFilters, handleRecordAction, RecordActionOutcome } = await import("../commands/list.js");
 
 const mockManifest = createMockManifest();
@@ -52,90 +54,6 @@ describe("commands/list.ts coverage", () => {
       });
     }
     restoreMocks(consoleMocks.log, consoleMocks.error);
-  });
-
-  // ── buildRecordLabel ──────────────────────────────────────────────────
-
-  describe("buildRecordLabel", () => {
-    it("returns name when set", () => {
-      const r: SpawnRecord = {
-        id: "1",
-        agent: "claude",
-        cloud: "sprite",
-        timestamp: "2026-01-01T00:00:00Z",
-        name: "my-server",
-      };
-      expect(buildRecordLabel(r)).toBe("my-server");
-    });
-
-    it("falls back to server_name when no name", () => {
-      const r: SpawnRecord = {
-        id: "1",
-        agent: "claude",
-        cloud: "sprite",
-        timestamp: "2026-01-01T00:00:00Z",
-        connection: {
-          ip: "1.2.3.4",
-          user: "root",
-          server_name: "srv-123",
-        },
-      };
-      expect(buildRecordLabel(r)).toBe("srv-123");
-    });
-
-    it("returns 'unnamed' when no name or server_name", () => {
-      const r: SpawnRecord = {
-        id: "1",
-        agent: "claude",
-        cloud: "sprite",
-        timestamp: "2026-01-01T00:00:00Z",
-      };
-      expect(buildRecordLabel(r)).toBe("unnamed");
-    });
-  });
-
-  // ── buildRecordSubtitle ───────────────────────────────────────────────
-
-  describe("buildRecordSubtitle", () => {
-    it("includes agent, cloud, and time", () => {
-      const r: SpawnRecord = {
-        id: "1",
-        agent: "claude",
-        cloud: "sprite",
-        timestamp: new Date().toISOString(),
-      };
-      const subtitle = buildRecordSubtitle(r, mockManifest);
-      expect(subtitle).toContain("Claude Code");
-      expect(subtitle).toContain("Sprite");
-    });
-
-    it("shows [deleted] for deleted connections", () => {
-      const r: SpawnRecord = {
-        id: "1",
-        agent: "claude",
-        cloud: "sprite",
-        timestamp: new Date().toISOString(),
-        connection: {
-          ip: "1.2.3.4",
-          user: "root",
-          deleted: true,
-        },
-      };
-      const subtitle = buildRecordSubtitle(r, mockManifest);
-      expect(subtitle).toContain("[deleted]");
-    });
-
-    it("falls back to key when manifest is null", () => {
-      const r: SpawnRecord = {
-        id: "1",
-        agent: "claude",
-        cloud: "sprite",
-        timestamp: new Date().toISOString(),
-      };
-      const subtitle = buildRecordSubtitle(r, null);
-      expect(subtitle).toContain("claude");
-      expect(subtitle).toContain("sprite");
-    });
   });
 
   // ── resolveListFilters ────────────────────────────────────────────────
@@ -179,37 +97,6 @@ describe("commands/list.ts coverage", () => {
       const result = await resolveListFilters("sprite");
       expect(result.cloudFilter).toBe("sprite");
       expect(result.agentFilter).toBeUndefined();
-    });
-  });
-
-  // ── cmdListClear ──────────────────────────────────────────────────────
-
-  describe("cmdListClear", () => {
-    it("reports no history when empty", async () => {
-      await cmdListClear();
-      expect(clack.logInfo).toHaveBeenCalled();
-    });
-
-    it("clears history when confirmed in non-interactive mode", async () => {
-      const records: SpawnRecord[] = [
-        {
-          id: "1",
-          agent: "claude",
-          cloud: "sprite",
-          timestamp: "2026-01-01T00:00:00Z",
-        },
-      ];
-      writeFileSync(
-        join(testDir, "history.json"),
-        JSON.stringify({
-          version: 1,
-          records,
-        }),
-      );
-      // Make non-interactive
-      process.env.SPAWN_NON_INTERACTIVE = "1";
-      await cmdListClear();
-      expect(clack.logSuccess).toHaveBeenCalled();
     });
   });
 
@@ -361,16 +248,6 @@ describe("commands/list.ts coverage", () => {
       const result = await resolveListFilters("nonexistent", "sprite");
       expect(result.agentFilter).toBe("nonexistent");
       expect(result.cloudFilter).toBe("sprite");
-    });
-  });
-
-  // ── cmdLast ───────────────────────────────────────────────────────────
-
-  describe("cmdLast", () => {
-    it("shows no-history message when empty", async () => {
-      global.fetch = mock(async () => new Response(JSON.stringify(mockManifest)));
-      await cmdLast();
-      expect(clack.logInfo).toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/__tests__/cmd-run-cov.test.ts
+++ b/packages/cli/src/__tests__/cmd-run-cov.test.ts
@@ -103,19 +103,6 @@ describe("commands/run.ts coverage", () => {
     });
   });
 
-  // ── cmdRun with swapped arguments ─────────────────────────────────────
-
-  describe("cmdRun detectAndFixSwappedArgs", () => {
-    it("detects and fixes swapped agent/cloud arguments in dry run", async () => {
-      global.fetch = mock(async () => new Response(JSON.stringify(mockManifest)));
-      await loadManifest(true);
-      // Pass cloud name as agent, agent name as cloud
-      await cmdRun("sprite", "claude", undefined, true);
-      // Should still succeed as dry run (swap detection fixes it)
-      expect(clack.logInfo).toHaveBeenCalled();
-    });
-  });
-
   // ── cmdRun additional ─────────────────────────────────────────────
 
   describe("cmdRun validation", () => {


### PR DESCRIPTION
## Summary

- Removed 10 duplicate test cases that were already comprehensively covered in dedicated test files
- `cmd-list-cov.test.ts`: removed `buildRecordLabel` (3), `buildRecordSubtitle` (3), `cmdListClear` (2), `cmdLast` (1) — all duplicated in `cmdlast.test.ts` and `clear-history.test.ts`
- `cmd-run-cov.test.ts`: removed `cmdRun detectAndFixSwappedArgs` (1) — superseded by `commands-swap-resolve.test.ts` which has 10 thorough swap-detection tests

## Test plan

- [x] `bun test` passes: 2040 tests, 0 failures
- [x] `biome check` on modified files: no errors

-- qa/dedup-scanner