### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.29",
+  "version": "0.25.30",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/gcp/main.ts
+++ b/packages/cli/src/gcp/main.ts
@@ -6,7 +6,7 @@ import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
 import { shouldSkipCloudInit } from "../shared/cloud-init.js";
-import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY, runOrchestration } from "../shared/orchestrate.js";
+import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY, makeDockerExec, runOrchestration } from "../shared/orchestrate.js";
 import { logInfo, logStep, shellQuote } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
@@ -48,16 +48,13 @@ async function main() {
     useDocker = true;
   }
 
-  /** Wrap a command to run inside the Docker container instead of the host. */
-  function dockerExec(cmd: string): string {
-    return `docker exec ${DOCKER_CONTAINER_NAME} bash -c ${shellQuote(cmd)}`;
-  }
-
   const cloud: CloudOrchestrator = {
     cloudName: "gcp",
     cloudLabel: "GCP Compute Engine",
     runner: {
-      runServer: useDocker ? (cmd: string, timeoutSecs?: number) => runServer(dockerExec(cmd), timeoutSecs) : runServer,
+      runServer: useDocker
+        ? (cmd: string, timeoutSecs?: number) => runServer(makeDockerExec(cmd), timeoutSecs)
+        : runServer,
       uploadFile,
       downloadFile,
     },

--- a/packages/cli/src/hetzner/main.ts
+++ b/packages/cli/src/hetzner/main.ts
@@ -6,7 +6,7 @@ import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
 import { shouldSkipCloudInit } from "../shared/cloud-init.js";
-import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY, runOrchestration } from "../shared/orchestrate.js";
+import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY, makeDockerExec, runOrchestration } from "../shared/orchestrate.js";
 import { logInfo, logStep, shellQuote } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
@@ -49,17 +49,14 @@ async function main() {
     useDocker = true;
   }
 
-  /** Wrap a command to run inside the Docker container instead of the host. */
-  function dockerExec(cmd: string): string {
-    return `docker exec ${DOCKER_CONTAINER_NAME} bash -c ${shellQuote(cmd)}`;
-  }
-
   const cloud: CloudOrchestrator = {
     cloudName: "hetzner",
     cloudLabel: "Hetzner Cloud",
     skipAgentInstall: false,
     runner: {
-      runServer: useDocker ? (cmd: string, timeoutSecs?: number) => runServer(dockerExec(cmd), timeoutSecs) : runServer,
+      runServer: useDocker
+        ? (cmd: string, timeoutSecs?: number) => runServer(makeDockerExec(cmd), timeoutSecs)
+        : runServer,
       uploadFile,
       downloadFile,
     },

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -39,6 +39,11 @@ export const DOCKER_CONTAINER_NAME = "spawn-agent";
 /** Docker registry hosting spawn agent images. */
 export const DOCKER_REGISTRY = "ghcr.io/openrouterteam";
 
+/** Wrap a command to run inside the Docker container instead of the host. */
+export function makeDockerExec(cmd: string): string {
+  return `docker exec ${DOCKER_CONTAINER_NAME} bash -c ${shellQuote(cmd)}`;
+}
+
 export interface CloudOrchestrator {
   cloudName: string;
   cloudLabel: string;


### PR DESCRIPTION
## Summary

- Extracted duplicate `dockerExec` helper function that existed identically in both `gcp/main.ts` and `hetzner/main.ts` into a shared `makeDockerExec()` exported from `shared/orchestrate.ts`
- Both local functions wrapped commands with `docker exec ${DOCKER_CONTAINER_NAME} bash -c ${shellQuote(cmd)}` — identical implementations
- Both callers already imported from `shared/orchestrate.ts` so no new import dependency was added

## Scan results by category

**a) Dead code**: None found — all functions in `sh/shared/*.sh` and `packages/cli/src/` are called.

**b) Stale references**: None found — all sourced files in e2e scripts exist, all TypeScript imports resolve.

**c) Python usage**: None found — no `python3 -c` or `python -c` calls in shell scripts.

**d) Duplicate utilities**: Found and fixed — `dockerExec` function was defined identically in `gcp/main.ts` and `hetzner/main.ts`. Extracted to `shared/orchestrate.ts` as `makeDockerExec()`.

**e) Stale comments**: None found requiring removal.

## Test plan
- [x] `bunx @biomejs/biome check` — 0 errors
- [x] `bun test` — 1956 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)