### PR TITLE
refactor: remove dead code and stale references

### DIFF
--- a/packages/cli/src/__tests__/aws-cov.test.ts
+++ b/packages/cli/src/__tests__/aws-cov.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { mockClackPrompts } from "./test-helpers";
+import { mockBunSpawn, mockClackPrompts } from "./test-helpers";
 
 // Must mock clack before importing aws module
 mockClackPrompts();
@@ -27,54 +27,6 @@ function mockSpawnSync(exitCode: number, stdout = "", stderr = "") {
     resourceUsage: undefined,
     pid: 1234,
   } satisfies ReturnType<typeof Bun.spawnSync>);
-}
-
-function mockBunSpawn(exitCode = 0, stdout = "", stderr = "") {
-  const mockProc = {
-    pid: 1234,
-    exitCode: Promise.resolve(exitCode),
-    exited: Promise.resolve(exitCode),
-    stdout: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stdout));
-        c.close();
-      },
-    }),
-    stderr: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stderr));
-        c.close();
-      },
-    }),
-    kill: mock(() => {}),
-    ref: () => {},
-    unref: () => {},
-    stdin: new WritableStream(),
-    resourceUsage: () =>
-      ({
-        cpuTime: {
-          system: 0,
-          user: 0,
-          total: 0,
-        },
-        maxRSS: 0,
-        sharedMemorySize: 0,
-        unsharedDataSize: 0,
-        unsharedStackSize: 0,
-        minorPageFaults: 0,
-        majorPageFaults: 0,
-        swapCount: 0,
-        inBlock: 0,
-        outBlock: 0,
-        ipcMessagesSent: 0,
-        ipcMessagesReceived: 0,
-        signalsReceived: 0,
-        voluntaryContextSwitches: 0,
-        involuntaryContextSwitches: 0,
-      }) satisfies ReturnType<ReturnType<typeof Bun.spawn>["resourceUsage"]>,
-  };
-  // biome-ignore lint: test mock
-  return spyOn(Bun, "spawn").mockReturnValue(mockProc as ReturnType<typeof Bun.spawn>);
 }
 
 let origFetch: typeof global.fetch;

--- a/packages/cli/src/__tests__/do-cov.test.ts
+++ b/packages/cli/src/__tests__/do-cov.test.ts
@@ -1,59 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { mockClackPrompts } from "./test-helpers";
+import { mockBunSpawn, mockClackPrompts } from "./test-helpers";
 
 mockClackPrompts();
 
 import { DEFAULT_DO_REGION, DEFAULT_DROPLET_SIZE, getConnectionInfo } from "../digitalocean/digitalocean";
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function mockBunSpawn(exitCode = 0, stdout = "", stderr = "") {
-  const mockProc = {
-    pid: 1234,
-    exitCode: Promise.resolve(exitCode),
-    exited: Promise.resolve(exitCode),
-    stdout: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stdout));
-        c.close();
-      },
-    }),
-    stderr: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stderr));
-        c.close();
-      },
-    }),
-    kill: mock(() => {}),
-    ref: () => {},
-    unref: () => {},
-    stdin: new WritableStream(),
-    resourceUsage: () =>
-      ({
-        cpuTime: {
-          system: 0,
-          user: 0,
-          total: 0,
-        },
-        maxRSS: 0,
-        sharedMemorySize: 0,
-        unsharedDataSize: 0,
-        unsharedStackSize: 0,
-        minorPageFaults: 0,
-        majorPageFaults: 0,
-        swapCount: 0,
-        inBlock: 0,
-        outBlock: 0,
-        ipcMessagesSent: 0,
-        ipcMessagesReceived: 0,
-        signalsReceived: 0,
-        voluntaryContextSwitches: 0,
-        involuntaryContextSwitches: 0,
-      }) satisfies ReturnType<ReturnType<typeof Bun.spawn>["resourceUsage"]>,
-  };
-  // biome-ignore lint: test mock
-  return spyOn(Bun, "spawn").mockReturnValue(mockProc as ReturnType<typeof Bun.spawn>);
-}
 
 let origFetch: typeof global.fetch;
 let origEnv: NodeJS.ProcessEnv;

--- a/packages/cli/src/__tests__/gcp-cov.test.ts
+++ b/packages/cli/src/__tests__/gcp-cov.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { mockClackPrompts } from "./test-helpers";
+import { mockBunSpawn, mockClackPrompts } from "./test-helpers";
 
 mockClackPrompts();
 
