### PR TITLE
fix(e2e): add cursor agent to e2e test framework

### DIFF
--- a/sh/e2e/lib/common.sh
+++ b/sh/e2e/lib/common.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-ALL_AGENTS="claude openclaw zeroclaw codex opencode kilocode hermes junie"
+ALL_AGENTS="claude openclaw zeroclaw codex opencode kilocode hermes junie cursor"
 PROVISION_TIMEOUT="${PROVISION_TIMEOUT:-720}"
 INSTALL_WAIT="${INSTALL_WAIT:-600}"
 INPUT_TEST_TIMEOUT="${INPUT_TEST_TIMEOUT:-120}"

--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -327,6 +327,11 @@ input_test_junie() {
   return 0
 }
 
+input_test_cursor() {
+  log_warn "cursor is TUI-only — skipping input test"
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 # run_input_test AGENT APP_NAME
 #
@@ -354,6 +359,7 @@ run_input_test() {
     kilocode)  input_test_kilocode          ;;
     hermes)    input_test_hermes            ;;
     junie)     input_test_junie            ;;
+    cursor)    input_test_cursor           ;;
     *)
       log_err "Unknown agent for input test: ${agent}"
       return 1
@@ -743,6 +749,40 @@ verify_junie() {
   return "${failures}"
 }
 
+verify_cursor() {
+  local app="$1"
+  local failures=0
+
+  # Binary check — cursor installs to ~/.cursor/bin/agent
+  log_step "Checking cursor binary..."
+  if cloud_exec "${app}" "PATH=\$HOME/.cursor/bin:\$HOME/.bun/bin:\$PATH command -v agent" >/dev/null 2>&1; then
+    log_ok "cursor (agent) binary found"
+  else
+    log_err "cursor (agent) binary not found"
+    failures=$((failures + 1))
+  fi
+
+  # Env check: CURSOR_API_KEY
+  log_step "Checking cursor env (CURSOR_API_KEY)..."
+  if cloud_exec "${app}" "grep -q CURSOR_API_KEY ~/.spawnrc" >/dev/null 2>&1; then
+    log_ok "CURSOR_API_KEY present in .spawnrc"
+  else
+    log_err "CURSOR_API_KEY not found in .spawnrc"
+    failures=$((failures + 1))
+  fi
+
+  # Env check: OPENROUTER_API_KEY
+  log_step "Checking cursor env (OPENROUTER_API_KEY)..."
+  if cloud_exec "${app}" "grep -q OPENROUTER_API_KEY ~/.spawnrc" >/dev/null 2>&1; then
+    log_ok "OPENROUTER_API_KEY present in .spawnrc"
+  else
+    log_err "OPENROUTER_API_KEY not found in .spawnrc"
+    failures=$((failures + 1))
+  fi
+
+  return "${failures}"
+}
+
 # ---------------------------------------------------------------------------
 # verify_agent AGENT APP_NAME
 #
@@ -772,6 +812,7 @@ verify_agent() {
     kilocode)  verify_kilocode "${app}"  || agent_failures=$? ;;
     hermes)    verify_hermes "${app}"    || agent_failures=$? ;;
     junie)     verify_junie "${app}"    || agent_failures=$? ;;
+    cursor)    verify_cursor "${app}"   || agent_failures=$? ;;
     *)
       log_err "Unknown agent: ${agent}"
       return 1


### PR DESCRIPTION
## Summary

- Adds `cursor` to `ALL_AGENTS` in `sh/e2e/lib/common.sh` so cursor is included in automated e2e sweeps
- Adds `verify_cursor` function checking for the `agent` binary (`~/.cursor/bin`), `CURSOR_API_KEY`, and `OPENROUTER_API_KEY` in `.spawnrc`
- Adds `cursor)` dispatch case in `verify_agent()`
- Adds `input_test_cursor` (TUI-only stub, skips with a warning) following the pattern used by `hermes`, `opencode`, and `kilocode`
- Adds `cursor)` dispatch case in `run_input_test()`

Fixes #3042

## Test plan

- [x] \`bash -n sh/e2e/lib/common.sh\` — syntax OK
- [x] \`bash -n sh/e2e/lib/verify.sh\` — syntax OK
- [x] \`bun test\` — 2013/2013 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- refactor/issue-fixer