### PR TITLE
fix(security): shell-quote package names in cloud-init scripts

### DIFF
--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -899,6 +899,7 @@ export async function ensureSshKey(): Promise<void> {
 
 function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
   const packages = getPackagesForTier(tier);
+  const quotedPackages = packages.map((p) => shellQuote(p)).join(" ");
   const lines = [
     "#!/bin/bash",
     "export DEBIAN_FRONTEND=noninteractive",
@@ -908,7 +909,7 @@ function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
     "  chmod 600 /swapfile && mkswap /swapfile >/dev/null && swapon /swapfile",
     "fi",
     "apt-get update -y",
-    `apt-get install -y --no-install-recommends ${packages.join(" ")}`,
+    `apt-get install -y --no-install-recommends ${quotedPackages}`,
   ];
   if (needsNode(tier)) {
     lines.push(

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1025,13 +1025,14 @@ export async function promptDoRegion(): Promise<string> {
 
 function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
   const packages = getPackagesForTier(tier);
+  const quotedPackages = packages.map((p) => shellQuote(p)).join(" ");
   const lines = [
     "#!/bin/bash",
     "set -e",
     "export HOME=/root",
     "export DEBIAN_FRONTEND=noninteractive",
     "apt-get update -y",
-    `apt-get install -y --no-install-recommends ${packages.join(" ")}`,
+    `apt-get install -y --no-install-recommends ${quotedPackages}`,
   ];
   if (needsNode(tier)) {
     lines.push(`${NODE_INSTALL_CMD} || true`);

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -693,12 +693,13 @@ function getStartupScript(tier: CloudInitTier = "full"): string {
   assertSafeUsername(resolveUsername());
 
   const packages = getPackagesForTier(tier);
+  const quotedPackages = packages.map((p) => shellQuote(p)).join(" ");
   const lines = [
     "#!/bin/bash",
     "export HOME=/root",
     "export DEBIAN_FRONTEND=noninteractive",
     "apt-get update -y",
-    `apt-get install -y --no-install-recommends ${packages.join(" ")}`,
+    `apt-get install -y --no-install-recommends ${quotedPackages}`,
     "# Install GitHub CLI (gh) via official APT repo — baked into cloud-init",
     "# so it's available before post-provision SSH (avoids race condition #3206)",
     'curl -fsSL --proto "=https" https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null',

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -304,6 +304,7 @@ export async function ensureSshKey(): Promise<void> {
 
 function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
   const packages = getPackagesForTier(tier);
+  const quotedPackages = packages.map((p) => shellQuote(p)).join(" ");
   const lines = [
     "#!/bin/bash",
     "export HOME=/root",
@@ -311,7 +312,7 @@ function getCloudInitUserdata(tier: CloudInitTier = "full"): string {
     "# Guarantee the cloud-init marker is written on exit (success, failure, or signal)",
     "trap 'touch /home/ubuntu/.cloud-init-complete 2>/dev/null; touch /root/.cloud-init-complete' EXIT",
     "apt-get update -y || true",
-    `apt-get install -y --no-install-recommends ${packages.join(" ")} || true`,
+    `apt-get install -y --no-install-recommends ${quotedPackages} || true`,
   ];
   if (needsNode(tier)) {
     lines.push(`${NODE_INSTALL_CMD} || true`);


### PR DESCRIPTION
## Summary

- Apply `shellQuote()` to all package names interpolated into cloud-init startup scripts across GCP, AWS, Hetzner, and DigitalOcean
- Defense-in-depth against supply chain attacks where compromised `getPackagesForTier()` output could inject shell metacharacters into root-executed cloud-init scripts

Fixes #3216

## Test plan

- [x] All 2032 existing tests pass (0 failures)
- [x] Biome lint clean on all 4 changed files
- [x] Verified `shellQuote` is already imported in all affected modules

-- refactor/security-auditor