### PR TITLE
fix(security): timing-safe auth + rate limit SPA endpoints

### DIFF
--- a/.claude/skills/setup-spa/main.ts
+++ b/.claude/skills/setup-spa/main.ts
@@ -1317,8 +1317,13 @@ function isHttpAuthed(req: Request): boolean {
   if (!TRIGGER_SECRET) return false;
   const given = req.headers.get("Authorization") ?? "";
   const expected = `Bearer ${TRIGGER_SECRET}`;
-  if (given.length !== expected.length) return false;
-  return timingSafeEqual(Buffer.from(given), Buffer.from(expected));
+  // Use try/catch instead of length pre-check: timingSafeEqual throws on length
+  // mismatch, and the pre-check leaks the expected secret length via timing (CWE-208).
+  try {
+    return timingSafeEqual(Buffer.from(given), Buffer.from(expected));
+  } catch {
+    return false;
+  }
 }
 
 /** Post a Block Kit candidate card to Slack and store in DB. */
@@ -1597,6 +1602,20 @@ async function postRedditReply(postId: string, replyText: string): Promise<Respo
   });
 }
 
+/** Simple token-bucket rate limiter: max 10 requests per minute per endpoint. */
+const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
+function checkRateLimit(endpoint: string): boolean {
+  const now = Date.now();
+  const bucket = rateLimitBuckets.get(endpoint) ?? { count: 0, resetAt: now + 60_000 };
+  if (now > bucket.resetAt) {
+    bucket.count = 0;
+    bucket.resetAt = now + 60_000;
+  }
+  bucket.count = bucket.count + 1;
+  rateLimitBuckets.set(endpoint, bucket);
+  return bucket.count <= 10;
+}
+
 /** Start the HTTP server for growth candidate ingestion. */
 function startHttpServer(client: SlackClient): void {
   if (!TRIGGER_SECRET) {
@@ -1610,6 +1629,9 @@ function startHttpServer(client: SlackClient): void {
       const url = new URL(req.url);
 
       if (req.method === "GET" && url.pathname === "/health") {
+        if (!checkRateLimit("/health")) {
+          return Response.json({ error: "rate limit exceeded" }, { status: 429 });
+        }
         return Response.json({
           status: "ok",
         });
@@ -1625,6 +1647,9 @@ function startHttpServer(client: SlackClient): void {
               status: 401,
             },
           );
+        }
+        if (!checkRateLimit("/candidate")) {
+          return Response.json({ error: "rate limit exceeded" }, { status: 429 });
         }
 
         let body: unknown;
@@ -1667,6 +1692,9 @@ function startHttpServer(client: SlackClient): void {
               status: 401,
             },
           );
+        }
+        if (!checkRateLimit("/reply")) {
+          return Response.json({ error: "rate limit exceeded" }, { status: 429 });
         }
 
         const replySchema = v.object({


### PR DESCRIPTION
**Why:** `isHttpAuthed()` leaks `TRIGGER_SECRET` length via timing side-channel (CWE-208) due to early length comparison before `timingSafeEqual`; `/candidate`, `/reply`, `/health` endpoints have no rate limiting, allowing spam/DoS with a stolen or brute-forced secret.

Fixes #3201
Fixes #3204

## Changes

- **`isHttpAuthed()`**: remove explicit `given.length !== expected.length` pre-check. Node's `timingSafeEqual` throws when buffer lengths differ, so wrapping in `try/catch` is both correct and timing-safe.
- **`startHttpServer()`**: add token-bucket rate limiter (`checkRateLimit()`, 10 req/min per endpoint). Returns HTTP 429 when a bucket is exhausted.

-- refactor/team-lead