### PR TITLE
test: remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/cmd-fix-cov.test.ts
+++ b/packages/cli/src/__tests__/cmd-fix-cov.test.ts
@@ -243,80 +243,14 @@ describe("cmdFix (additional coverage)", () => {
   });
 });
 
-// ── Tests: fixSpawn connection edge cases ────────────────────────────────────
+// ── Tests: fixSpawn success message ──────────────────────────────────────────
+// (error paths are covered in cmd-fix.test.ts; this covers the exact success message)
 
 describe("fixSpawn connection edge cases", () => {
   beforeEach(() => {
     clack.logError.mockReset();
-    clack.logInfo.mockReset();
     clack.logSuccess.mockReset();
     clack.logStep.mockReset();
-  });
-
-  it("shows error when record has no connection", async () => {
-    const record = makeRecord({
-      connection: undefined,
-    });
-    await fixSpawn(record, mockManifest);
-    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("no connection information"));
-  });
-
-  it("shows error when connection is deleted", async () => {
-    const record = makeRecord({
-      connection: {
-        ip: "1.2.3.4",
-        user: "root",
-        cloud: "hetzner",
-        deleted: true,
-      },
-    });
-    await fixSpawn(record, mockManifest);
-    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("has been deleted"));
-  });
-
-  it("shows error for sprite-console connections", async () => {
-    const record = makeRecord({
-      connection: {
-        ip: "sprite-console",
-        user: "root",
-        cloud: "sprite",
-      },
-    });
-    await fixSpawn(record, mockManifest);
-    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("Sprite console"));
-  });
-
-  it("shows error for unknown agent", async () => {
-    const record = makeRecord({
-      agent: "nonexistent-agent",
-      connection: {
-        ip: "1.2.3.4",
-        user: "root",
-        cloud: "hetzner",
-      },
-    });
-    await fixSpawn(record, mockManifest);
-    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("Unknown agent"));
-  });
-
-  it("shows error when fix script runner throws", async () => {
-    const mockRunner = mock(async () => {
-      throw new Error("SSH connection refused");
-    });
-    const record = makeRecord();
-    await fixSpawn(record, mockManifest, {
-      runScript: mockRunner,
-    });
-    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("Fix failed"));
-  });
-
-  it("shows error when fix script exits non-zero", async () => {
-    const mockRunner = mock(async () => false);
-    const record = makeRecord();
-    await fixSpawn(record, mockManifest, {
-      runScript: mockRunner,
-    });
-    expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("exited with an error"));
   });
 
   it("shows success when fix script succeeds", async () => {

--- a/packages/cli/src/__tests__/icon-integrity.test.ts
+++ b/packages/cli/src/__tests__/icon-integrity.test.ts
@@ -49,28 +49,18 @@ function isPng(filePath: string): boolean {
 
 describe("Icon Integrity", () => {
   describe("Agent icons", () => {
-    for (const id of Object.keys(manifest.agents)) {
-      const pngPath = join(AGENT_ASSETS, `${id}.png`);
-
-      it(`${id}.png exists`, () => {
-        expect(existsSync(pngPath)).toBe(true);
-      });
-
-      it(`${id}.png is actual PNG data`, () => {
-        expect(isPng(pngPath)).toBe(true);
-      });
-
-      it(`${id} manifest icon URL ends with .png`, () => {
+    it("all agent icons exist, are valid PNGs, and are correctly referenced", () => {
+      for (const id of Object.keys(manifest.agents)) {
+        const pngPath = join(AGENT_ASSETS, `${id}.png`);
+        expect(existsSync(pngPath), `${id}.png must exist`).toBe(true);
+        expect(isPng(pngPath), `${id}.png must contain PNG magic bytes`).toBe(true);
         const parsed = v.parse(IconEntry, manifest.agents[id]);
-        expect(parsed.icon).toEndWith(`${id}.png`);
-      });
-
-      it(`${id} .sources.json ext is "png"`, () => {
-        expect(id in AGENT_SOURCES).toBe(true);
-        const parsed = v.parse(SourceEntry, AGENT_SOURCES[id]);
-        expect(parsed.ext).toBe("png");
-      });
-    }
+        expect(parsed.icon, `${id} manifest icon URL must end with .png`).toEndWith(`${id}.png`);
+        expect(id in AGENT_SOURCES, `${id} must have a .sources.json entry`).toBe(true);
+        const src = v.parse(SourceEntry, AGENT_SOURCES[id]);
+        expect(src.ext, `${id} .sources.json ext must be "png"`).toBe("png");
+      }
+    });
 
     it("no .jpg files in assets/agents/", () => {
       const files = readdirSync(AGENT_ASSETS);
@@ -80,32 +70,21 @@ describe("Icon Integrity", () => {
   });
 
   describe("Cloud icons", () => {
-    for (const id of Object.keys(manifest.clouds)) {
-      const parsed = v.safeParse(IconEntry, manifest.clouds[id]);
-      if (!parsed.success) {
-        continue;
-      }
-
-      const pngPath = join(CLOUD_ASSETS, `${id}.png`);
-
-      it(`${id}.png exists`, () => {
-        expect(existsSync(pngPath)).toBe(true);
-      });
-
-      it(`${id}.png is actual PNG data`, () => {
-        expect(isPng(pngPath)).toBe(true);
-      });
-
-      it(`${id} manifest icon URL ends with .png`, () => {
-        expect(parsed.output.icon).toEndWith(`${id}.png`);
-      });
-
-      it(`${id} .sources.json ext is "png"`, () => {
-        expect(id in CLOUD_SOURCES).toBe(true);
+    it("all cloud icons exist, are valid PNGs, and are correctly referenced", () => {
+      for (const id of Object.keys(manifest.clouds)) {
+        const parsed = v.safeParse(IconEntry, manifest.clouds[id]);
+        if (!parsed.success) {
+          continue;
+        }
+        const pngPath = join(CLOUD_ASSETS, `${id}.png`);
+        expect(existsSync(pngPath), `${id}.png must exist`).toBe(true);
+        expect(isPng(pngPath), `${id}.png must contain PNG magic bytes`).toBe(true);
+        expect(parsed.output.icon, `${id} manifest icon URL must end with .png`).toEndWith(`${id}.png`);
+        expect(id in CLOUD_SOURCES, `${id} must have a .sources.json entry`).toBe(true);
         const src = v.parse(SourceEntry, CLOUD_SOURCES[id]);
-        expect(src.ext).toBe("png");
-      });
-    }
+        expect(src.ext, `${id} .sources.json ext must be "png"`).toBe("png");
+      }
+    });
 
     it("no .jpg files in assets/clouds/", () => {
       const files = readdirSync(CLOUD_ASSETS);

--- a/packages/cli/src/__tests__/manifest-type-contracts.test.ts
+++ b/packages/cli/src/__tests__/manifest-type-contracts.test.ts
@@ -42,15 +42,15 @@ describe("Agent required field types", () => {
     "launch",
   ] as const;
 
-  for (const field of nonEmptyStringFields) {
-    it(`${field} should be a non-empty string for all agents`, () => {
+  it("name, description, install, launch should be non-empty strings for all agents", () => {
+    for (const field of nonEmptyStringFields) {
       for (const [key, agent] of allAgents) {
         const val = agent[field];
         expect(typeof val, `agent "${key}" ${field}`).toBe("string");
         expect(String(val).length, `agent "${key}" ${field} length`).toBeGreaterThan(0);
       }
-    });
-  }
+    }
+  });
 
   it("url should be a valid URL string for all agents", () => {
     for (const [key, agent] of allAgents) {
@@ -153,16 +153,16 @@ describe("Cloud required field types", () => {
     "interactive_method",
   ] as const;
 
-  for (const field of nonEmptyStringFields) {
-    it(`${field} should be a non-empty string for all clouds`, () => {
+  it("name, description, price, type, auth, provision_method, exec_method, interactive_method should be non-empty strings for all clouds", () => {
+    for (const field of nonEmptyStringFields) {
       for (const [key, cloud] of allClouds) {
         const val = cloud[field];
         expect(typeof val, `cloud "${key}" ${field}`).toBe("string");
         // auth can be "none" but must be present
         expect(String(val).length, `cloud "${key}" ${field} length`).toBeGreaterThan(0);
       }
-    });
-  }
+    }
+  });
 
   it("url should be a valid URL string for all clouds", () => {
     for (const [key, cloud] of allClouds) {
@@ -310,15 +310,15 @@ describe("Agent metadata field types", () => {
     "tagline",
   ] as const;
 
-  for (const field of nonEmptyStringFields) {
-    it(`${field} should be a non-empty string for all agents`, () => {
+  it("creator, license, language, runtime, tagline should be non-empty strings for all agents", () => {
+    for (const field of nonEmptyStringFields) {
       for (const [key, agent] of allAgents) {
         const val = agent[field];
         expect(typeof val, `agent "${key}" ${field}`).toBe("string");
         expect(String(val).length, `agent "${key}" ${field} length`).toBeGreaterThan(0);
       }
-    });
-  }
+    }
+  });
 
   it("repo should match owner/repo format for all agents", () => {
     for (const [key, agent] of allAgents) {
@@ -327,19 +327,17 @@ describe("Agent metadata field types", () => {
     }
   });
 
-  const dateMonthFields = [
-    "created",
-    "added",
-  ] as const;
-
-  for (const field of dateMonthFields) {
-    it(`${field} should be YYYY-MM format for all agents`, () => {
+  it("created and added should be YYYY-MM format for all agents", () => {
+    for (const field of [
+      "created",
+      "added",
+    ] as const) {
       for (const [key, agent] of allAgents) {
         expect(typeof agent[field], `agent "${key}" ${field}`).toBe("string");
         expect(agent[field], `agent "${key}" ${field} format`).toMatch(/^\d{4}-\d{2}$/);
       }
-    });
-  }
+    }
+  });
 
   it("github_stars should be a non-negative integer for all agents", () => {
     for (const [key, agent] of allAgents) {


### PR DESCRIPTION
## Summary

- **`cmd-fix-cov.test.ts`**: Remove 6 duplicate `fixSpawn` tests already covered in `cmd-fix.test.ts` (no-connection, deleted, sprite-console, unknown-agent, runner-throws, runner-returns-false). Keep only the unique success message check ("fixed successfully").
- **`icon-integrity.test.ts`**: Consolidate 54 per-entity `it()` blocks (4 separate tests per agent/cloud) into 4 data-driven `it()` blocks. Same 67 expect() calls, 50 fewer test cases.
- **`manifest-type-contracts.test.ts`**: Consolidate 3 sets of per-field `for` loops that each created an `it()` per field into single grouped tests. Same 662 expect() calls, 15 fewer test cases.

**Net result**: 1875 → 1809 tests (-66), 0 regressions, lint clean, all expect() assertions preserved.

## Test plan

- [x] `bun test` passes (1875 → 1809 tests, 0 failures)
- [x] `bunx @biomejs/biome check src/` passes with zero errors
- [x] All removed tests were true duplicates or per-entity expansions with identical assertions

-- qa/dedup-scanner