### PR TITLE
fix(e2e): fix manual .spawnrc creation on Sprite (stdin piping broken)

### DIFF
--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -292,11 +292,13 @@ CLOUD_ENV
     return 1
   fi
 
-  # SECURITY: env_b64 is piped via stdin — it is NOT interpolated into the
-  # remote command string. The command argument to cloud_exec is a fixed
-  # string with no variable substitution from user-controlled data.
+  # SECURITY: env_b64 is embedded directly in the command string. This is safe
+  # because env_b64 is validated above to contain only [A-Za-z0-9+/=] — the
+  # standard base64 alphabet — which cannot break out of single quotes or
+  # cause shell injection. Piping via stdin is NOT used because Sprite's exec
+  # driver replaces stdin with the command pipe, causing piped data to be lost.
   # The \$ escapes below are for remote shell variables, not local ones.
-  if printf '%s' "${env_b64}" | cloud_exec "${app_name}" "base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc && \
+  if cloud_exec "${app_name}" "printf '%s' '${env_b64}' | base64 -d > ~/.spawnrc && chmod 600 ~/.spawnrc && \
     for _rc in ~/.bashrc ~/.profile ~/.bash_profile; do \
     grep -q 'source ~/.spawnrc' \"\$_rc\" 2>/dev/null || printf '%s\n' '[ -f ~/.spawnrc ] && source ~/.spawnrc' >> \"\$_rc\"; done" >/dev/null 2>&1; then
     log_ok "Manual .spawnrc created successfully"


### PR DESCRIPTION
## Summary

- The manual `.spawnrc` fallback in `provision.sh` was using `printf '%s' "${env_b64}" | cloud_exec ...`
- This works for SSH-based clouds (Hetzner, GCP, AWS) where stdin passes through the SSH connection
- But Sprite's `_sprite_exec` replaces stdin with a command pipe: `printf '%s' "${cmd}" | sprite exec -s NAME -- bash`
- This causes the outer `env_b64` pipe to be discarded — `base64 -d` receives nothing and writes an empty `.spawnrc`
- Result: verification fails with `[FAIL] OPENROUTER_API_KEY not found in .spawnrc` and `[FAIL] Failed to create manual .spawnrc`

**Fix**: embed the base64 data directly in the command string using `printf '%s' '${env_b64}'`. Safe because `env_b64` is validated to contain only `[A-Za-z0-9+/=]` (standard base64 alphabet), which cannot escape single quotes or inject shell commands.

**Confirmed by E2E run**: Both `sprite/claude` and `sprite/openclaw` failed with this exact error. After this fix the manual creation will correctly decode the credentials on Sprite VMs.

## Test plan

- [ ] Run `./sh/e2e/e2e.sh --cloud sprite claude --skip-input-test` and confirm claude passes
- [ ] Run `./sh/e2e/e2e.sh --cloud sprite openclaw --skip-input-test` and confirm openclaw passes (install may still fail with "connection closed" but manual .spawnrc fallback should succeed)
- [ ] Verify `bash -n sh/e2e/lib/provision.sh` passes (done in PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)