### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -17,7 +17,6 @@ export {
   cmdClouds,
   cmdMatrix,
   getMissingClouds,
-  getTerminalWidth,
 } from "./info.js";
 // interactive.ts — cmdInteractive, cmdAgentInteractive
 export { cmdAgentInteractive, cmdInteractive } from "./interactive.js";

--- a/packages/cli/src/shared/agent-tarball.ts
+++ b/packages/cli/src/shared/agent-tarball.ts
@@ -160,7 +160,7 @@ export async function tryTarballInstall(
 
 // ─── Parallel tarball: local download + SCP upload ──────────────────────────
 
-export interface LocalTarball {
+interface LocalTarball {
   localPath: string;
   cleanup: () => void;
 }


### PR DESCRIPTION
## Summary

- **Removed unnecessary `export` from `LocalTarball` interface** in `packages/cli/src/shared/agent-tarball.ts` — this type is only used internally as the return type of `downloadTarballLocally`; it was never imported from outside the module (verified via codebase-wide grep)
- **Removed stale `getTerminalWidth` re-export** from `packages/cli/src/commands/index.ts` — this function is defined and called only inside `commands/info.ts` itself; it was re-exported in the barrel file but never imported from there by any consumer or test file
- **Bump CLI version** 0.25.18 → 0.25.19 (patch, per CLI version policy)

## Scanning approach

Performed systematic scan across all 5 categories:
- **Dead code**: Checked all exports in `sh/shared/*.sh`, `packages/cli/src/shared/`, `packages/cli/src/commands/`, and per-cloud modules for callers — found 2 items with no external callers
- **Stale references**: Checked all shell `source`/`import` statements and TypeScript imports — all referenced files exist
- **Python usage**: None found (`python3 -c` / `python -c` absent from all `sh/` scripts)
- **Duplicate utilities**: `getCloudInitUserdata` appears in multiple cloud modules but each has cloud-specific differences — not a true duplicate
- **Stale comments**: No comments referencing removed infrastructure or deleted files found

## Test plan

- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — 1867 pass, 0 fail
- [x] No regressions: `LocalTarball` is only used as return type of `downloadTarballLocally` (TypeScript infers the type without the explicit export); `getTerminalWidth` remains exported from `info.ts` and is called internally

-- qa/code-quality