### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/__tests__/README.md
+++ b/packages/cli/src/__tests__/README.md
@@ -118,6 +118,7 @@ bun test src/__tests__/manifest.test.ts
 - `agent-tarball.test.ts` — `tryTarballInstall`: GitHub Release tarball install, fallback, URL validation
 - `gateway-resilience.test.ts` — `startGateway` systemd unit with auto-restart and cron heartbeat
 - `digitalocean-token.test.ts` — DigitalOcean token storage, retrieval, and API client helpers
+- `do-min-size.test.ts` — DigitalOcean minimum droplet size enforcement: `slugRamGb` RAM comparison, `AGENT_MIN_SIZE` map
 - `do-payment-warning.test.ts` — `ensureDoToken` proactive payment method reminder for first-time DigitalOcean users
 - `do-snapshot.test.ts` — `findSpawnSnapshot`: DigitalOcean snapshot lookup, filtering, error handling
 - `hetzner-pagination.test.ts` — Hetzner API pagination: multi-page server listing and cursor handling
@@ -140,6 +141,9 @@ bun test src/__tests__/manifest.test.ts
 
 ### Manifest (extended)
 - `icon-integrity.test.ts` — Icon file existence and format validation
+
+### Docker mode
+- `docker-cloudinit-skip.test.ts` — Docker mode skips cloud-init wait: Hetzner and GCP `waitForReady` condition includes `useDocker` flag
 
 ### Support files (not test files)
 - `test-helpers.ts` — Shared fixtures: `createMockManifest`, `mockClackPrompts`, `setupTestEnvironment`, etc.


### PR DESCRIPTION
## Summary

- Scanned all `sh/shared/*.sh`, `packages/cli/src/`, and `sh/e2e/` for dead code, stale references, python usage, and duplicate utilities — no issues found in these categories
- Found and documented 2 test files that existed on disk but were missing from `packages/cli/src/__tests__/README.md`:
  - `do-min-size.test.ts` — DigitalOcean minimum droplet size enforcement (`slugRamGb` comparison)
  - `docker-cloudinit-skip.test.ts` — Docker mode skips cloud-init wait for Hetzner and GCP

## Findings by category

**a) Dead code**: None found. All functions in `sh/shared/*.sh` and TypeScript exports have callers.

**b) Stale references**: None found. All imports reference existing files; all shell script `source` calls point to existing files.

**c) Python usage**: None found. No `python3 -c` or `python -c` in any shell scripts.

**d) Duplicate utilities**: None found. Cloud modules (`aws/`, `hetzner/`, `gcp/`, `digitalocean/`) share utilities through `shared/` correctly.

**e) Stale comments**: None found. Existing `# unused but part of the interface` comments are accurate.

## Test plan
- [x] `bash -n` passes on all `.sh` files
- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — 1947 pass, 0 fail

-- qa/code-quality