### PR TITLE
fix(prompts): stop infinite shutdown loop after TeamDelete in non-interactive mode

### DIFF
--- a/.claude/skills/setup-agent-team/refactor-issue-prompt.md
+++ b/.claude/skills/setup-agent-team/refactor-issue-prompt.md
@@ -74,7 +74,7 @@ Track lifecycle: "pending-review" → "under-review" → "in-progress". Check la
 7. Keep pushing commits to the same branch as work progresses
 8. When fix is complete and tests pass: `gh pr ready NUMBER`, post update comment linking PR
 9. Do NOT close the issue — `Fixes #SPAWN_ISSUE_PLACEHOLDER` auto-closes on merge
-10. Clean up: `git worktree remove WORKTREE_BASE_PLACEHOLDER`, shutdown teammates
+10. Clean up: run `git worktree remove WORKTREE_BASE_PLACEHOLDER` and call `TeamDelete` in ONE turn, then output a plain-text summary with **NO further tool calls**. A text-only response ends the non-interactive session immediately.
 
 ## Commit Markers
 
@@ -84,5 +84,6 @@ Every commit: `Agent: issue-fixer` + `Co-Authored-By: Claude Sonnet 4.5 <noreply
 
 - Run tests after every change
 - If fix is not straightforward (>10 min), comment on issue explaining complexity and exit
+- **NO TOOLS AFTER TeamDelete.** After calling `TeamDelete`, do NOT call any other tool. Output plain text only to end the session. Any tool call after `TeamDelete` causes an infinite shutdown prompt loop in non-interactive (-p) mode. See issue #3103.
 
 Begin now. Fix issue #SPAWN_ISSUE_PLACEHOLDER.

--- a/.claude/skills/setup-agent-team/refactor-team-prompt.md
+++ b/.claude/skills/setup-agent-team/refactor-team-prompt.md
@@ -273,6 +273,8 @@ Setup: `mkdir -p WORKTREE_BASE_PLACEHOLDER`. Cleanup: `git worktree prune` at cy
 
 **The session ENDS when you produce a response with NO tool calls.** EVERY iteration MUST include at minimum: `TaskList` + `Bash("sleep 15")`.
 
+**EXCEPTION — After TeamDelete:** Once `TeamDelete` has been called and completed (step 4 of the shutdown sequence), your VERY NEXT response MUST be plain text only with **NO tool calls**. Do NOT call `TaskList`, `Bash`, or any other tool after `TeamDelete`. A text-only response is the termination signal for the non-interactive harness. Any tool call after `TeamDelete` causes an infinite loop of shutdown prompt injections.
+
 Keep looping until:
 - All tasks are completed OR
 - Time budget is reached (10 min warn, 12 min shutdown, 15 min force)
@@ -289,10 +291,12 @@ Follow this exact shutdown sequence:
 1. At 10 min: broadcast "wrap up" to all teammates
 2. At 12 min: send `shutdown_request` to EACH teammate by name
 3. Wait for ALL shutdown confirmations — keep calling `TaskList` while waiting
-4. After all confirmations: `git worktree prune && rm -rf WORKTREE_BASE_PLACEHOLDER`
-5. Print summary and exit
+4. In ONE turn: call `TeamDelete`, then run `git worktree prune && rm -rf WORKTREE_BASE_PLACEHOLDER` — do everything in this single turn
+5. **Output a plain-text summary and STOP** — do NOT call any tool after `TeamDelete`. This text-only response ends the session.
 
 **NEVER exit without shutting down all teammates first.** If a teammate doesn't respond to shutdown_request within 2 minutes, send it again.
+
+**CRITICAL — NO TOOLS AFTER TeamDelete.** After `TeamDelete` returns (whether success or "No team name found"), you MUST NOT make any further tool calls. Output your final summary as plain text and stop. Any tool call after `TeamDelete` triggers an infinite shutdown prompt loop in non-interactive (-p) mode. See issue #3103.
 
 ## Safety
 


### PR DESCRIPTION
**Why:** After `TeamDelete` completes in `-p` (non-interactive) mode, the Claude Code harness keeps re-injecting \"Shut down your team\" prompts every turn, burning all remaining turns without doing useful work. Fixing this stops needless session waste on every refactor/issue-fix cycle.

## Root Cause

The Monitor Loop in both prompt files instructed the team lead to call `TaskList` + `Bash` on **EVERY** iteration. After `TeamDelete`, if Claude calls any tool, the harness gets another turn — and injects another shutdown prompt — causing an infinite loop.

## Fix

Added an explicit `EXCEPTION — After TeamDelete` section to the Monitor Loop in `refactor-team-prompt.md`:
- After `TeamDelete` returns, the team lead's next response MUST be plain-text only (no tool calls)
- A text-only response is the termination signal for non-interactive mode

Updated `refactor-issue-prompt.md` Workflow step 10 and Safety section with the same guidance.

## Files Changed

- `.claude/skills/setup-agent-team/refactor-team-prompt.md` — Monitor Loop exception + Lifecycle Management clarification
- `.claude/skills/setup-agent-team/refactor-issue-prompt.md` — Workflow step 10 + Safety note

Fixes #3103

-- refactor/issue-fixer