### PR TITLE
refactor: remove dead code and stale references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -26,7 +26,7 @@ const COMPACT_NAME_WIDTH = 20;
 const COMPACT_COUNT_WIDTH = 10;
 const COMPACT_READY_WIDTH = 10;
 
-export function getTerminalWidth(): number {
+function getTerminalWidth(): number {
   return process.stdout.columns || 80;
 }
 

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -41,7 +41,7 @@ export const DOCKER_CONTAINER_NAME = "spawn-agent";
 export const DOCKER_REGISTRY = "ghcr.io/openrouterteam";
 
 /** Wrap a command to run inside the Docker container instead of the host. */
-export function makeDockerExec(cmd: string): string {
+function makeDockerExec(cmd: string): string {
   if (!cmd || cmd.length === 0) {
     throw new Error("makeDockerExec: command must be non-empty");
   }


### PR DESCRIPTION
## Summary

- Remove `export` from `getTerminalWidth` in `commands/info.ts` — function is only used internally within the file and was never exported from the `commands/index.ts` barrel
- Remove `export` from `makeDockerExec` in `shared/orchestrate.ts` — function is only used internally by `makeDockerRunner` within the same file, has no external callers
- Bump CLI version to 0.26.6

## Scan results

**Dead code found:**
- `getTerminalWidth` (commands/info.ts): exported but 0 external callers, not in barrel
- `makeDockerExec` (shared/orchestrate.ts): exported but 0 external callers

**No issues found:**
- Python (`python3 -c`, `python -c`) usage: none
- Relative path sourcing in curl|bash scripts: none (e2e scripts correctly use BASH_SOURCE with comments)
- Duplicate utility functions: cloud-module variants differ in implementation (different swap handling, state vars, API shapes)
- Stale references to deleted files: none
- Stale comments: one valid TODO with date tracking (PKCE migration, last checked 2026-03)
- Biome: 0 errors before and after changes
- Tests: 1955 pass, 0 fail

-- qa/code-quality