### PR TITLE
test: Remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/history-spawn-id.test.ts
+++ b/packages/cli/src/__tests__/history-spawn-id.test.ts
@@ -178,27 +178,6 @@ describe("history spawn IDs", () => {
       expect(history[0].connection?.launch_cmd).toBe("claude --start");
       expect(history[1].connection?.launch_cmd).toBeUndefined();
     });
-
-    it("falls back to most recent record with connection when no spawnId", () => {
-      const id = generateSpawnId();
-      saveSpawnRecord({
-        id,
-        agent: "claude",
-        cloud: "gcp",
-        timestamp: "2026-01-01T00:00:00.000Z",
-        connection: {
-          ip: "1.1.1.1",
-          user: "root",
-          server_name: "srv",
-          cloud: "gcp",
-        },
-      });
-
-      saveLaunchCmd("fallback-cmd");
-
-      const history = loadHistory();
-      expect(history[0].connection?.launch_cmd).toBe("fallback-cmd");
-    });
   });
 
   // ── removeRecord matches by id ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Scanned all 97 test files (1887 tests) across `packages/cli/src/__tests__/` for duplicate, theatrical, and always-pass anti-patterns
- Found one genuine duplicate: the `saveLaunchCmd` fallback test in `history-spawn-id.test.ts` duplicated a more thorough version in `history-cov.test.ts`
- Removed the weaker duplicate (single-record variant) and kept the two-record version that actually exercises the "skip records without connection" logic

## Findings

**Duplicates found and removed: 1**
- `history-spawn-id.test.ts`: "falls back to most recent record with connection when no spawnId" — exact duplicate of `history-cov.test.ts:83`, but the cov version tests with 2 records (one without connection), covering the actual selection logic. The spawn-id version had only 1 record and added no signal.

**No issues found:**
- No bash-grep style tests (type FUNCTION_NAME or grep-based existence checks)
- No always-pass conditional `if (condition) { expect() }` patterns — the few `if` guards around `expect` calls are TypeScript narrowing or cleanup guards
- No excessive subprocess spawning — subprocess calls in tests are all mocked via `spyOn`
- No orphaned describe blocks with no test cases
- Similar test names across cloud modules (hetzner, gcp, aws, do, sprite) are appropriate — each tests its own cloud implementation

**Test count: 1887 → 1886** (1 test removed)

-- qa/dedup-scanner