### PR TITLE
fix(ux): deduplicate install messages, add newlines to SSH polling

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.15",
+  "version": "0.25.16",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/ui-cov.test.ts
+++ b/packages/cli/src/__tests__/ui-cov.test.ts
@@ -85,17 +85,19 @@ describe("logging functions", () => {
     expect(stderrOutput.join("")).toContain("test step");
   });
 
-  it("logStepInline writes without newline", () => {
+  it("logStepInline writes message (newline-terminated in non-TTY)", () => {
     logStepInline("inline msg");
     const output = stderrOutput.join("");
     expect(output).toContain("inline msg");
-    expect(output).not.toEndWith("\n");
+    // In non-TTY (test environment), output ends with newline instead of \r overwrite
+    expect(output).toEndWith("\n");
   });
 
-  it("logStepDone clears the line", () => {
+  it("logStepDone is no-op in non-TTY", () => {
     logStepDone();
     const output = stderrOutput.join("");
-    expect(output).toContain("\r");
+    // In non-TTY (test environment), logStepDone writes nothing
+    expect(output).toBe("");
   });
 
   it("logDebug only outputs when SPAWN_DEBUG=1", () => {

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -102,7 +102,7 @@ async function installClaudeCode(runner: CloudRunner): Promise<void> {
 
   const claudePath = "$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$HOME/.n/bin";
   const pathSetup = `for rc in ~/.bashrc ~/.profile ~/.bash_profile ~/.zshrc; do grep -q '.claude/local/bin' "$rc" 2>/dev/null || printf '\\n# Claude Code PATH\\nexport PATH="$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH"\\n' >> "$rc"; done`;
-  const finalize = `claude install --force 2>/dev/null || true; ${pathSetup}`;
+  const finalize = `claude install --force >/dev/null 2>&1 || true; ${pathSetup}`;
 
   const script = [
     `export PATH="${claudePath}:$PATH"`,
@@ -125,7 +125,7 @@ async function installClaudeCode(runner: CloudRunner): Promise<void> {
     logError("Claude Code installation failed");
     throw new Error("Claude Code install failed");
   }
-  logInfo("Claude Code installed");
+  logInfo("Claude Code agent installed successfully");
 }
 
 async function setupClaudeCodeConfig(runner: CloudRunner, apiKey: string): Promise<void> {

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -532,9 +532,7 @@ async function postInstall(
   }
 
   // Launch agent
-  logInfo(`${agent.name} is ready`);
-  process.stderr.write("\n");
-  logInfo(`${cloud.cloudLabel} setup completed successfully!`);
+  logInfo(`Agent setup complete — ${agent.name} is ready on ${cloud.cloudLabel}`);
   process.stderr.write("\n");
 
   const launchCmd = agent.launchCmd();

--- a/packages/cli/src/shared/ui.ts
+++ b/packages/cli/src/shared/ui.ts
@@ -38,14 +38,21 @@ export function logStep(msg: string): void {
   process.stderr.write(`${CYAN}${msg}${NC}\n`);
 }
 
-/** Overwrite the current line with a status message (no newline). Call logStepDone() when finished. */
+/** Overwrite the current line with a status message (no newline). Call logStepDone() when finished.
+ *  Falls back to newline-separated output when stderr is not a TTY (e.g., piped or captured). */
 export function logStepInline(msg: string): void {
-  process.stderr.write(`\r${CYAN}${msg}${NC}\x1b[K`);
+  if (process.stderr.isTTY) {
+    process.stderr.write(`\r${CYAN}${msg}${NC}\x1b[K`);
+  } else {
+    process.stderr.write(`${CYAN}${msg}${NC}\n`);
+  }
 }
 
 /** End an inline status line by moving to the next line. */
 export function logStepDone(): void {
-  process.stderr.write("\r\x1b[K");
+  if (process.stderr.isTTY) {
+    process.stderr.write("\r\x1b[K");
+  }
 }
 
 /** Prompt for a line of user input. Throws if non-interactive.


### PR DESCRIPTION
**Why:** Installation success message is printed up to 4x creating confusion about whether multiple installations occurred; SSH port polling output runs together without newlines when stderr is not a TTY; post-install completion messages are redundant.

Fixes #2899

## Changes
- Suppress stdout+stderr from `claude install --force` finalize step to prevent duplicate "successfully installed" messages from both the curl installer and the forced re-install
- Add TTY detection to `logStepInline` / `logStepDone`: when stderr is a TTY, use carriage return for in-place updates; when not a TTY (piped/captured), use newline-separated output so each SSH polling attempt is readable
- Consolidate two separate post-install messages ("X is ready" + "Y setup completed successfully!") into one clear milestone: "Agent setup complete -- X is ready on Y"
- Bump CLI version to 0.25.16
- Update ui-cov tests to match new non-TTY behavior

## Test plan
- [x] biome check passes (0 errors)
- [x] bun test passes (1868/1868)
- [ ] Verify install message appears only once during `spawn claude hetzner`
- [ ] Verify SSH polling has newlines when captured by E2E harness

-- refactor/ux-engineer