### PR TITLE
feat: headless promptCmd, link in cloud picker, default headless steps

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.30.14",
+  "version": "0.31.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -9,6 +9,7 @@ import { hasSavedOpenRouterKey } from "../shared/oauth.js";
 import { asyncTryCatch, tryCatch, unwrapOr } from "../shared/result.js";
 import { maybeShowStarPrompt } from "../shared/star-prompt.js";
 import { validateModelId } from "../shared/ui.js";
+import { cmdLink } from "./link.js";
 import { activeServerPicker } from "./list.js";
 import { execScript, showDryRunPreview } from "./run.js";
 import {
@@ -103,6 +104,13 @@ async function selectCloud(
       });
     }
   }
+
+  // Add "Link Existing Server" option at the bottom for BYOS workflow
+  options.push({
+    value: "link-existing",
+    label: "Link Existing Server",
+    hint: "bring your own server via IP address",
+  });
 
   const cloudChoice = await p.select({
     message: "Select a cloud",
@@ -283,6 +291,17 @@ export async function cmdInteractive(): Promise<void> {
   const { clouds, hintOverrides } = getAndValidateCloudChoices(manifest, agentChoice);
   const cloudChoice = await selectCloud(manifest, clouds, hintOverrides);
 
+  // Handle "Link Existing Server" — redirect to spawn link with the agent pre-selected
+  if (cloudChoice === "link-existing") {
+    p.outro("Switching to link mode...");
+    await cmdLink([
+      "link",
+      "--agent",
+      agentChoice,
+    ]);
+    return;
+  }
+
   await preflightCredentialCheck(manifest, cloudChoice);
 
   // Skip setup prompt if steps already set via --steps or --config
@@ -336,6 +355,17 @@ export async function cmdAgentInteractive(agent: string, prompt?: string, dryRun
 
   const { clouds, hintOverrides } = getAndValidateCloudChoices(manifest, resolvedAgent);
   const cloudChoice = await selectCloud(manifest, clouds, hintOverrides);
+
+  // Handle "Link Existing Server" — redirect to spawn link with the agent pre-selected
+  if (cloudChoice === "link-existing") {
+    p.outro("Switching to link mode...");
+    await cmdLink([
+      "link",
+      "--agent",
+      resolvedAgent,
+    ]);
+    return;
+  }
 
   if (dryRun) {
     showDryRunPreview(manifest, resolvedAgent, cloudChoice, prompt);

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -980,6 +980,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       configure: (apiKey) => setupClaudeCodeConfig(runner, apiKey),
       launchCmd: () =>
         "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude",
+      promptCmd: (prompt) =>
+        `source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.claude/local/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH; claude -p --dangerously-skip-permissions ${shellQuote(prompt)}`,
       updateCmd:
         'export PATH="$HOME/.claude/local/bin:$HOME/.npm-global/bin:$HOME/.local/bin:$HOME/.bun/bin:$HOME/.n/bin:$PATH"; ' +
         "npm install -g @anthropic-ai/claude-code@latest 2>/dev/null || " +
@@ -1001,6 +1003,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       ],
       configure: () => setupCodexConfig(runner),
       launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex",
+      promptCmd: (prompt) =>
+        `source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; codex --full-auto ${shellQuote(prompt)}`,
       updateCmd: `${NPM_AUTO_UPDATE_SETUP} && ` + "npm install -g $_NPM_G_FLAGS @openai/codex@latest",
     },
 
@@ -1029,6 +1033,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         preLaunchMsg: "Your web dashboard will open automatically — use it for WhatsApp QR scanning and channel setup.",
         launchCmd: () =>
           "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; openclaw tui",
+        promptCmd: (prompt: string) =>
+          `source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; openclaw run ${shellQuote(prompt)}`,
         tunnel: {
           remotePort: 18789,
           browserUrl: (localPort: number) => `http://localhost:${localPort}/#token=${dashboardToken}`,
@@ -1046,6 +1052,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         `OPENROUTER_API_KEY=${apiKey}`,
       ],
       launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode",
+      promptCmd: (prompt) =>
+        `source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; opencode --prompt ${shellQuote(prompt)}`,
       updateCmd: openCodeInstallCmd(),
     },
 
@@ -1066,6 +1074,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         `KILO_OPEN_ROUTER_API_KEY=${apiKey}`,
       ],
       launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode",
+      promptCmd: (prompt) =>
+        `source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; kilocode --prompt ${shellQuote(prompt)}`,
       updateCmd: `${NPM_AUTO_UPDATE_SETUP} && ` + "npm install -g $_NPM_G_FLAGS @kilocode/cli@latest",
     },
 
@@ -1101,6 +1111,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       },
       launchCmd: () =>
         "source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.local/bin:$HOME/.hermes/hermes-agent/venv/bin:$PATH; hermes",
+      promptCmd: (prompt) =>
+        `source ~/.spawnrc 2>/dev/null; export PATH=$HOME/.local/bin:$HOME/.hermes/hermes-agent/venv/bin:$PATH; hermes ${shellQuote(prompt)}`,
       updateCmd:
         // Same SSH→HTTPS rewrite for auto-update runs
         'git config --global url."https://github.com/".insteadOf "ssh://git@github.com/" && ' +
@@ -1123,6 +1135,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         `OPENROUTER_API_KEY=${apiKey}`,
       ],
       launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; junie",
+      promptCmd: (prompt) =>
+        `source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; junie --prompt ${shellQuote(prompt)}`,
       updateCmd: `${NPM_AUTO_UPDATE_SETUP} && ` + "npm install -g $_NPM_G_FLAGS @jetbrains/junie-cli@latest",
     },
 
