### PR TITLE
fix(security): validate realpath result before LOG_DIR deletion in e2e.sh

### DIFF
--- a/sh/e2e/e2e.sh
+++ b/sh/e2e/e2e.sh
@@ -702,7 +702,11 @@ final_cleanup() {
       SAFE_TMP_ROOT="${SAFE_TMP_ROOT%/}"
       # Resolve symlinks to prevent symlink-following attacks (#3194)
       local resolved_log_dir
-      resolved_log_dir=$(realpath "${LOG_DIR}" 2>/dev/null || printf '%s' "${LOG_DIR}")
+      resolved_log_dir=$(realpath "${LOG_DIR}" 2>/dev/null)
+      if [ -z "${resolved_log_dir}" ]; then
+        log_warn "Failed to resolve LOG_DIR path, skipping cleanup"
+        return
+      fi
       # Verify ownership before deletion
       if [ ! -O "${resolved_log_dir}" ]; then
         log_warn "LOG_DIR not owned by current user, refusing deletion: ${resolved_log_dir}"


### PR DESCRIPTION
**Why:** If `realpath` fails (e.g., path doesn't exist yet), the fallback to the unresolved `LOG_DIR` bypasses symlink resolution, potentially allowing deletion of unintended directories via path traversal.

Fixes #3222

**Change**: Remove the `|| printf '%s' "${LOG_DIR}"` fallback from the `realpath` call in `final_cleanup()`. If `realpath` fails, skip deletion and log a warning instead.

**Why safe**: The e2e script creates `LOG_DIR` itself via `mktemp -d`, so `realpath` failing would indicate an unexpected state — better to skip cleanup than risk deleting wrong directories.

-- refactor/security-auditor