### PR TITLE
fix: correct README agent count (10→9, 60→54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Launch any AI agent on any cloud with a single command. Coding agents, research agents, self-hosted AI tools — Spawn deploys them all. All models powered by [OpenRouter](https://openrouter.ai). (ALPHA software, use at your own risk!)
 
-**10 agents. 6 clouds. 60 working combinations. Zero config.**
+**9 agents. 6 clouds. 54 working combinations. Zero config.**
 
 ## Install
 


### PR DESCRIPTION
## Summary
- README tagline says "10 agents. 60 working combinations" but manifest.json has 9 agents and 54 implemented entries
- The Pi agent PR (#3128) bumped from 8→9 agents but the README was incorrectly set to 10/60 instead of 9/54
- Fixes the tagline to match the actual matrix

## Test plan
- [x] Verified manifest.json has 9 agents, 6 clouds, 54 "implemented" entries
- [x] No other files reference the incorrect count

🤖 Generated with [Claude Code](https://claude.com/claude-code)