### PR TITLE
fix(sandbox): use Docker runner for agent.configure() in sandbox mode

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/sandbox.test.ts
+++ b/packages/cli/src/__tests__/sandbox.test.ts
@@ -204,3 +204,63 @@ describe("sandbox mode", () => {
     expect(betaFeatures.includes("tarball")).toBe(true);
   });
 });
+
+// ─── sandbox runner isolation ───────────────────────────────────────────────
+
+describe("sandbox agent runner isolation", () => {
+  it("agent.configure() uses Docker runner, not host runner, when sandbox is active", async () => {
+    const { createCloudAgents } = await import("../shared/agent-setup");
+    const { makeDockerRunner } = await import("../shared/orchestrate");
+
+    const hostCommands: string[] = [];
+    const hostRunner = {
+      runServer: async (cmd: string) => {
+        hostCommands.push(cmd);
+      },
+      uploadFile: async (_l: string, _r: string) => {},
+      downloadFile: async (_r: string, _l: string) => {},
+    };
+
+    // Create agents with Docker-wrapped runner (as sandbox mode does)
+    const dockerRunner = makeDockerRunner(hostRunner);
+    const { resolveAgent: resolve } = createCloudAgents(dockerRunner);
+    const agent = resolve("claude");
+
+    // Run configure — it should use the Docker runner
+    if (agent.configure) {
+      await agent.configure("test-key");
+    }
+
+    // All commands from configure should go through docker exec
+    const nonDockerCmds = hostCommands.filter((cmd) => !cmd.includes("docker"));
+    expect(nonDockerCmds).toEqual([]);
+
+    // At least one command should contain "docker exec" or "docker cp"
+    const dockerCmds = hostCommands.filter((cmd) => cmd.includes("docker exec") || cmd.includes("docker cp"));
+    expect(dockerCmds.length).toBeGreaterThan(0);
+  });
+
+  it("agent.configure() uses host runner directly without sandbox", async () => {
+    const { createCloudAgents } = await import("../shared/agent-setup");
+
+    const hostCommands: string[] = [];
+    const hostRunner = {
+      runServer: async (cmd: string) => {
+        hostCommands.push(cmd);
+      },
+      uploadFile: async (_l: string, _r: string) => {},
+      downloadFile: async (_r: string, _l: string) => {},
+    };
+
+    const { resolveAgent: resolve } = createCloudAgents(hostRunner);
+    const agent = resolve("claude");
+
+    if (agent.configure) {
+      await agent.configure("test-key");
+    }
+
+    // Without sandbox, commands run directly (no docker wrapping)
+    const dockerCmds = hostCommands.filter((cmd) => cmd.includes("docker exec"));
+    expect(dockerCmds).toEqual([]);
+  });
+});

--- a/packages/cli/src/local/main.ts
+++ b/packages/cli/src/local/main.ts
@@ -6,6 +6,7 @@ import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import * as p from "@clack/prompts";
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import { createCloudAgents } from "../shared/agent-setup.js";
 import { makeDockerRunner, runOrchestration } from "../shared/orchestrate.js";
 import { logWarn } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
@@ -28,11 +29,22 @@ async function main() {
     process.exit(1);
   }
 
-  const agent = resolveAgent(agentName);
-
   // Check if --beta sandbox is active
   const betaFeatures = (process.env.SPAWN_BETA ?? "").split(",");
   const useSandbox = betaFeatures.includes("sandbox");
+
+  const baseRunner = {
+    runServer: runLocal,
+    uploadFile: async (l: string, r: string) => uploadFile(l, r),
+    downloadFile: async (r: string, l: string) => downloadFile(r, l),
+  };
+
+  // When sandboxed, recreate agents with the Docker-wrapped runner so that
+  // agent.configure() / agent.install() closures execute inside the container
+  // instead of writing config files directly to the host filesystem.
+  const agent = useSandbox
+    ? createCloudAgents(makeDockerRunner(baseRunner)).resolveAgent(agentName)
+    : resolveAgent(agentName);
 
   // If sandboxed, ensure Docker is installed (auto-install if missing)
   if (useSandbox) {
@@ -58,12 +70,6 @@ async function main() {
       process.exit(0);
     }
   }
-
-  const baseRunner = {
-    runServer: runLocal,
-    uploadFile: async (l: string, r: string) => uploadFile(l, r),
-    downloadFile: async (r: string, l: string) => downloadFile(r, l),
-  };
 
   const cloud: CloudOrchestrator = {
     cloudName: "local",


### PR DESCRIPTION
## Summary

- Agent config functions (`setupClaudeCodeConfig`, `setupCodexConfig`, etc.) captured the bare host runner from `local/agents.ts`, bypassing the `makeDockerRunner` wrapper
- This caused config files like `~/.claude/settings.json` to be written directly to the host filesystem instead of inside the sandbox container
- Fix: when `--beta sandbox` is active, recreate agents via `createCloudAgents(makeDockerRunner(baseRunner))` so `configure()`/`install()` closures execute inside the container

## Test plan

- [x] New tests in `sandbox.test.ts` verify Docker runner isolation for agent.configure()
- [x] Full test suite passes (1964 tests, 0 failures)
- [x] Biome lint clean (172 files, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)