### PR TITLE
test: remove duplicate validator tests from ui-cov.test.ts

### DIFF
--- a/packages/cli/src/__tests__/ui-cov.test.ts
+++ b/packages/cli/src/__tests__/ui-cov.test.ts
@@ -35,9 +35,6 @@ import {
   prompt,
   promptSpawnNameShared,
   selectFromList,
-  validateModelId,
-  validateRegionName,
-  validateServerName,
 } from "../shared/ui";
 
 // ── Setup / Teardown ────────────────────────────────────────────────────
@@ -244,34 +241,6 @@ describe("loadApiToken", () => {
     writeFileSync(join(configPath, "bad.json"), "not json");
     const token = loadApiToken("bad");
     expect(token).toBeNull();
-  });
-});
-
-// ── validators ─────────────────────────────────────────────────────
-
-describe("validators", () => {
-  it("validateServerName accepts valid names", () => {
-    expect(validateServerName("my-server-123")).toBe(true);
-  });
-
-  it("validateServerName rejects invalid names", () => {
-    expect(validateServerName("bad name!")).toBe(false);
-  });
-
-  it("validateRegionName accepts valid regions", () => {
-    expect(validateRegionName("us-east-1")).toBe(true);
-  });
-
-  it("validateRegionName rejects invalid regions", () => {
-    expect(validateRegionName("bad region!")).toBe(false);
-  });
-
-  it("validateModelId accepts valid model IDs", () => {
-    expect(validateModelId("anthropic/claude-3.5-sonnet")).toBe(true);
-  });
-
-  it("validateModelId rejects invalid model IDs", () => {
-    expect(validateModelId("bad model ID!")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- The `validators` describe block in `ui-cov.test.ts` contained 6 tests that were exact duplicates of tests already covered exhaustively in `ui-utils.test.ts`
- `validateServerName`: 2 superficial tests removed (ui-utils.test.ts has 5 thorough tests)
- `validateRegionName`: 2 superficial tests removed (ui-utils.test.ts has 4 thorough tests)
- `validateModelId`: 2 superficial tests removed (ui-utils.test.ts has 6 thorough tests)
- Also removed the now-unused imports from the import statement

## Why this matters

The removed tests only checked one accept + one reject per validator — they provided no signal beyond what `ui-utils.test.ts` already covers with edge cases (length boundaries, special characters, leading/trailing dashes, injection attempts, etc.). Having both created false confidence and suite bloat.

## Test plan

- [x] `bun test` passes: 1947 tests, 0 failures (6 duplicate tests removed)
- [x] `bunx @biomejs/biome check src/` passes: 0 errors

-- qa/dedup-scanner