### PR TITLE
fix(security): quote branch name variables to prevent word-splitting

### DIFF
--- a/.claude/skills/setup-agent-team/qa.sh
+++ b/.claude/skills/setup-agent-team/qa.sh
@@ -175,23 +175,25 @@ fi
 
 # Delete merged qa-related remote branches
 MERGED_BRANCHES=$(git branch -r --merged origin/main | grep -E 'origin/qa/' | sed 's|origin/||' | tr -d ' ') || true
-for branch in $MERGED_BRANCHES; do
+while IFS= read -r branch; do
+    [[ -z "${branch}" ]] && continue
     if is_safe_branch_name "$branch"; then
         git push origin --delete -- "$branch" 2>&1 | tee -a "${LOG_FILE}" && log "Deleted merged branch: $branch" || true
     else
         log "WARNING: Skipping branch with unsafe name: ${branch}"
     fi
-done
+done <<< "${MERGED_BRANCHES}"
 
 # Delete stale local qa branches
 LOCAL_BRANCHES=$(git branch --list 'qa/*' | tr -d ' *') || true
-for branch in $LOCAL_BRANCHES; do
+while IFS= read -r branch; do
+    [[ -z "${branch}" ]] && continue
     if is_safe_branch_name "$branch"; then
         git branch -D -- "$branch" 2>&1 | tee -a "${LOG_FILE}" || true
     else
         log "WARNING: Skipping local branch with unsafe name: ${branch}"
     fi
-done
+done <<< "${LOCAL_BRANCHES}"
 
 log "Pre-cycle cleanup done."
 

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -189,23 +189,25 @@ fi
 
 # Delete merged security-related remote branches (team-building/*, review-pr-*)
 MERGED_BRANCHES=$(git branch -r --merged origin/main | grep -E 'origin/(team-building/|review-pr-)' | sed 's|origin/||' | tr -d ' ') || true
-for branch in $MERGED_BRANCHES; do
+while IFS= read -r branch; do
+    [[ -z "${branch}" ]] && continue
     if is_safe_branch_name "$branch"; then
         git push origin --delete -- "$branch" 2>&1 | tee -a "${LOG_FILE}" && log "Deleted merged branch: $branch" || true
     else
         log "WARNING: Skipping branch with unsafe name: ${branch}"
     fi
-done
+done <<< "${MERGED_BRANCHES}"
 
 # Delete stale local security-related branches
 LOCAL_BRANCHES=$(git branch --list 'team-building/*' --list 'review-pr-*' | tr -d ' *') || true
-for branch in $LOCAL_BRANCHES; do
+while IFS= read -r branch; do
+    [[ -z "${branch}" ]] && continue
     if is_safe_branch_name "$branch"; then
         git branch -D -- "$branch" 2>&1 | tee -a "${LOG_FILE}" || true
     else
         log "WARNING: Skipping local branch with unsafe name: ${branch}"
     fi
-done
+done <<< "${LOCAL_BRANCHES}"
 
 log "Pre-cycle cleanup done."
 


### PR DESCRIPTION
## Summary

- Replace `for branch in $VAR` with `while IFS= read -r branch` loops in `qa.sh` and `security.sh`
- Prevents word-splitting on branch names containing spaces or special characters (MEDIUM severity)
- Adds `[[ -z "${branch}" ]] && continue` guards to skip empty lines from heredoc input

## What changed

**`.claude/skills/setup-agent-team/qa.sh`** (lines 177-196):
- Remote branch cleanup loop: `for branch in $MERGED_BRANCHES` -> `while IFS= read -r branch`
- Local branch cleanup loop: `for branch in $LOCAL_BRANCHES` -> `while IFS= read -r branch`

**`.claude/skills/setup-agent-team/security.sh`** (lines 191-210):
- Remote branch cleanup loop: `for branch in $MERGED_BRANCHES` -> `while IFS= read -r branch`
- Local branch cleanup loop: `for branch in $LOCAL_BRANCHES` -> `while IFS= read -r branch`

## Test plan

- [x] `bash -n` syntax check passes on both files
- [x] `bunx @biomejs/biome check src/` passes with 0 errors
- [x] `bun test` passes (1981 tests, 0 failures)

Fixes #2837

-- refactor/style-reviewer