### PR TITLE
fix: rethrow normalized Error in tryCatchIf/asyncTryCatchIf

### DIFF
--- a/packages/shared/src/__tests__/result.test.ts
+++ b/packages/shared/src/__tests__/result.test.ts
@@ -134,6 +134,21 @@ describe("tryCatchIf", () => {
       }),
     ).toThrow("unexpected");
   });
+
+  it("re-throws non-Error values as normalized Error instances", () => {
+    const guard = () => false;
+    // Wrap in tryCatch to capture the re-thrown value without raw try/catch
+    const result = tryCatch(() =>
+      tryCatchIf(guard, () => {
+        throw "raw string error";
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error.message).toBe("raw string error");
+    }
+  });
 });
 
 describe("asyncTryCatchIf", () => {
@@ -166,6 +181,20 @@ describe("asyncTryCatchIf", () => {
         throw new Error("unexpected");
       }),
     ).rejects.toThrow("unexpected");
+  });
+
+  it("re-throws non-Error values as normalized Error instances", async () => {
+    const guard = () => false;
+    const result = await asyncTryCatch(() =>
+      asyncTryCatchIf(guard, async () => {
+        throw 404;
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error.message).toBe("404");
+    }
   });
 });
 

--- a/packages/shared/src/result.ts
+++ b/packages/shared/src/result.ts
@@ -54,7 +54,7 @@ export function tryCatchIf<T>(guard: (err: Error) => boolean, fn: () => T): Resu
     if (guard(err)) {
       return Err(err);
     }
-    throw e;
+    throw err;
   }
 }
 
@@ -70,7 +70,7 @@ export async function asyncTryCatchIf<T>(guard: (err: Error) => boolean, fn: () 
     if (guard(err)) {
       return Err(err);
     }
-    throw e;
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary
- `tryCatchIf` and `asyncTryCatchIf` normalize caught values to `Error` instances but then re-threw the raw original value when the guard returned false
- If something threw a string or number, downstream code expecting `Error` instances (`.message`, `.stack`) would break
- Two-character fix: `throw e` → `throw err` in both functions
- Also reformatted test file to pass biome (existing formatting was non-compliant)

## Test plan
- [x] Biome lint passes (0 errors)
- [x] `bun test src/__tests__/result.test.ts` passes (32/32, 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)