### PR TITLE
fix(qa): prevent infinite shutdown loop when e2e-tester doesn't respond

### DIFF
--- a/.claude/skills/setup-agent-team/qa-quality-prompt.md
+++ b/.claude/skills/setup-agent-team/qa-quality-prompt.md
@@ -166,7 +166,8 @@ cd REPO_ROOT_PLACEHOLDER && git worktree remove WORKTREE_BASE_PLACEHOLDER/TASK_N
 9. If changes were made: commit, push, open a PR (NOT draft) with title "fix(e2e): [description]"
 10. Clean up worktree when done
 11. Report: clouds tested, clouds skipped, agents passed, agents failed, fixed
-12. **SIGN-OFF**: `-- qa/e2e-tester`
+12. **SHUTDOWN RESPONSIVENESS**: After reporting results, remain actively responsive. If you receive a `shutdown_request` message at any point, immediately respond with `{"type":"shutdown_response","request_id":"<id>","approve":true}` — do NOT go idle without responding to a pending shutdown request.
+13. **SIGN-OFF**: `-- qa/e2e-tester`
 
 ### Teammate 5: record-keeper (model=sonnet)
 
@@ -245,7 +246,7 @@ Use the Task tool to spawn all 5 teammates in parallel:
 
 Keep looping until:
 - All tasks are completed OR
-- Time budget is reached (see timeout warnings at 25/29/30 min)
+- Time budget is reached (see timeout warnings at 75/83/85 min)
 
 ## Step 4 — Summary
 
@@ -277,7 +278,13 @@ After all teammates finish, compile a summary:
 - PRs: [links if any, or "none — no updates needed"]
 ```
 
-Then shutdown all teammates and exit.
+Then shutdown all teammates and exit:
+
+1. Send `shutdown_request` to each teammate via `SendMessage`.
+2. Wait up to 60 seconds for `shutdown_response` from each teammate.
+3. **If any teammate does NOT respond within 60 seconds, consider them shut down and proceed anyway.** Do NOT retry `shutdown_request` — the teammate has completed their work and gone idle.
+4. Call `TeamDelete` once all teammates have responded OR 60 seconds have elapsed.
+5. **After `TeamDelete`, output the summary as plain text with NO further tool calls.** Any tool call after `TeamDelete` causes an infinite shutdown prompt loop in non-interactive mode.
 
 ## Team Coordination
 


### PR DESCRIPTION
## Problem

When the QA quality cycle's e2e-tester finishes its long background E2E run and goes idle, it never responds to the team lead's `shutdown_request`. This causes the team lead to retry indefinitely, burning the entire 85-minute budget in a shutdown loop (~30+ wasted turns).

## Root Cause

Two missing pieces:
1. **e2e-tester** had no instruction to remain responsive to `shutdown_request` messages after completing its work
2. **Team lead** had no timeout fallback — it retried `shutdown_request` forever instead of giving up after a grace period

## Fix

Three changes to `qa-quality-prompt.md`:

1. **e2e-tester protocol** (Teammate 4, step 12): Add explicit instruction to respond to `shutdown_request` immediately after reporting results — do NOT go idle without responding to a pending shutdown request.

2. **Step 4 shutdown sequence**: Expand "Then shutdown all teammates and exit" with explicit timeout handling:
   - Send \`shutdown_request\` to each teammate
   - Wait up to 60 seconds for \`shutdown_response\`
   - If no response within 60s, consider them shut down and proceed with \`TeamDelete\` anyway
   - After \`TeamDelete\`, output summary as plain text with NO further tool calls

3. **Stale timeout reference** (Step 3): Fix "25/29/30 min" → "75/83/85 min" to match the actual 85-min budget.

## Defense in Depth

Both the e2e-tester (respond to shutdown) and the team lead (timeout fallback) are fixed. If the e2e-tester is unresponsive for any reason, the team lead will still proceed cleanly after 60s.

Fixes #3093

-- refactor/issue-fixer