### PR TITLE
fix: use POSIX normalize for remote Linux paths

### DIFF
--- a/packages/cli/src/__tests__/ssh-cov.test.ts
+++ b/packages/cli/src/__tests__/ssh-cov.test.ts
@@ -13,9 +13,8 @@ import * as net from "node:net";
 // Suppress stderr during tests — restored in afterAll to avoid contamination
 let stderrSpy: ReturnType<typeof spyOn>;
 
-const { spawnInteractive, startSshTunnel, waitForSsh, SSH_BASE_OPTS, SSH_INTERACTIVE_OPTS } = await import(
-  "../shared/ssh.js"
-);
+const { spawnInteractive, startSshTunnel, waitForSsh, validateRemotePath, SSH_BASE_OPTS, SSH_INTERACTIVE_OPTS } =
+  await import("../shared/ssh.js");
 
 /** Create a fake socket (EventEmitter) that satisfies net.Socket interface for testing. */
 function createFakeSocket(): net.Socket {
@@ -271,6 +270,40 @@ describe("waitForSsh", () => {
     expect(bunSpawnSpy).toHaveBeenCalled();
     bunSpawnSpy.mockRestore();
     connectSpy.mockRestore();
+  });
+});
+
+// ── validateRemotePath ───────────────────────────────────────────────
+
+describe("validateRemotePath", () => {
+  it("accepts valid Linux paths with forward slashes", () => {
+    expect(validateRemotePath("/home/user/config.json")).toBe("/home/user/config.json");
+    expect(validateRemotePath("/root/.spawn-tarball")).toBe("/root/.spawn-tarball");
+    expect(validateRemotePath("$HOME/.config/spawn")).toBe("$HOME/.config/spawn");
+  });
+
+  it("normalizes using POSIX rules (no backslashes)", () => {
+    // normalize should collapse double slashes but never introduce backslashes
+    const result = validateRemotePath("/home//user///file.txt");
+    expect(result).toBe("/home/user/file.txt");
+    expect(result).not.toContain("\\");
+  });
+
+  it("rejects path traversal", () => {
+    expect(() => validateRemotePath("/home/../etc/passwd")).toThrow("path traversal");
+    expect(() => validateRemotePath("../etc/shadow")).toThrow("path traversal");
+  });
+
+  it("rejects empty path", () => {
+    expect(() => validateRemotePath("")).toThrow("must not be empty");
+  });
+
+  it("rejects argument injection", () => {
+    expect(() => validateRemotePath("/-evil")).toThrow('must not start with "-"');
+  });
+
+  it("rejects unsafe characters", () => {
+    expect(() => validateRemotePath("/home/user;rm -rf")).toThrow("unsafe characters");
   });
 });
 

--- a/packages/cli/src/shared/ssh.ts
+++ b/packages/cli/src/shared/ssh.ts
@@ -2,7 +2,7 @@
 
 import { spawnSync as nodeSpawnSync } from "node:child_process";
 import { connect } from "node:net";
-import { normalize } from "node:path";
+import { normalize } from "node:path/posix";
 import { asyncTryCatch, tryCatch } from "./result.js";
 import { logError, logInfo, logStep, logStepDone, logStepInline } from "./ui.js";
 


### PR DESCRIPTION
## Summary
- `validateRemotePath()` used `normalize()` from `node:path` which is platform-dependent — on Windows it converts `/` to `\`
- Remote paths are always Linux paths (SSH/SCP to Linux VMs), so backslashes break the character allowlist and reject every valid path
- Switched to `node:path/posix` so normalization always uses forward slashes regardless of client OS
- Added 6 tests for `validateRemotePath` covering valid paths, POSIX normalization, traversal, empty, injection, and unsafe chars

## Test plan
- [x] Biome lint passes (0 errors)
- [x] `bun test src/__tests__/ssh-cov.test.ts` passes (15/15, 6 new)
- [ ] Manual: verify on Windows that `spawn claude hetzner` doesn't fail during config upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)