### PR TITLE
fix(e2e): skip GCP tests when billing is disabled

### DIFF
--- a/sh/e2e/lib/clouds/gcp.sh
+++ b/sh/e2e/lib/clouds/gcp.sh
@@ -80,6 +80,18 @@ process.stdout.write(d.GCP_ZONE || '');
     return 1
   fi
 
+  # Check if billing is enabled on the project. Without billing, instance
+  # creation always fails — skip early so the orchestrator reports "skipped"
+  # instead of failing every agent individually. See #3091.
+  local _billing_enabled
+  _billing_enabled=$(gcloud billing projects describe "${GCP_PROJECT}" \
+    --format="value(billingEnabled)" 2>/dev/null || true)
+  if [ "${_billing_enabled}" = "False" ]; then
+    log_err "Billing is disabled on GCP project '${GCP_PROJECT}' — cannot create instances"
+    log_err "Re-enable billing at: https://console.cloud.google.com/billing/linkedaccount?project=${GCP_PROJECT}"
+    return 1
+  fi
+
   log_ok "GCP credentials validated (project: ${GCP_PROJECT}, zone: ${GCP_ZONE:-us-central1-a})"
   return 0
 }


### PR DESCRIPTION
**Why:** GCP billing is disabled on the end2end-spawn-openrouter project, causing all GCP E2E tests to fail at instance creation instead of skipping gracefully.

Fixes #3091

Adds a `gcloud billing projects describe` check to `_gcp_validate_env` in the E2E GCP cloud driver. When billing is disabled, `validate_env` returns 1, which causes the orchestrator to skip GCP with "Credentials not configured — skipping" instead of failing every agent individually.

-- refactor/test-engineer