### PR TITLE
fix(security): shellQuote cmd in runServer() across all cloud providers

### DIFF
--- a/packages/cli/src/__tests__/do-cov.test.ts
+++ b/packages/cli/src/__tests__/do-cov.test.ts
@@ -167,7 +167,7 @@ describe("digitalocean/runServer", () => {
     await runServer("echo hello", 10, "1.2.3.4");
     const args = spy.mock.calls[0][0];
     const sshCmd = args[args.length - 1];
-    expect(sshCmd).toMatch(/^bash -c '/);
+    expect(sshCmd).toContain("bash -c 'echo hello'");
     spy.mockRestore();
   });
 

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -181,7 +181,7 @@ describe("hetzner/runServer", () => {
     await runServer("echo hello", 10, "1.2.3.4");
     const args = spy.mock.calls[0][0];
     const sshCmd = args[args.length - 1];
-    expect(sshCmd).toMatch(/^bash -c '/);
+    expect(sshCmd).toContain("bash -c 'echo hello'");
     spy.mockRestore();
   });
 

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1117,7 +1117,7 @@ export async function runServer(cmd: string, timeoutSecs?: number): Promise<void
   if (!cmd || /\0/.test(cmd)) {
     throw new Error("Invalid command: must be non-empty and must not contain null bytes");
   }
-  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && bash -c ${shellQuote(cmd)}`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
   const proc = Bun.spawn(
     [
@@ -1125,7 +1125,7 @@ export async function runServer(cmd: string, timeoutSecs?: number): Promise<void
       ...SSH_BASE_OPTS,
       ...keyOpts,
       `${SSH_USER}@${_state.instanceIp}`,
-      `bash -c ${shellQuote(fullCmd)}`,
+      fullCmd,
     ],
     {
       stdio: [

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1334,7 +1334,7 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
     throw new Error("Invalid command: must be non-empty and must not contain null bytes");
   }
   const serverIp = ip || _state.serverIp;
-  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && bash -c ${shellQuote(cmd)}`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const proc = Bun.spawn(
@@ -1343,7 +1343,7 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
       ...SSH_BASE_OPTS,
       ...keyOpts,
       `root@${serverIp}`,
-      `bash -c ${shellQuote(fullCmd)}`,
+      fullCmd,
     ],
     {
       stdio: [

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -985,7 +985,7 @@ export async function runServer(cmd: string, timeoutSecs?: number): Promise<void
     throw new Error("Invalid command: must be non-empty and must not contain null bytes");
   }
   const username = resolveUsername();
-  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && bash -c ${shellQuote(cmd)}`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const proc = Bun.spawn(
@@ -994,7 +994,7 @@ export async function runServer(cmd: string, timeoutSecs?: number): Promise<void
       ...SSH_BASE_OPTS,
       ...keyOpts,
       `${username}@${_state.serverIp}`,
-      `bash -c ${shellQuote(fullCmd)}`,
+      fullCmd,
     ],
     {
       stdio: [

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -745,7 +745,7 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
     throw new Error("Invalid command: must be non-empty and must not contain null bytes");
   }
   const serverIp = ip || _state.serverIp;
-  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && ${cmd}`;
+  const fullCmd = `export PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && bash -c ${shellQuote(cmd)}`;
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 
   const proc = Bun.spawn(
@@ -754,7 +754,7 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
       ...SSH_BASE_OPTS,
       ...keyOpts,
       `root@${serverIp}`,
-      `bash -c ${shellQuote(fullCmd)}`,
+      fullCmd,
     ],
     {
       stdio: [


### PR DESCRIPTION
## Summary

Defense-in-depth fix for command injection in `runServer()` across all four cloud providers (AWS, GCP, Hetzner, DigitalOcean).

**Before:** `cmd` was interpolated raw into `fullCmd` string, relying on the outer `shellQuote(fullCmd)` wrapper for safety. While technically safe (the outer single quotes protected `cmd`), this made the safety non-obvious and fragile.

**After:** `cmd` gets its own explicit `shellQuote(cmd)` call inside `fullCmd`, matching the pattern already used in `interactiveSession()`. The SSH command is passed directly (no redundant outer `bash -c` wrapper).

**Pattern change:**
```typescript
// Before:
const fullCmd = `export PATH="..." && ${cmd}`;
ssh ... `bash -c ${shellQuote(fullCmd)}`

// After:
const fullCmd = `export PATH="..." && bash -c ${shellQuote(cmd)}`;
ssh ... fullCmd
```

Fixes #2859

- AWS (`aws.ts`), GCP (`gcp.ts`), Hetzner (`hetzner.ts`), DigitalOcean (`digitalocean.ts`) all updated
- Tests updated to match new command structure
- All 1946 tests pass, biome lint clean
- Version bump: 0.25.10 → 0.25.11

-- refactor/security-auditor