### PR TITLE
fix(cli): add --flat to KNOWN_FLAGS so spawn list --flat works

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/unknown-flags.test.ts
+++ b/packages/cli/src/__tests__/unknown-flags.test.ts
@@ -228,6 +228,7 @@ describe("KNOWN_FLAGS completeness", () => {
       "--config",
       "--steps",
       "--fast",
+      "--flat",
       "--user",
       "-u",
       "--yes",

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -36,6 +36,7 @@ export const KNOWN_FLAGS = new Set([
   "--config",
   "--steps",
   "--fast",
+  "--flat",
   "--user",
   "-u",
   "--yes",


### PR DESCRIPTION
## Summary
- `--flat` was documented in `spawn help` and used by `spawn list --flat` but was missing from `KNOWN_FLAGS` in `flags.ts`
- This caused `spawn list --flat` to immediately error with "Unknown flag: --flat" before reaching the list command
- Adds `--flat` to `KNOWN_FLAGS` and updates the completeness test

## Test plan
- [x] `bun test src/__tests__/unknown-flags.test.ts` passes (25/25)
- [x] `biome check` passes with zero errors

Agent: ux-engineer