### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/do-min-size.test.ts
+++ b/packages/cli/src/__tests__/do-min-size.test.ts
@@ -6,27 +6,47 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { AGENT_MIN_SIZE, slugRamGb } from "../digitalocean/digitalocean.js";
 
-const CLI_SRC = resolve(import.meta.dir, "..");
-const source = readFileSync(resolve(CLI_SRC, "digitalocean/main.ts"), "utf-8");
-
-describe("DigitalOcean minimum droplet size enforcement", () => {
-  it("uses slugRamGb comparison instead of hardcoded slug equality", () => {
-    // The old bug: dropletSize === "s-2vcpu-2gb" only caught the exact default
-    expect(source).not.toContain('dropletSize === "s-2vcpu-2gb"');
-    // The fix: compare RAM parsed from slugs
-    expect(source).toContain("slugRamGb(dropletSize) < slugRamGb(minSize)");
+describe("slugRamGb", () => {
+  it("parses RAM from standard DO slugs", () => {
+    expect(slugRamGb("s-2vcpu-2gb")).toBe(2);
+    expect(slugRamGb("s-2vcpu-4gb")).toBe(4);
+    expect(slugRamGb("s-4vcpu-8gb")).toBe(8);
   });
 
-  it("defines slugRamGb helper to parse RAM from DO slugs", () => {
-    expect(source).toContain("function slugRamGb(slug: string): number");
-    // Should use a regex to extract the GB number from the slug
-    expect(source).toContain("(\\d+)gb");
+  it("parses RAM from intel-variant slugs", () => {
+    expect(slugRamGb("s-2vcpu-4gb-intel")).toBe(4);
+    expect(slugRamGb("s-2vcpu-2gb-intel")).toBe(2);
   });
 
-  it("AGENT_MIN_SIZE includes openclaw with 4gb minimum", () => {
-    expect(source).toContain('openclaw: "s-2vcpu-4gb"');
+  it("returns 0 for unparseable slugs", () => {
+    expect(slugRamGb("")).toBe(0);
+    expect(slugRamGb("unknown-slug")).toBe(0);
+    expect(slugRamGb("s-2vcpu")).toBe(0);
+  });
+
+  it("allows RAM comparison between slugs for min-size enforcement", () => {
+    // a 2gb slug is below the 4gb minimum
+    expect(slugRamGb("s-2vcpu-2gb")).toBeLessThan(slugRamGb("s-2vcpu-4gb"));
+    // a 4gb slug satisfies the 4gb minimum
+    expect(slugRamGb("s-2vcpu-4gb")).not.toBeLessThan(slugRamGb("s-2vcpu-4gb"));
+    // an 8gb slug also satisfies the 4gb minimum
+    expect(slugRamGb("s-4vcpu-8gb")).toBeGreaterThan(slugRamGb("s-2vcpu-4gb"));
+  });
+});
+
+describe("AGENT_MIN_SIZE", () => {
+  it("requires at least 4GB for openclaw", () => {
+    const minSlug = AGENT_MIN_SIZE["openclaw"];
+    expect(minSlug).toBeDefined();
+    expect(slugRamGb(minSlug!)).toBeGreaterThanOrEqual(4);
+  });
+
+  it("maps agent names to valid DO slugs", () => {
+    for (const [agent, slug] of Object.entries(AGENT_MIN_SIZE)) {
+      expect(typeof agent).toBe("string");
+      expect(slugRamGb(slug)).toBeGreaterThan(0);
+    }
   });
 });

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -907,6 +907,19 @@ const DROPLET_SIZES: DropletSize[] = [
 
 export const DEFAULT_DROPLET_SIZE = "s-2vcpu-2gb";
 
+/** Extract RAM in GB from a DO slug like "s-2vcpu-4gb" or "s-2vcpu-4gb-intel". Returns 0 if unparseable. */
+export function slugRamGb(slug: string): number {
+  const match = slug.match(/-(\d+)gb/);
+  return match ? Number(match[1]) : 0;
+}
+
+/** Agents that need more than the default 2GB RAM (e.g. openclaw-plugins OOMs on 2GB) */
+export const AGENT_MIN_SIZE: Record<string, string> = {
+  // s-2vcpu-4gb is used (not s-2vcpu-4gb-intel) because the intel variant
+  // is no longer available in nyc3 (the default E2E region). Both offer 2 vCPUs and 4GB RAM.
+  openclaw: "s-2vcpu-4gb",
+};
+
 // ─── Region Options ──────────────────────────────────────────────────────────
 
 interface DoRegion {

--- a/packages/cli/src/digitalocean/main.ts
+++ b/packages/cli/src/digitalocean/main.ts
@@ -9,6 +9,7 @@ import { runOrchestration } from "../shared/orchestrate.js";
 import { logInfo } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
+  AGENT_MIN_SIZE,
   checkAccountStatus,
   createServer as createDroplet,
   downloadFile,
@@ -21,23 +22,11 @@ import {
   promptDropletSize,
   promptSpawnName,
   runServer,
+  slugRamGb,
   uploadFile,
   waitForCloudInit,
   waitForSshOnly,
 } from "./digitalocean.js";
-
-/** Agents that need more than the default 2GB RAM (e.g. openclaw-plugins OOMs on 2GB) */
-const AGENT_MIN_SIZE: Record<string, string> = {
-  // s-2vcpu-4gb is used (not s-2vcpu-4gb-intel) because the intel variant
-  // is no longer available in nyc3 (the default E2E region). Both offer 2 vCPUs and 4GB RAM.
-  openclaw: "s-2vcpu-4gb",
-};
-
-/** Extract RAM in GB from a DO slug like "s-2vcpu-4gb" or "s-2vcpu-4gb-intel". Returns 0 if unparseable. */
-function slugRamGb(slug: string): number {
-  const match = slug.match(/-(\d+)gb/);
-  return match ? Number(match[1]) : 0;
-}
 
 /** DO marketplace image slugs — hardcoded from vendor portal (approved 2026-03-13) */
 const MARKETPLACE_IMAGES: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Replaced 3 bash-grep style tests in `do-min-size.test.ts` that read source files via `readFileSync` and checked for string presence — an anti-pattern that tests implementation details, not behavior
- Exported `slugRamGb` and `AGENT_MIN_SIZE` from `digitalocean/digitalocean.ts` (moved from `main.ts` which runs on import, making it untestable)
- Rewrote tests to call functions directly with inputs and assert on outputs: 3 source-grep tests → 6 real behavior tests

## Anti-pattern fixed

**Before** (tests read source code, not behavior):
```typescript
const source = readFileSync(resolve(CLI_SRC, "digitalocean/main.ts"), "utf-8");
it("uses slugRamGb comparison instead of hardcoded slug equality", () => {
  expect(source).not.toContain('dropletSize === "s-2vcpu-2gb"');
  expect(source).toContain("slugRamGb(dropletSize) < slugRamGb(minSize)");
});
```

**After** (tests call functions and assert outputs):
```typescript
import { AGENT_MIN_SIZE, slugRamGb } from "../digitalocean/digitalocean.js";
it("parses RAM from standard DO slugs", () => {
  expect(slugRamGb("s-2vcpu-2gb")).toBe(2);
  expect(slugRamGb("s-2vcpu-4gb")).toBe(4);
});
```

## Test plan
- [x] `bun test` passes: 1950 tests, 0 failures (was 1947 before — 3 new tests added net)
- [x] `bunx @biomejs/biome check src/` passes with zero errors

-- qa/dedup-scanner