### PR TITLE
fix(security): add base64 validation consistency in agent-setup.ts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -554,6 +554,12 @@ export async function startGateway(runner: CloudRunner): Promise<void> {
 
   const wrapperB64 = Buffer.from(wrapperScript).toString("base64");
   const unitB64 = Buffer.from(unitFile).toString("base64");
+  if (!/^[A-Za-z0-9+/=]+$/.test(wrapperB64)) {
+    throw new Error("Unexpected characters in base64 output");
+  }
+  if (!/^[A-Za-z0-9+/=]+$/.test(unitB64)) {
+    throw new Error("Unexpected characters in base64 output");
+  }
 
   const script = [
     "source ~/.spawnrc 2>/dev/null",
@@ -855,6 +861,15 @@ export async function setupAutoUpdate(runner: CloudRunner, agentName: string, up
   const wrapperB64 = Buffer.from(wrapperScript).toString("base64");
   const unitB64 = Buffer.from(unitFile).toString("base64");
   const timerB64 = Buffer.from(timerFile).toString("base64");
+  if (!/^[A-Za-z0-9+/=]+$/.test(wrapperB64)) {
+    throw new Error("Unexpected characters in base64 output");
+  }
+  if (!/^[A-Za-z0-9+/=]+$/.test(unitB64)) {
+    throw new Error("Unexpected characters in base64 output");
+  }
+  if (!/^[A-Za-z0-9+/=]+$/.test(timerB64)) {
+    throw new Error("Unexpected characters in base64 output");
+  }
 
   const script = [
     "if ! command -v systemctl >/dev/null 2>&1; then exit 0; fi",


### PR DESCRIPTION
**Why:** `wrapperB64`, `unitB64`, and `timerB64` were interpolated into shell single-quoted strings without the validation guard that `settingsB64` already has. This adds defense-in-depth consistency.

## Changes

- Added `/^[A-Za-z0-9+/=]+$/` validation for `wrapperB64`, `unitB64`, `timerB64` in `agent-setup.ts`
- Matches existing pattern already used for `settingsB64` (line 152)
- No behavior change for valid inputs; throws early on unexpected base64 output
- Patch version bump to 0.26.2

Fixes #2986

-- refactor/security-auditor