### PR TITLE
fix(security): add base64 validation for GitHub token (#3079)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.27.6",
+  "version": "0.27.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -299,6 +299,9 @@ export async function offerGithubAuth(runner: CloudRunner, explicitlyRequested?:
   let ghCmd = "curl --proto '=https' -fsSL https://openrouter.ai/labs/spawn/shared/github-auth.sh | bash";
   if (githubToken) {
     const tokenB64 = Buffer.from(githubToken).toString("base64");
+    if (!/^[A-Za-z0-9+/=]+$/.test(tokenB64)) {
+      throw new Error("Unexpected characters in base64 output");
+    }
     ghCmd = `export GITHUB_TOKEN=$(printf '%s' ${shellQuote(tokenB64)} | base64 -d) && ${ghCmd}`;
   }
 


### PR DESCRIPTION
**Why:** Defense-in-depth gap — the base64-encoded GitHub token was the only base64 value in agent-setup.ts not validated before shell interpolation.

## Summary

`offerGithubAuth()` base64-encodes the GitHub token and passes it through `shellQuote()` for use in a remote SSH command. While `shellQuote()` (POSIX single-quote escaping + null byte rejection) already provides adequate protection, every other base64 value in the same file (`wrapperB64`, `unitB64`, `timerB64`) includes an explicit `/^[A-Za-z0-9+/=]+$/` validation guard before use. This PR adds the same guard to `tokenB64` for consistency.

## Assessment of the broader issue

After auditing all code paths mentioned in #3079:

- **`shellQuote()`** uses correct POSIX single-quote escaping (`'\''` technique) with null byte rejection — robust against injection
- **`sanitizeTermValue()`** uses a strict allowlist for TERM values — stronger than quoting
- **`validateRemotePath()`** uses character allowlist + traversal checks — safe for its use case
- **All user-controllable inputs** (API keys, tokens, git config values) are properly `shellQuote()`-wrapped
- **Base64 values** from hardcoded strings and from `orchestrate.ts`/`spawn-skill.ts` already had validation

The only gap was `tokenB64` in `offerGithubAuth()` which is now fixed.

Fixes #3079

-- refactor/security-auditor