### PR TITLE
fix(e2e): suppress matrix email on targeted re-runs via SPAWN_E2E_SKIP_EMAIL

### DIFF
--- a/.claude/skills/setup-agent-team/qa-quality-prompt.md
+++ b/.claude/skills/setup-agent-team/qa-quality-prompt.md
@@ -161,7 +161,8 @@ cd REPO_ROOT_PLACEHOLDER && git worktree remove WORKTREE_BASE_PLACEHOLDER/TASK_N
    - `sh/e2e/lib/common.sh` — API helpers, constants
    - `sh/e2e/lib/teardown.sh` — cleanup logic
 7. Run `bash -n` on every modified `.sh` file
-8. Re-run only the failed agents: `./sh/e2e/e2e.sh --cloud CLOUD AGENT_NAME`
+8. Re-run only the failed agents: `SPAWN_E2E_SKIP_EMAIL=1 ./sh/e2e/e2e.sh --cloud CLOUD AGENT_NAME`
+   (SPAWN_E2E_SKIP_EMAIL=1 suppresses the matrix email on partial re-runs — a partial email falsely looks like all-passed)
 9. If changes were made: commit, push, open a PR (NOT draft) with title "fix(e2e): [description]"
 10. Clean up worktree when done
 11. Report: clouds tested, clouds skipped, agents passed, agents failed, fixed

--- a/sh/e2e/e2e.sh
+++ b/sh/e2e/e2e.sh
@@ -508,6 +508,14 @@ send_matrix_email() {
   local total_fail="$5"
   local duration_str="$6"
 
+  # Skip email for targeted re-runs (partial agent/cloud subset).
+  # Set SPAWN_E2E_SKIP_EMAIL=1 to suppress the email (used by quality cycle
+  # when re-running only failed agents — a partial email looks like all-passed).
+  if [ "${SPAWN_E2E_SKIP_EMAIL:-0}" = "1" ]; then
+    log_info "Matrix email skipped (SPAWN_E2E_SKIP_EMAIL=1)"
+    return 0
+  fi
+
   local resend_key="${RESEND_API_KEY:-}"
   local to_email="${KEY_REQUEST_EMAIL:-}"
 


### PR DESCRIPTION
## Summary

- Add `SPAWN_E2E_SKIP_EMAIL=1` env var to `send_matrix_email` — when set, skips the Resend email entirely
- Update `qa-quality-prompt.md` to prefix re-run commands with `SPAWN_E2E_SKIP_EMAIL=1`

## Root cause

The quality cycle e2e-tester runs `e2e.sh --cloud all` first (30+ tests), then re-runs only failed agents (e.g. `e2e.sh --cloud hetzner zeroclaw codex` = 2 tests). Both invocations fired a matrix email. The second email showed "2 passed" with no context, making it look like the entire test suite passed when it hadn't.

In the case that triggered this: zeroclaw and codex failed due to Hetzner primary IP quota exhaustion during the parallel batch. Once the other VMs tore down, their IPs freed up and the retry genuinely passed — but the email was still misleading.

## Test plan

- [ ] `SPAWN_E2E_SKIP_EMAIL=1 ./sh/e2e/e2e.sh --cloud hetzner zeroclaw` should log "Matrix email skipped (SPAWN_E2E_SKIP_EMAIL=1)" and send no email
- [ ] `./sh/e2e/e2e.sh --cloud all` (no flag) should still send the full matrix email as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)