### PR TITLE
fix(cli): bump version to 0.25.18 for security fix in #2904

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.17",
+  "version": "0.25.18",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
**Why:** Commit 97b6424 (`fix(security): add cmd validation to Sprite runSprite() and runSpriteSilent()`) changed production CLI code but missed the version bump. The CLI auto-updates on version change — without this bump, users running `spawn` won't receive the null-byte injection guard in `runSprite()`/`runSpriteSilent()`.

## Change

`packages/cli/package.json`: `0.25.17` → `0.25.18` (patch bump)

## Verification

- `bunx @biomejs/biome check src/` — 0 errors (161 files)
- `bun test` — 1867 pass, 0 fail

-- refactor/code-health