### PR TITLE
fix(cursor): remove stale ~/.cursor/bin references missed in #3058 migration

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -332,7 +332,7 @@
           }
         }
       },
-      "notes": "Works with OpenRouter via --endpoint flag pointing to openrouter.ai/api/v1 and CURSOR_API_KEY set to OpenRouter key. Binary installs to ~/.cursor/bin/agent.",
+      "notes": "Works with OpenRouter via --endpoint flag pointing to openrouter.ai/api/v1 and CURSOR_API_KEY set to OpenRouter key. Binary installs to ~/.local/bin/agent.",
       "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/agents/cursor.png",
       "featured_cloud": [
         "digitalocean",

--- a/sh/e2e/lib/provision.sh
+++ b/sh/e2e/lib/provision.sh
@@ -378,7 +378,7 @@ _ensure_agent_binary() {
   # PATH includes all common binary locations for detection.
   local bin_name=""
   local install_cmd=""
-  local path_prefix='export PATH="$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.claude/local/bin:$HOME/.cursor/bin:/usr/local/bin:$PATH"'
+  local path_prefix='export PATH="$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.claude/local/bin:/usr/local/bin:$PATH"'
 
   case "${agent}" in
     claude)

--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -755,7 +755,7 @@ verify_cursor() {
 
   # Binary check — cursor installs to ~/.local/bin/agent (since 2026-03-25)
   log_step "Checking cursor binary..."
-  if cloud_exec "${app}" "PATH=\$HOME/.local/bin:\$HOME/.cursor/bin:\$HOME/.bun/bin:\$PATH command -v agent" >/dev/null 2>&1; then
+  if cloud_exec "${app}" "PATH=\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH command -v agent" >/dev/null 2>&1; then
     log_ok "cursor (agent) binary found"
   else
     log_err "cursor (agent) binary not found"


### PR DESCRIPTION
## Summary

Cleans up three remaining stale `~/.cursor/bin` references that were not caught in the #3058 path migration:

- **`manifest.json:335`**: Updated `notes` field from `~/.cursor/bin/agent` → `~/.local/bin/agent` (users see this in `spawn cursor` info output)
- **`sh/e2e/lib/provision.sh:381`**: Removed `$HOME/.cursor/bin:` from `path_prefix` PATH string (dead weight since cursor now installs to `~/.local/bin`)
- **`sh/e2e/lib/verify.sh:758`**: Removed `$HOME/.cursor/bin:` from binary detection PATH check (stale fallback, `~/.local/bin` already present)

## Test plan
- [x] `bash -n` passes on both modified `.sh` files
- [x] No remaining `cursor/bin` references in `.json`, `.sh`, `.ts`, or `.md` files
- [x] No CLI changes (no version bump needed per issue description)

Fixes #3065

-- refactor/issue-fixer