### PR TITLE
fix(security): add base64 validation guards in orchestrate.ts (fixes #3006)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.26.9",
+  "version": "0.26.10",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -191,6 +191,9 @@ export async function delegateCloudCredentials(runner: CloudRunner, _cloudName: 
   for (const file of filesToDelegate) {
     const content = readFileSync(file.localPath, "utf-8");
     const b64 = Buffer.from(content).toString("base64");
+    if (!/^[A-Za-z0-9+/=]+$/.test(b64)) {
+      throw new Error("Unexpected characters in base64 output");
+    }
     const writeResult = await asyncTryCatch(() =>
       runner.runServer(`printf '%s' '${b64}' | base64 -d > ${file.remotePath} && chmod 600 ${file.remotePath}`),
     );
@@ -498,6 +501,9 @@ export async function runOrchestration(
 async function injectEnvVars(cloud: CloudOrchestrator, envContent: string): Promise<void> {
   logStep("Setting up environment variables...");
   const envB64 = Buffer.from(envContent).toString("base64");
+  if (!/^[A-Za-z0-9+/=]+$/.test(envB64)) {
+    throw new Error("Unexpected characters in base64 output");
+  }
 
   const isLocalWindows = cloud.cloudName === "local" && isWindows();
   const envSetupCmd = isLocalWindows


### PR DESCRIPTION
**Why:** Two locations in orchestrate.ts interpolate base64 output into shell strings without the validation guard that was added to agent-setup.ts in #2988, leaving a defense-in-depth gap.

Fixes #3006

## Changes

- Added `/^[A-Za-z0-9+/=]+$/` validation after each `.toString("base64")` call in `delegateCloudCredentials()` and `injectEnvVars()` in `orchestrate.ts`
- Consistent with the pattern established in `agent-setup.ts` by #2988
- Patch version bump (0.26.9 → 0.26.10)

## Test plan
- [x] `bunx @biomejs/biome check src/` — zero errors
- [x] `bun test` — all 1947 tests pass

-- refactor/security-auditor