### PR TITLE
fix(security): validate paths and agent names to prevent traversal/injection

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/local/local.ts
+++ b/packages/cli/src/local/local.ts
@@ -1,12 +1,51 @@
 // local/local.ts — Core local provider: runs commands on the user's machine
 
 import { copyFileSync, mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY } from "../shared/orchestrate.js";
 import { getUserHome } from "../shared/paths.js";
 import { getLocalShell } from "../shared/shell.js";
 import { spawnInteractive } from "../shared/ssh.js";
 import { logInfo, logStep } from "../shared/ui.js";
+
+// ─── Validation ─────────────────────────────────────────────────────────────
+
+/** Allowed pattern for agent names: lowercase alphanumeric and hyphens only. */
+const AGENT_NAME_PATTERN = /^[a-z0-9-]+$/;
+
+/**
+ * Validate an agent name to prevent command injection in shell operations.
+ * Agent names must match /^[a-z0-9-]+$/.
+ */
+export function validateAgentName(name: string): string {
+  if (!name) {
+    throw new Error("Invalid agent name: must not be empty");
+  }
+  if (!AGENT_NAME_PATTERN.test(name)) {
+    throw new Error(`Invalid agent name: must match [a-z0-9-]+, got: ${name}`);
+  }
+  return name;
+}
+
+/**
+ * Validate a local file path to prevent path traversal attacks.
+ * Rejects paths containing ".." segments after expansion.
+ */
+export function validateLocalPath(filePath: string): string {
+  const home = getUserHome();
+  // Expand ~ and $HOME before resolving
+  const expanded = filePath.replace(/^\$HOME/, home).replace(/^~/, home);
+  // Reject raw ".." before normalize (catches crafted paths)
+  if (expanded.includes("..")) {
+    throw new Error(`Invalid path: path traversal detected ("..") in: ${filePath}`);
+  }
+  const resolved = resolve(expanded);
+  // Defense in depth: check resolved path for ".."
+  if (resolved.includes("..")) {
+    throw new Error(`Invalid path: path traversal detected ("..") in resolved: ${resolved}`);
+  }
+  return resolved;
+}
 
 // ─── Execution ───────────────────────────────────────────────────────────────
 
@@ -38,20 +77,20 @@ export async function runLocal(cmd: string): Promise<void> {
 
 /** Copy a file locally, expanding ~ in the destination path. */
 export function uploadFile(localPath: string, remotePath: string): void {
-  const expanded = remotePath.replace(/^~/, getUserHome());
-  mkdirSync(dirname(expanded), {
+  const validated = validateLocalPath(remotePath);
+  mkdirSync(dirname(validated), {
     recursive: true,
   });
-  copyFileSync(localPath, expanded);
+  copyFileSync(localPath, validated);
 }
 
 /** Copy a file locally (reverse direction), expanding ~ and $HOME in the source path. */
 export function downloadFile(remotePath: string, localPath: string): void {
-  const expanded = remotePath.replace(/^\$HOME/, getUserHome()).replace(/^~/, getUserHome());
+  const validated = validateLocalPath(remotePath);
   mkdirSync(dirname(localPath), {
     recursive: true,
   });
-  copyFileSync(expanded, localPath);
+  copyFileSync(validated, localPath);
 }
 
 // ─── Interactive Session ─────────────────────────────────────────────────────
@@ -254,6 +293,8 @@ export async function ensureDocker(): Promise<void> {
 
 /** Pull the agent Docker image and start a container. */
 export async function pullAndStartContainer(agentName: string): Promise<void> {
+  validateAgentName(agentName);
+
   // Clean up any stale container (ignore errors)
   Bun.spawnSync(
     [


### PR DESCRIPTION
**Why:** Fixes two HIGH severity security vulnerabilities: path traversal in local file operations (uploadFile/downloadFile bypass path validation) and command injection via unsanitized agentName in Docker shell commands.

Fixes #3136
Fixes #3135

## Changes
- Added `validateLocalPath()` to `local.ts` that resolves path and checks for traversal attempts
- Added `validateAgentName()` to validate agent names match `[a-z0-9-]+` before Docker operations
- Applied validations at the entry point of `uploadFile`, `downloadFile`, and `pullAndStartContainer`
- Version bump to 0.30.5

## Test plan
- [x] All 2025 existing tests pass
- [x] Biome lint: zero errors
- [ ] Verify `uploadFile("src", "~/../../etc/passwd")` throws
- [ ] Verify `pullAndStartContainer("foo; rm -rf /")` throws

-- refactor/security-auditor