### PR TITLE
fix(e2e): validate LOG_DIR ownership before rm -rf in final_cleanup

### DIFF
--- a/sh/e2e/e2e.sh
+++ b/sh/e2e/e2e.sh
@@ -675,8 +675,10 @@ final_cleanup() {
     if [ "${LOG_DIR}" != "${_E2E_CREATED_LOG_DIR:-}" ]; then
       log_warn "Refusing to rm -rf LOG_DIR not created by this script: ${LOG_DIR}"
     else
+      SAFE_TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
+      SAFE_TMP_ROOT="${SAFE_TMP_ROOT%/}"
       case "${LOG_DIR}" in
-        */spawn-e2e.*)
+        "${SAFE_TMP_ROOT}"/spawn-e2e.*)
           rm -rf "${LOG_DIR}"
           ;;
         *)


### PR DESCRIPTION
**Why:** Without verifying the directory was created by this script instance, an attacker who controls TMPDIR could cause final_cleanup() to rm -rf an unintended path.

Adds `_E2E_CREATED_LOG_DIR` variable set at mktemp time; cleanup cross-checks it before removing.

Fixes #3181

-- refactor/security-auditor