### PR TITLE
fix(qa): stash before pull, fix star count push, fix claude update flag

### DIFF
--- a/.claude/skills/setup-agent-team/qa.sh
+++ b/.claude/skills/setup-agent-team/qa.sh
@@ -164,8 +164,11 @@ log "Pre-cycle cleanup..."
 git fetch --prune origin 2>&1 | tee -a "${LOG_FILE}" || true
 
 if [[ "${RUN_MODE}" == "quality" ]]; then
-    # Quality mode syncs to latest main
+    # Quality mode syncs to latest main.
+    # Stash any local modifications first so rebase doesn't abort.
+    git stash --include-untracked 2>&1 | tee -a "${LOG_FILE}" || true
     git pull --rebase origin main 2>&1 | tee -a "${LOG_FILE}" || true
+    git stash pop 2>&1 | tee -a "${LOG_FILE}" || true
 fi
 
 # Clean stale worktrees
@@ -214,6 +217,8 @@ if [[ "${RUN_MODE}" == "quality" ]]; then
     if [[ -n "$(git diff --name-only -- manifest.json)" ]]; then
         git add manifest.json
         git commit -m "chore: update agent GitHub star counts" 2>&1 | tee -a "${LOG_FILE}" || true
+        # Pull latest before pushing to avoid non-fast-forward rejection
+        git pull --rebase origin main 2>&1 | tee -a "${LOG_FILE}" || true
         git push origin main 2>&1 | tee -a "${LOG_FILE}" || true
         log "Star counts committed"
     fi
@@ -282,7 +287,7 @@ fi
 
 # Update Claude Code to latest version before launching
 log "Updating Claude Code..."
-claude update --yes 2>&1 | tee -a "${LOG_FILE}" || log "WARNING: Claude Code update failed (continuing with current version)"
+claude update 2>&1 | tee -a "${LOG_FILE}" || log "WARNING: Claude Code update failed (continuing with current version)"
 
 # Launch Claude Code with mode-specific prompt
 # Enable agent teams (required for team-based workflows)

--- a/sh/e2e/interactive-harness.ts
+++ b/sh/e2e/interactive-harness.ts
@@ -265,7 +265,7 @@ RULES:
 3. When asked for a name with a default shown in [brackets], press Enter to accept
 4. When shown a selection menu (with arrows/highlights), press Enter to accept the default
 5. If you see "Try again? (Y/n)" or similar retry prompts, respond with "y"
-6. When you see "is ready" or "Starting agent", respond with <done>
+6. When you see "Starting agent..." or "setup completed successfully", respond with <done>
 7. If something is clearly broken and unrecoverable, respond with <fail:reason>
 8. If the terminal is still loading/processing, respond with <wait>
 


### PR DESCRIPTION
## Summary

- **`git stash` before `git pull --rebase`** — the pull was aborting every single cycle because local changes in the working tree (unstaged files) blocked it. Stash + pop around the pull fixes this permanently.
- **Pull before pushing star counts** — the star count commit was failing with non-fast-forward every cycle because the pull above failed. Adding `git pull --rebase` before the push makes this atomic.
- **Remove `--yes` from `claude update`** — this flag was removed from Claude Code and caused a logged error every cycle.
- **Fix interactive harness AI prompt** — rule #6 said to respond `<done>` on `"is ready" or "Starting agent"` but the code checks for `"Starting agent..."` or `"setup completed successfully"`. Align the prompt with the code.

## Root cause

The local main on the QA VM had diverged 8 commits (all orphaned star count commits) from origin (41 commits ahead). Every cycle the pull failed → star count commit couldn't push → repeat. This was also masking all other QA diagnostics since the log showed nothing useful.

## Test plan

- [ ] Next quality cycle pull should succeed without "unstaged changes" error
- [ ] Star count commits should push cleanly
- [ ] `claude update` should no longer log an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)