### PR TITLE
fix(e2e): load GCP_ZONE from ~/.config/spawn/gcp.json in E2E driver

### DIFF
--- a/sh/e2e/lib/clouds/gcp.sh
+++ b/sh/e2e/lib/clouds/gcp.sh
@@ -18,11 +18,48 @@ _GCP_INSTANCE_APP=""
 # _gcp_validate_env
 #
 # Check that the gcloud CLI is installed and credentials are valid.
-# Requires GCP_PROJECT to be set.
+# Requires GCP_PROJECT to be set. Loads GCP_PROJECT and GCP_ZONE from
+# ~/.config/spawn/gcp.json if not already in the environment.
 # Returns 0 on success, 1 on failure.
 # ---------------------------------------------------------------------------
 _gcp_validate_env() {
   local missing=0
+
+  # Load GCP_PROJECT and GCP_ZONE from ~/.config/spawn/gcp.json if not set.
+  # This allows the QA VM to configure the correct zone without env var exports.
+  local _gcp_config="${HOME}/.config/spawn/gcp.json"
+  if [ -f "${_gcp_config}" ]; then
+    if [ -z "${GCP_PROJECT:-}" ]; then
+      local _proj
+      if command -v jq >/dev/null 2>&1; then
+        _proj=$(jq -r '.GCP_PROJECT // "" | select(. != null)' "${_gcp_config}" 2>/dev/null)
+      else
+        _proj=$(_FILE="${_gcp_config}" bun -e "
+import fs from 'fs';
+const d = JSON.parse(fs.readFileSync(process.env._FILE, 'utf8'));
+process.stdout.write(d.GCP_PROJECT || '');
+" 2>/dev/null)
+      fi
+      if [ -n "${_proj}" ]; then
+        export GCP_PROJECT="${_proj}"
+      fi
+    fi
+    if [ -z "${GCP_ZONE:-}" ]; then
+      local _zone
+      if command -v jq >/dev/null 2>&1; then
+        _zone=$(jq -r '.GCP_ZONE // "" | select(. != null)' "${_gcp_config}" 2>/dev/null)
+      else
+        _zone=$(_FILE="${_gcp_config}" bun -e "
+import fs from 'fs';
+const d = JSON.parse(fs.readFileSync(process.env._FILE, 'utf8'));
+process.stdout.write(d.GCP_ZONE || '');
+" 2>/dev/null)
+      fi
+      if [ -n "${_zone}" ]; then
+        export GCP_ZONE="${_zone}"
+      fi
+    fi
+  fi
 
   if ! command -v gcloud >/dev/null 2>&1; then
     log_err "gcloud CLI not found. Install from https://cloud.google.com/sdk/docs/install"


### PR DESCRIPTION
## Summary

- GCP E2E tests were defaulting to `us-central1-a` when `GCP_ZONE` was not set in the environment
- The QA VM has `GCP_ZONE=europe-west1-b` configured in `~/.config/spawn/gcp.json` but `_gcp_validate_env` never loaded it
- This caused 3 E2E failures (openclaw, opencode, kilocode on GCP) with SSH timeouts due to GCP resource exhaustion in `us-central1-a`
- Fix: load both `GCP_PROJECT` and `GCP_ZONE` from `~/.config/spawn/gcp.json` in `_gcp_validate_env` when not already set in the environment

## Test plan

- [x] Re-ran `gcp/openclaw`, `gcp/opencode`, `gcp/kilocode` from the worktree with the fix applied
- [x] All 3 now PASS (zone shows `europe-west1-b` in logs)
- [x] `bash -n` passes on the modified script
- [x] Fix uses the same `jq`/`bun` fallback pattern already used in `key-request.sh`

-- qa/e2e-tester