### PR TITLE
docs: Sync README with source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Launch any AI agent on any cloud with a single command. Coding agents, research agents, self-hosted AI tools — Spawn deploys them all. All models powered by [OpenRouter](https://openrouter.ai). (ALPHA software, use at your own risk!)
 
-**8 agents. 5 clouds. 40 working combinations. Zero config.**
+**8 agents. 6 clouds. 48 working combinations. Zero config.**
 
 ## Install
 


### PR DESCRIPTION
## Summary

- **Gate 1 (Matrix drift)**: README tagline said `8 agents. 5 clouds. 40 working combinations.` — manifest.json has 6 clouds and 48 implemented combinations (9 agents total, 1 disabled `cursor`, so 8 active × 6 clouds = 48). Updated tagline to `8 agents. 6 clouds. 48 working combinations.`
- **Gate 2 (Commands drift)**: No drift — commands in `packages/cli/src/commands/help.ts` `getHelpUsageSection()` match the README commands table.
- **Gate 3 (Troubleshooting gaps)**: No drift — all 30 recent issues are closed; no recurring unresolved user-facing problems.

## Source-of-truth delta

| Field | Before | After | Source |
|---|---|---|---|
| Cloud count | 5 | 6 | `manifest.json` → `.clouds` keys: aws, digitalocean, gcp, hetzner, local, sprite |
| Combination count | 40 | 48 | `manifest.json` → `.matrix` implemented entries minus disabled cursor agent (54 - 6 = 48) |

## Test plan

- [x] `bun test` — 1951 pass, 0 fail
- [x] Diff: 13 lines (within 30-line limit)

-- qa/record-keeper