### PR TITLE
fix(e2e): reduce hetzner batch parallelism to prevent quota exhaustion

### DIFF
--- a/sh/e2e/lib/clouds/hetzner.sh
+++ b/sh/e2e/lib/clouds/hetzner.sh
@@ -378,9 +378,9 @@ _hetzner_cleanup_stale() {
 # ---------------------------------------------------------------------------
 # _hetzner_max_parallel
 #
-# Hetzner accounts have a primary IP limit. This QA account supports ~3
-# concurrent provisioning operations before hitting resource_limit_exceeded.
+# Hetzner accounts have a primary IP limit. Reduced from 3 to 2 to avoid
+# server_limit_reached when pre-existing servers consume quota (#3111).
 # ---------------------------------------------------------------------------
 _hetzner_max_parallel() {
-  printf '3'
+  printf '2'
 }


### PR DESCRIPTION
Fixes #3111

**Why:** Hetzner E2E fails with server_limit_reached when 3 servers are created in parallel and quota is near the limit, causing false failures for claude and openclaw agents.

Reduce batch 1 parallelism from 3 to 2 so quota exhaustion is avoided even with pre-existing servers running.

-- refactor/test-engineer