### PR TITLE
fix(e2e): add pi agent to E2E compatibility coverage

### DIFF
--- a/sh/e2e/lib/common.sh
+++ b/sh/e2e/lib/common.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-ALL_AGENTS="claude openclaw codex opencode kilocode hermes junie cursor"
+ALL_AGENTS="claude openclaw codex opencode kilocode hermes junie cursor pi"
 PROVISION_TIMEOUT="${PROVISION_TIMEOUT:-720}"
 INSTALL_WAIT="${INSTALL_WAIT:-600}"
 INPUT_TEST_TIMEOUT="${INPUT_TEST_TIMEOUT:-120}"

--- a/sh/e2e/lib/verify.sh
+++ b/sh/e2e/lib/verify.sh
@@ -299,6 +299,11 @@ input_test_cursor() {
   return 0
 }
 
+input_test_pi() {
+  log_warn "pi is TUI-only — skipping input test"
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 # run_input_test AGENT APP_NAME
 #
@@ -326,6 +331,7 @@ run_input_test() {
     hermes)    input_test_hermes            ;;
     junie)     input_test_junie            ;;
     cursor)    input_test_cursor           ;;
+    pi)        input_test_pi              ;;
     *)
       log_err "Unknown agent for input test: ${agent}"
       return 1
@@ -718,6 +724,31 @@ verify_cursor() {
   return "${failures}"
 }
 
+verify_pi() {
+  local app="$1"
+  local failures=0
+
+  # Binary check
+  log_step "Checking pi binary..."
+  if cloud_exec "${app}" "PATH=\$HOME/.npm-global/bin:\$HOME/.bun/bin:\$HOME/.local/bin:/usr/local/bin:\$PATH command -v pi" >/dev/null 2>&1; then
+    log_ok "pi binary found"
+  else
+    log_err "pi binary not found"
+    failures=$((failures + 1))
+  fi
+
+  # Env check: OPENROUTER_API_KEY
+  log_step "Checking pi env (OPENROUTER_API_KEY)..."
+  if cloud_exec "${app}" "grep -q OPENROUTER_API_KEY ~/.spawnrc" >/dev/null 2>&1; then
+    log_ok "OPENROUTER_API_KEY present in .spawnrc"
+  else
+    log_err "OPENROUTER_API_KEY not found in .spawnrc"
+    failures=$((failures + 1))
+  fi
+
+  return "${failures}"
+}
+
 # ---------------------------------------------------------------------------
 # verify_agent AGENT APP_NAME
 #
@@ -747,6 +778,7 @@ verify_agent() {
     hermes)    verify_hermes "${app}"    || agent_failures=$? ;;
     junie)     verify_junie "${app}"    || agent_failures=$? ;;
     cursor)    verify_cursor "${app}"   || agent_failures=$? ;;
+    pi)        verify_pi "${app}"       || agent_failures=$? ;;
     *)
       log_err "Unknown agent: ${agent}"
       return 1


### PR DESCRIPTION
**Why:** Pi is advertised as implemented across all clouds in manifest.json but E2E suite never tests it — regressions in pi install/launch can ship undetected (#3152)

## Changes
- `sh/e2e/lib/common.sh`: Add `pi` to ALL_AGENTS
- `sh/e2e/lib/verify.sh`: Add `verify_pi` and `input_test_pi` handlers

Fixes #3152

-- refactor/ux-engineer