### PR TITLE
fix(e2e): fix openclaw DO size and kilocode Sprite install failures

### DIFF
--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -893,7 +893,7 @@ const DROPLET_SIZES: DropletSize[] = [
   },
   {
     id: "s-2vcpu-4gb-intel",
-    label: "2 vCPU \u00b7 4 GB RAM \u00b7 $28/mo (Intel, available in all regions)",
+    label: "2 vCPU \u00b7 4 GB RAM \u00b7 $28/mo (Intel)",
   },
   {
     id: "s-4vcpu-8gb",

--- a/packages/cli/src/digitalocean/main.ts
+++ b/packages/cli/src/digitalocean/main.ts
@@ -28,9 +28,9 @@ import {
 
 /** Agents that need more than the default 2GB RAM (e.g. openclaw-plugins OOMs on 2GB) */
 const AGENT_MIN_SIZE: Record<string, string> = {
-  // s-2vcpu-4gb-intel is used instead of s-2vcpu-4gb because the non-intel variant
-  // is not available in nyc3 (the default E2E region). Both offer 2 vCPUs and 4GB RAM.
-  openclaw: "s-2vcpu-4gb-intel",
+  // s-2vcpu-4gb is used (not s-2vcpu-4gb-intel) because the intel variant
+  // is no longer available in nyc3 (the default E2E region). Both offer 2 vCPUs and 4GB RAM.
+  openclaw: "s-2vcpu-4gb",
 };
 
 /** DO marketplace image slugs — hardcoded from vendor portal (approved 2026-03-13) */

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -928,7 +928,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         installAgent(
           runner,
           "Kilo Code",
-          `${NPM_PREFIX_SETUP} && npm install -g \${_NPM_G_FLAGS} @kilocode/cli && ${NPM_GLOBAL_PATH_PERSIST} && ${KILOCODE_BINARY_VERIFY}`,
+          `cd "$HOME" && ${NPM_PREFIX_SETUP} && npm install -g \${_NPM_G_FLAGS} @kilocode/cli && ${NPM_GLOBAL_PATH_PERSIST} && ${KILOCODE_BINARY_VERIFY}`,
         ),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,


### PR DESCRIPTION
## Summary

- **DigitalOcean openclaw**: `s-2vcpu-4gb-intel` is no longer available in the `nyc3` region (default E2E region). Switched `AGENT_MIN_SIZE` for openclaw to `s-2vcpu-4gb` (standard, non-intel variant) which IS available in nyc3 and provides the same specs (2 vCPU, 4GB RAM). Also removed stale "available in all regions" label from the intel variant in the size list.
- **Sprite kilocode**: `npm install -g @kilocode/cli` fails with "The current working directory was deleted" during the postinstall script on Sprite VMs. Added `cd "$HOME"` before the npm install command to ensure we start from a stable, persistent directory.
- **Version**: bumped to 0.25.19

## Test plan

- [ ] Re-run `./sh/e2e/e2e.sh --cloud digitalocean openclaw` — expect PASS
- [ ] Re-run `./sh/e2e/e2e.sh --cloud sprite kilocode` — expect PASS

-- qa/e2e-tester