### PR TITLE
fix(openclaw): always set model after onboard to prevent wrong default

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -459,17 +459,16 @@ async function setupOpenclawConfig(
     await uploadConfigFile(runner, fallbackConfig, "$HOME/.openclaw/openclaw.json");
   }
 
-  // Set custom model if user selected one different from the onboard default
-  if (modelId !== "openrouter/auto") {
-    const modelResult = await asyncTryCatchIf(isOperationalError, () =>
-      runner.runServer(
-        "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
-          `openclaw config set agents.defaults.model.primary ${shellQuote(modelId)} >/dev/null`,
-      ),
-    );
-    if (!modelResult.ok) {
-      logWarn("Custom model config failed (non-fatal)");
-    }
+  // Always set the model after onboard — `openclaw onboard` may pick its own
+  // default (e.g. arcee/trinity-large-thinking) instead of openrouter/auto.
+  const modelResult = await asyncTryCatchIf(isOperationalError, () =>
+    runner.runServer(
+      "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH; " +
+        `openclaw config set agents.defaults.model.primary ${shellQuote(modelId)} >/dev/null`,
+    ),
+  );
+  if (!modelResult.ok) {
+    logWarn("Model config failed (non-fatal)");
   }
 
   // Disable Docker sandboxing — when Docker is installed on the VM, openclaw


### PR DESCRIPTION
## Summary
- `openclaw onboard --non-interactive` now defaults to `arcee/trinity-large-thinking` instead of using the OpenRouter provider
- Previously we only ran `openclaw config set agents.defaults.model.primary` when the user picked a custom model (`!== "openrouter/auto"`)
- Now we always set it after onboard, ensuring `openrouter/auto` (or the user's custom model) is used

## Root cause
OpenClaw updated their onboard flow to pick their own default model. The old guard `if (modelId !== "openrouter/auto")` skipped the config set, trusting onboard to do the right thing.

## Test plan
- [x] 2032 tests pass
- [x] Biome lint clean
- [ ] Manual: `spawn openclaw digitalocean` → verify model is `openrouter/auto` not `arcee/trinity-large-thinking`

🤖 Generated with [Claude Code](https://claude.com/claude-code)