### PR TITLE
feat(cli): add star-the-repo nudge after successful spawns

### DIFF
--- a/packages/cli/src/__tests__/star-prompt.test.ts
+++ b/packages/cli/src/__tests__/star-prompt.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as p from "@clack/prompts";
+import { isString } from "@openrouter/spawn-shared";
+import * as v from "valibot";
+import { parseJsonWith } from "../shared/parse.js";
+
+/**
+ * Tests for maybeShowStarPrompt():
+ * - Skips on first-time users (< 2 successful spawns)
+ * - Shows message to returning users (2+ successful spawns)
+ * - Respects 30-day cooldown (skips if shown recently)
+ * - Shows again after 30 days have elapsed
+ * - Saves starPromptShownAt to preferences after showing
+ * - Silently ignores errors
+ */
+
+const { maybeShowStarPrompt } = await import("../shared/star-prompt.js");
+
+describe("maybeShowStarPrompt", () => {
+  let historyDir: string;
+  let prefsPath: string;
+  let originalSpawnHome: string | undefined;
+  let originalHome: string | undefined;
+  let logMessageSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    originalSpawnHome = process.env.SPAWN_HOME;
+    originalHome = process.env.HOME;
+
+    // Use the sandbox HOME set by preload.ts
+    const home = process.env.HOME ?? "/tmp/spawn-test-home-star";
+    historyDir = join(home, ".spawn");
+    prefsPath = join(home, ".config", "spawn", "preferences.json");
+
+    // Clean up any existing history/prefs
+    if (existsSync(historyDir)) {
+      rmSync(historyDir, {
+        recursive: true,
+      });
+    }
+    if (existsSync(prefsPath)) {
+      rmSync(prefsPath);
+    }
+
+    process.env.SPAWN_HOME = historyDir;
+    logMessageSpy = spyOn(p.log, "message").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logMessageSpy.mockRestore();
+    process.env.SPAWN_HOME = originalSpawnHome;
+    process.env.HOME = originalHome;
+  });
+
+  function writeHistory(
+    records: Array<{
+      id: string;
+      agent: string;
+      cloud: string;
+      timestamp: string;
+      connection?: {
+        ip: string;
+        user: string;
+      };
+    }>,
+  ) {
+    mkdirSync(historyDir, {
+      recursive: true,
+    });
+    writeFileSync(
+      join(historyDir, "history.json"),
+      JSON.stringify({
+        version: 1,
+        records,
+      }),
+    );
+  }
+
+  it("skips if fewer than 2 successful spawns", () => {
+    writeHistory([
+      {
+        id: "1",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+
+    maybeShowStarPrompt();
+
+    expect(logMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips if no history at all", () => {
+    maybeShowStarPrompt();
+    expect(logMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows message after 2+ successful spawns", () => {
+    writeHistory([
+      {
+        id: "1",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.4",
+          user: "root",
+        },
+      },
+      {
+        id: "2",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.5",
+          user: "root",
+        },
+      },
+    ]);
+
+    maybeShowStarPrompt();
+
+    expect(logMessageSpy).toHaveBeenCalledTimes(1);
+    const msg = logMessageSpy.mock.calls[0]?.[0];
+    expect(isString(msg) && msg.includes("github.com/OpenRouterTeam/spawn")).toBe(true);
+  });
+
+  it("saves starPromptShownAt to preferences after showing", () => {
+    writeHistory([
+      {
+        id: "1",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.4",
+          user: "root",
+        },
+      },
+      {
+        id: "2",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.5",
+          user: "root",
+        },
+      },
+    ]);
+
+    const before = Date.now();
+    maybeShowStarPrompt();
+    const after = Date.now();
+
+    expect(existsSync(prefsPath)).toBe(true);
+    const PrefsSchema = v.object({
+      starPromptShownAt: v.optional(v.string()),
+    });
+    const prefs = parseJsonWith(readFileSync(prefsPath, "utf-8"), PrefsSchema);
+    expect(prefs).not.toBeNull();
+    expect(typeof prefs?.starPromptShownAt).toBe("string");
+    const shownAt = new Date(prefs?.starPromptShownAt ?? "").getTime();
+    expect(shownAt).toBeGreaterThanOrEqual(before);
+    expect(shownAt).toBeLessThanOrEqual(after);
+  });
+
+  it("skips if shown within 30 days", () => {
+    writeHistory([
+      {
+        id: "1",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.4",
+          user: "root",
+        },
+      },
+      {
+        id: "2",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.5",
+          user: "root",
+        },
+      },
+    ]);
+
+    // Write a recent shownAt timestamp (1 day ago)
+    const recentDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    mkdirSync(join(prefsPath, ".."), {
+      recursive: true,
+    });
+    writeFileSync(
+      prefsPath,
+      JSON.stringify({
+        starPromptShownAt: recentDate,
+      }),
+    );
+
+    maybeShowStarPrompt();
+
+    expect(logMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows again after 30 days have elapsed", () => {
+    writeHistory([
+      {
+        id: "1",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.4",
+          user: "root",
+        },
+      },
+      {
+        id: "2",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.5",
+          user: "root",
+        },
+      },
+    ]);
+
+    // Write an old shownAt timestamp (31 days ago)
+    const oldDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+    mkdirSync(join(prefsPath, ".."), {
+      recursive: true,
+    });
+    writeFileSync(
+      prefsPath,
+      JSON.stringify({
+        starPromptShownAt: oldDate,
+      }),
+    );
+
+    maybeShowStarPrompt();
+
+    expect(logMessageSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves existing preferences fields when saving", () => {
+    writeHistory([
+      {
+        id: "1",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.4",
+          user: "root",
+        },
+      },
+      {
+        id: "2",
+        agent: "claude",
+        cloud: "sprite",
+        timestamp: new Date().toISOString(),
+        connection: {
+          ip: "1.2.3.5",
+          user: "root",
+        },
+      },
+    ]);
+
+    mkdirSync(join(prefsPath, ".."), {
+      recursive: true,
+    });
+    writeFileSync(
+      prefsPath,
+      JSON.stringify({
+        models: {
+          claude: "anthropic/claude-sonnet-4-6",
+        },
+      }),
+    );
+
+    maybeShowStarPrompt();
+
+    const PrefsWithModelsSchema = v.object({
+      models: v.optional(v.record(v.string(), v.string())),
+      starPromptShownAt: v.optional(v.string()),
+    });
+    const prefs = parseJsonWith(readFileSync(prefsPath, "utf-8"), PrefsWithModelsSchema);
+    expect(prefs).not.toBeNull();
+    expect(prefs?.models?.["claude"]).toBe("anthropic/claude-sonnet-4-6");
+    expect(typeof prefs?.starPromptShownAt).toBe("string");
+  });
+});

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -7,6 +7,7 @@ import { agentKeys } from "../manifest.js";
 import { getAgentOptionalSteps } from "../shared/agents.js";
 import { hasSavedOpenRouterKey } from "../shared/oauth.js";
 import { asyncTryCatch, tryCatch, unwrapOr } from "../shared/result.js";
