### PR TITLE
fix(security): validate cmd parameter in sprite interactiveSession

### DIFF
--- a/packages/cli/src/__tests__/sprite-keep-alive.test.ts
+++ b/packages/cli/src/__tests__/sprite-keep-alive.test.ts
@@ -100,6 +100,18 @@ describe("installSpriteKeepAlive", () => {
   });
 });
 
+// ── Tests: interactiveSession validation ──────────────────────────────────────
+
+describe("sprite/interactiveSession input validation", () => {
+  it("rejects empty command", async () => {
+    await expect(interactiveSession("")).rejects.toThrow("Invalid command");
+  });
+
+  it("rejects command with null bytes", async () => {
+    await expect(interactiveSession("echo\x00hi")).rejects.toThrow("Invalid command");
+  });
+});
+
 // ── Tests: interactiveSession ─────────────────────────────────────────────────
 
 describe("interactiveSession (keep-alive wrapper)", () => {

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -704,6 +704,9 @@ export async function installSpriteKeepAlive(): Promise<void> {
  * /v1/tasks API for the duration of the session.
  */
 export async function interactiveSession(cmd: string, spawnFn?: (args: string[]) => number): Promise<number> {
+  if (!cmd || /\0/.test(cmd)) {
+    throw new Error("Invalid command: must be non-empty and must not contain null bytes");
+  }
   const spriteCmd = getSpriteCmd()!;
 
   // Encode the session command to handle multi-line restart loop scripts safely


### PR DESCRIPTION
**Why:** HIGH command injection risk -- sprite's `interactiveSession` passes raw `cmd` string directly to `bash -c` without validation, unlike all other cloud providers (aws, hetzner, digitalocean, gcp) which reject empty strings and null bytes.

**What:** Add the same `!cmd || /\0/.test(cmd)` guard at the top of sprite's `interactiveSession`, plus matching test cases.

Fixes #2881

-- refactor/ux-engineer