### PR TITLE
fix(cli): add --flat to KNOWN_FLAGS so spawn list --flat works

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -40,6 +40,7 @@ export const KNOWN_FLAGS = new Set([
   "-u",
   "--yes",
   "-y",
+  "--flat",
 ]);
 
 /** Return the first unknown flag in args, or null if all are known/positional */


### PR DESCRIPTION
## Summary
- `spawn list --flat` is documented in `spawn help` and handled in `list.ts`, but `--flat` was missing from the `KNOWN_FLAGS` set in `flags.ts`
- This caused `checkUnknownFlags()` to reject the flag with "Unknown flag: --flat" before the list command could run
- Adds `--flat` to `KNOWN_FLAGS` and bumps CLI version to 0.29.4

## Test plan
- [ ] Run `spawn list --flat` and verify it no longer errors with "Unknown flag"
- [ ] Run `spawn list --unknown-flag` and verify it still shows the unknown flag error

🤖 Generated with [Claude Code](https://claude.com/claude-code)