### PR TITLE
test: remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/cmd-link-cov.test.ts
+++ b/packages/cli/src/__tests__/cmd-link-cov.test.ts
@@ -274,23 +274,6 @@ describe("cmdLink (additional coverage)", () => {
     expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("not reachable"));
   });
 
-  it("exits with error when no IP provided", async () => {
-    const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
-    await asyncTryCatch(() =>
-      cmdLink(
-        [
-          "link",
-        ],
-        {
-          tcpCheck: TCP_REACHABLE,
-          sshCommand: SSH_NO_DETECT,
-        },
-      ),
-    );
-    expect(processExitSpy).toHaveBeenCalledWith(1);
-    consoleSpy.mockRestore();
-  });
-
   it("exits with error for invalid IP address", async () => {
     const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
     await asyncTryCatch(() =>

--- a/packages/cli/src/__tests__/history.test.ts
+++ b/packages/cli/src/__tests__/history.test.ts
@@ -60,29 +60,19 @@ describe("history", () => {
       expect(loadHistory()).toEqual([]);
     });
 
-    it("returns empty array when file contains a non-array JSON value", () => {
-      writeFileSync(
-        join(testDir, "history.json"),
+    it("returns empty array when file contains an unrecognized JSON value", () => {
+      // All non-array, non-v1 JSON values hit the same "Unrecognized format" branch
+      for (const content of [
         JSON.stringify({
           not: "array",
         }),
-      );
-      expect(loadHistory()).toEqual([]);
-    });
-
-    it("returns empty array when file contains a JSON string", () => {
-      writeFileSync(join(testDir, "history.json"), JSON.stringify("just a string"));
-      expect(loadHistory()).toEqual([]);
-    });
-
-    it("returns empty array when file contains JSON null", () => {
-      writeFileSync(join(testDir, "history.json"), "null");
-      expect(loadHistory()).toEqual([]);
-    });
-
-    it("returns empty array when file contains JSON number", () => {
-      writeFileSync(join(testDir, "history.json"), "42");
-      expect(loadHistory()).toEqual([]);
+        JSON.stringify("just a string"),
+        "null",
+        "42",
+      ]) {
+        writeFileSync(join(testDir, "history.json"), content);
+        expect(loadHistory()).toEqual([]);
+      }
     });
 
     it("loads multiple records preserving order", () => {

--- a/packages/cli/src/__tests__/orchestrate-cov.test.ts
+++ b/packages/cli/src/__tests__/orchestrate-cov.test.ts
@@ -517,22 +517,6 @@ describe("orchestrate SPAWN_NAME", () => {
   });
 });
 
-// ── preLaunch hooks ───────────────────────────────────────────────────
-
-describe("orchestrate preLaunch", () => {
-  it("calls preLaunch when defined", async () => {
-    const preLaunch = mock(() => Promise.resolve());
-    const cloud = createMockCloud();
-    const agent = createMockAgent({
-      preLaunch,
-    });
-
-    await runSafe(cloud, agent, "testagent");
-
-    expect(preLaunch).toHaveBeenCalledTimes(1);
-  });
-});
-
 // ── tunnel support ────────────────────────────────────────────────────
 
 describe("orchestrate tunnel", () => {

--- a/packages/cli/src/__tests__/update-check-cov.test.ts
+++ b/packages/cli/src/__tests__/update-check-cov.test.ts
@@ -68,22 +68,6 @@ describe("update-check.ts coverage", () => {
   // ── checkForUpdates skip conditions ────────────────────────────────────
 
   describe("checkForUpdates skip conditions", () => {
-    it("skips in test environment (NODE_ENV=test)", async () => {
-      process.env.NODE_ENV = "test";
-      global.fetch = mock(async () => new Response("1.0.0"));
-      const { checkForUpdates } = await import("../update-check");
-      await checkForUpdates();
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
-
-    it("skips when SPAWN_NO_UPDATE_CHECK=1", async () => {
-      process.env.SPAWN_NO_UPDATE_CHECK = "1";
-      global.fetch = mock(async () => new Response("1.0.0"));
-      const { checkForUpdates } = await import("../update-check");
-      await checkForUpdates();
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
-
     it("skips when recently backed off", async () => {
       writeUpdateFailed(Date.now()); // failed just now
       global.fetch = mock(async () => new Response("1.0.0"));


### PR DESCRIPTION
## Summary

- Consolidated 4 identical "unrecognized JSON value" tests in `history.test.ts` into one data-driven test (non-array object, JSON string, null, and number all hit the same `parseHistoryData` code branch)
- Removed duplicate "exits with error when no IP provided" from `cmd-link-cov.test.ts` (already covered identically in `cmd-link.test.ts`)
- Removed duplicate "skips in test environment" and "skips when SPAWN_NO_UPDATE_CHECK=1" from `update-check-cov.test.ts` (already covered in `update-check.test.ts`)
- Removed duplicate "calls preLaunch when defined" from `orchestrate-cov.test.ts` (same mock setup and assertion as in `orchestrate.test.ts`)

**Net result**: 7 tests removed, 1866 tests passing (down from 1873), 0 failures.

## Test plan

- [x] `bun test` passes with 1866 tests, 0 failures
- [x] `bunx @biomejs/biome check` passes on all 4 modified files

-- qa/dedup-scanner