@@ -51,54 +51,6 @@ function mockSpawnSyncWithGcloud(exitCode: number, stdout = "", stderr = "") {
 /** Mock spawnSync to only satisfy the `which gcloud` check (for tests that mock Bun.spawn separately). */
 function mockWhichGcloud() {
   return spyOn(Bun, "spawnSync").mockReturnValue(WHICH_GCLOUD_OK);
-}
-
-function mockBunSpawn(exitCode = 0, stdout = "", stderr = "") {
-  const mockProc = {
-    pid: 1234,
-    exitCode: Promise.resolve(exitCode),
-    exited: Promise.resolve(exitCode),
-    stdout: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stdout));
-        c.close();
-      },
-    }),
-    stderr: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stderr));
-        c.close();
-      },
-    }),
-    kill: mock(() => {}),
-    ref: () => {},
-    unref: () => {},
-    stdin: new WritableStream(),
-    resourceUsage: () =>
-      ({
-        cpuTime: {
-          system: 0,
-          user: 0,
-          total: 0,
-        },
-        maxRSS: 0,
-        sharedMemorySize: 0,
-        unsharedDataSize: 0,
-        unsharedStackSize: 0,
-        minorPageFaults: 0,
-        majorPageFaults: 0,
-        swapCount: 0,
-        inBlock: 0,
-        outBlock: 0,
-        ipcMessagesSent: 0,
-        ipcMessagesReceived: 0,
-        signalsReceived: 0,
-        voluntaryContextSwitches: 0,
-        involuntaryContextSwitches: 0,
-      }) satisfies ReturnType<ReturnType<typeof Bun.spawn>["resourceUsage"]>,
-  };
-  // biome-ignore lint: test mock
-  return spyOn(Bun, "spawn").mockReturnValue(mockProc as ReturnType<typeof Bun.spawn>);
 }
 
 let origFetch: typeof global.fetch;

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -1,59 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { mockClackPrompts } from "./test-helpers";
+import { mockBunSpawn, mockClackPrompts } from "./test-helpers";
 
 mockClackPrompts();
 
 import { DEFAULT_LOCATION, DEFAULT_SERVER_TYPE, getConnectionInfo } from "../hetzner/hetzner";
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function mockBunSpawn(exitCode = 0, stdout = "", stderr = "") {
-  const mockProc = {
-    pid: 1234,
-    exitCode: Promise.resolve(exitCode),
-    exited: Promise.resolve(exitCode),
-    stdout: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stdout));
-        c.close();
-      },
-    }),
-    stderr: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stderr));
-        c.close();
-      },
-    }),
-    kill: mock(() => {}),
-    ref: () => {},
-    unref: () => {},
-    stdin: new WritableStream(),
-    resourceUsage: () =>
-      ({
-        cpuTime: {
-          system: 0,
-          user: 0,
-          total: 0,
-        },
-        maxRSS: 0,
-        sharedMemorySize: 0,
-        unsharedDataSize: 0,
-        unsharedStackSize: 0,
-        minorPageFaults: 0,
-        majorPageFaults: 0,
-        swapCount: 0,
-        inBlock: 0,
-        outBlock: 0,
-        ipcMessagesSent: 0,
-        ipcMessagesReceived: 0,
-        signalsReceived: 0,
-        voluntaryContextSwitches: 0,
-        involuntaryContextSwitches: 0,
-      }) satisfies ReturnType<ReturnType<typeof Bun.spawn>["resourceUsage"]>,
-  };
-  // biome-ignore lint: test mock
-  return spyOn(Bun, "spawn").mockReturnValue(mockProc as ReturnType<typeof Bun.spawn>);
-}
 
 let origFetch: typeof global.fetch;
 let origEnv: NodeJS.ProcessEnv;

--- a/packages/cli/src/__tests__/sprite-cov.test.ts
+++ b/packages/cli/src/__tests__/sprite-cov.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { mockClackPrompts } from "./test-helpers";
+import { mockBunSpawn, mockClackPrompts } from "./test-helpers";
 
 mockClackPrompts();
 
@@ -17,54 +17,6 @@ function mockSpawnSync(exitCode: number, stdout = "", stderr = "") {
     resourceUsage: undefined,
     pid: 1234,
   } satisfies ReturnType<typeof Bun.spawnSync>);
