### PR TITLE
fix(security): prevent command injection in runServer() (DO, Hetzner)

### DIFF
--- a/packages/cli/src/__tests__/do-cov.test.ts
+++ b/packages/cli/src/__tests__/do-cov.test.ts
@@ -161,6 +161,16 @@ describe("digitalocean/runServer", () => {
     spy.mockRestore();
   });
 
+  it("wraps command with bash -c and shellQuote to prevent injection", async () => {
+    const spy = mockBunSpawn(0);
+    const { runServer } = await import("../digitalocean/digitalocean");
+    await runServer("echo hello", 10, "1.2.3.4");
+    const args = spy.mock.calls[0][0];
+    const sshCmd = args[args.length - 1];
+    expect(sshCmd).toMatch(/^bash -c '/);
+    spy.mockRestore();
+  });
+
   it("throws on non-zero exit", async () => {
     const spy = mockBunSpawn(1);
     const { runServer } = await import("../digitalocean/digitalocean");

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -175,6 +175,16 @@ describe("hetzner/runServer", () => {
     spy.mockRestore();
   });
 
+  it("wraps command with bash -c and shellQuote to prevent injection", async () => {
+    const spy = mockBunSpawn(0);
+    const { runServer } = await import("../hetzner/hetzner");
+    await runServer("echo hello", 10, "1.2.3.4");
+    const args = spy.mock.calls[0][0];
+    const sshCmd = args[args.length - 1];
+    expect(sshCmd).toMatch(/^bash -c '/);
+    spy.mockRestore();
+  });
+
   it("throws on non-zero exit", async () => {
     const spy = mockBunSpawn(1);
     const { runServer } = await import("../hetzner/hetzner");

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1343,7 +1343,7 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
       ...SSH_BASE_OPTS,
       ...keyOpts,
       `root@${serverIp}`,
-      fullCmd,
+      `bash -c ${shellQuote(fullCmd)}`,
     ],
     {
       stdio: [

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -753,7 +753,7 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
       ...SSH_BASE_OPTS,
       ...keyOpts,
       `root@${serverIp}`,
-      fullCmd,
+      `bash -c ${shellQuote(fullCmd)}`,
     ],
     {
       stdio: [


### PR DESCRIPTION
## Summary

- **DigitalOcean and Hetzner `runServer()` passed commands to SSH without shell-quoting**, allowing metacharacters (`;`, `|`, `$()`, backticks, etc.) to be interpreted by the remote shell — a HIGH severity command injection vector (CWE-78).
- Applied the same `bash -c ${shellQuote(fullCmd)}` pattern already used by AWS and GCP modules.
- Added tests verifying the SSH command argument starts with `bash -c '` (proving shellQuote wrapping).
- Bumped CLI version to 0.25.6.

Fixes #2836

## Test plan

- [x] `bunx @biomejs/biome check src/` passes (0 errors)
- [x] `bun test` passes (1983 tests, 0 failures)
- [x] New tests verify `Bun.spawn` receives shell-quoted command for both DO and Hetzner
- [ ] Manual: deploy an agent on DO/Hetzner and verify `runServer` still works end-to-end

-- refactor/security-auditor