### PR TITLE
fix(types): remove `as` type assertions from test mocks

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.19",
+  "version": "0.25.20",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/test-helpers.ts
+++ b/packages/cli/src/__tests__/test-helpers.ts
@@ -183,7 +183,7 @@ export function mockClackPrompts(overrides?: Partial<ClackPromptsMock>): ClackPr
  * and sprite-cov test files. Centralised here to avoid repetition.
  */
 export function mockBunSpawn(exitCode = 0, stdout = "", stderr = "") {
-  function createMockProc() {
+  function createMockProc(): ReturnType<typeof Bun.spawn> {
     return {
       pid: 1234,
       exitCode: Promise.resolve(exitCode),
@@ -201,9 +201,11 @@ export function mockBunSpawn(exitCode = 0, stdout = "", stderr = "") {
         },
       }),
       kill: mock(() => {}),
+      killed: false,
       ref: () => {},
       unref: () => {},
       stdin: new WritableStream(),
+      signalCode: null,
       resourceUsage: () =>
         ({
           cpuTime: {
@@ -229,8 +231,7 @@ export function mockBunSpawn(exitCode = 0, stdout = "", stderr = "") {
     };
   }
   // Return a fresh mock proc per call so ReadableStreams are not reused
-  // biome-ignore lint: test mock
-  return spyOn(Bun, "spawn").mockImplementation(() => createMockProc() as ReturnType<typeof Bun.spawn>);
+  return spyOn(Bun, "spawn").mockImplementation(() => createMockProc());
 }
 
 // ── Fetch Mocks ────────────────────────────────────────────────────────────────

--- a/packages/cli/src/__tests__/ui-cov.test.ts
+++ b/packages/cli/src/__tests__/ui-cov.test.ts
@@ -159,26 +159,30 @@ describe("selectFromList", () => {
 
 describe("openBrowser", () => {
   it("shows URL in stderr output on linux", () => {
-    // biome-ignore lint: test mock — spawnSync return type needs assertion
     const spawnSyncSpy = spyOn(Bun, "spawnSync").mockReturnValue({
       exitCode: 1,
       stdout: Buffer.from(""),
       stderr: Buffer.from(""),
       success: false,
-    } satisfies Partial<ReturnType<typeof Bun.spawnSync>> as ReturnType<typeof Bun.spawnSync>);
+      signalCode: null,
+      resourceUsage: undefined,
+      pid: 0,
+    } satisfies ReturnType<typeof Bun.spawnSync>);
     openBrowser("https://example.com");
     spawnSyncSpy.mockRestore();
     expect(stderrOutput.join("")).toContain("https://example.com");
   });
 
   it("shows different message when browser opens successfully", () => {
-    // biome-ignore lint: test mock — spawnSync return type needs assertion
     const spawnSyncSpy = spyOn(Bun, "spawnSync").mockReturnValue({
       exitCode: 0,
       stdout: Buffer.from(""),
       stderr: Buffer.from(""),
       success: true,
-    } satisfies Partial<ReturnType<typeof Bun.spawnSync>> as ReturnType<typeof Bun.spawnSync>);
+      signalCode: null,
+      resourceUsage: undefined,
+      pid: 0,
+    } satisfies ReturnType<typeof Bun.spawnSync>);
     openBrowser("https://example.com");
     spawnSyncSpy.mockRestore();
     expect(stderrOutput.join("")).toContain("https://example.com");


### PR DESCRIPTION
## Why

3 `as` type assertions in test files violate the project's no-`as`-assertions rule:
- `packages/cli/src/__tests__/ui-cov.test.ts:168` — `as ReturnType<typeof Bun.spawnSync>`
- `packages/cli/src/__tests__/ui-cov.test.ts:181` — `as ReturnType<typeof Bun.spawnSync>`
- `packages/cli/src/__tests__/test-helpers.ts:233` — `as ReturnType<typeof Bun.spawn>`

## Changes

- **ui-cov.test.ts**: Added missing `signalCode`, `resourceUsage`, and `pid` fields to `spawnSync` mock objects so they satisfy `ReturnType<typeof Bun.spawnSync>` directly. Removed `biome-ignore` comments and `Partial<...> as ...` casts.
- **test-helpers.ts**: Added missing `killed` and `signalCode` fields to `Bun.spawn` mock. Changed `createMockProc` return type annotation to `ReturnType<typeof Bun.spawn>` so the `as` cast on the `mockImplementation` call is no longer needed. Removed `biome-ignore` comment.
- Bumped CLI version to 0.25.20.

## Verification

- `bunx @biomejs/biome check src/` — 0 violations (161 files)
- `bun test` — 1864 pass, 0 fail

-- refactor/style-reviewer