### PR TITLE
fix(fix): add missing LANG export to buildFixScript

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.26",
+  "version": "0.25.27",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/cmd-fix.test.ts
+++ b/packages/cli/src/__tests__/cmd-fix.test.ts
@@ -50,6 +50,7 @@ describe("buildFixScript", () => {
     expect(script).toContain("set -eo pipefail");
     expect(script).toContain("Re-injecting credentials");
     expect(script).toContain("IS_SANDBOX");
+    expect(script).toContain("LANG=");
     expect(script).toContain(".npm-global/bin");
     expect(script).toContain(".bun/bin");
     expect(script).toContain(".cargo/bin");
@@ -130,21 +131,27 @@ describe("buildFixScript", () => {
     expect(script).toContain("Re-installing agent");
   });
 
-  it("prepends IS_SANDBOX and PATH before agent env vars (matches generateEnvConfig)", () => {
+  it("prepends IS_SANDBOX, LANG, and PATH before agent env vars (matches generateEnvConfig)", () => {
     const script = buildFixScript(mockManifest, "claude");
 
     const isSandboxIdx = script.indexOf("IS_SANDBOX");
+    const langIdx = script.indexOf("LANG=");
     const pathIdx = script.indexOf(".npm-global/bin");
     const anthropicIdx = script.indexOf("ANTHROPIC_API_KEY");
 
-    // All three must be present
+    // All four must be present
     expect(isSandboxIdx).toBeGreaterThan(-1);
+    expect(langIdx).toBeGreaterThan(-1);
     expect(pathIdx).toBeGreaterThan(-1);
     expect(anthropicIdx).toBeGreaterThan(-1);
 
-    // IS_SANDBOX and PATH must come before agent-specific env vars
+    // IS_SANDBOX, LANG, PATH must come before agent-specific env vars
     expect(isSandboxIdx).toBeLessThan(anthropicIdx);
+    expect(langIdx).toBeLessThan(anthropicIdx);
     expect(pathIdx).toBeLessThan(anthropicIdx);
+    // LANG must come after IS_SANDBOX and before PATH
+    expect(isSandboxIdx).toBeLessThan(langIdx);
+    expect(langIdx).toBeLessThan(pathIdx);
   });
 
   it("throws for unknown agent", () => {

--- a/packages/cli/src/commands/fix.ts
+++ b/packages/cli/src/commands/fix.ts
@@ -51,8 +51,9 @@ export function buildFixScript(manifest: Manifest, agentKey: string): string {
   lines.push("echo '==> Re-injecting credentials...'");
   // Write new .spawnrc atomically: write to .new then mv into place
   lines.push("{");
-  // Always prepend IS_SANDBOX and PATH — matches generateEnvConfig() in shared/agents.ts
+  // Always prepend IS_SANDBOX, LANG, and PATH — matches generateEnvConfig() in shared/agents.ts
   lines.push("  printf 'export IS_SANDBOX=\\x271\\x27\\n'");
+  lines.push("  printf 'export LANG=\\x27C.UTF-8\\x27\\n'");
   lines.push(
     "  printf 'export PATH=\"$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.claude/local/bin:/usr/local/bin:$PATH\"\\n'",
   );


### PR DESCRIPTION
**Why:** `spawn fix` regenerates `.spawnrc` without `export LANG='C.UTF-8'`, causing garbled Unicode rendering in agent TUIs (e.g., Claude Code) on fixed spawns. This is a half-migration from commit f93c799d which added the locale export to `generateEnvConfig()` but missed the parallel `buildFixScript()` path.

## Changes

- `packages/cli/src/commands/fix.ts`: Add `printf 'export LANG=\x27C.UTF-8\x27\n'` between IS_SANDBOX and PATH, with updated comment
- `packages/cli/src/__tests__/cmd-fix.test.ts`: Add `LANG=` containment assertion + ordering assertion (IS_SANDBOX < LANG < PATH < agent vars) to lock in the fix
- `packages/cli/package.json`: Patch version bump 0.25.26 → 0.25.27

## Test plan

- [x] `bun test` — 1889 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` — 0 errors

-- refactor/code-health