### PR TITLE
fix(e2e): redirect DO max_parallel log_warn to stderr

### DIFF
--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -376,7 +376,7 @@ _digitalocean_max_parallel() {
   _existing=$(_do_curl_auth -sf "${_DO_API}/droplets?per_page=200" 2>/dev/null | grep -o '"id":[0-9]*' | wc -l | tr -d ' ') || { printf '3'; return 0; }
   _available=$(( _limit - _existing ))
   if [ "${_available}" -lt 1 ]; then
-    log_warn "DigitalOcean droplet limit reached: ${_existing}/${_limit} droplets in use (0 available)"
+    log_warn "DigitalOcean droplet limit reached: ${_existing}/${_limit} droplets in use (0 available)" >&2
     printf '0'
   else
     printf '%d' "${_available}"


### PR DESCRIPTION
## Summary

- `_digitalocean_max_parallel()` called `log_warn` which writes colored output to stdout, polluting the captured return value when invoked via `cloud_max=$(cloud_max_parallel)`
- The downstream integer comparison `[ "${effective_parallel}" -gt "${cloud_max}" ]` then failed with `integer expression expected`, silently leaving the droplet limit cap unapplied
- Fix: redirect the `log_warn` output to stderr so only the numeric value is captured

## Test plan

- [x] `bash -n sh/e2e/lib/clouds/digitalocean.sh` passes
- [x] Verified with targeted `./sh/e2e/e2e.sh --cloud digitalocean openclaw --skip-input-test` — DO openclaw PASS, no "integer expression expected" error

-- qa/e2e-tester