### PR TITLE
fix: add pi and daytona to embedded skill lists

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.30.11",
+  "version": "0.30.12",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/spawn-skill.ts
+++ b/packages/cli/src/shared/spawn-skill.ts
@@ -30,8 +30,8 @@ You have the \`spawn\` CLI installed. Use it to provision cloud VMs with AI agen
 spawn <agent> <cloud> --headless --output json --prompt "task description"
 \`\`\`
 
-**Agents:** claude, codex, cursor, openclaw, opencode, kilocode, hermes, junie
-**Clouds:** hetzner, digitalocean, aws, gcp, sprite
+**Agents:** claude, codex, cursor, openclaw, opencode, kilocode, hermes, junie, pi
+**Clouds:** hetzner, digitalocean, aws, gcp, daytona, sprite
 
 Returns JSON: \`{"status":"success","ip_address":"...","ssh_user":"root","server_id":"..."}\`
 
@@ -74,7 +74,7 @@ const HERMES_SNIPPET = `
 
 You have the \`spawn\` CLI for creating child cloud VMs with AI agents.
 Use \`spawn <agent> <cloud> --headless --output json --prompt "task"\` to delegate work.
-Available agents: claude, codex, cursor, openclaw, opencode, kilocode, hermes, junie.
+Available agents: claude, codex, cursor, openclaw, opencode, kilocode, hermes, junie, pi.
 Cloud credentials are pre-configured. Run \`spawn list --json\` to see children.
 \`--headless\` only provisions. To run a prompt on the child: \`ssh root@<ip> "bash -lc 'claude -p --dangerously-skip-permissions \\"prompt\\"'"\`. Always use \`bash -lc\` (binaries are in ~/.local/bin/).
 `;


### PR DESCRIPTION
**Why:** Agents spawned via the skill system cannot delegate work to Pi or provision on Daytona — the embedded agent/cloud lists in `spawn-skill.ts` were not updated when these were added in #3156 and #3168.

## Changes

- Add `pi` to the agent lists in `SKILL_BODY` and `HERMES_SNIPPET`
- Add `daytona` to the clouds list in `SKILL_BODY`
- Patch version bump (0.30.11 → 0.30.12)

## Test plan

- [x] `bunx @biomejs/biome check src/` — zero errors
- [x] `bun test` — 2026 tests pass

-- refactor/code-health