### PR TITLE
test: remove duplicate and theatrical tests

### DIFF
--- a/packages/cli/src/__tests__/cmd-delete-cov.test.ts
+++ b/packages/cli/src/__tests__/cmd-delete-cov.test.ts
@@ -160,19 +160,6 @@ describe("confirmAndDelete", () => {
     const confirmCall = clack.confirm.mock.calls[0];
     expect(confirmCall?.[0].message).toContain("9.8.7.6");
   });
-
-  it("intercepts stderr writes to update spinner", async () => {
-    clack.confirm.mockResolvedValue(true);
-    // Handler that writes to stderr during execution
-    const handler = mock(async () => {
-      // stderr.write is intercepted during delete, but we mock it
-      return true;
-    });
-    const record = makeRecord();
-
-    const result = await confirmAndDelete(record, mockManifest, handler);
-    expect(result).toBe(true);
-  });
 });
 
 describe("cmdDelete", () => {

--- a/packages/cli/src/__tests__/orchestrate-cov.test.ts
+++ b/packages/cli/src/__tests__/orchestrate-cov.test.ts
@@ -501,39 +501,6 @@ describe("orchestrate tunnel", () => {
   });
 });
 
-// ── restart loop wrapping ─────────────────────────────────────────────
-
-describe("orchestrate restart loop", () => {
-  it("wraps launch command in restart loop for non-local cloud", async () => {
-    const sessionFn = mock(() => Promise.resolve(0));
-    const cloud = createMockCloud({
-      cloudName: "hetzner",
-      interactiveSession: sessionFn,
-    });
-    const agent = createMockAgent();
-
-    await runSafe(cloud, agent, "testagent");
-
-    const cmd = sessionFn.mock.calls[0][0];
-    expect(cmd).toContain("_spawn_restarts=0");
-    expect(cmd).toContain("_spawn_max=10");
-  });
-
-  it("does not wrap in restart loop for local cloud", async () => {
-    const sessionFn = mock(() => Promise.resolve(0));
-    const cloud = createMockCloud({
-      cloudName: "local",
-      interactiveSession: sessionFn,
-    });
-    const agent = createMockAgent();
-
-    await runSafe(cloud, agent, "testagent");
-
-    const cmd = sessionFn.mock.calls[0][0];
-    expect(cmd).not.toContain("_spawn_restarts");
-  });
-});
-
 // ── step validation with unknown steps ────────────────────────────────
 
 describe("orchestrate unknown steps", () => {


### PR DESCRIPTION
## Summary

- Removed 2 duplicate restart-loop tests from `orchestrate-cov.test.ts` that were weaker copies of tests already in `orchestrate.test.ts` (fewer assertions — missing "my-agent --run" and "Restarting in 5s" checks)
- Removed 1 theatrical test from `cmd-delete-cov.test.ts`: "intercepts stderr writes to update spinner" claimed to test stderr interception but the handler was a no-op mock and only asserted the return value; identical scenario already covered by "calls custom deleteHandler and reports success" in the same file. Real stderr/spinner behavior is properly covered by `delete-spinner.test.ts`

**Net change: -3 tests, 0 regressions** (1883 pass, 0 fail)

## Test plan

- [x] `bun test` passes with 1883 tests, 0 failures
- [x] `bunx @biomejs/biome check` passes on modified files with 0 errors

-- qa/dedup-scanner