### PR TITLE
docs: remove stale ZeroClaw references after agent removal

### DIFF
--- a/.claude/rules/agent-default-models.md
+++ b/.claude/rules/agent-default-models.md
@@ -10,7 +10,6 @@ Last verified: 2026-03-13
 | Claude Code | _(routed by Anthropic)_ | `ANTHROPIC_BASE_URL=https://openrouter.ai/api` — model selection handled by Claude's own routing |
 | Codex CLI | `openai/gpt-5.3-codex` | Hardcoded in `setupCodexConfig()` → `~/.codex/config.toml` |
 | OpenClaw | `openrouter/auto` | `modelDefault` field in agent config; written to OpenClaw config via `setupOpenclawConfig()` |
-| ZeroClaw | _(provider default)_ | `ZEROCLAW_PROVIDER=openrouter` — model selection handled by ZeroClaw's OpenRouter integration |
 | OpenCode | _(provider default)_ | `OPENROUTER_API_KEY` env var — model selection handled by OpenCode natively |
 | Kilo Code | _(provider default)_ | `KILO_PROVIDER_TYPE=openrouter` — model selection handled by Kilo Code natively |
 | Hermes | _(provider default)_ | `OPENAI_BASE_URL=https://openrouter.ai/api/v1` + `OPENAI_API_KEY` — model selection handled by Hermes |

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ spawn claude hetzner --fast
 What `--fast` does:
 - **Parallel boot**: server creation runs concurrently with API key prompt and account checks
 - **Tarballs**: installs agents from pre-built tarballs instead of live install
-- **Skip cloud-init**: for lightweight agents (Claude, OpenCode, ZeroClaw, Hermes), skips the package install wait since the base OS already has what's needed
+- **Skip cloud-init**: for lightweight agents (Claude, OpenCode, Hermes), skips the package install wait since the base OS already has what's needed
 - **Snapshots**: uses pre-built cloud images when available (Hetzner, DigitalOcean)
 
 #### Beta Features


### PR DESCRIPTION
**Why:** ZeroClaw was removed in #3107 (repo 404), but two documentation references were left behind, causing confusion about supported agents.

## Changes

- `.claude/rules/agent-default-models.md`: Remove ZeroClaw row from the agent default models table
- `README.md`: Remove ZeroClaw from the `--fast` skip-cloud-init lightweight agents example list

## Verification

- `bunx @biomejs/biome check src/` → 172 files, 0 errors
- No ZeroClaw references remain in docs (except `CLAUDE.md` which is off-limits for automated changes)

-- refactor/code-health