### PR TITLE
fix(cursor): update binary path from ~/.cursor/bin to ~/.local/bin

### DIFF
--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -207,10 +207,10 @@ async function setupCursorConfig(runner: CloudRunner, _apiKey: string): Promise<
   // Spawn rule should be world-readable (not sensitive)
   await runner.runServer("chmod 644 ~/.cursor/rules/spawn.mdc");
 
-  // Persist PATH so agent binary is available
+  // Persist PATH so agent binary is available (cursor installs to ~/.local/bin since 2026-03-25)
   const pathScript = [
-    'grep -q ".cursor/bin" ~/.bashrc 2>/dev/null || printf \'\\nexport PATH="$HOME/.cursor/bin:$PATH"\\n\' >> ~/.bashrc',
-    'grep -q ".cursor/bin" ~/.zshrc 2>/dev/null || printf \'\\nexport PATH="$HOME/.cursor/bin:$PATH"\\n\' >> ~/.zshrc',
+    'grep -q ".local/bin" ~/.bashrc 2>/dev/null || printf \'\\nexport PATH="$HOME/.local/bin:$PATH"\\n\' >> ~/.bashrc',
+    'grep -q ".local/bin" ~/.zshrc 2>/dev/null || printf \'\\nexport PATH="$HOME/.local/bin:$PATH"\\n\' >> ~/.zshrc',
   ].join(" && ");
 
   await runner.runServer(pathScript);
@@ -1175,7 +1175,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
           runner,
           "Cursor CLI",
           "curl https://cursor.com/install -fsS | bash && " +
-            'export PATH="$HOME/.cursor/bin:$PATH" && ' +
+            'export PATH="$HOME/.local/bin:$PATH" && ' +
             "agent --version",
         ),
       envVars: (apiKey) => [
@@ -1184,8 +1184,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       ],
       configure: (apiKey) => setupCursorConfig(runner, apiKey),
       launchCmd: () =>
-        'source ~/.spawnrc 2>/dev/null; export PATH="$HOME/.cursor/bin:$PATH"; agent --endpoint https://openrouter.ai/api/v1',
-      updateCmd: 'export PATH="$HOME/.cursor/bin:$PATH"; agent update',
+        'source ~/.spawnrc 2>/dev/null; export PATH="$HOME/.local/bin:$PATH"; agent --endpoint https://openrouter.ai/api/v1',
+      updateCmd: 'export PATH="$HOME/.local/bin:$PATH"; agent update',
     },
   };
 }

--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -753,9 +753,9 @@ verify_cursor() {
   local app="$1"
   local failures=0
 
-  # Binary check — cursor installs to ~/.cursor/bin/agent
+  # Binary check — cursor installs to ~/.local/bin/agent (since 2026-03-25)
   log_step "Checking cursor binary..."
-  if cloud_exec "${app}" "PATH=\$HOME/.cursor/bin:\$HOME/.bun/bin:\$PATH command -v agent" >/dev/null 2>&1; then
+  if cloud_exec "${app}" "PATH=\$HOME/.local/bin:\$HOME/.cursor/bin:\$HOME/.bun/bin:\$PATH command -v agent" >/dev/null 2>&1; then
     log_ok "cursor (agent) binary found"
   else
     log_err "cursor (agent) binary not found"


### PR DESCRIPTION
## Summary

- The cursor installer (as of 2026-03-25 release `2026.03.25-933d5a6`) changed its binary install location from `~/.cursor/bin/agent` to `~/.local/bin/agent`
- This caused cursor to fail E2E verification on hetzner and gcp (binary not found check)
- Sprite passed because it uses pre-baked snapshots with older cursor installed

## Changes

- `packages/cli/src/shared/agent-setup.ts`: Update PATH references in `install`, `launchCmd`, `updateCmd`, and `setupCursorConfig` pathScript from `~/.cursor/bin` to `~/.local/bin`
- `sh/e2e/lib/verify.sh`: Update `verify_cursor` binary check to look in `~/.local/bin` first
- Bump CLI to 0.27.3

## Test plan

- [x] Ran `bash -n sh/e2e/lib/verify.sh` — passes
- [x] Ran `bunx @biomejs/biome check packages/cli/src/shared/agent-setup.ts` — no errors
- [x] Re-ran cursor E2E on hetzner with worktree code — cursor PASSED (1m 10s)

-- qa/e2e-tester