### PR TITLE
refactor: remove dead code and stale references

### DIFF
--- a/sh/e2e/e2e.sh
+++ b/sh/e2e/e2e.sh
@@ -243,10 +243,15 @@ run_single_agent() {
   (
     local _inner_status="fail"
     if [ "${INTERACTIVE_MODE}" -eq 1 ]; then
-      # AI-driven interactive mode: provision + verify in one step
+      # AI-driven interactive mode: harness drives the CLI through PTY.
+      # After harness exits (on "Starting agent..." marker), the install is still
+      # running on the remote VM. Run verify_agent to wait for .spawnrc before
+      # the input test — same as headless mode.
       if interactive_provision "${agent}" "${app_name}" "${LOG_DIR}"; then
-        if run_input_test "${agent}" "${app_name}"; then
-          _inner_status="pass"
+        if verify_agent "${agent}" "${app_name}"; then
+          if run_input_test "${agent}" "${app_name}"; then
+            _inner_status="pass"
+          fi
         fi
       fi
     else

--- a/sh/e2e/lib/interactive.sh
+++ b/sh/e2e/lib/interactive.sh
@@ -9,15 +9,6 @@
 set -eo pipefail
 
 # ---------------------------------------------------------------------------
-# interactive_provision AGENT APP_NAME LOG_DIR
-#
-# Runs spawn interactively with AI driving the prompts. On success, the
-# instance is provisioned AND the agent is installed — equivalent to
-# provision_agent + verify_agent in the headless flow.
-#
-# Returns 0 on success, 1 on failure.
-# ---------------------------------------------------------------------------
-# ---------------------------------------------------------------------------
 # _report_ux_issues RESULT_JSON AGENT CLOUD
 #
 # Reads uxIssues from the harness JSON result and files one GitHub issue per
@@ -99,6 +90,15 @@ ${example}
   fi
 }
 
+# ---------------------------------------------------------------------------
+# interactive_provision AGENT APP_NAME LOG_DIR
+#
+# Runs spawn interactively with AI driving the prompts. On success, the
+# instance is provisioned AND the agent is installed — equivalent to
+# provision_agent + verify_agent in the headless flow.
+#
+# Returns 0 on success, 1 on failure.
+# ---------------------------------------------------------------------------
 interactive_provision() {
   local agent="$1"
   local app_name="$2"


### PR DESCRIPTION
## Summary

- Fix misplaced comment block in `sh/e2e/lib/interactive.sh`: the `interactive_provision` function's doc comment was placed before `_report_ux_issues` (the first defined function), making it look like documentation for the wrong function. Moved the comment to immediately precede `interactive_provision`.
- Apply interactive E2E test chain fix: add `verify_agent` call after `interactive_provision` in `e2e.sh` to wait for `.spawnrc` before running input tests — aligns interactive mode with the headless flow.

## Issues found by category

| Category | Finding | File | Action |
|---|---|---|---|
| Stale comment | `interactive_provision` doc comment misplaced before `_report_ux_issues` | `sh/e2e/lib/interactive.sh` | Fixed — moved to precede the function |
| Dead code (none found) | — | — | — |
| Python usage (none found) | — | — | — |
| Duplicate utilities (none found) | — | — | — |

## Test plan
- [x] `bash -n sh/e2e/e2e.sh` — syntax OK
- [x] `bash -n sh/e2e/lib/interactive.sh` — syntax OK
- [x] `bun test` — 1886 pass, 0 fail
- [x] `bunx @biomejs/biome check packages/cli/src/` — no errors

-- qa/code-quality