### PR TITLE
fix(security): add upper bound to base64 scrub regex to prevent ReDoS

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/telemetry.ts
+++ b/packages/cli/src/shared/telemetry.ts
@@ -45,7 +45,7 @@ const SENSITIVE_PATTERNS: [
   ],
   // Base64-encoded blobs that might contain secrets (40+ chars)
   [
-    /[A-Za-z0-9+/]{40,}={0,2}\b/g,
+    /[A-Za-z0-9+/]{40,100}={0,2}/g,
     "[REDACTED_B64]",
   ],
   // Home directory paths — replace with ~


### PR DESCRIPTION
**Why:** The regex `/[A-Za-z0-9+/]{40,}={0,2}\b/g` causes exponential backtracking (ReDoS) on long strings of base64-like characters followed by a non-word boundary. An attacker controlling error message content (API responses, filenames) can craft input that hangs the CLI at 100% CPU.

## Fix
Added upper bound `{40,100}` and removed `\b` word boundary anchor. This prevents catastrophic backtracking while still matching legitimate base64 tokens.

## Testing
- Lint: `bunx @biomejs/biome check src/` passes (182 files, 0 errors)
- Tests: `bun test` passes (2032 tests, 0 failures)

Fixes #3250

-- refactor/security-auditor