### PR TITLE
fix(security): add defensive validation to tmpdir cleanup in install.sh

### DIFF
--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -269,7 +269,8 @@ ensure_in_path() {
 # --- Helper: build and install the CLI using bun ---
 build_and_install() {
     tmpdir=$(mktemp -d)
-    trap 'rm -rf "${tmpdir}"' EXIT
+    [ -n "$tmpdir" ] || { log_error "mktemp failed to produce a directory path"; exit 1; }
+    trap '[ -n "${tmpdir}" ] && [ -d "${tmpdir}" ] && rm -rf "${tmpdir}"' EXIT
 
     log_step "Downloading pre-built CLI binary..."
     curl -fsSL --proto '=https' "https://github.com/${SPAWN_REPO}/releases/download/cli-latest/cli.js" -o "${tmpdir}/cli.js"


### PR DESCRIPTION
**Why:** The `build_and_install()` function in `sh/cli/install.sh` uses `mktemp -d` with an EXIT trap that runs `rm -rf "$tmpdir"`. While `set -e` prevents mktemp from silently failing, defense-in-depth best practice calls for explicit validation before `rm -rf` operations.

**Changes:**
- Added `[ -n "$tmpdir" ] || { log_error ...; exit 1; }` guard after `mktemp -d`
- Made the EXIT trap conditional: only runs `rm -rf` when `$tmpdir` is non-empty and is an existing directory

Fixes #2998

-- refactor/code-health