### PR TITLE
refactor: use getSpawnCloudConfigPath(), remove dead _cloudName param

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.26.10",
+  "version": "0.26.11",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/recursive-spawn.test.ts
+++ b/packages/cli/src/__tests__/recursive-spawn.test.ts
@@ -269,7 +269,7 @@ describe("recursive spawn", () => {
       };
 
       // No credential files exist in test sandbox, so should warn and return
-      await delegateCloudCredentials(mockRunner, "hetzner");
+      await delegateCloudCredentials(mockRunner);
 
       // Should not have run mkdir since there are no files to delegate
       expect(commands.length).toBe(0);
@@ -294,7 +294,7 @@ describe("recursive spawn", () => {
         downloadFile: async () => {},
       };
 
-      await delegateCloudCredentials(mockRunner, "hetzner");
+      await delegateCloudCredentials(mockRunner);
 
       // Should have run mkdir + 2 file writes
       expect(commands.length).toBe(3);
@@ -326,7 +326,7 @@ describe("recursive spawn", () => {
       };
 
       // Should not throw
-      await delegateCloudCredentials(mockRunner, "hetzner");
+      await delegateCloudCredentials(mockRunner);
       // At least 2 calls: mkdir + file write(s) that fail
       expect(callCount).toBeGreaterThanOrEqual(2);
     });
@@ -351,7 +351,7 @@ describe("recursive spawn", () => {
       };
 
       // Should not throw, just warn
-      await delegateCloudCredentials(mockRunner, "hetzner");
+      await delegateCloudCredentials(mockRunner);
       // mkdir was called and failed
       expect(callCount).toBe(1);
     });

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -14,7 +14,7 @@ import { offerGithubAuth, setupAutoUpdate, wrapSshCall } from "./agent-setup.js"
 import { tryTarballInstall } from "./agent-tarball.js";
 import { generateEnvConfig } from "./agents.js";
 import { getOrPromptApiKey } from "./oauth.js";
-import { getSpawnCloudConfigPath, getSpawnPreferencesPath, getUserHome } from "./paths.js";
+import { getSpawnCloudConfigPath, getSpawnPreferencesPath } from "./paths.js";
 import { asyncTryCatch, asyncTryCatchIf, isOperationalError, tryCatch } from "./result.js";
 import { isWindows } from "./shell.js";
 import { injectSpawnSkill } from "./spawn-skill.js";
@@ -137,7 +137,7 @@ export async function installSpawnCli(runner: CloudRunner): Promise<void> {
 }
 
 /** Copy local cloud credentials to the remote VM for recursive spawning. */
-export async function delegateCloudCredentials(runner: CloudRunner, _cloudName: string): Promise<void> {
+export async function delegateCloudCredentials(runner: CloudRunner): Promise<void> {
   logStep("Delegating cloud credentials to VM...");
 
   const filesToDelegate: {
@@ -147,7 +147,6 @@ export async function delegateCloudCredentials(runner: CloudRunner, _cloudName: 
 
   // Delegate ALL cloud credentials so the child VM can spawn on any cloud,
   // not just the one the parent is running on.
-  const configDir = `${getUserHome()}/.config/spawn`;
   const cloudNames = [
     "hetzner",
     "digitalocean",
@@ -166,7 +165,7 @@ export async function delegateCloudCredentials(runner: CloudRunner, _cloudName: 
   }
 
   // OpenRouter credentials (always needed for child spawns)
-  const orConfigPath = `${configDir}/openrouter.json`;
+  const orConfigPath = getSpawnCloudConfigPath("openrouter");
   if (existsSync(orConfigPath)) {
     filesToDelegate.push({
       localPath: orConfigPath,
@@ -577,7 +576,7 @@ async function postInstall(
     (!enabledSteps || enabledSteps.has("spawn"))
   ) {
     await installSpawnCli(cloud.runner);
-    await delegateCloudCredentials(cloud.runner, cloud.cloudName);
+    await delegateCloudCredentials(cloud.runner);
     await injectSpawnSkill(cloud.runner, agentName);
   }
 


### PR DESCRIPTION
**Why:** Prevents silent path breakage if spawn config dir moves; removes dead parameter

## Summary
- Replace hand-constructed `~/.config/spawn/openrouter.json` path in `delegateCloudCredentials()` with `getSpawnCloudConfigPath("openrouter")` from `paths.ts` (single source of truth)
- Remove unused `_cloudName` parameter from `delegateCloudCredentials()` — the function delegates ALL cloud credentials unconditionally regardless of which cloud is active
- Remove now-unused `getUserHome` import from `orchestrate.ts`
- Update 4 call sites in `recursive-spawn.test.ts`
- Bump CLI version to 0.26.11

Fixes #3010

## Test plan
- [x] All 1947 tests pass (0 failures)
- [x] Biome lint clean (0 errors)
- [x] Verified `delegateCloudCredentials` test coverage still exercises all branches (skip, delegate, write-fail, mkdir-fail)

-- refactor/ux-engineer