### PR TITLE
fix: add --yes/-y to KNOWN_FLAGS for headless delete

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.26.12",
+  "version": "0.26.13",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/unknown-flags.test.ts
+++ b/packages/cli/src/__tests__/unknown-flags.test.ts
@@ -89,6 +89,8 @@ describe("Unknown Flag Detection", () => {
         "--reauth",
         "--prune",
         "--json",
+        "--yes",
+        "-y",
       ];
       for (const flag of knownFlagsToTest) {
         expect(
@@ -228,6 +230,8 @@ describe("KNOWN_FLAGS completeness", () => {
       "--fast",
       "--user",
       "-u",
+      "--yes",
+      "-y",
     ];
     // Every flag in the expected list must exist in KNOWN_FLAGS.
     for (const flag of expected) {

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -31,6 +31,7 @@ function getHelpUsageSection(): string {
   spawn delete                       Delete a previously spawned server (aliases: rm, destroy, kill)
   spawn delete -a <agent>            Filter servers by agent
   spawn delete -c <cloud>            Filter servers by cloud
+  spawn delete --name <name> --yes   Headless delete by name (no prompts)
   spawn status                       Show live state of cloud servers (aliases: ps)
   spawn status -a <agent>            Filter status by agent (or --agent)
   spawn status -c <cloud>            Filter status by cloud (or --cloud)

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -38,6 +38,8 @@ export const KNOWN_FLAGS = new Set([
   "--fast",
   "--user",
   "-u",
+  "--yes",
+  "-y",
 ]);
 
 /** Return the first unknown flag in args, or null if all are known/positional */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -149,6 +149,10 @@ function checkUnknownFlags(args: string[]): void {
     console.error(`    ${pc.cyan("-c, --cloud")}         Filter history by cloud`);
     console.error(`    ${pc.cyan("--clear")}             Clear all spawn history`);
     console.error();
+    console.error(`  For ${pc.cyan("spawn delete")}:`);
+    console.error(`    ${pc.cyan("--name <name>")}       Filter by server name or ID`);
+    console.error(`    ${pc.cyan("--yes, -y")}           Skip confirmation (required for non-interactive)`);
+    console.error();
     console.error(`  Run ${pc.cyan("spawn help")} for full usage information.`);
     process.exit(1);
   }


### PR DESCRIPTION
**Why:** `spawn delete --name <name> --yes` fails with "Unknown flag: --yes" because PR #3015 added these flags to the delete command but didn't register them in `KNOWN_FLAGS`. Users (and agents doing recursive spawning) cannot use headless delete.

## Changes

- Add `--yes` and `-y` to `KNOWN_FLAGS` in `flags.ts` so they pass the unknown-flag check
- Add `spawn delete --name <name> --yes` to help text in `help.ts`
- Add delete-specific flag section to `checkUnknownFlags` error output in `index.ts`
- Update `unknown-flags.test.ts` completeness test to include the new flags
- Bump CLI version to 0.26.13

## Test plan

- [x] All 1944 tests pass (0 failures)
- [x] Biome lint clean (0 errors)
- [ ] Manual: `spawn delete --name nonexistent --yes` no longer errors with "Unknown flag"

-- refactor/code-health