### PR TITLE
refactor: Normalize unused-arg comments in headless_env functions

### DIFF
--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -73,7 +73,7 @@ _digitalocean_validate_env() {
 # ---------------------------------------------------------------------------
 _digitalocean_headless_env() {
   local app="$1"
-  # local agent="$2"  # unused but part of the interface
+  # $2 = agent (unused but part of the interface)
 
   printf 'export DO_DROPLET_NAME="%s"\n' "${app}"
   printf 'export DO_DROPLET_SIZE="%s"\n' "${DO_DROPLET_SIZE:-${_DO_DEFAULT_SIZE}}"

--- a/sh/e2e/lib/clouds/gcp.sh
+++ b/sh/e2e/lib/clouds/gcp.sh
@@ -92,7 +92,7 @@ process.stdout.write(d.GCP_ZONE || '');
 # ---------------------------------------------------------------------------
 _gcp_headless_env() {
   local app="$1"
-  # local agent="$2"  # unused but part of the interface
+  # $2 = agent (unused but part of the interface)
 
   printf 'export GCP_INSTANCE_NAME="%s"\n' "${app}"
   printf 'export GCP_PROJECT="%s"\n' "${GCP_PROJECT:-}"

--- a/sh/e2e/lib/clouds/sprite.sh
+++ b/sh/e2e/lib/clouds/sprite.sh
@@ -129,7 +129,7 @@ _sprite_validate_env() {
 # ---------------------------------------------------------------------------
 _sprite_headless_env() {
   local app="$1"
-  # local agent="$2"  # unused but part of the interface
+  # $2 = agent (unused but part of the interface)
 
   printf 'export SPRITE_NAME="%s"\n' "${app}"
   if [ -n "${_SPRITE_ORG}" ]; then


### PR DESCRIPTION
## Summary

- GCP, Sprite, and DigitalOcean cloud E2E scripts had `# local agent="\$2"` (commented-out code) in their `_headless_env` functions to document that `\$2` is part of the interface but unused
- Hetzner already used the cleaner documentation style: `# \$2 = agent (unused but part of the interface)`
- This normalizes the three inconsistent files to match Hetzner's style

## Findings from full dead code scan

Full scan covered:
- **Python usage**: None found — all good
- **Dead functions in sh/shared/**: None — all functions in `github-auth.sh`, `key-request.sh`, `sprite-keep-running.sh` are properly called
- **Stale references to deleted files**: None in production code
- **Duplicate TypeScript utilities**: `waitForSsh` wrappers in `aws.ts` and `gcp.ts` are intentional thin wrappers using module-level state — not problematic duplicates
- **Dead TypeScript exports**: All exports are used in production code or intentionally exported for unit testing
- **ESM/require violations**: None — codebase is clean ESM throughout
- **Biome lint**: 0 errors across 172 files
- **Tests**: 1972 pass, 0 fail

The only concrete change is the comment style normalization in 3 files.

## Test plan

- [x] `bash -n` on all 3 modified `.sh` files — all pass
- [x] `bun test` in `packages/cli` — 1972 pass, 0 fail
- [x] `bunx @biomejs/biome check src/` — 0 errors

-- qa/code-quality