@@ -1140,6 +1154,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
         `OPENROUTER_API_KEY=${apiKey}`,
       ],
       launchCmd: () => "source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; pi",
+      promptCmd: (prompt) =>
+        `source ~/.spawnrc 2>/dev/null; source ~/.zshrc 2>/dev/null; pi --prompt ${shellQuote(prompt)}`,
       updateCmd: `${NPM_AUTO_UPDATE_SETUP} && ` + "npm install -g $_NPM_G_FLAGS @mariozechner/pi-coding-agent@latest",
     },
 
@@ -1163,6 +1179,8 @@ function createAgents(runner: CloudRunner): Record<string, AgentConfig> {
       preLaunch: () => startCursorProxy(runner),
       launchCmd: () =>
         'source ~/.spawnrc 2>/dev/null; export PATH="$HOME/.local/bin:$PATH"; agent --endpoint https://api2.cursor.sh',
+      promptCmd: (prompt) =>
+        `source ~/.spawnrc 2>/dev/null; export PATH="$HOME/.local/bin:$PATH"; agent --endpoint https://api2.cursor.sh --prompt ${shellQuote(prompt)}`,
       updateCmd: 'export PATH="$HOME/.local/bin:$PATH"; agent update',
     },
   };

--- a/packages/cli/src/shared/agents.ts
+++ b/packages/cli/src/shared/agents.ts
@@ -40,6 +40,12 @@ export interface AgentConfig {
   preLaunchMsg?: string;
   /** Shell command to launch the agent interactively. */
   launchCmd: () => string;
+  /**
+   * Shell command to run the agent with a prompt non-interactively.
+   * Used by headless mode when --prompt is provided.
+   * If undefined, headless --prompt will set SPAWN_PROMPT env var but not auto-execute.
+   */
+  promptCmd?: (prompt: string) => string;
   /** Cloud-init dependency tier. Defaults to "full" if unset. */
   cloudInitTier?: CloudInitTier;
   /** Skip tarball install attempt (e.g., already using snapshot). */

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -546,6 +546,7 @@ async function postInstall(
   // Parse enabled setup steps
   let enabledSteps: Set<string> | undefined;
   const stepsEnv = process.env.SPAWN_ENABLED_STEPS;
+  const isHeadless = process.env.SPAWN_HEADLESS === "1";
   if (stepsEnv !== undefined) {
     const stepNames = stepsEnv.split(",").filter(Boolean);
     if (stepNames.length > 0) {
@@ -558,6 +559,11 @@ async function postInstall(
     } else {
       enabledSteps = new Set();
     }
+  } else if (isHeadless) {
+    // In headless mode, default to auto-update only (use --steps all to override)
+    enabledSteps = new Set([
+      "auto-update",
+    ]);
   }
 
   // Agent-specific configuration
@@ -726,10 +732,21 @@ async function postInstall(
   saveLaunchCmd(launchCmd, spawnId);
 
   // In headless mode, provisioning is done — skip the interactive session.
-  // The VM is healthy and the agent is installed; callers can SSH in or use `spawn connect`.
-  const isHeadless = process.env.SPAWN_HEADLESS === "1";
+  // If --prompt was provided and the agent has a promptCmd, execute the prompt on the VM.
   if (isHeadless) {
-    logInfo("Headless mode — provisioning complete. Skipping interactive session.");
+    const headlessPrompt = process.env.SPAWN_PROMPT;
+    if (headlessPrompt && agent.promptCmd) {
+      logInfo("Headless mode — running prompt on provisioned VM...");
+      const promptRunCmd = agent.promptCmd(headlessPrompt);
+      const promptResult = await asyncTryCatch(() => cloud.runner.runServer(promptRunCmd, 600));
+      if (!promptResult.ok) {
+        logWarn(`Prompt execution failed: ${getErrorMessage(promptResult.error)}`);
+      } else {
+        logInfo("Prompt execution completed");
+      }
+    } else {
+      logInfo("Headless mode — provisioning complete. Skipping interactive session.");
+    }
     if (tunnelHandle) {
       tunnelHandle.stop();
     }


### PR DESCRIPTION
**Why:** Issue #3174 tracks re-implementation of closed PR #3161's features for seamless headless mode and link improvements.

Fixes #3174

## Changes
- **`promptCmd` on all agents**: Added `promptCmd` field to `AgentConfig` interface and implemented it for all 9 agents (claude, codex, openclaw, opencode, kilocode, hermes, junie, pi, cursor). When `--prompt` is provided in headless mode, the agent runs the prompt non-interactively on the provisioned VM instead of just setting `SPAWN_PROMPT`.
- **"Link Existing Server" in cloud picker**: Added a BYOS option at the bottom of the cloud picker in both `cmdInteractive` and `cmdAgentInteractive`. Selecting it redirects to `spawn link` with the agent pre-selected.
- **Default headless `--steps` to `auto-update`**: Headless mode now defaults to `--steps auto-update` when `SPAWN_ENABLED_STEPS` is not explicitly set, preventing unnecessary interactive-only steps from running. Users can override with `--steps all`.
- **Version bump**: 0.30.14 -> 0.31.0 (minor — new feature)

## Files changed
- `packages/cli/src/shared/agents.ts` — `promptCmd` field on `AgentConfig`
- `packages/cli/src/shared/agent-setup.ts` — `promptCmd` implementations for all agents
- `packages/cli/src/shared/orchestrate.ts` — headless default steps + promptCmd execution
- `packages/cli/src/commands/interactive.ts` — "Link Existing Server" in cloud picker
- `packages/cli/package.json` — version bump

-- refactor/ux-engineer