### PR TITLE
style: remove unnecessary `as never` casts from oauth-cov.test.ts

### DIFF
--- a/packages/cli/src/__tests__/oauth-cov.test.ts
+++ b/packages/cli/src/__tests__/oauth-cov.test.ts
@@ -140,8 +140,7 @@ describe("getOrPromptApiKey", () => {
 
   it("throws after 3 failed OAuth + manual attempts", async () => {
     // Mock Bun.serve to fail (so OAuth flow returns null)
-    // biome-ignore lint: test mock
-    const serveSpy = spyOn(Bun, "serve" as never).mockImplementation(() => {
+    const serveSpy = spyOn(Bun, "serve").mockImplementation(() => {
       throw new Error("port in use");
     });
     // Mock p.text to return empty (manual entry fails)
@@ -168,8 +167,7 @@ describe("getOrPromptApiKey", () => {
     process.env.SPAWN_ENABLED_STEPS = "github";
 
     // OAuth will fail, manual will fail => throws
-    // biome-ignore lint: test mock
-    const serveSpy = spyOn(Bun, "serve" as never).mockImplementation(() => {
+    const serveSpy = spyOn(Bun, "serve").mockImplementation(() => {
       throw new Error("port in use");
     });
     textSpy.mockImplementation(async () => "");
@@ -208,8 +206,7 @@ describe("getOrPromptApiKey", () => {
 
   it("returns key from manual entry via prompt after OAuth fails", async () => {
     // Simulate OAuth failure via Bun.serve throwing
-    // biome-ignore lint: test mock
-    const serveSpy = spyOn(Bun, "serve" as never).mockImplementation(() => {
+    const serveSpy = spyOn(Bun, "serve").mockImplementation(() => {
       throw new Error("port in use");
     });
     const validKey = "sk-or-v1-" + "f".repeat(64);
@@ -223,8 +220,7 @@ describe("getOrPromptApiKey", () => {
   });
 
   it("sets OPENROUTER_API_KEY in process.env on success from manual entry", async () => {
-    // biome-ignore lint: test mock
-    const serveSpy = spyOn(Bun, "serve" as never).mockImplementation(() => {
+    const serveSpy = spyOn(Bun, "serve").mockImplementation(() => {
       throw new Error("port in use");
     });
     const validKey = "sk-or-v1-" + "e".repeat(64);
@@ -239,8 +235,7 @@ describe("getOrPromptApiKey", () => {
   });
 
   it("accepts non-standard key format when user confirms", async () => {
-    // biome-ignore lint: test mock
-    const serveSpy = spyOn(Bun, "serve" as never).mockImplementation(() => {
+    const serveSpy = spyOn(Bun, "serve").mockImplementation(() => {
       throw new Error("port in use");
     });
     let callCount = 0;


### PR DESCRIPTION
## Summary

- Removes 5 `as never` type assertions from `spyOn(Bun, "serve" as never)` calls in `oauth-cov.test.ts`
- Removes associated `// biome-ignore lint: test mock` directives
- `spyOn(Bun, "serve")` works correctly without the cast (verified at both runtime and type-check level)

**Rule violated:** `.claude/rules/type-safety.md` — only `as const` is exempt from the type assertion ban.

## Verification

- `bunx @biomejs/biome check src/` — 166 files, 0 errors
- `bun test` — 1953 tests, 0 failures