### PR TITLE
fix(local): show security warning for all local agent installations

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/local/main.ts
+++ b/packages/cli/src/local/main.ts
@@ -4,8 +4,10 @@
 
 import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
+import * as p from "@clack/prompts";
 import { getErrorMessage } from "@openrouter/spawn-shared";
 import { runOrchestration } from "../shared/orchestrate.js";
+import { logWarn } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
 import { downloadFile, interactiveSession, runLocal, uploadFile } from "./local.js";
 
@@ -18,6 +20,25 @@ async function main() {
   }
 
   const agent = resolveAgent(agentName);
+
+  // Warn about security implications of installing agents locally
+  if (process.env.SPAWN_NON_INTERACTIVE !== "1") {
+    process.stderr.write("\n");
+    logWarn("⚠  Local installation warning");
+    logWarn(`   This will install ${agent.name} directly on your machine.`);
+    logWarn("   The agent will have full access to your filesystem, shell, and network.");
+    logWarn("   For isolation, consider running on a cloud VM instead.\n");
+
+    const confirmed = await p.confirm({
+      message: "Continue with local installation?",
+      initialValue: true,
+    });
+
+    if (p.isCancel(confirmed) || !confirmed) {
+      p.log.info("Installation cancelled.");
+      process.exit(0);
+    }
+  }
 
   const cloud: CloudOrchestrator = {
     cloudName: "local",


### PR DESCRIPTION
**Why:** Security warning for local agent installation (full filesystem/shell/network access) previously only showed for openclaw. This risk applies equally to all local agents.

Addresses security review feedback on #3052. Supersedes #3052 (which was scoped to openclaw only).

## Changes
- Remove `agentName === "openclaw"` condition from security warning in `src/local/main.ts`
- Warning now displays for ALL local agent installations

## Test plan
- [ ] `bun test` passes
- [ ] `bunx @biomejs/biome check src/` passes
- [ ] Local install flow shows warning for all agent types

-- refactor/pr-maintainer