### PR TITLE
fix: skip cloud-init wait in Hetzner Docker mode

### DIFF
--- a/packages/cli/src/__tests__/docker-cloudinit-skip.test.ts
+++ b/packages/cli/src/__tests__/docker-cloudinit-skip.test.ts
@@ -1,0 +1,30 @@
+/**
+ * docker-cloudinit-skip.test.ts — Verify Docker mode skips cloud-init wait.
+ *
+ * When --beta docker is active, waitForReady() must skip cloud-init polling
+ * and only wait for SSH. This test reads the orchestrator source files to
+ * verify the useDocker check is present in the waitForReady condition.
+ *
+ * Without this, non-minimal agents (openclaw, codex) wait 5 minutes for a
+ * cloud-init marker that never appears when using Docker app images.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const CLI_SRC = resolve(import.meta.dir, "..");
+
+describe("Docker mode skips cloud-init wait", () => {
+  it("Hetzner waitForReady includes useDocker in skip condition", () => {
+    const source = readFileSync(resolve(CLI_SRC, "hetzner/main.ts"), "utf-8");
+    // The waitForReady condition must include useDocker to skip cloud-init
+    // when Docker mode is active (matching GCP's implementation)
+    expect(source).toContain("useDocker || snapshotId || cloud.skipCloudInit");
+  });
+
+  it("GCP waitForReady includes useDocker in skip condition", () => {
+    const source = readFileSync(resolve(CLI_SRC, "gcp/main.ts"), "utf-8");
+    expect(source).toContain("useDocker || cloud.skipCloudInit");
+  });
+});

--- a/packages/cli/src/hetzner/main.ts
+++ b/packages/cli/src/hetzner/main.ts
@@ -87,7 +87,7 @@ async function main() {
     },
     getServerName,
     async waitForReady() {
-      if (snapshotId || cloud.skipCloudInit) {
+      if (useDocker || snapshotId || cloud.skipCloudInit) {
         await waitForSshOnly();
       } else {
         await waitForCloudInit();


### PR DESCRIPTION
## Summary
- Hetzner's `waitForReady()` was missing the `useDocker` check that GCP already has
- Non-minimal agents (openclaw, codex) with `--beta docker` waited 5 minutes for a cloud-init marker that never appears on Docker CE app images
- Added `useDocker` to the skip condition: `if (useDocker || snapshotId || cloud.skipCloudInit)`
- Added source-level regression test verifying both Hetzner and GCP include the `useDocker` check

## Test plan
- [x] Biome lint passes (0 errors)
- [x] New test `docker-cloudinit-skip.test.ts` passes (2/2)
- [ ] Manual: deploy openclaw on Hetzner with `--beta docker` and verify no 5-minute wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)