### PR TITLE
feat(gcp): default boot disk to 40 GB, configurable via GCP_DISK_SIZE

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.11",
+  "version": "0.25.12",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -144,6 +144,10 @@ const ZONES: ZoneOption[] = [
 
 export const DEFAULT_ZONE = "us-central1-a";
 
+// ─── Disk Size ───────────────────────────────────────────────────────────────
+
+export const DEFAULT_DISK_SIZE_GB = 40;
+
 // ─── State ──────────────────────────────────────────────────────────────────
 
 interface GcpState {
@@ -763,6 +767,7 @@ export async function createInstance(
     `--machine-type=${machineType}`,
     `--image-family=${family}`,
     `--image-project=${project}`,
+    `--boot-disk-size=${process.env.GCP_DISK_SIZE ?? String(DEFAULT_DISK_SIZE_GB)}GB`,
     `--network=${process.env.GCP_NETWORK ?? "default"}`,
     `--subnet=${process.env.GCP_SUBNET ?? "default"}`,
     ...(tmpFile

--- a/sh/gcp/README.md
+++ b/sh/gcp/README.md
@@ -62,6 +62,19 @@ OPENROUTER_API_KEY=sk-or-v1-xxxxx \
   bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/claude.sh)
 ```
 
+## Custom Disk Size
+
+By default, instances are created with a **40 GB** boot disk. Override with `GCP_DISK_SIZE` (in GB):
+
+| Variable | Default | Description |
+|---|---|---|
+| `GCP_DISK_SIZE` | `40` | Boot disk size in GB |
+
+```bash
+GCP_DISK_SIZE=80 \
+  bash <(curl -fsSL https://openrouter.ai/labs/spawn/gcp/claude.sh)
+```
+
 ## Custom VPC / Subnet
 
 If your GCP project's default VPC uses **custom subnet mode** (common in enterprise or org-managed projects), set these env vars to override the default network/subnet:


### PR DESCRIPTION
## Summary

- Adds `--boot-disk-size` to the `gcloud compute instances create` args (was missing entirely, so GCP defaulted to 10 GB which is too small for coding agents)
- Defaults to **40 GB** — sufficient for node_modules, apt packages, cloned repos, and build caches
- Overridable via `GCP_DISK_SIZE` env var (in GB)
- Documents the new env var in `sh/gcp/README.md`

Closes #2866

## Test plan
- [x] Biome lint passes (0 errors)
- [x] All 2149 tests pass
- [ ] Manual verification: `GCP_DISK_SIZE=60 spawn run gcp/claude` creates instance with 60 GB disk
- [ ] Manual verification: default (no env var) creates instance with 40 GB disk

_Filed from Slack by SPA_