### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/preflight-credentials.test.ts
+++ b/packages/cli/src/__tests__/preflight-credentials.test.ts
@@ -1,11 +1,11 @@
 import type { Manifest } from "../manifest";
 
-import { afterEach, beforeEach, describe, it, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { preflightCredentialCheck } from "../commands/index.js";
 import { mockClackPrompts } from "./test-helpers";
 
 // Must be called before dynamic imports that use @clack/prompts
-mockClackPrompts();
+const clack = mockClackPrompts();
 
 function makeManifest(cloudAuth: string): Manifest {
   return {
@@ -29,8 +29,6 @@ function makeManifest(cloudAuth: string): Manifest {
 
 describe("preflightCredentialCheck", () => {
   const savedEnv: Record<string, string | undefined> = {};
-  let stderrSpy: ReturnType<typeof spyOn>;
-  let stderrOutput: string[];
 
   function setEnv(key: string, value: string) {
     if (!(key in savedEnv)) {
@@ -47,20 +45,10 @@ describe("preflightCredentialCheck", () => {
   }
 
   beforeEach(() => {
-    stderrOutput = [];
-    // Capture all stderr output — clack log functions eventually write here
-    stderrSpy = spyOn(process.stderr, "write").mockImplementation((chunk) => {
-      stderrOutput.push(String(chunk));
-      return true;
-    });
-    // Also capture console.warn/log which clack might use
-    spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
-      stderrOutput.push(args.map(String).join(" "));
-    });
+    clack.logWarn.mockClear();
   });
 
   afterEach(() => {
-    stderrSpy.mockRestore();
     for (const [key, value] of Object.entries(savedEnv)) {
       if (value === undefined) {
         delete process.env[key];
@@ -73,44 +61,58 @@ describe("preflightCredentialCheck", () => {
     }
   });
 
-  it("should pass when all credentials are present", async () => {
+  it("emits no warnings when all credentials are present", async () => {
     setEnv("OPENROUTER_API_KEY", "sk-or-test");
     setEnv("HCLOUD_TOKEN", "test-token");
     await preflightCredentialCheck(makeManifest("HCLOUD_TOKEN"), "testcloud");
-    // No crash = pass
+    expect(clack.logWarn.mock.calls.length).toBe(0);
   });
 
-  it("should warn when cloud-specific credential is missing", async () => {
+  it("warns with cloud credential name when cloud token is missing", async () => {
     setEnv("OPENROUTER_API_KEY", "sk-or-test");
     clearEnv("HCLOUD_TOKEN");
-    // Should not throw
     await preflightCredentialCheck(makeManifest("HCLOUD_TOKEN"), "testcloud");
+    expect(clack.logWarn.mock.calls.length).toBeGreaterThan(0);
+    const warnText = String(clack.logWarn.mock.calls[0]?.[0] ?? "");
+    expect(warnText).toContain("HCLOUD_TOKEN");
   });
 
-  it("should warn when OPENROUTER_API_KEY is missing", async () => {
+  it("warns with OPENROUTER_API_KEY name when API key is missing", async () => {
     clearEnv("OPENROUTER_API_KEY");
     setEnv("HCLOUD_TOKEN", "test-token");
     await preflightCredentialCheck(makeManifest("HCLOUD_TOKEN"), "testcloud");
+    expect(clack.logWarn.mock.calls.length).toBeGreaterThan(0);
+    const warnText = String(clack.logWarn.mock.calls[0]?.[0] ?? "");
+    expect(warnText).toContain("OPENROUTER_API_KEY");
   });
 
-  it("should warn about multiple missing credentials", async () => {
+  it("warns about all missing credentials when both are absent", async () => {
     clearEnv("OPENROUTER_API_KEY");
     clearEnv("HCLOUD_TOKEN");
     await preflightCredentialCheck(makeManifest("HCLOUD_TOKEN"), "testcloud");
+    expect(clack.logWarn.mock.calls.length).toBeGreaterThan(0);
+    const warnText = String(clack.logWarn.mock.calls[0]?.[0] ?? "");
+    expect(warnText).toContain("OPENROUTER_API_KEY");
+    expect(warnText).toContain("HCLOUD_TOKEN");
   });
 
-  it("should not warn when auth is cli and OPENROUTER_API_KEY is present", async () => {
+  it("emits no warnings for cli auth when OPENROUTER_API_KEY is present", async () => {
     setEnv("OPENROUTER_API_KEY", "sk-or-test");
     await preflightCredentialCheck(makeManifest("cli"), "testcloud");
+    expect(clack.logWarn.mock.calls.length).toBe(0);
   });
 
-  it("should warn for CLI-based auth when OPENROUTER_API_KEY is missing", async () => {
+  it("warns about OPENROUTER_API_KEY for cli auth when key is missing", async () => {
     clearEnv("OPENROUTER_API_KEY");
     await preflightCredentialCheck(makeManifest("cli"), "testcloud");
+    expect(clack.logWarn.mock.calls.length).toBeGreaterThan(0);
+    const warnText = String(clack.logWarn.mock.calls[0]?.[0] ?? "");
+    expect(warnText).toContain("OPENROUTER_API_KEY");
   });
 
-  it("should handle auth=none without warnings", async () => {
+  it("emits no warnings for auth=none even when all credentials are missing", async () => {
     clearEnv("OPENROUTER_API_KEY");
     await preflightCredentialCheck(makeManifest("none"), "testcloud");
+    expect(clack.logWarn.mock.calls.length).toBe(0);
   });
 });

--- a/packages/cli/src/__tests__/sprite-cov.test.ts
+++ b/packages/cli/src/__tests__/sprite-cov.test.ts
@@ -82,6 +82,8 @@ describe("sprite/ensureSpriteCli", () => {
 
     const { ensureSpriteCli } = await import("../sprite/sprite");
     await ensureSpriteCli();
+    // spawnSync called twice: once to locate sprite, once for version
+    expect(spy.mock.calls.length).toBe(2);
     spy.mockRestore();
   });
 
@@ -108,6 +110,8 @@ describe("sprite/ensureSpriteCli", () => {
 
     const { ensureSpriteCli } = await import("../sprite/sprite");
     await ensureSpriteCli();
+    // spawnSync called twice: locate + version check
+    expect(spy.mock.calls.length).toBe(2);
     spy.mockRestore();
   });
 
@@ -142,6 +146,8 @@ describe("sprite/ensureSpriteCli", () => {
 
     const { ensureSpriteCli } = await import("../sprite/sprite");
     await ensureSpriteCli();
+    // Bun.spawn was called to run the installer
+    expect(spawnSpy.mock.calls.length).toBeGreaterThan(0);
     spawnSyncSpy.mockRestore();
     spawnSpy.mockRestore();
   });
@@ -160,7 +166,7 @@ describe("sprite/ensureSpriteCli", () => {
 // ─── ensureSpriteAuthenticated ───────────────────────────────────────────────
 
 describe("sprite/ensureSpriteAuthenticated", () => {
-  it("succeeds when already authenticated", async () => {
+  it("succeeds when already authenticated without running login", async () => {
     const spy = spyOn(Bun, "spawnSync")
       .mockReturnValueOnce({
         exitCode: 0,
@@ -180,13 +186,17 @@ describe("sprite/ensureSpriteAuthenticated", () => {
         resourceUsage: undefined,
         pid: 2,
       } satisfies ReturnType<typeof Bun.spawnSync>);
+    const spawnSpy = mockBunSpawn(0);
 
     const { ensureSpriteAuthenticated } = await import("../sprite/sprite");
     await ensureSpriteAuthenticated();
+    // Already authenticated: Bun.spawn (login) should NOT have been invoked
+    expect(spawnSpy.mock.calls.length).toBe(0);
     spy.mockRestore();
+    spawnSpy.mockRestore();
   });
 
-  it("uses SPRITE_ORG from env", async () => {
+  it("uses SPRITE_ORG from env without triggering login", async () => {
     process.env.SPRITE_ORG = "env-org";
     const spy = spyOn(Bun, "spawnSync")
       .mockReturnValueOnce({
@@ -207,10 +217,14 @@ describe("sprite/ensureSpriteAuthenticated", () => {
         resourceUsage: undefined,
         pid: 2,
       } satisfies ReturnType<typeof Bun.spawnSync>);
+    const spawnSpy = mockBunSpawn(0);
 
     const { ensureSpriteAuthenticated } = await import("../sprite/sprite");
     await ensureSpriteAuthenticated();
+    // org from env + already authed: no Bun.spawn (login) invoked
+    expect(spawnSpy.mock.calls.length).toBe(0);
     spy.mockRestore();
+    spawnSpy.mockRestore();
   });
 
   it("runs login when not authenticated and succeeds", async () => {
@@ -251,6 +265,8 @@ describe("sprite/ensureSpriteAuthenticated", () => {
 
     const { ensureSpriteAuthenticated } = await import("../sprite/sprite");
     await ensureSpriteAuthenticated();
+    // Not authenticated initially: Bun.spawn (login) must have been called
+    expect(spawnSpy.mock.calls.length).toBeGreaterThan(0);
     spawnSyncSpy.mockRestore();
     spawnSpy.mockRestore();
   });
@@ -288,7 +304,7 @@ describe("sprite/ensureSpriteAuthenticated", () => {
 // ─── createSprite ────────────────────────────────────────────────────────────
 
 describe("sprite/createSprite", () => {
-  it("reuses existing sprite if already exists", async () => {
+  it("reuses existing sprite without creating a new one", async () => {
     const spy = spyOn(Bun, "spawnSync")
       .mockReturnValueOnce({
         exitCode: 0,
@@ -308,10 +324,14 @@ describe("sprite/createSprite", () => {
         resourceUsage: undefined,
         pid: 2,
       } satisfies ReturnType<typeof Bun.spawnSync>);
+    const spawnSpy = mockBunSpawn(0);
 
     const { createSprite } = await import("../sprite/sprite");
     await createSprite("my-sprite");
+    // Existing sprite found: Bun.spawn (create) should NOT have been called
+    expect(spawnSpy.mock.calls.length).toBe(0);
     spy.mockRestore();
+    spawnSpy.mockRestore();
   });
 
   it("creates new sprite when not existing", async () => {
@@ -361,6 +381,8 @@ describe("sprite/createSprite", () => {
 
     const { createSprite } = await import("../sprite/sprite");
     await createSprite("new-sprite");
+    // No existing sprite: Bun.spawn (create) must have been called
+    expect(spawnSpy.mock.calls.length).toBeGreaterThan(0);
     spawnSyncSpy.mockRestore();
     spawnSpy.mockRestore();
   });
@@ -369,7 +391,7 @@ describe("sprite/createSprite", () => {
 // ─── verifySpriteConnectivity ────────────────────────────────────────────────
 
 describe("sprite/verifySpriteConnectivity", () => {
-  it("succeeds on first attempt", async () => {
+  it("succeeds on first attempt with exactly two spawnSync calls", async () => {
     // Set poll delay to 0 for tests
     process.env.SPRITE_CONNECTIVITY_POLL_DELAY = "0";
     const spy = spyOn(Bun, "spawnSync")
@@ -394,6 +416,8 @@ describe("sprite/verifySpriteConnectivity", () => {
 
     const { verifySpriteConnectivity } = await import("../sprite/sprite");
     await verifySpriteConnectivity(1);
+    // locate sprite + connectivity check = 2 calls
+    expect(spy.mock.calls.length).toBe(2);
     spy.mockRestore();
   });
 });
@@ -411,11 +435,12 @@ describe("sprite/uploadFileSprite", () => {
     await expect(uploadFileSprite("/local/file", "/-evil")).rejects.toThrow("Invalid remote path");
   });
 
-  it("succeeds for valid paths", async () => {
+  it("succeeds for valid paths and calls sprite exec", async () => {
     const spawnSyncSpy = mockSpawnSync(0, "/usr/bin/sprite");
     const spawnSpy = mockBunSpawn(0);
     const { uploadFileSprite } = await import("../sprite/sprite");
     await uploadFileSprite("/tmp/local.txt", "/root/file.txt");
+    expect(spawnSpy.mock.calls.length).toBeGreaterThan(0);
     spawnSyncSpy.mockRestore();
     spawnSpy.mockRestore();
   });
@@ -429,11 +454,12 @@ describe("sprite/downloadFileSprite", () => {
     await expect(downloadFileSprite("/root/bad;rm", "/tmp/out")).rejects.toThrow("Invalid remote path");
   });
 
-  it("handles $HOME prefix", async () => {
+  it("handles $HOME prefix and calls sprite exec", async () => {
     const spawnSyncSpy = mockSpawnSync(0, "/usr/bin/sprite");
     const spawnSpy = mockBunSpawn(0, "file contents");
     const { downloadFileSprite } = await import("../sprite/sprite");
     await downloadFileSprite("$HOME/file.txt", "/tmp/out.txt");
+    expect(spawnSpy.mock.calls.length).toBeGreaterThan(0);
     spawnSyncSpy.mockRestore();
     spawnSpy.mockRestore();
   });
@@ -442,11 +468,12 @@ describe("sprite/downloadFileSprite", () => {
 // ─── destroyServer ───────────────────────────────────────────────────────────
 
 describe("sprite/destroyServer", () => {
-  it("succeeds when sprite destroy returns 0", async () => {
+  it("succeeds when sprite destroy returns 0 and calls destroy command", async () => {
     const spawnSyncSpy = mockSpawnSync(0, "/usr/bin/sprite");
     const spawnSpy = mockBunSpawn(0);
     const { destroyServer } = await import("../sprite/sprite");
     await destroyServer("test-sprite");
+    expect(spawnSpy.mock.calls.length).toBeGreaterThan(0);
     spawnSyncSpy.mockRestore();
     spawnSpy.mockRestore();
   });
@@ -487,11 +514,13 @@ describe("sprite/runSprite", () => {
 // ─── setupShellEnvironment ───────────────────────────────────────────────────
 
 describe("sprite/setupShellEnvironment", () => {
-  it("sets up shell environment", async () => {
+  it("invokes multiple sprite exec commands to configure PATH and shell", async () => {
     const spawnSyncSpy = mockSpawnSync(0, "/usr/bin/sprite");
     const spawnSpy = mockBunSpawn(0);
     const { setupShellEnvironment } = await import("../sprite/sprite");
     await setupShellEnvironment();
+    // setupShellEnvironment runs multiple sprite exec calls (sed cleanup, PATH config, zsh check, etc.)
+    expect(spawnSpy.mock.calls.length).toBeGreaterThan(1);
     spawnSyncSpy.mockRestore();
     spawnSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

- **20 theatrical tests replaced** across 2 files: all had zero `expect()` calls (always passed regardless of function behavior)
- `preflight-credentials.test.ts`: 7 tests with comments like `// No crash = pass` — rewrote to use `logWarn` mock from `mockClackPrompts()` to assert warnings fire (and don't fire) with correct credential names
- `sprite-cov.test.ts`: 13 tests that called functions and discarded results — added `Bun.spawn` call-count assertions to verify authenticated vs unauthenticated paths, reuse vs create, connectivity check, and shell environment setup

## Test plan
- [x] `bun test packages/cli/` — 1946 pass, 0 fail (no regressions)
- [x] `bunx @biomejs/biome check` — clean on modified files
- [x] New `expect()` calls: 0 → 12 in preflight-credentials, 11 → 24 in sprite-cov

-- qa/dedup-scanner