### PR TITLE
fix: resolve UX issues in spawn claude hetzner (issue #2977)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.25.31",
+  "version": "0.25.32",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -26,6 +26,7 @@ import {
   getServerNameFromEnv,
   jsonEscape,
   loadApiToken,
+  logDebug,
   logError,
   logInfo,
   logStep,
@@ -838,21 +839,38 @@ export async function runServer(cmd: string, timeoutSecs?: number, ip?: string):
     {
       stdio: [
         "ignore",
-        "inherit",
-        "inherit",
+        "pipe",
+        "pipe",
       ],
     },
   );
 
   const timeout = (timeoutSecs || 300) * 1000;
   const timer = setTimeout(() => killWithTimeout(proc), timeout);
-  const runResult = await asyncTryCatch(() => proc.exited);
+  // Drain both pipes to prevent buffer deadlocks, then await exit
+  const runResult = await asyncTryCatch(async () => {
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const exitCode = await proc.exited;
+    return {
+      stdout,
+      stderr,
+      exitCode,
+    };
+  });
   clearTimeout(timer);
   if (!runResult.ok) {
     throw runResult.error;
   }
-  if (runResult.data !== 0) {
-    throw new Error(`run_server failed (exit ${runResult.data}): ${cmd}`);
+  if (runResult.data.exitCode !== 0) {
+    // Show captured stderr on failure for debugging
+    const stderr = runResult.data.stderr.trim();
+    if (stderr) {
+      logDebug(stderr);
+    }
+    throw new Error(`run_server failed (exit ${runResult.data.exitCode}): ${cmd}`);
   }
 }
 
@@ -929,7 +947,7 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   }
   const serverIp = ip || _state.serverIp;
   const term = sanitizeTermValue(process.env.TERM || "xterm-256color");
-  const fullCmd = `export TERM='${term}' LANG='C.UTF-8' PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
+  const fullCmd = `export TERM='${term}' LANG='C.UTF-8' LC_ALL='C.UTF-8' PATH="$HOME/.npm-global/bin:$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH" && exec bash -l -c ${shellQuote(cmd)}`;
 
   const keyOpts = getSshKeyOpts(await ensureSshKeys());
 

--- a/packages/cli/src/shared/agents.ts
+++ b/packages/cli/src/shared/agents.ts
@@ -187,6 +187,7 @@ export function generateEnvConfig(pairs: string[]): string {
     "export IS_SANDBOX='1'",
     "# UTF-8 locale — required for agent TUIs that use Unicode (e.g. Claude Code)",
     "export LANG='C.UTF-8'",
+    "export LC_ALL='C.UTF-8'",
     "# Ensure agent binaries are in PATH on reconnect",
     'export PATH="$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.claude/local/bin:/usr/local/bin:$PATH"',
   ];


### PR DESCRIPTION
**Why:** Fixes 3 UX regressions in `spawn claude hetzner`: raw ANSI escape sequences, garbled welcome UI, and duplicate status message spam (15+ times) — all causing confusing/unreadable output for users.

Fixes #2977

## Changes

### 1. Suppress remote command output in `runServer()` (`hetzner.ts`)
Changed `stdio` from `["ignore", "inherit", "inherit"]` to `["ignore", "pipe", "pipe"]` so that remote SSH command output (install scripts, package managers, etc.) is captured instead of being forwarded raw to the local terminal. This fixes:
- **ANSI escape sequences** from remote spinners/progress bars being rendered as literal characters (`[35m`, etc.) since the non-PTY SSH connection doesn't interpret them
- **Duplicate status messages** (15+ repeats) from remote commands accumulating on the local terminal alongside the CLI's own status messages

Captured stderr is still available via `logDebug()` on command failure for troubleshooting.

### 2. Add `LC_ALL=C.UTF-8` for consistent locale (`hetzner.ts` + `agents.ts`)
Added `LC_ALL='C.UTF-8'` to both:
- The interactive SSH session env exports (ensures the TUI renders with correct encoding)
- The `.spawnrc` env config (persists across reconnects)

`LC_ALL` overrides all `LC_*` categories, preventing any locale category from falling back to non-UTF-8 encoding which could cause garbled Unicode in Claude Code's welcome interface.

### 3. Version bump
Patch bump to `0.25.32`.

## Test plan
- [x] `bunx @biomejs/biome check src/` — zero errors
- [x] `bun test` — 1886 tests pass

-- refactor/ux-engineer