### PR TITLE
fix: rewrite git+ssh to HTTPS for hermes pip install on cloud VMs (fixes #2955)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.28",
+  "version": "0.25.29",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -1030,7 +1030,11 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         installAgent(
           runner,
           "Hermes Agent",
-          "curl --proto '=https' -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
+          // Force git to use HTTPS instead of SSH for GitHub URLs — pip dependencies
+          // using git+ssh:// timeout on cloud VMs where outbound SSH is blocked/slow.
+          'git config --global url."https://github.com/".insteadOf "ssh://git@github.com/" && ' +
+            'git config --global url."https://github.com/".insteadOf "git@github.com:" && ' +
+            "curl --proto '=https' -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
           600,
         ),
       envVars: (apiKey) => [
@@ -1050,6 +1054,9 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       launchCmd: () =>
         "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.local/bin:$HOME/.hermes/hermes-agent/venv/bin:$PATH; hermes",
       updateCmd:
+        // Same SSH→HTTPS rewrite for auto-update runs
+        'git config --global url."https://github.com/".insteadOf "ssh://git@github.com/" && ' +
+        'git config --global url."https://github.com/".insteadOf "git@github.com:" && ' +
         "curl --proto '=https' -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
     },
 


### PR DESCRIPTION
**Why:** Hermes fails to install on hetzner/gcp/digitalocean because the mini-swe-agent pip dependency uses `git+ssh://` URLs that timeout on fresh cloud VMs where outbound SSH to GitHub is blocked or slow. PR #2956 increased the timeout but didn't address the root cause.

## Changes

- **`packages/cli/src/shared/agent-setup.ts`**: Add `git config --global url."https://github.com/".insteadOf` rules before the hermes install command and `updateCmd` to rewrite `git+ssh://git@github.com/` and `git@github.com:` to HTTPS. This eliminates the SSH connection timeout at the source.
- **`packages/cli/package.json`**: Version bump 0.25.28 → 0.25.29

## How it works

Before running the hermes install script, we configure git globally on the remote VM to rewrite SSH-based GitHub URLs to HTTPS:
```
git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
git config --global url."https://github.com/".insteadOf "git@github.com:"
```

This means when pip encounters a `git+ssh://git@github.com/...` dependency, git transparently rewrites it to `git+https://github.com/...`, which works reliably on all cloud VMs without SSH key setup.

Fixes #2955

-- refactor/ux-engineer