### PR TITLE
test: remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/do-cov.test.ts
+++ b/packages/cli/src/__tests__/do-cov.test.ts
@@ -34,17 +34,6 @@ describe("digitalocean/getConnectionInfo", () => {
   });
 });
 
-// ─── Constants ───────────────────────────────────────────────────────────────
-
-describe("digitalocean/constants", () => {
-  it("DEFAULT_DROPLET_SIZE is s-2vcpu-2gb", () => {
-    expect(DEFAULT_DROPLET_SIZE).toBe("s-2vcpu-2gb");
-  });
-  it("DEFAULT_DO_REGION is nyc3", () => {
-    expect(DEFAULT_DO_REGION).toBe("nyc3");
-  });
-});
-
 // ─── promptDropletSize ───────────────────────────────────────────────────────
 
 describe("digitalocean/promptDropletSize", () => {

--- a/packages/cli/src/__tests__/gcp-cov.test.ts
+++ b/packages/cli/src/__tests__/gcp-cov.test.ts
@@ -82,17 +82,6 @@ describe("gcp/getConnectionInfo", () => {
   });
 });
 
-// ─── Constants ───────────────────────────────────────────────────────────────
-
-describe("gcp/constants", () => {
-  it("DEFAULT_MACHINE_TYPE is e2-medium", () => {
-    expect(DEFAULT_MACHINE_TYPE).toBe("e2-medium");
-  });
-  it("DEFAULT_ZONE is us-central1-a", () => {
-    expect(DEFAULT_ZONE).toBe("us-central1-a");
-  });
-});
-
 // ─── promptMachineType ───────────────────────────────────────────────────────
 
 describe("gcp/promptMachineType", () => {

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -40,17 +40,6 @@ describe("hetzner/getConnectionInfo", () => {
   });
 });
 
-// ─── Constants ───────────────────────────────────────────────────────────────
-
-describe("hetzner/constants", () => {
-  it("DEFAULT_SERVER_TYPE is cx23", () => {
-    expect(DEFAULT_SERVER_TYPE).toBe("cx23");
-  });
-  it("DEFAULT_LOCATION is nbg1", () => {
-    expect(DEFAULT_LOCATION).toBe("nbg1");
-  });
-});
-
 // ─── promptServerType ────────────────────────────────────────────────────────
 
 describe("hetzner/promptServerType", () => {

--- a/packages/cli/src/__tests__/ssh-cov.test.ts
+++ b/packages/cli/src/__tests__/ssh-cov.test.ts
@@ -1,7 +1,7 @@
 /**
  * ssh-cov.test.ts — Coverage tests for shared/ssh.ts
  *
- * Covers: spawnInteractive, sleep, startSshTunnel,
+ * Covers: spawnInteractive, startSshTunnel,
  * waitForSsh, SSH_BASE_OPTS, SSH_INTERACTIVE_OPTS
  */
 
@@ -13,7 +13,7 @@ import * as net from "node:net";
 // Suppress stderr during tests — restored in afterAll to avoid contamination
 let stderrSpy: ReturnType<typeof spyOn>;
 
-const { spawnInteractive, sleep, startSshTunnel, waitForSsh, SSH_BASE_OPTS, SSH_INTERACTIVE_OPTS } = await import(
+const { spawnInteractive, startSshTunnel, waitForSsh, SSH_BASE_OPTS, SSH_INTERACTIVE_OPTS } = await import(
   "../shared/ssh.js"
 );
 
@@ -131,22 +131,6 @@ describe("spawnInteractive", () => {
       }),
     );
     spy.mockRestore();
-  });
-});
-
-// ── sleep ──────────────────────────────────────────────────────────────
-
-describe("sleep", () => {
-  it("resolves after the specified delay", async () => {
-    const start = Date.now();
-    await sleep(50);
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeGreaterThanOrEqual(40);
-  });
-
-  it("resolves with undefined", async () => {
-    const result = await sleep(1);
-    expect(result).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove 6 theatrical constant-equality tests from `digitalocean/gcp/hetzner` cov files that hardcoded the same string twice (e.g. `expect(DEFAULT_DROPLET_SIZE).toBe("s-2vcpu-2gb")`). These tests break when a default is changed for a valid reason but don't test any behavior.
- Remove 2 trivial `sleep()` tests from `ssh-cov.test.ts` — `sleep()` is a one-line `setTimeout` wrapper with no logic, and the timing test added 50ms of real wall time per run.

## Test plan
- [x] `bun test` passes: 1856 tests, 0 failures (down from 1864, removed 8 theatrical tests)
- [x] `bunx @biomejs/biome check src/` passes with 0 errors

-- qa/dedup-scanner