### PR TITLE
test: remove duplicate cmdFix tests from cmd-fix-cov.test.ts

### DIFF
--- a/packages/cli/src/__tests__/cmd-fix-cov.test.ts
+++ b/packages/cli/src/__tests__/cmd-fix-cov.test.ts
@@ -4,15 +4,13 @@
  * Covers paths not exercised in cmd-fix.test.ts:
  * - fixSpawn with security validation failures for server_id/server_name
  * - fixSpawn loading manifest from network when it fails
- * - cmdFix non-interactive mode with multiple servers
- * - cmdFix with interactive picker (select + cancel)
+ * - fixSpawn label fallbacks (record name, IP)
+ * - fixSpawn success message
  */
 
 import type { SpawnRecord } from "../history";
 
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { tryCatch } from "@openrouter/spawn-shared";
 import { createMockManifest, mockClackPrompts } from "./test-helpers";
 
@@ -25,7 +23,7 @@ const clack = mockClackPrompts({
 });
 
 // ── Import modules under test ───────────────────────────────────────────────
-const { fixSpawn, cmdFix } = await import("../commands/fix.js");
+const { fixSpawn } = await import("../commands/fix.js");
 const { _resetCacheForTesting } = await import("../manifest.js");
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -140,106 +138,6 @@ describe("fixSpawn (additional coverage)", () => {
       runScript: mockRunner,
     });
     expect(clack.logStep).toHaveBeenCalledWith(expect.stringContaining("1.2.3.4"));
-  });
-});
-
-// ── Tests: cmdFix edge cases ─────────────────────────────────────────────────
-
-describe("cmdFix (additional coverage)", () => {
-  let testDir: string;
-  let savedSpawnHome: string | undefined;
-  let processExitSpy: ReturnType<typeof spyOn>;
-
-  function writeHistory(records: SpawnRecord[]) {
-    writeFileSync(
-      join(testDir, "history.json"),
-      JSON.stringify({
-        version: 1,
-        records,
-      }),
-    );
-  }
-
-  beforeEach(() => {
-    testDir = join(process.env.HOME ?? "", `spawn-fix-cov-${Date.now()}`);
-    mkdirSync(testDir, {
-      recursive: true,
-    });
-    savedSpawnHome = process.env.SPAWN_HOME;
-    process.env.SPAWN_HOME = testDir;
-
-    clack.logError.mockReset();
-    clack.logInfo.mockReset();
-    clack.logSuccess.mockReset();
-
-    const savedFetch = global.fetch;
-    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
-    _resetCacheForTesting();
-
-    processExitSpy = spyOn(process, "exit").mockImplementation((_code?: number): never => {
-      throw new Error("process.exit");
-    });
-  });
-
-  afterEach(() => {
-    process.env.SPAWN_HOME = savedSpawnHome;
-    processExitSpy.mockRestore();
-    if (existsSync(testDir)) {
-      rmSync(testDir, {
-        recursive: true,
-        force: true,
-      });
-    }
-  });
-
-  it("fixes directly when only one server (no picker needed)", async () => {
-    const mockRunner = mock(async () => true);
-    writeHistory([
-      makeRecord({
-        id: "only-one",
-      }),
-    ]);
-
-    const savedFetch = global.fetch;
-    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
-    _resetCacheForTesting();
-
-    await cmdFix(undefined, {
-      runScript: mockRunner,
-    });
-
-    expect(mockRunner).toHaveBeenCalled();
-    global.fetch = savedFetch;
-  });
-
-  it("finds record by name when spawnId matches name", async () => {
-    const mockRunner = mock(async () => true);
-    writeHistory([
-      makeRecord({
-        id: "id-1",
-        name: "my-spawn",
-      }),
-      makeRecord({
-        id: "id-2",
-        name: "other-spawn",
-      }),
-    ]);
-
-    const savedFetch = global.fetch;
-    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify(mockManifest))));
-    _resetCacheForTesting();
-
-    await cmdFix("my-spawn", {
-      runScript: mockRunner,
-    });
-
-    expect(mockRunner).toHaveBeenCalled();
-    global.fetch = savedFetch;
-  });
-
-  it("shows no active spawns when history is empty", async () => {
-    await cmdFix();
-    expect(clack.logInfo).toHaveBeenCalledWith(expect.stringContaining("No active spawns"));
   });
 });
 


### PR DESCRIPTION
## Summary

Followup to #2907 — the cmd-fix-cov.test.ts cleanup was lost during a rebase conflict resolution.

Three tests in the `cmdFix (additional coverage)` describe block are exact duplicates of tests already in `cmd-fix.test.ts`:
- "fixes directly when only one server" = "directly fixes when only one active server"
- "finds record by name when spawnId matches name" = "fixes by spawn name"
- "shows no active spawns when history is empty" = "shows message when no active spawns"

Removed the duplicate describe block and its now-unused imports (`afterEach`, `existsSync`, `mkdirSync`, `rmSync`, `writeFileSync`, `join`, `spyOn`). Unique `fixSpawn` coverage is preserved.

## Test plan
- [x] `bun test cmd-fix-cov.test.ts` — 6 pass, 0 fail
- [x] `biome check` — clean

-- refactor/pr-maintainer