### PR TITLE
fix: spawn step skipped when no explicit --steps passed

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -551,7 +551,14 @@ async function postInstall(
   }
 
   // Spawn CLI + skill injection (recursive spawn)
-  if (enabledSteps?.has("spawn") && cloud.cloudName !== "local") {
+  // The "spawn" step is defaultOn when --beta recursive is active, so it should
+  // run when no explicit steps are selected (!enabledSteps) AND the beta flag is set.
+  const betaFeaturesPost = new Set((process.env.SPAWN_BETA ?? "").split(",").filter(Boolean));
+  if (
+    cloud.cloudName !== "local" &&
+    betaFeaturesPost.has("recursive") &&
+    (!enabledSteps || enabledSteps.has("spawn"))
+  ) {
     await installSpawnCli(cloud.runner);
     await delegateCloudCredentials(cloud.runner, cloud.cloudName);
     await injectSpawnSkill(cloud.runner, agentName);


### PR DESCRIPTION
## Summary

- The spawn skill injection condition used `enabledSteps?.has("spawn")` which evaluates to `undefined` (falsy) when no `--steps` flag is passed — meaning the spawn step never ran in the default flow
- Fixed to check `--beta recursive` directly and use `(!enabledSteps || enabledSteps.has("spawn"))`, matching the pattern used by `auto-update` and other `defaultOn` steps

## Test plan

- [ ] `spawn claude hetzner --beta recursive` → on VM: `/skills` shows spawn skill
- [ ] `spawn claude hetzner --beta recursive --steps spawn` → same result (explicit)
- [ ] `spawn claude hetzner` (no beta flag) → spawn step does NOT run

🤖 Generated with [Claude Code](https://claude.com/claude-code)