### PR TITLE
fix(test): fix flaky delegateCloudCredentials test due to cross-file sandbox pollution

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/recursive-spawn.test.ts
+++ b/packages/cli/src/__tests__/recursive-spawn.test.ts
@@ -246,6 +246,17 @@ describe("recursive spawn", () => {
   // ── delegateCloudCredentials ──────────────────────────────────────
 
   describe("delegateCloudCredentials", () => {
+    beforeEach(() => {
+      // Remove credential files that other test files may have written to the shared sandbox HOME
+      const configDir = join(process.env.HOME ?? "", ".config", "spawn");
+      if (existsSync(configDir)) {
+        rmSync(configDir, {
+          recursive: true,
+          force: true,
+        });
+      }
+    });
+
     it("skips when no credential files exist", async () => {
       const { delegateCloudCredentials } = await import("../shared/orchestrate.js");
       const commands: string[] = [];


### PR DESCRIPTION
**Why:** Fixes a reproducible test failure — `recursive spawn > delegateCloudCredentials > skips when no credential files exist` was failing 100% of the time in the full suite (1911 pass, 1 fail) while passing in isolation. CI would show a flaky test on every run.

## Root Cause

Bun's test runner shares a single preload-created `$HOME` temp directory across all test files in the same worker. Other test files write credential files to `$HOME/.config/spawn/` without cleanup:
- `oauth-cov.test.ts` writes `openrouter.json`
- `cmd-uninstall-cov.test.ts` writes `hetzner.json`

The `delegateCloudCredentials()` function scans `$HOME/.config/spawn/` for credential files. The "skips when no files exist" test found 2 leaked files and ran 2 commands instead of the expected 0.

## Fix

Add a `beforeEach` inside the `delegateCloudCredentials` describe block that removes `$HOME/.config/spawn/` before each test, making the test self-contained. This doesn't affect the "delegates credentials when files exist" test, which explicitly creates the files it needs.

## Verification

- Full suite: **1912 pass, 0 fail** (was 1911 pass, 1 fail)
- Biome: **clean** (0 errors, 164 files)
- Test passes in isolation and in full suite

-- refactor/code-health