### PR TITLE
fix(cursor): use real API key instead of dummy spawn-proxy value

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -299,7 +299,8 @@
       "install": "curl https://cursor.com/install -fsS | bash",
       "launch": "agent",
       "env": {
-        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
+        "CURSOR_API_KEY": "${OPENROUTER_API_KEY}"
       },
       "config_files": {
         "~/.cursor/cli-config.json": {

--- a/packages/cli/src/__tests__/agent-setup-cov.test.ts
+++ b/packages/cli/src/__tests__/agent-setup-cov.test.ts
@@ -222,6 +222,14 @@ describe("createCloudAgents", () => {
     }
   });
 
+  it("cursor agent uses real API key as CURSOR_API_KEY (not a dummy value)", () => {
+    const envVars = result.agents.cursor.envVars("sk-or-v1-real-key");
+    const cursorKeyVar = envVars.find((v: string) => v.startsWith("CURSOR_API_KEY="));
+    expect(cursorKeyVar).toBeDefined();
+    // Must use the actual API key, not a dummy like "spawn-proxy"
+    expect(cursorKeyVar).toBe("CURSOR_API_KEY=sk-or-v1-real-key");
+  });
+
   it("all agents have launchCmd returning non-empty string", () => {
     for (const agent of Object.values(result.agents)) {
       const cmd = agent.launchCmd();

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -1093,7 +1093,7 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         ),
       envVars: (apiKey) => [
         `OPENROUTER_API_KEY=${apiKey}`,
-        "CURSOR_API_KEY=spawn-proxy",
+        `CURSOR_API_KEY=${apiKey}`,
       ],
       configure: () => setupCursorProxy(runner),
       preLaunch: () => startCursorProxy(runner),


### PR DESCRIPTION
## Summary

- Use the actual `OPENROUTER_API_KEY` as `CURSOR_API_KEY` instead of the dummy `spawn-proxy` value
- Cursor CLI validates the API key format before connecting to the proxy endpoint — the dummy value fails immediately, causing an infinite restart loop
- Updated `manifest.json` to document the `CURSOR_API_KEY` env var
- Added test coverage verifying cursor agent uses real API key

Fixes #3166

-- refactor/ux-engineer