### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/agent-setup-cov.test.ts
+++ b/packages/cli/src/__tests__/agent-setup-cov.test.ts
@@ -80,8 +80,9 @@ describe("offerGithubAuth", () => {
       uploadFile: mock(() => Promise.resolve()),
       downloadFile: mock(() => Promise.resolve()),
     };
-    // Should not throw
     await offerGithubAuth(runner, true);
+    // runServer was attempted — error swallowed, not rethrown
+    expect(runner.runServer).toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/__tests__/auto-update.test.ts
+++ b/packages/cli/src/__tests__/auto-update.test.ts
@@ -241,6 +241,8 @@ describe("auto-update service", () => {
       };
 
       await setupAutoUpdate(runner, "claude", "npm install -g @anthropic-ai/claude-code@latest");
+      // runServer was attempted — failure is swallowed as non-fatal
+      expect(runServer).toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/__tests__/aws-cov.test.ts
+++ b/packages/cli/src/__tests__/aws-cov.test.ts
@@ -71,6 +71,8 @@ describe("aws/ensureAwsCli", () => {
     const spy = mockSpawnSync(0, "/usr/local/bin/aws");
     const { ensureAwsCli } = await import("../aws/aws");
     await ensureAwsCli();
+    // spawnSync called once for `which aws` — no install triggered
+    expect(spy).toHaveBeenCalledTimes(1);
     spy.mockRestore();
   });
 
@@ -79,6 +81,8 @@ describe("aws/ensureAwsCli", () => {
     process.env.SPAWN_NON_INTERACTIVE = "1";
     const { ensureAwsCli } = await import("../aws/aws");
     await ensureAwsCli();
+    // spawnSync called once for `which aws` — install skipped in non-interactive mode
+    expect(spy).toHaveBeenCalledTimes(1);
     spy.mockRestore();
   });
 });
