### PR TITLE
fix(security): replace eval with env var in daytona.ts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/daytona/daytona.ts
+++ b/packages/cli/src/daytona/daytona.ts
@@ -1074,22 +1074,24 @@ async function prepareOpenClawPreviewAccess(
  *  must be appended on demand rather than during initial setup when the preview host is unknown. */
 async function allowOpenClawPreviewOrigin(sandboxId: string, previewUrl: string): Promise<void> {
   const previewOrigin = new URL(previewUrl).origin;
-  const escapedOrigin = JSON.stringify(previewOrigin);
   const patchConfigCmd = [
+    `SPAWN_PREVIEW_ORIGIN=${shellQuote(previewOrigin)}`,
     "node -e",
     shellQuote(
       `
 const fs = require("node:fs");
-const path = process.env.HOME + "/.openclaw/openclaw.json";
-const config = JSON.parse(fs.readFileSync(path, "utf8"));
+const origin = process.env.SPAWN_PREVIEW_ORIGIN;
+if (!origin) { process.exit(1); }
+const cfgPath = process.env.HOME + "/.openclaw/openclaw.json";
+const config = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
 const gateway = config.gateway ?? (config.gateway = {});
 const controlUi = gateway.controlUi ?? (gateway.controlUi = {});
 const allowedOrigins = Array.isArray(controlUi.allowedOrigins) ? controlUi.allowedOrigins : [];
-if (!allowedOrigins.includes(${escapedOrigin})) {
-  allowedOrigins.push(${escapedOrigin});
+if (!allowedOrigins.includes(origin)) {
+  allowedOrigins.push(origin);
 }
 controlUi.allowedOrigins = allowedOrigins;
-fs.writeFileSync(path, JSON.stringify(config, null, 2) + "\\n", { mode: 0o600 });
+fs.writeFileSync(cfgPath, JSON.stringify(config, null, 2) + "\\n", { mode: 0o600 });
       `.trim(),
     ),
   ].join(" ");


### PR DESCRIPTION
**Why:** Prevents command injection via string interpolation into a Node.js inline script in `allowOpenClawPreviewOrigin()`. A compromised Daytona API or MITM attack returning a malicious `previewUrl` could break out of `JSON.stringify()` context and execute arbitrary Node.js code on the remote sandbox.

Fixes #3215

## Changes
- Pass the preview origin via `SPAWN_PREVIEW_ORIGIN` env var instead of interpolating it into the `node -e` script body
- The Node.js script reads `process.env.SPAWN_PREVIEW_ORIGIN` at runtime — no user-controlled data enters the code string
- Added a guard (`if (!origin) { process.exit(1); }`) for the env var
- No behavior change for valid inputs

## Test plan
- [x] `bunx @biomejs/biome check src/` passes with 0 errors
- [x] `bun test` passes (2026 tests, 0 failures)

-- refactor/security-auditor