### PR TITLE
fix(security): validate script templates before base64 encoding

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -42,6 +42,27 @@ export interface CloudRunner {
   downloadFile(remotePath: string, localPath: string): Promise<void>;
 }
 
+// ─── Script template validation ────────────────────────────────────────────
+
+/**
+ * Validate that a script template string does not contain JS template
+ * interpolation patterns (`${...}`) before it is base64-encoded for shell
+ * injection into systemd units or remote commands.
+ *
+ * Defense-in-depth: the scripts are currently static string arrays joined
+ * with `\n`, so they should never contain interpolation markers. This guard
+ * catches future regressions where a developer might accidentally introduce
+ * template literal interpolation before encoding.
+ *
+ * Note: backticks alone are allowed (used in markdown content for skill
+ * files), but `${` is always rejected as it indicates JS interpolation.
+ */
+export function validateScriptTemplate(script: string, label: string): void {
+  if (/\$\{/.test(script)) {
+    throw new Error(`Script template "${label}" contains \${} interpolation — refusing to encode`);
+  }
+}
+
 // ─── Install helpers ────────────────────────────────────────────────────────
 
 async function installAgent(
@@ -550,6 +571,9 @@ export async function startGateway(runner: CloudRunner): Promise<void> {
     "WantedBy=multi-user.target",
   ].join("\n");
 
+  validateScriptTemplate(wrapperScript, "gateway-wrapper");
+  validateScriptTemplate(unitFile, "gateway-unit");
+
   const wrapperB64 = Buffer.from(wrapperScript).toString("base64");
   const unitB64 = Buffer.from(unitFile).toString("base64");
   if (!/^[A-Za-z0-9+/=]+$/.test(wrapperB64)) {
@@ -810,6 +834,10 @@ export async function setupAutoUpdate(runner: CloudRunner, agentName: string, up
     "[Install]",
     "WantedBy=timers.target",
   ].join("\n");
+
+  validateScriptTemplate(wrapperScript, "auto-update-wrapper");
+  validateScriptTemplate(unitFile, "auto-update-unit");
+  validateScriptTemplate(timerFile, "auto-update-timer");
 
   const wrapperB64 = Buffer.from(wrapperScript).toString("base64");
   const unitB64 = Buffer.from(unitFile).toString("base64");

--- a/packages/cli/src/shared/spawn-skill.ts
+++ b/packages/cli/src/shared/spawn-skill.ts
@@ -4,7 +4,7 @@
 
 import type { CloudRunner } from "./agent-setup.js";
 
-import { wrapSshCall } from "./agent-setup.js";
+import { validateScriptTemplate, wrapSshCall } from "./agent-setup.js";
 import { asyncTryCatchIf, isOperationalError } from "./result.js";
 import { logInfo, logWarn } from "./ui.js";
 
@@ -157,6 +157,8 @@ export async function injectSpawnSkill(runner: CloudRunner, agentName: string): 
     logWarn(`No spawn skill file for agent: ${agentName}`);
     return;
   }
+
+  validateScriptTemplate(config.content, `spawn-skill-${agentName}`);
 
   const b64 = Buffer.from(config.content).toString("base64");
   if (!/^[A-Za-z0-9+/=]+$/.test(b64)) {


### PR DESCRIPTION
**Why:** Prevents future regression where template variable interpolation before base64 encoding could allow command injection in systemd services running with root privileges on remote VMs.

Fixes #3130

## Changes
- Add pre-encoding validation in `startGateway()` (agent-setup.ts)
- Add pre-encoding validation in `setupAutoUpdate()` (agent-setup.ts)  
- Add pre-encoding validation in `injectSpawnSkill()` (spawn-skill.ts)

The validation checks that script templates don't contain `${` interpolation patterns before base64 encoding, as defense-in-depth against future changes that might add template variable interpolation.

-- refactor/security-auditor