-}
-
-function mockBunSpawn(exitCode = 0, stdout = "", stderr = "") {
-  const mockProc = {
-    pid: 1234,
-    exitCode: Promise.resolve(exitCode),
-    exited: Promise.resolve(exitCode),
-    stdout: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stdout));
-        c.close();
-      },
-    }),
-    stderr: new ReadableStream({
-      start(c) {
-        c.enqueue(new TextEncoder().encode(stderr));
-        c.close();
-      },
-    }),
-    kill: mock(() => {}),
-    ref: () => {},
-    unref: () => {},
-    stdin: new WritableStream(),
-    resourceUsage: () =>
-      ({
-        cpuTime: {
-          system: 0,
-          user: 0,
-          total: 0,
-        },
-        maxRSS: 0,
-        sharedMemorySize: 0,
-        unsharedDataSize: 0,
-        unsharedStackSize: 0,
-        minorPageFaults: 0,
-        majorPageFaults: 0,
-        swapCount: 0,
-        inBlock: 0,
-        outBlock: 0,
-        ipcMessagesSent: 0,
-        ipcMessagesReceived: 0,
-        signalsReceived: 0,
-        voluntaryContextSwitches: 0,
-        involuntaryContextSwitches: 0,
-      }) satisfies ReturnType<ReturnType<typeof Bun.spawn>["resourceUsage"]>,
-  };
-  // biome-ignore lint: test mock
-  return spyOn(Bun, "spawn").mockReturnValue(mockProc as ReturnType<typeof Bun.spawn>);
 }
 
 let origEnv: NodeJS.ProcessEnv;

--- a/packages/cli/src/__tests__/test-helpers.ts
+++ b/packages/cli/src/__tests__/test-helpers.ts
@@ -175,6 +175,61 @@ export function mockClackPrompts(overrides?: Partial<ClackPromptsMock>): ClackPr
   return mocks;
 }
 
+// ── Bun.spawn Mock ─────────────────────────────────────────────────────────────
+
+/**
+ * Mocks Bun.spawn to return a fake process with the given exit code, stdout, and stderr.
+ * Identical helper was previously duplicated across aws-cov, gcp-cov, do-cov, hetzner-cov,
+ * and sprite-cov test files. Centralised here to avoid repetition.
+ */
+export function mockBunSpawn(exitCode = 0, stdout = "", stderr = "") {
+  const mockProc = {
+    pid: 1234,
+    exitCode: Promise.resolve(exitCode),
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(stdout));
+        c.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(stderr));
+        c.close();
+      },
+    }),
+    kill: mock(() => {}),
+    ref: () => {},
+    unref: () => {},
+    stdin: new WritableStream(),
+    resourceUsage: () =>
+      ({
+        cpuTime: {
+          system: 0,
+          user: 0,
+          total: 0,
+        },
+        maxRSS: 0,
+        sharedMemorySize: 0,
+        unsharedDataSize: 0,
+        unsharedStackSize: 0,
+        minorPageFaults: 0,
+        majorPageFaults: 0,
+        swapCount: 0,
+        inBlock: 0,
+        outBlock: 0,
+        ipcMessagesSent: 0,
+        ipcMessagesReceived: 0,
+        signalsReceived: 0,
+        voluntaryContextSwitches: 0,
+        involuntaryContextSwitches: 0,
+      }) satisfies ReturnType<ReturnType<typeof Bun.spawn>["resourceUsage"]>,
+  };
+  // biome-ignore lint: test mock
+  return spyOn(Bun, "spawn").mockReturnValue(mockProc as ReturnType<typeof Bun.spawn>);
+}
+
 // ── Fetch Mocks ────────────────────────────────────────────────────────────────
 
 export function mockSuccessfulFetch(data: unknown) {


### PR DESCRIPTION
## Summary

- Identified `mockBunSpawn` helper function copy-pasted identically across 5 test files: `aws-cov.test.ts`, `gcp-cov.test.ts`, `do-cov.test.ts`, `hetzner-cov.test.ts`, `sprite-cov.test.ts`
- Centralised the single canonical implementation in `packages/cli/src/__tests__/test-helpers.ts`
- Updated all 5 test files to import `mockBunSpawn` from `test-helpers` instead
- Net: -249 lines added, +60 lines removed (189 lines net removed)

## Scan results by category

| Category | Finding | Action |
|---|---|---|
| Dead code | None found in `sh/shared/*.sh` or production TS | No change |
| Stale references | None found (all file references valid) | No change |
| Python usage | None found | No change |
| **Duplicate utilities** | `mockBunSpawn` copied across 5 test files | **Fixed** |
| Stale comments | None requiring removal found | No change |

## Test plan

- [x] `bun test` — 2050 pass, 0 fail
- [x] `bunx @biomejs/biome check packages/cli/src/` — 0 errors
- [x] No shell scripts modified (no `bash -n` needed)

-- qa/code-quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)