### PR TITLE
fix: replace plan_mode_required with message-based approval in refactor team

### DIFF
--- a/.claude/skills/setup-agent-team/refactor-team-prompt.md
+++ b/.claude/skills/setup-agent-team/refactor-team-prompt.md
@@ -56,12 +56,15 @@ There are TWO tracks:
 ### Issue track (NO plan mode)
 Teammates assigned to fix a labeled issue (safe-to-work, security, bug) are spawned WITHOUT plan_mode_required. They go straight to fixing — no approval needed. The issue label IS the approval.
 
-### Proactive track (plan mode required)
-Teammates doing proactive scanning (no specific issue) are spawned WITH plan_mode_required. They must:
+### Proactive track (message-based approval — NEVER use plan_mode_required)
+**CRITICAL: NEVER spawn proactive teammates with `plan_mode_required`.** In non-interactive (`-p`) mode, plan_mode_required causes agents to hang indefinitely waiting for human UI approval that never arrives. They cannot process shutdown_request messages while blocked, which prevents TeamDelete from completing. This is the root cause of issues #3244, #3249, and #3256.
+
+Teammates doing proactive scanning (no specific issue) are spawned WITHOUT plan_mode_required. They use message-based approval instead:
 1. Scan the codebase and identify a candidate change
-2. Write a plan with: what files change, the concrete "Why:" justification, and the diff summary
-3. Call ExitPlanMode — this sends you (team lead) an approval request
-4. WAIT for your approval before creating the branch, committing, or pushing
+2. Write a plan proposal: what files change, the concrete "Why:" justification, and the diff summary
+3. Send the plan to you (team lead) via SendMessage — title: "Plan proposal: [brief description]"
+4. WAIT for your reply before creating the branch, committing, or pushing
+5. Proceed ONLY if you respond with "Approved" — stop and report "No action taken" if rejected or no reply within 3 minutes
 
 As team lead, REJECT proactive plans that:
 - Have vague justifications ("improves readability", "better error handling")
@@ -91,9 +94,9 @@ Filter out discovery team issues (labels: `discovery-team`, `cloud-proposal`, `a
 
 If there are more issues than teammates, prioritize: `security` > `bug` > `safe-to-work`.
 
-**Only AFTER all labeled issues are assigned** should remaining teammates do proactive scanning (with plan_mode_required).
+**Only AFTER all labeled issues are assigned** should remaining teammates do proactive scanning (message-based approval — see above). NEVER use plan_mode_required.
 
-If there are zero labeled issues, ALL teammates do proactive scanning with plan mode.
+If there are zero labeled issues, ALL teammates do proactive scanning with message-based approval.
 
 ## Time Budget
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
**Why:** Agents spawned with `plan_mode_required` in non-interactive (`-p`) mode hang indefinitely — they cannot process `shutdown_request` messages while blocked in the plan approval loop, causing `TeamDelete` to fail with "Cannot cleanup team with N active member(s)". This has occurred 3 times: #3244, #3249, and #3256.

## Root Cause

In non-interactive mode there is no human present to approve plans via the UI. The agent blocks in `ExitPlanMode` waiting for a `plan_approval_request` response that never comes. Mailbox messages (including `shutdown_request`) are not processed while the agent is blocked this way.

## Fix

Replace `plan_mode_required` for proactive teammates with **message-based approval**:
- Proactive agents are spawned **without** `plan_mode_required`
- They send their plan proposal to the team lead via `SendMessage`
- They wait up to 3 minutes for an "Approved" reply before proceeding
- This is fully compatible with non-interactive mode — messages are processed normally

The issue track (agents fixing labeled issues) is unchanged: still no plan mode needed.

## Changes

- `.claude/skills/setup-agent-team/refactor-team-prompt.md`: replaced plan_mode_required proactive track with message-based approval, added CRITICAL warning with issue references, updated all downstream references.

Fixes #3256

-- refactor/issue-fixer