+import { maybeShowStarPrompt } from "../shared/star-prompt.js";
 import { validateModelId } from "../shared/ui.js";
 import { activeServerPicker } from "./list.js";
 import { execScript, showDryRunPreview } from "./run.js";
@@ -272,7 +273,7 @@ export async function cmdInteractive(): Promise<void> {
   p.log.info(`Next time, run directly: ${pc.cyan(`spawn ${agentChoice} ${cloudChoice}`)}`);
   p.outro("Handing off to spawn script...");
 
-  await execScript(
+  const success = await execScript(
     cloudChoice,
     agentChoice,
     undefined,
@@ -281,6 +282,9 @@ export async function cmdInteractive(): Promise<void> {
     undefined,
     spawnName,
   );
+  if (success) {
+    maybeShowStarPrompt();
+  }
 }
 
 /** Interactive cloud selection when agent is already known (e.g. `spawn claude`) */
@@ -328,7 +332,7 @@ export async function cmdAgentInteractive(agent: string, prompt?: string, dryRun
   p.log.info(`Next time, run directly: ${pc.cyan(`spawn ${resolvedAgent} ${cloudChoice}`)}`);
   p.outro("Handing off to spawn script...");
 
-  await execScript(
+  const success = await execScript(
     cloudChoice,
     resolvedAgent,
     prompt,
@@ -337,4 +341,7 @@ export async function cmdAgentInteractive(agent: string, prompt?: string, dryRun
     undefined,
     spawnName,
   );
+  if (success) {
+    maybeShowStarPrompt();
+  }
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -12,6 +12,7 @@ import { loadManifest, RAW_BASE, REPO, SPAWN_CDN } from "../manifest.js";
 import { validateIdentifier, validatePrompt, validateScriptContent } from "../security.js";
 import { asyncTryCatch, isFileError, tryCatch, tryCatchIf } from "../shared/result.js";
 import { getLocalShell, isWindows } from "../shared/shell.js";
+import { maybeShowStarPrompt } from "../shared/star-prompt.js";
 import { logError, logInfo, logStep, prepareStdinForHandoff, toKebabCase } from "../shared/ui.js";
 import { promptSetupOptions, promptSpawnName } from "./interactive.js";
 import { handleRecordAction } from "./list.js";
@@ -660,7 +661,7 @@ export async function execScript(
   dashboardUrl?: string,
   debug?: boolean,
   spawnName?: string,
-): Promise<void> {
+): Promise<boolean> {
   // Generate a unique spawn ID and record the spawn before execution
   const spawnId = generateSpawnId();
   const parentId = process.env.SPAWN_PARENT_ID || undefined;
@@ -705,7 +706,7 @@ export async function execScript(
     if (!dlResult.ok) {
       const ghUrl = `https://github.com/${REPO}/releases/download/${cloud}-latest/${cloud}.js`;
       reportDownloadError(ghUrl, dlResult.error);
-      return;
+      return false;
     }
 
     const env: Record<string, string | undefined> = {
@@ -729,8 +730,9 @@ export async function execScript(
       const errMsg = getErrorMessage(r.error);
       handleUserInterrupt(errMsg, dashboardUrl);
       reportScriptFailure(errMsg, cloud, agent, authHint, prompt, dashboardUrl, spawnName);
+      return false;
     }
-    return;
+    return true;
   }
 
   // macOS/Linux: download the bash wrapper script and run via bash
@@ -740,13 +742,15 @@ export async function execScript(
   const dlResult = await asyncTryCatch(() => downloadScriptWithFallback(url, ghUrl));
   if (!dlResult.ok) {
     reportDownloadError(ghUrl, dlResult.error);
-    return;
+    return false;
   }
 
   const lastErr = runBashScript(dlResult.data, prompt, dashboardUrl, debug, spawnName);
   if (lastErr) {
     reportScriptFailure(lastErr, cloud, agent, authHint, prompt, dashboardUrl, spawnName);
+    return false;
   }
+  return true;
 }
 
 // ── Headless Mode ────────────────────────────────────────────────────────────
@@ -1226,5 +1230,16 @@ export async function cmdRun(
   const suffix = prompt ? " with prompt..." : "...";
   p.log.step(`Launching ${pc.bold(agentName)} on ${pc.bold(cloudName)}${suffix}`);
 
-  await execScript(cloud, agent, prompt, getAuthHint(manifest, cloud), manifest.clouds[cloud].url, debug, spawnName);
+  const success = await execScript(
+    cloud,
+    agent,
+    prompt,
+    getAuthHint(manifest, cloud),
+    manifest.clouds[cloud].url,
+    debug,
+    spawnName,
+  );
+  if (success) {
+    maybeShowStarPrompt();
+  }
 }

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -225,6 +225,7 @@ export interface OrchestrationOptions {
  */
 const PreferencesSchema = v.object({
   models: v.optional(v.record(v.string(), v.string())),
+  starPromptShownAt: v.optional(v.string()),
 });
 
 function loadPreferredModel(agentName: string): string | null {

--- a/packages/cli/src/shared/star-prompt.ts
+++ b/packages/cli/src/shared/star-prompt.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import * as p from "@clack/prompts";
+import * as v from "valibot";
+import { loadHistory } from "../history.js";
+import { parseJsonObj } from "./parse.js";
+import { getSpawnPreferencesPath } from "./paths.js";
+import { tryCatch } from "./result.js";
+
+const StarPreferencesSchema = v.object({
+  starPromptShownAt: v.optional(v.string()),
+});
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const MIN_SUCCESSFUL_SPAWNS = 2;
+
+/**
+ * Show a non-intrusive "star us on GitHub" message after a successful spawn.
+ * Only shown to returning users (2+ successful spawns) and at most once per 30 days.
+ * Silently skips on any error — this is purely optional UX.
+ */
+export function maybeShowStarPrompt(): void {
+  const result = tryCatch(() => {
+    // 1. Count successful spawns (records with a connection field)
+    const history = loadHistory();
+    const successCount = history.filter((r) => r.connection).length;
+    if (successCount < MIN_SUCCESSFUL_SPAWNS) {
+      return;
+    }
+
+    // 2. Read preferences and check if shown within 30 days
+    const prefsPath = getSpawnPreferencesPath();
+    const rawPrefs: Record<string, unknown> = existsSync(prefsPath)
+      ? (parseJsonObj(readFileSync(prefsPath, "utf-8")) ?? {})
+      : {};
+    const parsed = v.safeParse(StarPreferencesSchema, rawPrefs);
+    if (parsed.success && parsed.output.starPromptShownAt) {
+      const shownAt = new Date(parsed.output.starPromptShownAt).getTime();
+      if (Date.now() - shownAt < THIRTY_DAYS_MS) {
+        return;
+      }
+    }
+
+    // 3. Print the star message
+    p.log.message("⭐ Enjoying Spawn? Star us on GitHub!\n   https://github.com/OpenRouterTeam/spawn");
+
+    // 4. Save the updated timestamp
+    const merged = {
+      ...rawPrefs,
+      starPromptShownAt: new Date().toISOString(),
+    };
+    mkdirSync(dirname(prefsPath), {
+      recursive: true,
+    });
+    writeFileSync(prefsPath, JSON.stringify(merged, null, 2));
+  });
+  // Silently ignore errors — star prompt is non-critical
+  void result;
+}


### PR DESCRIPTION
## Summary

- Adds a non-intrusive ⭐ "Star us on GitHub!" message after successful spawn sessions
- Only shown to **returning users** (2+ successful spawns with a `connection` record)
- At most **once per 30 days** — not annoying
- Uses `@clack/prompts` `p.log.message` — no blocking prompt
- Skipped in headless mode (`cmdRunHeadless`)

## Implementation

- New `src/shared/star-prompt.ts` — `maybeShowStarPrompt()` helper
- `StarPreferencesSchema` tracked in `~/.config/spawn/preferences.json` via existing preferences infrastructure
- `PreferencesSchema` in `orchestrate.ts` extended with `starPromptShownAt?: string`
- `execScript()` return type changed from `void` → `boolean` to indicate success/failure
- Called after `execScript()` in `cmdRun()`, `cmdInteractive()`, and `cmdAgentInteractive()`

## Tests

7 unit tests added in `src/__tests__/star-prompt.test.ts` covering:
- Skips on first-time users (< 2 spawns)
- Skips on no history
- Shows message to returning users
- Saves `starPromptShownAt` to preferences
- Skips if shown within 30 days
- Shows again after 30 days elapsed
- Preserves existing preferences fields

**All 1951 tests pass. Zero biome lint errors.**

Fixes #3020

-- refactor/issue-fixer