### PR TITLE
refactor: Remove dead code and stale references

### DIFF
--- a/packages/cli/src/__tests__/README.md
+++ b/packages/cli/src/__tests__/README.md
@@ -24,6 +24,7 @@ bun test src/__tests__/manifest.test.ts
 
 ### Commands: happy paths
 - `cmdrun-happy-path.test.ts` — Successful download, history recording, env var passing
+- `pull-history.test.ts` — `cmdPullHistory`, `parseAndMergeChildHistory`: child spawn history import and deduplication
 - `cmd-interactive.test.ts` — Interactive agent/cloud selection flow
 - `cmd-listing-output.test.ts` — `cmdMatrix`, `cmdAgents`, `cmdClouds` output formatting
 - `cmdlast.test.ts` — `cmdLast`: history display and resumption
@@ -131,6 +132,8 @@ bun test src/__tests__/manifest.test.ts
 
 ### Shared helpers
 - `shared-helpers.test.ts` — `generateEnvConfig`, `hasStatus`, `toObjectArray`, `toRecord`
+- `spawn-skill.test.ts` — `getSpawnSkillPath`, `getSkillContent`, `injectSpawnSkill`, `isAppendMode`: skill injection per agent
+- `star-prompt.test.ts` — `maybeShowStarPrompt`: returning-user detection, 30-day cooldown, preference persistence
 
 ### OAuth and auth
 - `oauth-code-validation.test.ts` — `OAUTH_CODE_REGEX` format validation
@@ -138,6 +141,7 @@ bun test src/__tests__/manifest.test.ts
 
 ### History (extended)
 - `history-spawn-id.test.ts` — Unique spawn IDs, `saveVmConnection`/`saveLaunchCmd` by spawnId, concurrent spawn isolation
+- `recursive-spawn.test.ts` — `findDescendants`, `cmdTree`, `mergeChildHistory`, `exportHistory`: recursive child spawn tracking and tree output
 
 ### Manifest (extended)
 - `icon-integrity.test.ts` — Icon file existence and format validation


### PR DESCRIPTION
## Summary

Code quality sweep of the spawn codebase. One actionable finding:

- **Stale README entries**: 4 test files existed on disk but were missing from `packages/cli/src/__tests__/README.md`: `pull-history.test.ts`, `recursive-spawn.test.ts`, `spawn-skill.test.ts`, `star-prompt.test.ts`

## Scanned areas (all clean)

- **Dead code in `sh/shared/*.sh`**: No dead functions — `github-auth.sh`, `key-request.sh`, and `sprite-keep-running.sh` all have active callers
- **Stale references**: No shell scripts sourcing deleted files; all `e2e/lib/*.sh` files sourced by `e2e.sh` exist on disk
- **Python usage**: No `python3 -c` or `python -c` calls in shell scripts
- **Duplicate utilities**: `getCloudInitUserdata` exists in aws/hetzner/digitalocean but each version is cloud-specific (different users, PATH configs, error handling) — not a candidate for extraction
- **`as` type assertions**: None found (biome confirms 0 lint errors)
- **`echo -e` violations**: None
- **`source <(...)` violations**: None

## Test plan

- [x] `bun test`: 2013 pass, 0 fail
- [x] `bunx @biomejs/biome check packages/cli/src/`: 0 errors