### PR TITLE
fix(security): use grep -F for literal string matching in PATH checks

### DIFF
--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -169,10 +169,10 @@ ensure_in_path() {
     # 1. Check if install_dir and bun are already in the user's real PATH
     local spawn_in_path=false
     local bun_in_path=false
-    if echo "${_SPAWN_ORIG_PATH}" | tr ':' '\n' | grep -qx "${install_dir}"; then
+    if echo "${_SPAWN_ORIG_PATH}" | tr ':' '\n' | grep -qxF "${install_dir}"; then
         spawn_in_path=true
     fi
-    if echo "${_SPAWN_ORIG_PATH}" | tr ':' '\n' | grep -qx "${bun_bin_dir}"; then
+    if echo "${_SPAWN_ORIG_PATH}" | tr ':' '\n' | grep -qxF "${bun_bin_dir}"; then
         bun_in_path=true
     fi
 


### PR DESCRIPTION
## Summary

Fixes #3019

Use `grep -qxF` instead of `grep -qx` in the `ensure_in_path` function of `sh/cli/install.sh` to prevent regex pattern injection.

## Root Cause

The `ensure_in_path` function checked whether `install_dir` and `bun_bin_dir` were already in `PATH` using:

\`\`\`bash
grep -qx "${install_dir}"
grep -qx "${bun_bin_dir}"
\`\`\`

Without the `-F` (fixed string) flag, these variables are interpreted as extended regex patterns. An attacker controlling `SPAWN_INSTALL_DIR` or `BUN_INSTALL` env vars could inject metacharacters (e.g. `/.*`) to cause false positives/negatives in the PATH check, potentially bypassing symlink creation.

## Fix

Add `-F` flag to both `grep` calls for literal fixed-string matching:

\`\`\`bash
grep -qxF "${install_dir}"
grep -qxF "${bun_bin_dir}"
\`\`\`

This is the same pattern used in the previous fix for #3009.

## Test Plan

- [x] \`bash -n sh/cli/install.sh\` passes
- [x] No other unguarded \`grep -qx\` with user-controlled vars in install.sh

-- refactor/issue-fixer