### PR TITLE
test: remove duplicate tests from cmd-link-cov

### DIFF
--- a/packages/cli/src/__tests__/cmd-link-cov.test.ts
+++ b/packages/cli/src/__tests__/cmd-link-cov.test.ts
@@ -163,39 +163,6 @@ describe("cmdLink (additional coverage)", () => {
     expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("Invalid SSH user"));
   });
 
-  it("saves record in non-interactive mode (skips confirm)", async () => {
-    const { loadHistory } = await import("../history.js");
-
-    await cmdLink(
-      [
-        "link",
-        "1.2.3.4",
-        "--agent",
-        "claude",
-        "--cloud",
-        "hetzner",
-        "--user",
-        "root",
-      ],
-      {
-        tcpCheck: TCP_REACHABLE,
-        sshCommand: SSH_NO_DETECT,
-      },
-    );
-
-    // Non-interactive mode skips confirm and saves directly
-    expect(clack.logSuccess).toHaveBeenCalledWith(expect.stringContaining("Deployment linked"));
-    const records = loadHistory();
-    const thisRecord = records.find(
-      (r: {
-        connection?: {
-          ip?: string;
-        };
-      }) => r.connection?.ip === "1.2.3.4",
-    );
-    expect(thisRecord).toBeDefined();
-  });
-
   it("uses short flags for cloud and agent", async () => {
     const { loadHistory } = await import("../history.js");
 
@@ -274,24 +241,6 @@ describe("cmdLink (additional coverage)", () => {
     expect(clack.logError).toHaveBeenCalledWith(expect.stringContaining("not reachable"));
   });
 
-  it("exits with error for invalid IP address", async () => {
-    const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
-    await asyncTryCatch(() =>
-      cmdLink(
-        [
-          "link",
-          "not-an-ip!@#",
-        ],
-        {
-          tcpCheck: TCP_REACHABLE,
-          sshCommand: SSH_NO_DETECT,
-        },
-      ),
-    );
-    expect(processExitSpy).toHaveBeenCalledWith(1);
-    consoleSpy.mockRestore();
-  });
-
   it("runs detection spinner when cloud not provided", async () => {
     await cmdLink(
       [
@@ -310,37 +259,5 @@ describe("cmdLink (additional coverage)", () => {
 
     const spinnerCalls = clack.spinnerStart.mock.calls.map((c: unknown[]) => String(c[0]));
     expect(spinnerCalls.some((msg: string) => msg.includes("Auto-detecting"))).toBe(true);
-  });
-
-  it("generates default name from agent and IP when no --name flag", async () => {
-    const { loadHistory } = await import("../history.js");
-
-    await cmdLink(
-      [
-        "link",
-        "10.0.0.1",
-        "--agent",
-        "claude",
-        "--cloud",
-        "hetzner",
-        "--user",
-        "root",
-      ],
-      {
-        tcpCheck: TCP_REACHABLE,
-        sshCommand: SSH_NO_DETECT,
-      },
-    );
-
-    const records = loadHistory();
-    const rec = records.find(
-      (r: {
-        connection?: {
-          ip?: string;
-        };
-      }) => r.connection?.ip === "10.0.0.1",
-    );
-    expect(rec).toBeDefined();
-    expect(rec?.name).toBe("claude-10-0-0-1");
   });
 });


### PR DESCRIPTION
## Summary

- Scanned all 99 test files (1947 tests) for duplicate, theatrical, and wasteful patterns
- Found 3 duplicate tests in `cmd-link-cov.test.ts` that exactly replicate scenarios already covered in `cmd-link.test.ts`
- Removed those 3 tests; 1944 tests remain, all passing

## What was removed

From `packages/cli/src/__tests__/cmd-link-cov.test.ts`:

1. **"saves record in non-interactive mode"** — duplicate of `cmd-link.test.ts` "saves a spawn record when agent and cloud are provided via flags". Both call `cmdLink` with identical args (`claude`/`hetzner`/`1.2.3.4`/`root`), check `logSuccess`, and find the record in history.

2. **"exits with error for invalid IP address"** — duplicate of `cmd-link.test.ts` "exits with error for an invalid IP address". Both test the same rejection path with an invalid IP string.

3. **"generates default name from agent and IP when no --name flag"** — duplicate of `cmd-link.test.ts` "generates a default name from agent and IP". Both verify the `{agent}-{ip-with-dashes}` naming, with minor variation in input values only.

## What was NOT changed

- All 7 remaining tests in `cmd-link-cov.test.ts` cover unique paths not tested in `cmd-link.test.ts`: IMDS cloud auto-detection, `which`-binary agent fallback, SSH user validation, short flags, spinner behavior
- No other test files had real duplicates — similar describe names like "edge cases" or "valid inputs" were all within different parent scopes

-- qa/dedup-scanner