@@ -155,16 +159,17 @@ describe("aws/authenticate", () => {
 describe("aws/promptRegion", () => {
   it("uses AWS_DEFAULT_REGION from env", async () => {
     process.env.AWS_DEFAULT_REGION = "eu-west-1";
-    const { promptRegion } = await import("../aws/aws");
+    const { promptRegion, getState } = await import("../aws/aws");
     await promptRegion();
-    // Should not throw
+    expect(getState().awsRegion).toBe("eu-west-1");
   });
 
   it("uses LIGHTSAIL_REGION from env", async () => {
     delete process.env.AWS_DEFAULT_REGION;
     process.env.LIGHTSAIL_REGION = "ap-northeast-1";
-    const { promptRegion } = await import("../aws/aws");
+    const { promptRegion, getState } = await import("../aws/aws");
     await promptRegion();
+    expect(getState().awsRegion).toBe("ap-northeast-1");
   });
 
   it("throws on invalid region in env", async () => {
@@ -177,8 +182,11 @@ describe("aws/promptRegion", () => {
     delete process.env.AWS_DEFAULT_REGION;
     delete process.env.LIGHTSAIL_REGION;
     delete process.env.SPAWN_CUSTOM;
+    const regionBefore = process.env.AWS_DEFAULT_REGION;
     const { promptRegion } = await import("../aws/aws");
-    await promptRegion(); // no-op
+    await promptRegion();
+    // No region was set — env var unchanged
+    expect(process.env.AWS_DEFAULT_REGION).toBe(regionBefore);
   });
 });
 
@@ -326,14 +334,14 @@ describe("aws/destroyServer", () => {
   });
 
   it("succeeds via REST when name is given", async () => {
-    // Mock fetch for REST path
-    global.fetch = mock(() =>
+    const fetchMock = mock(() =>
       Promise.resolve(
         new Response("{}", {
           status: 200,
         }),
       ),
     );
+    global.fetch = fetchMock;
     // Set up state for REST mode by assigning env vars
     const spy = mockSpawnSync(1); // no aws cli
     process.env.AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
@@ -341,6 +349,8 @@ describe("aws/destroyServer", () => {
     const { authenticate, destroyServer } = await import("../aws/aws");
     await authenticate();
     await destroyServer("test-instance");
+    // fetch called for the Lightsail delete-instance REST request
+    expect(fetchMock).toHaveBeenCalled();
     spy.mockRestore();
   });
 });

--- a/packages/cli/src/__tests__/do-cov.test.ts
+++ b/packages/cli/src/__tests__/do-cov.test.ts
@@ -119,7 +119,8 @@ describe("digitalocean/promptSpawnName", () => {
     process.env.SPAWN_NAME_KEBAB = "existing-name";
     const { promptSpawnName } = await import("../digitalocean/digitalocean");
     await promptSpawnName();
-    // Should not throw or change env
+    // Existing value preserved — early return did not overwrite it
+    expect(process.env.SPAWN_NAME_KEBAB).toBe("existing-name");
   });
 
   it("uses DO_DROPLET_NAME when valid", async () => {
@@ -372,8 +373,11 @@ describe("digitalocean/promptSwitchAccount", () => {
 
 describe("digitalocean/checkAccountStatus", () => {
   it("returns immediately when no token", async () => {
+    const fetchMock = mock(() => Promise.resolve(new Response("{}")));
+    global.fetch = fetchMock;
     const { checkAccountStatus } = await import("../digitalocean/digitalocean");
-    // _state.token is empty by default
+    // _state.token is empty by default — should return early without calling fetch
     await checkAccountStatus();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/__tests__/gcp-cov.test.ts
+++ b/packages/cli/src/__tests__/gcp-cov.test.ts
@@ -157,6 +157,8 @@ describe("gcp/authenticate", () => {
     const spy = mockSpawnSync(0, "user@example.com\n");
     const { authenticate } = await import("../gcp/gcp");
     await authenticate();
+    // spawnSync called to locate gcloud and run auth list
+    expect(spy).toHaveBeenCalled();
     spy.mockRestore();
   });
 
@@ -182,6 +184,8 @@ describe("gcp/authenticate", () => {
 
     const { authenticate } = await import("../gcp/gcp");
     await authenticate();
+    // interactive login was triggered (Bun.spawn called for gcloud auth login)
+    expect(spawnSpy).toHaveBeenCalled();
     spawnSyncSpy.mockRestore();
     spawnSpy.mockRestore();
   });
@@ -195,6 +199,8 @@ describe("gcp/resolveProject", () => {
     const spy = mockSpawnSync(0, "/usr/bin/gcloud");
     const { resolveProject } = await import("../gcp/gcp");
     await resolveProject();
+    // GCP_PROJECT env var consumed — spawnSync not called for config lookup
+    expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });
 
@@ -451,6 +457,8 @@ describe("gcp/destroyInstance", () => {
     const mockSync = mockSpawnSync(0, "/usr/bin/gcloud");
     const { destroyInstance } = await import("../gcp/gcp");
     await destroyInstance("test-vm");
+    // Bun.spawn called to run gcloud instances delete
+    expect(spy).toHaveBeenCalled();
     spy.mockRestore();
     mockSync.mockRestore();
   });
@@ -472,6 +480,8 @@ describe("gcp/ensureGcloudCli", () => {
     const spy = mockSpawnSync(0, "/usr/bin/gcloud");
     const { ensureGcloudCli } = await import("../gcp/gcp");
     await ensureGcloudCli();
+    // spawnSync called once to locate gcloud — no install triggered
+    expect(spy).toHaveBeenCalledTimes(1);
     spy.mockRestore();
   });
 });
@@ -485,8 +495,12 @@ describe("gcp/checkBillingEnabled", () => {
     // Mock spawnSync to handle case where _state.project was set by prior tests
     // (module-level state persists across tests due to import caching)
     const spy = mockSpawnSyncWithGcloud(0, "true");
+    const fetchMock = mock(() => Promise.resolve(new Response("{}")));
+    global.fetch = fetchMock;
     const { checkBillingEnabled } = await import("../gcp/gcp");
     await checkBillingEnabled();
+    // fetch not called — billing check skipped when no project
+    expect(fetchMock).not.toHaveBeenCalled();
     spy.mockRestore();
   });
 });

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -117,8 +117,7 @@ describe("hetzner/getServerName", () => {
 describe("hetzner/ensureHcloudToken", () => {
   it("uses HCLOUD_TOKEN from env when valid", async () => {
     process.env.HCLOUD_TOKEN = "test-hcloud-token";
-    // Mock fetch to return valid server list (token validation)
-    global.fetch = mock(() =>
+    const fetchMock = mock(() =>
       Promise.resolve(
         new Response(
           JSON.stringify({
@@ -127,8 +126,11 @@ describe("hetzner/ensureHcloudToken", () => {
         ),
       ),
     );
+    global.fetch = fetchMock;
     const { ensureHcloudToken } = await import("../hetzner/hetzner");
     await ensureHcloudToken();
+    // fetch called to validate the token against Hetzner API
+    expect(fetchMock).toHaveBeenCalled();
   });
 
   it("warns when HCLOUD_TOKEN is invalid", async () => {
@@ -270,27 +272,14 @@ describe("hetzner/destroyServer", () => {
   });
 
   it("succeeds when API returns action", async () => {
-    global.fetch = mock(() =>
-      Promise.resolve(
-        new Response(
-          JSON.stringify({
-            action: {
-              id: 1,
-              status: "running",
-            },
-          }),
-        ),
-      ),
-    );
     // Need to set token first
     process.env.HCLOUD_TOKEN = "test-token";
     const tokenResp = JSON.stringify({
       servers: [],
     });
-    const origMock = global.fetch;
     // First call = token validation, then destroy
     let callCount = 0;
-    global.fetch = mock(() => {
+    const fetchMock = mock(() => {
       callCount++;
       if (callCount <= 1) {
         return Promise.resolve(new Response(tokenResp));
@@ -306,9 +295,12 @@ describe("hetzner/destroyServer", () => {
         ),
       );
     });
+    global.fetch = fetchMock;
     const { ensureHcloudToken, destroyServer } = await import("../hetzner/hetzner");
     await ensureHcloudToken();
     await destroyServer("12345");
+    // fetch called at least twice: once for token validation, once for delete
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it("throws when API returns error", async () => {

--- a/packages/cli/src/__tests__/ssh-cov.test.ts
+++ b/packages/cli/src/__tests__/ssh-cov.test.ts
@@ -291,6 +291,9 @@ describe("waitForSsh", () => {
       maxAttempts: 5,
     });
 
+    // TCP connect retried until open, then SSH handshake attempted
+    expect(connectSpy).toHaveBeenCalled();
+    expect(bunSpawnSpy).toHaveBeenCalled();
     bunSpawnSpy.mockRestore();
     connectSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

- Scanned all 99 test files for duplicate describe blocks, bash-grep tests, always-pass conditionals, and excessive subprocess spawning
- Found 19 tests with zero `expect()` calls (no real assertions — silent no-ops that only verified "does not throw")
- Replaced bare function calls with meaningful assertions on side effects: spy call counts, env var mutations, fetch call patterns

## Changes

**7 files modified** across `packages/cli/src/__tests__/`:

| File | Tests fixed | What was added |
|---|---|---|
| `agent-setup-cov.test.ts` | 1 | `runServer` called after graceful SSH failure |
| `auto-update.test.ts` | 1 | `runServer` called on non-fatal error |
| `aws-cov.test.ts` | 5 | `awsRegion` state set, `spawnSync` call counts, `fetch` called |
| `do-cov.test.ts` | 2 | Env var preserved on early return, `fetch` NOT called with no token |
| `gcp-cov.test.ts` | 6 | Spy call counts for `authenticate`/`destroyInstance`/`ensureGcloudCli`, `fetch` NOT called |
| `hetzner-cov.test.ts` | 2 | `fetch` call counts for token validation and delete |
| `ssh-cov.test.ts` | 1 | Both `connectSpy` and `bunSpawnSpy` called in `waitForSsh` |

**Test counts unchanged** (1925 pass, 0 fail). `expect()` calls: 4555 → 4575 (+20).

## Test plan

- [x] `bun test` — 1925 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` — 0 errors

-- qa/dedup-scanner