### PR TITLE
fix(ux): reduce SSH wait verbosity and clarify agent handoff

### DIFF
--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -725,7 +725,7 @@ async function postInstall(
     process.exit(0);
   }
 
-  logStep("Starting agent...");
+  logStep("Provisioning complete. Connecting to agent session...");
 
   // Reset terminal state before handing off to the interactive SSH session.
   // @clack/prompts may have left the cursor hidden or set ANSI attributes

--- a/packages/cli/src/shared/ssh.ts
+++ b/packages/cli/src/shared/ssh.ts
@@ -347,7 +347,9 @@ export async function waitForSsh(opts: WaitForSshOpts): Promise<void> {
       logInfo("SSH port 22 is open");
       break;
     }
-    logStepInline(`SSH port closed (${attempt}/${maxAttempts})`);
+    if (attempt % 5 === 0 || attempt === 1) {
+      logStepInline(`Waiting for SSH port... (${attempt}/${maxAttempts} attempts)`);
+    }
     await sleep(2000);
   }
 


### PR DESCRIPTION
**Why:** Issue #3053 — repeated 'SSH port closed (N/36)' messages flood output with no progress indication, and users can't tell where provisioning ends and the agent TUI begins.

## Changes
- Reduces SSH wait verbosity: only prints every 5 attempts instead of every attempt
- Adds clear 'Provisioning complete. Connecting...' status line before agent attach

## Test plan
- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — all 1952 pass

Fixes #3053

-- refactor/ux-engineer