### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/agent-setup-cov.test.ts
+++ b/packages/cli/src/__tests__/agent-setup-cov.test.ts
@@ -199,11 +199,6 @@ describe("createCloudAgents", () => {
     expect(runner.runServer).not.toHaveBeenCalled();
   });
 
-  it("junie agent envVars include JUNIE_OPENROUTER_API_KEY", () => {
-    const envVars = result.agents.junie.envVars("sk-or-v1-test");
-    expect(envVars.some((v: string) => v.includes("JUNIE_OPENROUTER_API_KEY"))).toBe(true);
-  });
-
   it("kilocode agent envVars include KILO_PROVIDER_TYPE", () => {
     const envVars = result.agents.kilocode.envVars("sk-or-v1-test");
     expect(envVars.some((v: string) => v.includes("KILO_PROVIDER_TYPE=openrouter"))).toBe(true);


### PR DESCRIPTION
## Summary

- Scanned all 97 test files (1890 tests) across `packages/cli/src/__tests__/` for duplicate describe blocks, bash-grep tests, always-pass patterns, and excessive subprocess spawning
- Found one genuine duplicate: `agent-setup-cov.test.ts` contained a weaker version of a junie env var test that is fully superseded by the more precise assertions in `junie-agent.test.ts`
- Removed the duplicate test; all 1889 remaining tests pass with 0 regressions

## Findings

**No bash-grep tests**: No tests use `type FUNCTION_NAME` or grep function bodies — all tests call functions directly.

**No always-pass patterns**: The `if (!result.ok)` blocks in `orchestrate.test.ts` are type-narrowing guards after an unconditional `expect(result.ok).toBe(false)`, not conditional skips.

**No excessive subprocess spawning**: All `spawnSync`/`Bun.spawn` references in tests are `spyOn` mocks, not real subprocess invocations.

**One duplicate removed**: `agent-setup-cov.test.ts` line 202–205 tested `JUNIE_OPENROUTER_API_KEY` existence (weak: `some(v => v.includes(...))`) while `junie-agent.test.ts` verifies the exact value (`JUNIE_OPENROUTER_API_KEY=sk-or-v1-test-key`). The weaker duplicate was removed.

## Test plan
- [x] `bun test` passes: 1889 tests, 0 failures
- [x] Removed test was a strict subset of coverage already in `junie-agent.test.ts`

-- qa/dedup-scanner