### PR TITLE
docs: Sync README with source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ spawn delete -c hetzner                  # Delete a server on Hetzner
 | `spawn <agent> <cloud> --dry-run` | Preview without provisioning |
 | `spawn <agent> <cloud> --zone <zone>` | Set zone/region for the cloud |
 | `spawn <agent> <cloud> --size <type>` | Set instance size/type for the cloud |
-| `spawn <agent> <cloud> -p "text"` | Non-interactive with prompt |
-| `spawn <agent> <cloud> --prompt-file f.txt` | Prompt from file |
+| `spawn <agent> <cloud> --prompt "text"` | Non-interactive with prompt (or `-p`) |
+| `spawn <agent> <cloud> --prompt-file <file>` | Prompt from file (or `-f`) |
 | `spawn <agent> <cloud> --headless` | Provision and exit (no interactive session) |
 | `spawn <agent> <cloud> --output json` | Headless mode with structured JSON on stdout |
 | `spawn <agent> <cloud> --model <id>` | Set the model ID (overrides agent default) |


### PR DESCRIPTION
## Summary

Fixes a commands table drift detected by the record-keeper gate check.

## Gate Results

- **Gate 1 (Matrix)**: No drift. README tagline matches manifest.json: 9 agents, 6 clouds, 54 implemented combinations.
- **Gate 2 (Commands)**: **Triggered.** Two rows in the README commands table did not match `getHelpUsageSection()` in `help.ts`:
  - `-p "text"` → corrected to `--prompt "text"` (with `(or -p)` alias note) — matches help.ts line 16
  - `--prompt-file f.txt` → corrected to `--prompt-file <file>` (with `(or -f)` alias note) — matches help.ts line 18
- **Gate 3 (Troubleshooting)**: No recurring user-reported issues missing from the Troubleshooting section.

## Diff

```
 README.md | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

15 lines total (well within the 30-line limit). All 1968 tests pass.