### PR TITLE
fix: prevent silent exit in --fast mode on Sprite

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -148,6 +148,12 @@ export async function runOrchestration(
     // ── Fast mode: server boot + setup prompts run concurrently ─────────
     // Start server creation, then do API key prompt, pre-provision, tarball
     // download, and account check in parallel with server boot.
+    //
+    // Keep a dummy timer on the event loop so Bun doesn't exit prematurely.
+    // When all concurrent promises settle (especially after Bun.serve.stop()
+    // in the OAuth flow removes its handle), the event loop can appear empty
+    // before the continuation starts new I/O — causing a silent exit(0).
+    const keepAlive = setInterval(() => {}, 60_000);
 
     const serverBootPromise = (async () => {
       const conn = await cloud.createServer(serverName);
@@ -257,6 +263,7 @@ export async function runOrchestration(
     }
 
     // Inject env + continue with shared post-install flow
+    clearInterval(keepAlive);
     await injectEnvVars(cloud, envContent);
     await postInstall(cloud, agent, agentName, apiKey, modelId, spawnId, options);
   } else {


### PR DESCRIPTION
## Summary
- In `--fast` mode on Sprite, the process exits silently (code 0) after OAuth completes — no agent install, no error message
- Root cause: `Bun.serve.stop(true)` in the OAuth flow removes the last event loop handle after all concurrent `Promise.allSettled` operations complete, causing Bun to drain the event loop before the `await` continuation can start new I/O
- Fix: keep a dummy `setInterval` handle alive during the fast-mode concurrent section, cleared before post-install

## Repro
```bash
spawn --fast   # select OpenClaw → Sprite
# Process exits silently after "Successfully obtained OpenRouter API key via OAuth!"
```

## Test plan
- [x] Existing orchestrate tests pass (69/69)
- [x] Biome lint clean
- [ ] Manual test: `spawn openclaw sprite --fast` completes full setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)