### PR TITLE
fix: prevent sprite idle shutdown during agent install

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.12",
+  "version": "0.25.13",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/sprite/main.ts
+++ b/packages/cli/src/sprite/main.ts
@@ -19,6 +19,8 @@ import {
   promptSpawnName,
   runSprite,
   setupShellEnvironment,
+  startLocalKeepAlive,
+  stopLocalKeepAlive,
   uploadFileSprite,
   verifySpriteConnectivity,
 } from "./sprite.js";
@@ -50,13 +52,20 @@ async function main() {
     async createServer(name: string) {
       await createSprite(name);
       await verifySpriteConnectivity();
+      // Start pinging the sprite URL locally to prevent idle shutdown
+      // during long operations (agent install, config). Stopped when
+      // the interactive session starts (remote keep-alive takes over).
+      startLocalKeepAlive();
       await setupShellEnvironment();
       await installSpriteKeepAlive();
       return getVmConnection();
     },
     getServerName,
     async waitForReady() {},
-    interactiveSession,
+    async interactiveSession(cmd: string, spawnFn?: (args: string[]) => number) {
+      stopLocalKeepAlive();
+      return interactiveSession(cmd, spawnFn);
+    },
   };
 
   await runOrchestration(cloud, agent, agentName);

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -84,7 +84,7 @@ async function spriteRetry<T>(desc: string, fn: () => Promise<T>): Promise<T> {
     }
 
     // Only retry on transient network errors
-    if (/TLS handshake timeout|connection closed|connection reset|connection refused/i.test(msg)) {
+    if (/TLS handshake timeout|connection closed|connection reset|connection refused|i\/o timeout/i.test(msg)) {
       logWarn(`${desc}: Transient error, retrying (${attempt}/${maxRetries})...`);
       await sleep(3000);
       continue;
@@ -384,6 +384,52 @@ export async function verifySpriteConnectivity(maxAttempts = 6): Promise<void> {
   logError(`Sprite '${_state.name}' failed to respond after ${maxAttempts} attempts`);
   logError("Try: sprite list, sprite logs, or recreate the sprite");
   throw new Error("Sprite connectivity timeout");
+}
+
+// ─── Local Keep-Alive ────────────────────────────────────────────────────────
+
+/**
+ * Background keep-alive that pings the sprite's public URL every 30s from the
+ * local machine. Prevents the sprite from going idle during long operations
+ * like agent installation (where the remote keep-alive script isn't running yet).
+ */
+let _keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+
+export function startLocalKeepAlive(): void {
+  if (_keepAliveTimer) {
+    return;
+  }
+
+  const cmd = getSpriteCmd();
+  if (!cmd || !_state.name) {
+    return;
+  }
+
+  // Get the sprite's public URL
+  const urlResult = spawnSync([
+    cmd,
+    ...orgFlags(),
+    "url",
+    "-s",
+    _state.name,
+  ]);
+  const urlMatch = urlResult.stdout.match(/https:\/\/\S+/);
+  if (!urlMatch) {
+    return;
+  }
+
+  const spriteUrl = urlMatch[0];
+  _keepAliveTimer = setInterval(() => {
+    // Fire-and-forget fetch to keep the sprite alive
+    fetch(spriteUrl).catch(() => {});
+  }, 30_000);
+}
+
+export function stopLocalKeepAlive(): void {
+  if (_keepAliveTimer) {
+    clearInterval(_keepAliveTimer);
+    _keepAliveTimer = null;
+  }
 }
 
 // ─── Shell Environment Setup ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Local keep-alive** — after sprite connectivity is verified, pings the sprite's public URL every 30s from the client machine. Prevents the sprite from going idle during long operations like `npm install openclaw`. Stops when the interactive session starts (remote `sprite-keep-running.sh` takes over).
- **`i/o timeout` in retry regex** — `spriteRetry` now recognizes `i/o timeout` as a transient error and retries instead of failing immediately. Previously attempts 2-3 would fail without retry since the pattern wasn't matched.

## Context
After #2869 merged, the `sprite-keep-running.sh` script exists but only protects the interactive session. The install phase (which runs via `sprite exec`) was still vulnerable to idle shutdown — the sprite would go down mid-`npm install`, causing `connection closed` then `i/o timeout` errors on retry.

## Test plan
- [ ] `spawn openclaw sprite` completes install without connection drops
- [ ] Existing sprite-keep-alive tests pass (`bun test src/__tests__/sprite-keep-alive.test.ts`)
- [ ] Lint clean (`bunx @biomejs/biome check src/sprite/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)