### PR TITLE
test: Remove duplicate generateCodeVerifier/generateCodeChallenge tests from oauth-cov

### DIFF
--- a/packages/cli/src/__tests__/oauth-cov.test.ts
+++ b/packages/cli/src/__tests__/oauth-cov.test.ts
@@ -1,8 +1,11 @@
 /**
  * oauth-cov.test.ts — Coverage tests for shared/oauth.ts
  *
- * Covers: generateCsrfState, generateCodeVerifier, generateCodeChallenge,
- * hasSavedOpenRouterKey, getOrPromptApiKey (env path, saved key path, manual entry)
+ * Covers: generateCsrfState, OAUTH_CSS, hasSavedOpenRouterKey, getOrPromptApiKey
+ * (env path, saved key path, manual entry).
+ *
+ * Note: generateCodeVerifier and generateCodeChallenge are fully covered by
+ * oauth-pkce.test.ts (including RFC 7636 test vectors) — not repeated here.
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
@@ -12,14 +15,7 @@ import { join } from "node:path";
 // (which would replace the global mock and disconnect other test files' spies).
 import * as p from "@clack/prompts";
 
-const {
-  generateCodeVerifier,
-  generateCodeChallenge,
-  generateCsrfState,
-  hasSavedOpenRouterKey,
-  getOrPromptApiKey,
-  OAUTH_CSS,
-} = await import("../shared/oauth.js");
+const { generateCsrfState, hasSavedOpenRouterKey, getOrPromptApiKey, OAUTH_CSS } = await import("../shared/oauth.js");
 
 let stderrSpy: ReturnType<typeof spyOn>;
 let origFetch: typeof global.fetch;
@@ -57,27 +53,6 @@ describe("generateCsrfState", () => {
     const a = generateCsrfState();
     const b = generateCsrfState();
     expect(a).not.toBe(b);
-  });
-});
-
-// ── generateCodeVerifier ───────────────────────────────────────────────
-
-describe("generateCodeVerifier", () => {
-  it("returns a 43-char base64url string", () => {
-    const v = generateCodeVerifier();
-    expect(v).toHaveLength(43);
-    expect(v).toMatch(/^[A-Za-z0-9_-]+$/);
-  });
-});
-
-// ── generateCodeChallenge ──────────────────────────────────────────────
-
-describe("generateCodeChallenge", () => {
-  it("generates deterministic challenge for same verifier", async () => {
-    const v = "test-verifier-for-challenge-test1234567890";
-    const c1 = await generateCodeChallenge(v);
-    const c2 = await generateCodeChallenge(v);
-    expect(c1).toBe(c2);
   });
 });
 


### PR DESCRIPTION
## Summary

- Removed 2 redundant test cases from `oauth-cov.test.ts` (`generateCodeVerifier` and `generateCodeChallenge` describe blocks)
- These were strict subsets of the more comprehensive `oauth-pkce.test.ts` coverage which includes RFC 7636 test vectors, uniqueness checks, padding validation, and base64url character verification
- Also removed the now-unused imports of `generateCodeVerifier` and `generateCodeChallenge` from the cov file

## Scan Results

Scanned 96 test files (~1866 tests) across all anti-pattern categories:

- **Duplicate describe blocks**: 6 name collisions found — all were nested under different parent describes or tested different aspects of the same function. The only true duplicate was the `generateCodeVerifier`/`generateCodeChallenge` pair.
- **Bash-grep/theatrical tests**: None found. No tests use `type FUNCTION` or grep function bodies.
- **Always-pass conditional expects**: None found. The one `if (existsSync...)` pattern was in test cleanup/setup, not wrapping assertions.
- **Excessive subprocess spawning**: None found. All `Bun.spawnSync` references in tests are mocked (using `satisfies ReturnType<typeof Bun.spawnSync>`), not actual spawns.

## Test Results

Before: 1866 pass, 0 fail
After: 1864 pass, 0 fail (exactly 2 removed)

Duplicates found: 1 (generateCodeVerifier + generateCodeChallenge as a pair)
Tests removed: 2
Tests rewritten: 0

-- qa/dedup-scanner