### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/history-trimming.test.ts
+++ b/packages/cli/src/__tests__/history-trimming.test.ts
@@ -3,13 +3,11 @@ import type { SpawnRecord } from "../history.js";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { filterHistory, loadHistory, saveSpawnRecord } from "../history.js";
+import { filterHistory } from "../history.js";
 
 /**
- * Tests for filterHistory ordering and saveSpawnRecord behavior.
- *
- * History has no entry cap — all records are kept indefinitely.
- * These tests verify ordering guarantees and basic save/load behavior.
+ * Tests for filterHistory ordering guarantees.
+ * (saveSpawnRecord tests are in history.test.ts)
  */
 
 describe("History Ordering and Save Behavior", () => {
@@ -35,39 +33,6 @@ describe("History Ordering and Save Behavior", () => {
         force: true,
       });
     }
-  });
-
-  // ── saveSpawnRecord ──────────────────────────────────────────────────────
-
-  describe("saveSpawnRecord", () => {
-    it("should keep all entries with no cap", () => {
-      // Save 200 records — all should be retained
-      for (let i = 0; i < 200; i++) {
-        saveSpawnRecord({
-          id: `id-${i}`,
-          agent: `agent-${i}`,
-          cloud: "hetzner",
-          timestamp: `2026-01-01T${String(Math.floor(i / 60)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}:00.000Z`,
-        });
-      }
-      const loaded = loadHistory();
-      expect(loaded).toHaveLength(200);
-      expect(loaded[0].agent).toBe("agent-0");
-      expect(loaded[199].agent).toBe("agent-199");
-    });
-
-    it("should assign id when missing", () => {
-      saveSpawnRecord({
-        id: "",
-        agent: "claude",
-        cloud: "sprite",
-        timestamp: "2026-01-01T00:00:00.000Z",
-      });
-      const loaded = loadHistory();
-      expect(loaded).toHaveLength(1);
-      expect(typeof loaded[0].id).toBe("string");
-      expect(loaded[0].id.length).toBeGreaterThan(0);
-    });
   });
 
   // ── filterHistory ordering guarantees ────────────────────────────────────

--- a/packages/cli/src/__tests__/history.test.ts
+++ b/packages/cli/src/__tests__/history.test.ts
@@ -318,6 +318,35 @@ describe("history", () => {
       expect(data.records[1].agent).toBe("codex");
     });
 
+    it("keeps all entries with no cap", () => {
+      // Save 200 records — all should be retained (history has no entry limit)
+      for (let i = 0; i < 200; i++) {
+        saveSpawnRecord({
+          id: `id-${i}`,
+          agent: `agent-${i}`,
+          cloud: "hetzner",
+          timestamp: `2026-01-01T${String(Math.floor(i / 60)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}:00.000Z`,
+        });
+      }
+      const loaded = loadHistory();
+      expect(loaded).toHaveLength(200);
+      expect(loaded[0].agent).toBe("agent-0");
+      expect(loaded[199].agent).toBe("agent-199");
+    });
+
+    it("assigns id when missing", () => {
+      saveSpawnRecord({
+        id: "",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: "2026-01-01T00:00:00.000Z",
+      });
+      const loaded = loadHistory();
+      expect(loaded).toHaveLength(1);
+      expect(typeof loaded[0].id).toBe("string");
+      expect(loaded[0].id.length).toBeGreaterThan(0);
+    });
+
     // Corruption recovery and backup tests are in history-corruption.test.ts
   });
 


### PR DESCRIPTION
## Summary

- Identified `saveSpawnRecord` describe block duplicated across `history-trimming.test.ts` and `history.test.ts`
- Moved the two unique tests ("no cap" 200-record retention, "assign id when missing") from `history-trimming.test.ts` into `history.test.ts` where the main `saveSpawnRecord` describe block lives
- Removed the now-empty duplicate describe block from `history-trimming.test.ts`
- `history-trimming.test.ts` now only covers what its name implies: `filterHistory` ordering guarantees

## Scan results

- **Duplicate describe blocks**: 1 found (`saveSpawnRecord` in 2 files) — fixed
- **Bash-grep tests** (test function existence rather than behavior): none found
- **Always-pass conditional expects**: none found
- **Excessive subprocess spawning**: all `spawnSync` usages are properly mocked via `spyOn` — no real subprocess spawning

## Test plan

- [x] `bun test` passes: 1868 tests, 0 failures
- [x] `biome check` passes on modified files

-- qa/dedup-scanner