### PR TITLE
fix: set SPAWN_NON_INTERACTIVE in headless mode

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.20",
+  "version": "0.25.21",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -818,6 +818,7 @@ function runScriptHeadless(script: string, prompt?: string, debug?: boolean, spa
   };
   env.SPAWN_HEADLESS = "1";
   env.SPAWN_MODE = "non-interactive";
+  env.SPAWN_NON_INTERACTIVE = "1";
   if (prompt) {
     env.SPAWN_PROMPT = prompt;
   }
@@ -870,6 +871,7 @@ function runBundleHeadless(
   };
   env.SPAWN_HEADLESS = "1";
   env.SPAWN_MODE = "non-interactive";
+  env.SPAWN_NON_INTERACTIVE = "1";
   if (prompt) {
     env.SPAWN_PROMPT = prompt;
   }


### PR DESCRIPTION
## Summary
- Headless mode (`--headless`/`--output json`) was setting `SPAWN_HEADLESS=1` and `SPAWN_MODE=non-interactive` but **not** `SPAWN_NON_INTERACTIVE=1`
- All cloud modules (GCP, Hetzner, DO, AWS) check `SPAWN_NON_INTERACTIVE` to skip interactive prompts
- This caused GCP to prompt for project confirmation (`Use project 'X'? [Y/n]`) even in headless mode, which fatally errored because stdin was closed
- Fixed in both `runScriptHeadless()` and `runBundleHeadless()`

## Repro
```
spawn claude gcp --headless --output json --name spawn-test-0
# → "Fatal: stdin closed unexpectedly during prompt"
```

## Test plan
- [x] `bun test cmd-run-cov.test.ts` — 16 pass
- [x] `bun test orchestrate.test.ts orchestrate-cov.test.ts gcp-cov.test.ts` — 108 pass
- [x] Biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)