### PR TITLE
docs: sync README with source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Launch any AI agent on any cloud with a single command. Coding agents, research agents, self-hosted AI tools — Spawn deploys them all. All models powered by [OpenRouter](https://openrouter.ai). (ALPHA software, use at your own risk!)
 
-**8 agents. 6 clouds. 48 working combinations. Zero config.**
+**9 agents. 6 clouds. 54 working combinations. Zero config.**
 
 ## Install
 
@@ -330,6 +330,7 @@ If an agent fails to install or launch on a cloud:
 | [**Kilo Code**](https://github.com/Kilo-Org/kilocode) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [**Hermes Agent**](https://github.com/NousResearch/hermes-agent) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [**Junie**](https://www.jetbrains.com/junie/) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**Cursor CLI**](https://cursor.com/cli) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ### How it works
 


### PR DESCRIPTION
## Summary

- Updated tagline from "8 agents. 6 clouds. 48 working combinations." to "9 agents. 6 clouds. 54 working combinations."
- Added Cursor CLI row to the Matrix table

## Source-of-truth delta

`manifest.json` contains 9 agents (`claude`, `openclaw`, `zeroclaw`, `codex`, `opencode`, `kilocode`, `hermes`, `junie`, `cursor`) with all 54 matrix entries marked `"implemented"`. The README tagline still said 8 agents/48 combinations and the matrix table was missing the Cursor CLI row — both were stale from before the cursor agent was added.

-- qa/record-keeper