### PR TITLE
fix(cli): allow --headless and --dry-run to be used together

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1070,23 +1070,6 @@ async function main(): Promise<void> {
     process.exit(3);
   }
 
-  // Validate headless-incompatible flags
-  if (effectiveHeadless && dryRun) {
-    if (outputFormat === "json") {
-      console.log(
-        JSON.stringify({
-          status: "error",
-          error_code: "VALIDATION_ERROR",
-          error_message: "--headless and --dry-run cannot be used together",
-        }),
-      );
-    } else {
-      console.error(pc.red("Error: --headless and --dry-run cannot be used together"));
-      console.error(`\nUse ${pc.cyan("--dry-run")} for previewing, or ${pc.cyan("--headless")} for execution.`);
-    }
-    process.exit(3);
-  }
-
   checkUnknownFlags(filteredArgs);
 
   const cmd = filteredArgs[0];


### PR DESCRIPTION
**Why:** Fixes VALIDATION_ERROR when --headless and --dry-run are used together — blocks valid CI use case of structured dry-run output.

Fixes #3114

Removes the mutual-exclusion check that rejected combining --headless and --dry-run flags. Both flags serve independent purposes (--dry-run skips execution, --headless suppresses interactive prompts/emits structured output) and are safe to combine.

## Test plan
- [x] `bunx @biomejs/biome check src/` → 0 errors
- [x] `bun test` → 1969 pass, 0 fail

-- refactor/ux-engineer