### PR TITLE
refactor(test): extract shouldSkipCloudInit helper and add unit tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.27",
+  "version": "0.25.28",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/cloud-init.test.ts
+++ b/packages/cli/src/__tests__/cloud-init.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getPackagesForTier, needsBun, needsNode } from "../shared/cloud-init.js";
+import { getPackagesForTier, needsBun, needsNode, shouldSkipCloudInit } from "../shared/cloud-init.js";
 
 describe("getPackagesForTier", () => {
   const MINIMAL_PACKAGES = [
@@ -111,5 +111,78 @@ describe("needsBun", () => {
   }
   it("defaults to true (full tier)", () => {
     expect(needsBun()).toBe(true);
+  });
+});
+
+describe("shouldSkipCloudInit", () => {
+  it("returns true when useDocker is true", () => {
+    expect(
+      shouldSkipCloudInit({
+        useDocker: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when snapshotId is a non-null string", () => {
+    expect(
+      shouldSkipCloudInit({
+        useDocker: false,
+        snapshotId: "snap-123",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when skipCloudInit is true", () => {
+    expect(
+      shouldSkipCloudInit({
+        useDocker: false,
+        skipCloudInit: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when all flags are off", () => {
+    expect(
+      shouldSkipCloudInit({
+        useDocker: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when snapshotId is null", () => {
+    expect(
+      shouldSkipCloudInit({
+        useDocker: false,
+        snapshotId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when snapshotId is undefined", () => {
+    expect(
+      shouldSkipCloudInit({
+        useDocker: false,
+        snapshotId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when skipCloudInit is false", () => {
+    expect(
+      shouldSkipCloudInit({
+        useDocker: false,
+        skipCloudInit: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when multiple flags are set", () => {
+    expect(
+      shouldSkipCloudInit({
+        useDocker: true,
+        snapshotId: "snap-1",
+        skipCloudInit: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/cli/src/gcp/main.ts
+++ b/packages/cli/src/gcp/main.ts
@@ -5,6 +5,7 @@
 import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import { shouldSkipCloudInit } from "../shared/cloud-init.js";
 import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY, runOrchestration } from "../shared/orchestrate.js";
 import { logInfo, logStep, shellQuote } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
@@ -85,7 +86,12 @@ async function main() {
     },
     getServerName,
     async waitForReady() {
-      if (useDocker || cloud.skipCloudInit) {
+      if (
+        shouldSkipCloudInit({
+          useDocker,
+          skipCloudInit: cloud.skipCloudInit,
+        })
+      ) {
         await waitForSshOnly();
       } else {
         await waitForCloudInit();

--- a/packages/cli/src/hetzner/main.ts
+++ b/packages/cli/src/hetzner/main.ts
@@ -5,6 +5,7 @@
 import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import { shouldSkipCloudInit } from "../shared/cloud-init.js";
 import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY, runOrchestration } from "../shared/orchestrate.js";
 import { logInfo, logStep, shellQuote } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
@@ -98,7 +99,13 @@ async function main() {
     },
     getServerName,
     async waitForReady() {
-      if (useDocker || snapshotId || cloud.skipCloudInit) {
+      if (
+        shouldSkipCloudInit({
+          useDocker,
+          snapshotId,
+          skipCloudInit: cloud.skipCloudInit,
+        })
+      ) {
         await waitForSshOnly();
       } else {
         await waitForCloudInit();

--- a/packages/cli/src/shared/cloud-init.ts
+++ b/packages/cli/src/shared/cloud-init.ts
@@ -46,3 +46,15 @@ export function needsNode(tier: CloudInitTier = "full"): boolean {
 export function needsBun(tier: CloudInitTier = "full"): boolean {
   return tier === "bun" || tier === "full";
 }
+
+/**
+ * Determines whether cloud-init wait should be skipped in favor of SSH-only wait.
+ * Extracted from the inline condition in hetzner/main.ts and gcp/main.ts.
+ */
+export function shouldSkipCloudInit(opts: {
+  useDocker: boolean;
+  snapshotId?: string | null | undefined;
+  skipCloudInit?: boolean;
+}): boolean {
+  return opts.useDocker || opts.snapshotId != null || (opts.skipCloudInit ?? false);
+}


### PR DESCRIPTION
**Why:** The theatrical source-grep test for docker-mode waitForReady was removed in #2953, but no real behavior tests were added. This extracts the condition into a testable exported function and adds a real unit test importing from the live source. Fixes #2952.

## Changes
- `packages/cli/src/shared/cloud-init.ts`: new exported `shouldSkipCloudInit` helper
- `packages/cli/src/hetzner/main.ts`: use `shouldSkipCloudInit` instead of inline condition
- `packages/cli/src/gcp/main.ts`: use `shouldSkipCloudInit` instead of inline condition  
- `packages/cli/src/__tests__/cloud-init.test.ts`: 8 real unit tests importing from source
- `packages/cli/package.json`: version bump 0.25.27 → 0.25.28

## Test plan
- [x] `bun test` — all 1895 tests pass
- [x] `bunx @biomejs/biome check src/` — 0 errors

-- refactor/test-engineer