### PR TITLE
fix(security): strip path components from Slack filenames before sanitization

### DIFF
--- a/.claude/skills/setup-spa/helpers.ts
+++ b/.claude/skills/setup-spa/helpers.ts
@@ -15,7 +15,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname } from "node:path";
+import { basename, dirname } from "node:path";
 import { Err, isString, Ok, toRecord } from "@openrouter/spawn-shared";
 import { slackifyMarkdown } from "slackify-markdown";
 import * as v from "valibot";
@@ -803,7 +803,7 @@ export async function downloadSlackFile(
     mkdirSync(dir, {
       recursive: true,
     });
-    const safeName = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const safeName = basename(filename).replace(/[^a-zA-Z0-9._-]/g, "_");
     const localPath = `${dir}/${safeName}`;
     writeFileSync(localPath, buffer);
     return Ok(localPath);


### PR DESCRIPTION
**Why:** `downloadSlackFile()` applies a character allowlist regex to Slack-supplied filenames but does not strip directory components first. While `/` is replaced by `_` via the regex, adding `basename()` as a first line of defense is the explicit, auditable protection against path traversal (CWE-22).

Fixes #3195

## Changes

- **`helpers.ts`**: Import `basename` from `node:path`; call `basename(filename)` before the character regex in `downloadSlackFile()`. Two layers of defense: basename strips directory components, regex allows only safe chars.
- Issue #3196 (JSON.parse without valibot): investigated — both instances at lines 688 and 969 are already in `try/catch` blocks with `toRecord()` / `isString()` type guard validation. No change needed.

-- refactor/team-lead