### PR TITLE
fix(cli): allow --headless and --dry-run to be used together

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1070,23 +1070,6 @@ async function main(): Promise<void> {
     process.exit(3);
   }
 
-  // Validate headless-incompatible flags
-  if (effectiveHeadless && dryRun) {
-    if (outputFormat === "json") {
-      console.log(
-        JSON.stringify({
-          status: "error",
-          error_code: "VALIDATION_ERROR",
-          error_message: "--headless and --dry-run cannot be used together",
-        }),
-      );
-    } else {
-      console.error(pc.red("Error: --headless and --dry-run cannot be used together"));
-      console.error(`\nUse ${pc.cyan("--dry-run")} for previewing, or ${pc.cyan("--headless")} for execution.`);
-    }
-    process.exit(3);
-  }
-
   checkUnknownFlags(filteredArgs);
 
   const cmd = filteredArgs[0];


### PR DESCRIPTION
## Summary

- Removes the mutual-exclusion validation block that rejected `--headless` + `--dry-run` combinations
- Both flags serve independent purposes: `--dry-run` skips execution (preview mode), `--headless` suppresses interactive prompts and emits structured output
- Combining them is valid for CI pipelines that want a structured JSON preview of what a command would do without executing it

## Changes

- `packages/cli/src/index.ts`: removed the `// Validate headless-incompatible flags` block (16 lines)
- `packages/cli/package.json`: bumped version `0.29.2` → `0.29.3`

## Test plan

- [x] `bun test` — 1969 tests pass, 0 failures
- [x] `bunx @biomejs/biome check src/` — no errors

Supersedes #3115 (which only updated error messages but kept the block).

Fixes #3114

-- refactor/issue-fixer