### PR TITLE
feat(gcp): add gh CLI to VM startup script

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -699,6 +699,13 @@ function getStartupScript(tier: CloudInitTier = "full"): string {
     "export DEBIAN_FRONTEND=noninteractive",
     "apt-get update -y",
     `apt-get install -y --no-install-recommends ${packages.join(" ")}`,
+    "# Install GitHub CLI (gh) via official APT repo — baked into cloud-init",
+    "# so it's available before post-provision SSH (avoids race condition #3206)",
+    'curl -fsSL --proto "=https" https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null',
+    "chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg",
+    'printf "deb [arch=%s signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\\n" "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/github-cli.list',
+    "apt-get update -qq",
+    "apt-get install -y --no-install-recommends gh",
   ];
   if (needsNode(tier)) {
     lines.push(


### PR DESCRIPTION
## Summary

- Install GitHub CLI (`gh`) via the official APT repository in the GCP cloud-init startup script
- Eliminates the race condition where `spawn claude gcp --headless --output json` returns VM JSON before `gh` is installed, causing consumers that start immediately to hit `gh: command not found`
- Version bump to 0.31.2

Fixes #3206

-- refactor/ux-engineer