### PR TITLE
test: remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/cmd-pick-cov.test.ts
+++ b/packages/cli/src/__tests__/cmd-pick-cov.test.ts
@@ -2,31 +2,11 @@
  * cmd-pick-cov.test.ts — Coverage tests for commands/pick.ts
  */
 
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { mockClackPrompts } from "./test-helpers";
 
 // ── Clack prompts mock ──────────────────────────────────────────────────────
 mockClackPrompts();
-
-// We need to mock the picker module since cmdPick imports it dynamically
-const mockParsePickerInput = mock((text: string) => {
-  if (!text.trim()) {
-    return [];
-  }
-  return text
-    .trim()
-    .split("\n")
-    .map((line: string) => {
-      const parts = line.split("\t");
-      return {
-        value: parts[0] || "",
-        label: parts[1] || parts[0] || "",
-        hint: parts[2] || undefined,
-      };
-    });
-});
-
-const mockPickToTTY = mock((_config: unknown) => "selected-value");
 
 // ── Import module under test ────────────────────────────────────────────────
 const { cmdPick } = await import("../commands/pick.js");
@@ -70,80 +50,5 @@ describe("cmdPick", () => {
     await expect(cmdPick([])).rejects.toThrow("process.exit(1)");
     expect(processExitSpy).toHaveBeenCalledWith(1);
     expect(stderrSpy).toHaveBeenCalled();
-  });
-
-  it("parses --prompt flag", async () => {
-    // We can't easily test the full picker flow without mocking the dynamic import,
-    // but we can verify flag parsing by checking that no options still exits
-    await expect(
-      cmdPick([
-        "--prompt",
-        "Choose one",
-      ]),
-    ).rejects.toThrow("process.exit(1)");
-  });
-
-  it("parses -p shorthand flag", async () => {
-    await expect(
-      cmdPick([
-        "-p",
-        "Choose one",
-      ]),
-    ).rejects.toThrow("process.exit(1)");
-  });
-
-  it("parses --default flag", async () => {
-    await expect(
-      cmdPick([
-        "--default",
-        "val1",
-      ]),
-    ).rejects.toThrow("process.exit(1)");
-  });
-
-  it("ignores unknown flags gracefully", async () => {
-    await expect(
-      cmdPick([
-        "--unknown",
-        "val",
-      ]),
-    ).rejects.toThrow("process.exit(1)");
-  });
-
-  it("collects remaining non-flag args", async () => {
-    // positional args are collected but cmdPick still needs stdin options
-    await expect(
-      cmdPick([
-        "positional",
-      ]),
-    ).rejects.toThrow("process.exit(1)");
-  });
-
-  it("ignores --default without a following value", async () => {
-    await expect(
-      cmdPick([
-        "--default",
-      ]),
-    ).rejects.toThrow("process.exit(1)");
-  });
-
-  it("ignores --prompt without a following value", async () => {
-    await expect(
-      cmdPick([
-        "--prompt",
-      ]),
-    ).rejects.toThrow("process.exit(1)");
-  });
-
-  it("handles multiple flags together", async () => {
-    await expect(
-      cmdPick([
-        "--prompt",
-        "Choose",
-        "--default",
-        "val1",
-        "--unknown-flag",
-      ]),
-    ).rejects.toThrow("process.exit(1)");
   });
 });

--- a/packages/cli/src/__tests__/ssh-cov.test.ts
+++ b/packages/cli/src/__tests__/ssh-cov.test.ts
@@ -39,23 +39,14 @@ afterEach(() => {
 // ── Constants ──────────────────────────────────────────────────────────
 
 describe("SSH constants", () => {
-  it("SSH_BASE_OPTS includes StrictHostKeyChecking", () => {
+  it("SSH_BASE_OPTS has required non-interactive options", () => {
     expect(SSH_BASE_OPTS).toContain("StrictHostKeyChecking=no");
-  });
-
-  it("SSH_BASE_OPTS includes BatchMode", () => {
     expect(SSH_BASE_OPTS).toContain("BatchMode=yes");
   });
 
-  it("SSH_INTERACTIVE_OPTS includes accept-new", () => {
+  it("SSH_INTERACTIVE_OPTS has interactive options and no BatchMode", () => {
     expect(SSH_INTERACTIVE_OPTS).toContain("StrictHostKeyChecking=accept-new");
-  });
-
-  it("SSH_INTERACTIVE_OPTS includes -t flag", () => {
     expect(SSH_INTERACTIVE_OPTS).toContain("-t");
-  });
-
-  it("SSH_INTERACTIVE_OPTS does not include BatchMode", () => {
     expect(SSH_INTERACTIVE_OPTS).not.toContain("BatchMode=yes");
   });
 });


### PR DESCRIPTION
## Summary

- **cmd-pick-cov.test.ts**: Removed 8 theatrical flag-parsing tests. All 8 called `cmdPick()` with different flag combinations (`--prompt`, `-p`, `--default`, `--unknown`, positional args, missing flag values, combined flags) but every single test verified only that `exit(1)` was thrown — because stdin is always TTY with no options, the flag parsing code is never meaningfully exercised. The comment in the original code even said "We can't easily test the full picker flow without mocking the dynamic import." Kept the one test that has real assertions (checks `processExitSpy` called with `1` AND `stderrSpy` called).

- **ssh-cov.test.ts**: Consolidated 5 single-assertion SSH constant tests into 2 tests. All 5 tested string membership in `SSH_BASE_OPTS` / `SSH_INTERACTIVE_OPTS` in separate `it()` blocks — one block per string. Merged into one test per constant with all assertions together.

## Test plan

- [x] `bun test` passes: 1857 tests, 0 failures
- [x] `bunx @biomejs/biome check src/` clean: 0 errors
- [x] Before: 1868 tests, 4454 expect() calls
- [x] After: 1857 tests, 4446 expect() calls (-11 tests, -8 expects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)