### PR TITLE
test: remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/manifest.test.ts
+++ b/packages/cli/src/__tests__/manifest.test.ts
@@ -1,8 +1,8 @@
 import type { Manifest } from "../manifest";
 import type { TestEnvironment } from "./test-helpers";
 
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   _resetCacheForTesting,
@@ -178,78 +178,6 @@ describe("manifest", () => {
       const fetchCount = fetchMock.mock.calls.length;
       await loadManifest();
       expect(fetchMock.mock.calls.length).toBe(fetchCount);
-    });
-
-    it("falls back to stale cache when fetch fails", async () => {
-      const cacheDir = join(env.testDir, "spawn");
-      mkdirSync(cacheDir, {
-        recursive: true,
-      });
-      writeFileSync(join(cacheDir, "manifest.json"), JSON.stringify(mockManifest));
-
-      _resetCacheForTesting();
-      global.fetch = mock(
-        async () =>
-          new Response("error", {
-            status: 500,
-          }),
-      );
-
-      const m = await loadManifest(true);
-      expect(m.agents.claude).toBeDefined();
-      expect(isStaleCache()).toBe(true);
-    });
-
-    it("throws when no cache and fetch fails", async () => {
-      _resetCacheForTesting();
-      global.fetch = mock(
-        async () =>
-          new Response("error", {
-            status: 500,
-          }),
-      );
-
-      const cacheFile = join(env.testDir, "spawn", "manifest.json");
-      if (existsSync(cacheFile)) {
-        rmSync(cacheFile);
-      }
-
-      await expect(loadManifest(true)).rejects.toThrow("Cannot load manifest");
-    });
-
-    it("throws when manifest from GitHub is invalid", async () => {
-      const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
-      global.fetch = mock(
-        async () =>
-          new Response(
-            JSON.stringify({
-              not: "a manifest",
-            }),
-          ),
-      );
-
-      const cacheFile = join(env.testDir, "spawn", "manifest.json");
-      if (existsSync(cacheFile)) {
-        rmSync(cacheFile);
-      }
-
-      await expect(loadManifest(true)).rejects.toThrow("Cannot load manifest");
-      consoleSpy.mockRestore();
-    });
-
-    it("throws when network errors occur and no cache exists", async () => {
-      const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
-      global.fetch = mock(async () => {
-        throw new Error("Network timeout");
-      });
-
-      const cacheFile = join(env.testDir, "spawn", "manifest.json");
-      if (existsSync(cacheFile)) {
-        rmSync(cacheFile);
-      }
-
-      await expect(loadManifest(true)).rejects.toThrow("Cannot load manifest");
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/packages/cli/src/__tests__/ssh-keys.test.ts
+++ b/packages/cli/src/__tests__/ssh-keys.test.ts
@@ -189,24 +189,6 @@ describe("discoverSshKeys", () => {
     expect(keys[0].privPath).toContain("id_ed25519");
     expect(keys[0].pubPath).toContain("id_ed25519.pub");
   });
-
-  it("discovers multiple key pairs and sorts ed25519 first", () => {
-    createFakeKeyPair("id_rsa", "rsa");
-    createFakeKeyPair("id_ed25519", "ed25519");
-
-    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation((args: string[]) => {
-      const pubPath = args[args.length - 1];
-      const type = pubPath.includes("ed25519") ? "ED25519" : "RSA";
-      return sshKeygenLfResult(type);
-    });
-
-    const keys = discoverSshKeys();
-    spawnSpy.mockRestore();
-    expect(keys).toHaveLength(2);
-    // ED25519 should sort first
-    expect(keys[0].name).toBe("id_ed25519");
-    expect(keys[1].name).toBe("id_rsa");
-  });
 });
 
 // ─── generateSshKey ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **`manifest.test.ts`**: Removed 4 duplicate `loadManifest` error/fallback tests that were already covered more thoroughly by `manifest-cache-lifecycle.test.ts`:
  - "falls back to stale cache when fetch fails" (HTTP 500) — lifecycle file tests HTTP 500, 403, TypeError, and json-parse-failure separately
  - "throws when no cache and fetch fails" (HTTP 500 + no cache) — lifecycle file has this exact scenario
  - "throws when manifest from GitHub is invalid" (invalid JSON shape + no cache) — lifecycle file covers this
  - "throws when network errors occur and no cache exists" (thrown Error + no cache) — lifecycle file has this

- **`ssh-keys.test.ts`**: Removed the 2-key sorting test "discovers multiple key pairs and sorts ed25519 first" which only validated that ED25519 sorts before RSA. This is superseded by `ssh-keys-cov.test.ts`'s 3-key test "sorts ed25519 before rsa before unknown types" (ED25519 > RSA > ECDSA), which validates the full sort order.

## Test plan

- [x] `bun test` passes: 2005 pass, 0 fail (unchanged count after removals)
- [x] `bunx @biomejs/biome check packages/cli/src/` passes with zero errors

-- qa/dedup-scanner