### PR TITLE
fix: add cursor to AGENT_SKILLS, add pi/cursor to spawn-skill tests

### DIFF
--- a/packages/cli/src/__tests__/spawn-skill.test.ts
+++ b/packages/cli/src/__tests__/spawn-skill.test.ts
@@ -35,8 +35,16 @@ describe("getSpawnSkillPath", () => {
       "~/.hermes/SOUL.md",
     ],
     [
+      "cursor",
+      "~/.cursor/rules/spawn.md",
+    ],
+    [
       "junie",
       "~/.junie/AGENTS.md",
+    ],
+    [
+      "pi",
+      "~/.pi/agent/skills/spawn/SKILL.md",
     ],
   ];
 
@@ -65,7 +73,9 @@ describe("isAppendMode", () => {
       "openclaw",
       "opencode",
       "kilocode",
+      "cursor",
       "junie",
+      "pi",
     ];
     for (const agent of overwriteAgents) {
       expect(isAppendMode(agent), `agent "${agent}"`).toBe(false);
@@ -83,7 +93,9 @@ describe("getSkillContent", () => {
     "opencode",
     "kilocode",
     "hermes",
+    "cursor",
     "junie",
+    "pi",
   ];
 
   for (const agent of agents) {
@@ -110,7 +122,9 @@ describe("getSkillContent", () => {
   for (const agent of [
     "opencode",
     "kilocode",
+    "cursor",
     "junie",
+    "pi",
   ]) {
     it(`${agent} content is plain markdown (no YAML frontmatter)`, () => {
       const content = getSkillContent(agent);
@@ -180,7 +194,9 @@ describe("injectSpawnSkill", () => {
       "opencode",
       "kilocode",
       "hermes",
+      "cursor",
       "junie",
+      "pi",
     ];
     for (const agent of agents) {
       let capturedCmd = "";

--- a/packages/cli/src/shared/spawn-skill.ts
+++ b/packages/cli/src/shared/spawn-skill.ts
@@ -119,6 +119,11 @@ const AGENT_SKILLS: Record<string, SkillConfig> = {
     content: HERMES_SNIPPET,
     append: true,
   },
+  cursor: {
+    remotePath: "~/.cursor/rules/spawn.md",
+    content: SKILL_BODY,
+    append: false,
+  },
   junie: {
     remotePath: "~/.junie/AGENTS.md",
     content: SKILL_BODY,


### PR DESCRIPTION
## Summary
- Add `cursor` entry to `AGENT_SKILLS` in `spawn-skill.ts` with `remotePath: "~/.cursor/rules/spawn.md"` — cursor was the only manifest agent missing from the spawn skill map, causing `injectSpawnSkill` to silently skip cursor VMs when `--beta recursive` is active
- Add `pi` and `cursor` to all test arrays in `spawn-skill.test.ts` — pi was added to `AGENT_SKILLS` but never reflected in tests

## Test plan
- [x] `bun test` — 2014 pass, 0 fail (4 new test cases for pi + cursor)
- [x] `bunx @biomejs/biome check src/` — 0 errors

Agent: code-health
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>