### PR TITLE
fix(security): array-based spawn for docker commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.30.6",
+  "version": "0.30.7",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/sandbox.test.ts
+++ b/packages/cli/src/__tests__/sandbox.test.ts
@@ -3,7 +3,7 @@ import { mockBunSpawn, mockClackPrompts } from "./test-helpers";
 
 mockClackPrompts();
 
-import { cleanupContainer, ensureDocker, isDockerAvailable, pullAndStartContainer } from "../local/local";
+import { cleanupContainer, ensureDocker, isDockerAvailable, pullAndStartContainer, runLocalArgs } from "../local/local";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -136,7 +136,7 @@ describe("pullAndStartContainer", () => {
   it("cleans up stale container, pulls image, and starts new container", async () => {
     // Mock spawnSync for cleanup call
     const syncSpy = mockSpawnSync(0);
-    // Mock Bun.spawn for runLocal calls
+    // Mock Bun.spawn for runLocalArgs calls (array-based, no shell)
     const spawnSpy = mockBunSpawn(0);
 
     await pullAndStartContainer("claude");
@@ -149,22 +149,73 @@ describe("pullAndStartContainer", () => {
       "spawn-agent",
     ]);
 
-    // Bun.spawn calls: docker pull, docker run
+    // Bun.spawn calls: docker pull, docker run (array args, no shell)
     const spawnCalls = spawnSpy.mock.calls;
     expect(spawnCalls.length).toBe(2);
 
-    // Pull command
-    const pullCmd = spawnCalls[0][0][2];
-    expect(pullCmd).toContain("docker pull");
-    expect(pullCmd).toContain("ghcr.io/openrouterteam/spawn-claude:latest");
+    // Pull command — passed as array directly, not through a shell
+    expect(spawnCalls[0][0]).toEqual([
+      "docker",
+      "pull",
+      "ghcr.io/openrouterteam/spawn-claude:latest",
+    ]);
 
-    // Run command
-    const runCmd = spawnCalls[1][0][2];
-    expect(runCmd).toContain("docker run -d");
-    expect(runCmd).toContain("--name spawn-agent");
-    expect(runCmd).toContain("ghcr.io/openrouterteam/spawn-claude:latest");
+    // Run command — passed as array directly, not through a shell
+    expect(spawnCalls[1][0]).toEqual([
+      "docker",
+      "run",
+      "-d",
+      "--name",
+      "spawn-agent",
+      "ghcr.io/openrouterteam/spawn-claude:latest",
+    ]);
 
     syncSpy.mockRestore();
+    spawnSpy.mockRestore();
+  });
+});
+
+// ─── runLocalArgs ──────────────────────────────────────────────────────────
+
+describe("runLocalArgs", () => {
+  it("spawns command with array args (no shell interpretation)", async () => {
+    const spawnSpy = mockBunSpawn(0);
+    await runLocalArgs([
+      "echo",
+      "hello",
+      "world",
+    ]);
+    expect(spawnSpy.mock.calls[0][0]).toEqual([
+      "echo",
+      "hello",
+      "world",
+    ]);
+    spawnSpy.mockRestore();
+  });
+
+  it("throws on non-zero exit code", async () => {
+    const spawnSpy = mockBunSpawn(1);
+    expect(
+      runLocalArgs([
+        "false",
+      ]),
+    ).rejects.toThrow("Command failed (exit 1): false");
+    spawnSpy.mockRestore();
+  });
+
+  it("does not interpret shell metacharacters in arguments", async () => {
+    const spawnSpy = mockBunSpawn(0);
+    await runLocalArgs([
+      "echo",
+      "$(whoami)",
+      "; rm -rf /",
+    ]);
+    // Args are passed directly, not through a shell
+    expect(spawnSpy.mock.calls[0][0]).toEqual([
+      "echo",
+      "$(whoami)",
+      "; rm -rf /",
+    ]);
     spawnSpy.mockRestore();
   });
 });

--- a/packages/cli/src/local/local.ts
+++ b/packages/cli/src/local/local.ts
@@ -73,6 +73,22 @@ export async function runLocal(cmd: string): Promise<void> {
   }
 }
 
+/** Run a command locally using an argument array (no shell interpretation). */
+export async function runLocalArgs(args: ReadonlyArray<string>): Promise<void> {
+  const proc = Bun.spawn(args, {
+    stdio: [
+      "inherit",
+      "inherit",
+      "inherit",
+    ],
+    env: process.env,
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(`Command failed (exit ${exitCode}): ${args.join(" ")}`);
+  }
+}
+
 // ─── File Operations ─────────────────────────────────────────────────────────
 
 /** Copy a file locally, expanding ~ in the destination path. */
@@ -314,10 +330,21 @@ export async function pullAndStartContainer(agentName: string): Promise<void> {
 
   const image = `${DOCKER_REGISTRY}/spawn-${agentName}:latest`;
   logStep(`Pulling Docker image ${image}...`);
-  await runLocal(`docker pull ${image}`);
+  await runLocalArgs([
+    "docker",
+    "pull",
+    image,
+  ]);
 
   logStep("Starting agent container...");
-  await runLocal(`docker run -d --name ${DOCKER_CONTAINER_NAME} ${image}`);
+  await runLocalArgs([
+    "docker",
+    "run",
+    "-d",
+    "--name",
+    DOCKER_CONTAINER_NAME,
+    image,
+  ]);
   logInfo("Agent container running");
 }
 


### PR DESCRIPTION
**Why:** `pullAndStartContainer()` in `local.ts` used string interpolation to build shell commands passed to `runLocal()` (which runs `bash -c`). While `validateAgentName()` and constant values mitigate risk today, this lacked defense-in-depth — any future change relaxing validation could enable shell injection.

## Changes

- Added `runLocalArgs()` function that uses `Bun.spawn()` with array arguments (no shell interpretation)
- Replaced `runLocal()` calls in `pullAndStartContainer()` with `runLocalArgs()` for `docker pull` and `docker run`
- Updated existing tests to match array-based args
- Added new tests for `runLocalArgs()` including shell metacharacter non-interpretation
- Patch version bump to 0.30.7

Fixes #3144

-- refactor/security-auditor