### PR TITLE
fix: auto-reconnect on Sprite connection drops

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.7",
+  "version": "0.25.8",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -540,9 +540,11 @@ async function postInstall(
 
   const sessionCmd = cloud.cloudName === "local" ? launchCmd : wrapWithRestartLoop(launchCmd);
 
-  // Auto-reconnect on SSH drops (exit 255). Ctrl+C (exit 0 or 130) exits immediately.
-  // Only applies to remote clouds — local sessions don't have SSH drops.
+  // Auto-reconnect on connection drops. Ctrl+C (exit 0 or 130) exits immediately.
+  // Only applies to remote clouds — local sessions don't have connection drops.
+  // SSH exits 255 on connection loss; Sprite CLI exits 1 on "connection closed".
   const maxReconnects = cloud.cloudName === "local" ? 0 : 5;
+  const isConnectionDrop = (code: number): boolean => code === 255 || (cloud.cloudName === "sprite" && code === 1);
   let exitCode = 0;
 
   for (let attempt = 0; attempt <= maxReconnects; attempt++) {
@@ -554,14 +556,12 @@ async function postInstall(
     }
     exitCode = await cloud.interactiveSession(sessionCmd);
 
-    // SSH exit 255 = connection dropped/timed out — retry
-    // Everything else (0 = clean exit, 130 = Ctrl+C, other = agent crash) — stop
-    if (exitCode !== 255) {
+    if (!isConnectionDrop(exitCode)) {
       break;
     }
   }
 
-  if (exitCode === 255) {
+  if (isConnectionDrop(exitCode)) {
     process.stderr.write("\n");
     logWarn("Could not reconnect. Server is still running.");
     logInfo("Reconnect manually: spawn connect");


### PR DESCRIPTION
## Summary
- Sprite CLI exits with code 1 on "connection closed" (unlike SSH which exits 255)
- The orchestrator's reconnect loop now treats exit code 1 on Sprite as a connection drop
- Retries up to 5 times with 3s delay, same behavior as SSH reconnect on other clouds

## Test plan
- [x] Lint passes
- [x] Tests pass (2024/2024)
- [ ] Verify Sprite session auto-reconnects after "connection closed" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)