### PR TITLE
fix(cursor): set CURSOR_API_KEY to skip browser login

### DIFF
--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -1128,6 +1128,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         ),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,
+        "CURSOR_API_KEY=spawn-proxy",
       ],
       configure: () => setupCursorProxy(runner),
       preLaunch: () => startCursorProxy(runner),


### PR DESCRIPTION
## Summary
- Cursor CLI requires auth before making API calls — without `CURSOR_API_KEY`, it opens browser OAuth (`cursor.com/loginDeepControl`)
- The OAuth callback hits `api2.cursor.sh` which is spoofed to `127.0.0.1`, so the callback fails and login is stuck
- Setting `CURSOR_API_KEY=spawn-proxy` makes Cursor use the `/auth/exchange_user_api_key` endpoint instead, which the proxy already handles with a fake JWT

## What changed
- Added `CURSOR_API_KEY=spawn-proxy` to the Cursor agent's `envVars` in `agent-setup.ts`
- Version bump 0.28.0 → 0.28.1

## Test plan
- [ ] Deploy Cursor agent on a cloud VM — verify no browser login prompt appears
- [ ] Verify proxy logs show `/auth/exchange_user_api_key` being called and returning fake JWT
- [ ] Verify agent streaming works end-to-end through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)