### PR TITLE
ci: add cursor agent to Docker image pipeline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        agent: [claude, codex, openclaw, opencode, kilocode, zeroclaw, hermes, junie]
+        agent: [claude, codex, cursor, openclaw, opencode, kilocode, zeroclaw, hermes, junie]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/sh/docker/cursor.Dockerfile
+++ b/sh/docker/cursor.Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base packages
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      curl git ca-certificates unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Cursor CLI
+RUN curl -fsSL https://cursor.com/install | bash || \
+    [ -f /root/.local/bin/cursor ]
+
+# Ensure tools are on PATH for all shells
+RUN for rc in /root/.bashrc /root/.zshrc; do \
+      grep -q '.local/bin' "$rc" 2>/dev/null || \
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$rc"; \
+    done
+
+CMD ["/bin/sleep", "inf"]


### PR DESCRIPTION
## Summary
- Adds `sh/docker/cursor.Dockerfile` — ubuntu:24.04 base with Cursor CLI installed via official installer
- Adds `cursor` to the agent matrix in `docker.yml` workflow
- Nightly builds will produce `ghcr.io/openrouterteam/spawn-cursor:latest`

## Test plan
- [ ] Trigger `Build Docker Images` workflow manually and verify cursor image builds
- [ ] `docker run --rm ghcr.io/openrouterteam/spawn-cursor:latest which cursor` returns a valid path
- [ ] Verify `--beta docker` mode works with cursor on Hetzner/GCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)