### PR TITLE
fix(security): validate bun path before symlinking in install.sh (fixes #3009)

### DIFF
--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -182,6 +182,21 @@ ensure_in_path() {
     local linked=false
     local bun_path
     bun_path="$(command -v bun 2>/dev/null || true)"
+    # Validate bun is in an expected directory before symlinking with elevated
+    # privileges. If an attacker controls PATH, `command -v bun` could resolve
+    # to a malicious binary — symlinking that to /usr/local/bin with sudo would
+    # be a privilege escalation vector.
+    if [ -n "$bun_path" ]; then
+        case "$bun_path" in
+            "${HOME}/.bun/bin/bun"|"${HOME}/.local/bin/bun"|/usr/local/bin/bun|"${BUN_INSTALL}/bin/bun")
+                # Expected bun installation location — safe to symlink
+                ;;
+            *)
+                log_warn "bun found at unexpected location: ${bun_path} — skipping symlink"
+                bun_path=""
+                ;;
+        esac
+    fi
     if [ "$spawn_in_path" = false ]; then
         if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
             safe_ln_sf "${install_dir}/spawn" /usr/local/bin/spawn && linked=true


### PR DESCRIPTION
**Why:** Prevents privilege escalation if attacker controls PATH before install runs

## Summary

- Adds allowlist validation for the bun binary path resolved via `command -v bun` in `ensure_in_path()` before it is used in symlink operations that may run with `sudo`
- Accepted locations: `$HOME/.bun/bin/bun`, `$HOME/.local/bin/bun`, `/usr/local/bin/bun`, `$BUN_INSTALL/bin/bun`
- If bun is found at an unexpected location, the path is cleared and a warning is logged — the symlink is skipped rather than creating a link to an untrusted binary
- No behavior change for normal installations where bun is in a standard location

## Attack scenario addressed

If an attacker can prepend a directory to `PATH` before `install.sh` runs (e.g., via `.bashrc` injection or a compromised parent process), `command -v bun` would resolve to their malicious binary. The script would then symlink it to `/usr/local/bin/bun` with sudo privileges, giving the attacker persistent root-accessible code execution.

## Test plan

- [x] `bash -n sh/cli/install.sh` passes (syntax check)
- [ ] Manual: run installer with bun in `$HOME/.bun/bin/bun` — should work normally
- [ ] Manual: set `PATH=/tmp/evil:$PATH` with a fake `/tmp/evil/bun` — should see warning and skip symlink

Fixes #3009

-- refactor/security-auditor