### PR TITLE
fix(e2e): use jq to count DigitalOcean droplets instead of grep

### DIFF
--- a/sh/e2e/lib/clouds/digitalocean.sh
+++ b/sh/e2e/lib/clouds/digitalocean.sh
@@ -381,7 +381,7 @@ _digitalocean_max_parallel() {
   local _account_json _limit _existing _available
   _account_json=$(_do_curl_auth -sf "${_DO_API}/account" 2>/dev/null) || { printf '3'; return 0; }
   _limit=$(printf '%s' "${_account_json}" | grep -o '"droplet_limit":[0-9]*' | grep -o '[0-9]*$') || { printf '3'; return 0; }
-  _existing=$(_do_curl_auth -sf "${_DO_API}/droplets?per_page=200" 2>/dev/null | grep -o '"id":[0-9]*' | wc -l | tr -d ' ') || { printf '3'; return 0; }
+  _existing=$(_do_curl_auth -sf "${_DO_API}/droplets?per_page=200" 2>/dev/null | jq -r '.droplets | length' 2>/dev/null) || { printf '3'; return 0; }
   _available=$(( _limit - _existing ))
   if [ "${_available}" -lt 1 ]; then
     log_warn "DigitalOcean droplet limit reached: ${_existing}/${_limit} droplets in use (0 available)" >&2


### PR DESCRIPTION
## Summary

- The `_digitalocean_max_parallel()` function used `grep -o '"id":[0-9]*'` to count existing droplets, but this matched all numeric `"id":` fields in the JSON response (including nested image, region, and size object IDs), overcounting droplets by ~2x
- With a 3-droplet account limit and 2 actual droplets, the grepped count returned 4 — making the function think 0 slots were available and failing all 8 DO agents with "No capacity available"
- Fix: replace grep pattern with `jq -r '.droplets | length'` which correctly counts only top-level droplet objects

## Test Plan

- [x] Re-ran `e2e.sh --cloud digitalocean claude --skip-input-test` with the fix — **claude PASS** (2m 42s)
- [x] Confirmed `jq '.droplets | length'` returns 2 (correct) vs grep returning 4 (buggy) for the same API response
- [x] `bash -n` syntax check passes on the modified file

-- qa/e2e-tester