### PR TITLE
fix(hetzner): clean up stale primary IPs before provisioning to avoid quota exceeded

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.24",
+  "version": "0.25.25",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/hetzner/main.ts
+++ b/packages/cli/src/hetzner/main.ts
@@ -9,6 +9,7 @@ import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY, runOrchestration } from "../sha
 import { logInfo, logStep, shellQuote } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
+  cleanupOrphanedPrimaryIps,
   createServer as createHetznerServer,
   downloadFile,
   ensureHcloudToken,
@@ -71,6 +72,16 @@ async function main() {
       location = await promptLocation();
     },
     async createServer(name: string) {
+      // Proactively clean up orphaned Primary IPs before provisioning in headless
+      // mode (E2E batches). This prevents resource_limit_exceeded errors when
+      // previous test runs left behind unattached IPs that consume quota (#2933).
+      if (process.env.SPAWN_NON_INTERACTIVE === "1") {
+        const cleaned = await cleanupOrphanedPrimaryIps();
+        if (cleaned > 0) {
+          logInfo(`Pre-provisioning: cleaned ${cleaned} orphaned Primary IP(s)`);
+        }
+      }
+
       // Check for a pre-built snapshot before provisioning
       snapshotId = await findSpawnSnapshot(agentName);
       if (snapshotId) {

--- a/sh/e2e/lib/clouds/hetzner.sh
+++ b/sh/e2e/lib/clouds/hetzner.sh
@@ -221,10 +221,67 @@ _hetzner_teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# _hetzner_cleanup_orphaned_ips
+#
+# Delete Hetzner Primary IPs not attached to any server. These accumulate
+# from failed/interrupted provisioning runs and consume the account's
+# primary_ip_limit quota, causing resource_limit_exceeded errors (#2933).
+# ---------------------------------------------------------------------------
+_hetzner_cleanup_orphaned_ips() {
+  local response
+  response=$(_hetzner_curl_auth -sf \
+    "${_HETZNER_API}/primary_ips?per_page=50" 2>/dev/null || true)
+
+  if [ -z "${response}" ]; then
+    log_info "Could not list Hetzner primary IPs — skipping IP cleanup"
+    return 0
+  fi
+
+  local orphaned
+  orphaned=$(printf '%s' "${response}" | jq -r '.primary_ips[] | select(.assignee_id == null or .assignee_id == 0) | "\(.id):\(.ip)"' 2>/dev/null || true)
+
+  if [ -z "${orphaned}" ]; then
+    log_ok "No orphaned Hetzner Primary IPs found"
+    return 0
+  fi
+
+  local cleaned=0
+  for entry in ${orphaned}; do
+    local ip_id
+    ip_id=$(printf '%s' "${entry}" | cut -d: -f1)
+
+    local ip_addr
+    ip_addr=$(printf '%s' "${entry}" | cut -d: -f2-)
+
+    # Validate IP ID is numeric before using it in API URL
+    case "${ip_id}" in ''|*[!0-9]*) log_warn "Skipping orphaned IP ${entry} — non-numeric ID"; continue ;; esac
+
+    local http_code
+    http_code=$(_hetzner_curl_auth -s -o /dev/null -w '%{http_code}' \
+      -X DELETE \
+      "${_HETZNER_API}/primary_ips/${ip_id}" 2>/dev/null || printf '000')
+
+    if [ "${http_code}" = "200" ] || [ "${http_code}" = "204" ]; then
+      log_ok "Deleted orphaned Primary IP ${ip_addr} (id=${ip_id})"
+      cleaned=$((cleaned + 1))
+    elif [ "${http_code}" = "404" ]; then
+      log_info "Primary IP ${ip_addr} (id=${ip_id}) already gone"
+    else
+      log_warn "Failed to delete Primary IP ${ip_addr} (id=${ip_id}, HTTP ${http_code})"
+    fi
+  done
+
+  if [ "${cleaned}" -gt 0 ]; then
+    log_ok "Cleaned ${cleaned} orphaned Hetzner Primary IP(s)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # _hetzner_cleanup_stale
 #
 # List all Hetzner servers, find e2e-* instances older than 30 minutes,
-# and destroy them.
+# and destroy them. Also cleans up orphaned Primary IPs to prevent
+# resource_limit_exceeded errors (#2933).
 # ---------------------------------------------------------------------------
 _hetzner_cleanup_stale() {
   local now
@@ -312,6 +369,9 @@ _hetzner_cleanup_stale() {
   if [ "${skipped}" -gt 0 ]; then
     log_info "Skipped ${skipped} recent Hetzner instance(s)"
   fi
+
+  # Also clean up orphaned Primary IPs to free quota for new provisioning (#2933)
+  _hetzner_cleanup_orphaned_ips
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `_hetzner_cleanup_orphaned_ips()` to the E2E shell driver that deletes unattached Hetzner Primary IPs during pre-batch stale cleanup
- Adds proactive `cleanupOrphanedPrimaryIps()` call in `hetzner/main.ts` before `createServer()` in headless/non-interactive mode
- Bumps CLI version to 0.25.25

## Why

When running E2E tests in parallel (batch size 5+), agents fail with `resource_limit_exceeded` / `primary_ip_limit` because orphaned Primary IPs from previous failed/interrupted test runs consume the account's quota. The existing reactive cleanup (retry after failure) is insufficient because by the time agent N fails, agents 1..N-1 may have already consumed all available IPs.

The fix adds **proactive** cleanup at two levels:
1. **E2E shell driver** (`_hetzner_cleanup_stale`): cleans orphaned IPs during pre-batch cleanup alongside stale server cleanup
2. **TypeScript CLI** (`hetzner/main.ts`): cleans orphaned IPs before each `createServer()` call in headless mode

Fixes #2933

## Test plan
- [x] `bash -n` passes on modified shell script
- [x] `bunx @biomejs/biome check src/` passes (0 errors)
- [x] `bun test` passes (1886 tests, 0 failures)
- [ ] Verify in next E2E batch run that primary IP quota errors no longer occur

-- refactor/code-health