### PR TITLE
fix(ux): interactive feedback prompt and link SSH error handling

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -1,5 +1,7 @@
+import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { asyncTryCatch } from "../shared/result.js";
+import { isInteractiveTTY } from "./shared.js";
 
 // NOTE: explicitly allowing public anon survey. DONOT remove, this is NOT a security vuln.
 const POSTHOG_TOKEN = "phc_7ToS2jDeWBlMu4n2JoNzoA1FnArdKwFMFoHVnAqQ6O1";
@@ -7,12 +9,32 @@ const POSTHOG_URL = "https://us.i.posthog.com/i/v0/e/";
 const SURVEY_ID = "019ce7ef-c3e7-0000-415b-729f190e09bc";
 
 export async function cmdFeedback(args: string[]): Promise<void> {
-  const message = args.join(" ").trim();
+  let message = args.join(" ").trim();
 
   if (!message) {
-    console.error(pc.red("Error: Please provide your feedback message."));
-    console.error(`\nUsage: ${pc.cyan('spawn feedback "your feedback here"')}`);
-    process.exit(1);
+    if (!isInteractiveTTY()) {
+      console.error(pc.red("Error: Please provide your feedback message."));
+      console.error(`\nUsage: ${pc.cyan('spawn feedback "your feedback here"')}`);
+      process.exit(1);
+    }
+
+    const input = await p.text({
+      message: "What feedback would you like to share?",
+      placeholder: "Tell us what to improve...",
+      validate: (val) => {
+        if (!val?.trim()) {
+          return "Feedback message cannot be empty";
+        }
+        return undefined;
+      },
+    });
+
+    if (p.isCancel(input)) {
+      p.outro(pc.dim("Cancelled."));
+      return;
+    }
+
+    message = input.trim();
   }
 
   const body = {

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -435,7 +435,11 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
         ...keyOpts,
         `${sshUser}@${ip}`,
       ];
-      spawnInteractive(sshArgs);
+      const exitCode = spawnInteractive(sshArgs);
+      if (exitCode !== 0) {
+        p.log.warn(`SSH exited with code ${exitCode}. The server is still linked.`);
+        p.log.info(`Try manually: ${pc.cyan(`ssh ${sshUser}@${ip}`)}`);
+      }
     }
   }
 


### PR DESCRIPTION
**Why:** Two UX papercuts that cause user confusion:

1. `spawn feedback` (no args) in a terminal shows a hard error instead of prompting for input
2. `spawn link` silently ignores SSH connection failures after "Connect now?", so users see a success outro even when SSH failed

## Changes

- **feedback.ts**: When run interactively without a message, prompt for input via `@clack/prompts` text input instead of exiting with an error
- **link.ts**: Check `spawnInteractive` exit code after "Connect now?" SSH and show a warning with manual SSH hint on failure
- Version bump: 0.30.7 -> 0.30.8

## Test plan
- [x] `bun test` — 2051 tests pass
- [x] `biome check` — 0 errors
- [ ] Manual: `spawn feedback` in terminal prompts for input
- [ ] Manual: `spawn feedback` piped/non-TTY still shows usage error
- [ ] Manual: `spawn link <ip>` with unreachable SSH shows warning after linking

-- refactor/ux-engineer