### PR TITLE
fix: resolve 4 production TypeScript type errors

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -319,8 +319,11 @@ export async function pullChildHistory(record: SpawnRecord): Promise<void> {
     const childRecords: SpawnRecord[] = [];
     for (const el of parsed) {
       const result = v.safeParse(SpawnRecordSchema, el);
-      if (result.success) {
-        childRecords.push(result.output);
+      if (result.success && result.output.id) {
+        childRecords.push({
+          ...result.output,
+          id: result.output.id,
+        });
       }
     }
     if (childRecords.length > 0) {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1196,11 +1196,13 @@ export async function cmdRunHeadless(agent: string, cloud: string, opts: Headles
     if (conn.user && tryCatch(() => validateUsername(conn.user)).ok) {
       connectionFields.ssh_user = conn.user;
     }
-    if (conn.server_id && tryCatch(() => validateServerIdentifier(conn.server_id)).ok) {
-      connectionFields.server_id = conn.server_id;
+    const serverId = conn.server_id;
+    if (serverId && tryCatch(() => validateServerIdentifier(serverId)).ok) {
+      connectionFields.server_id = serverId;
     }
-    if (conn.server_name && tryCatch(() => validateServerIdentifier(conn.server_name)).ok) {
-      connectionFields.server_name = conn.server_name;
+    const serverName = conn.server_name;
+    if (serverName && tryCatch(() => validateServerIdentifier(serverName)).ok) {
+      connectionFields.server_name = serverName;
     }
   }
 

--- a/packages/cli/src/local/local.ts
+++ b/packages/cli/src/local/local.ts
@@ -83,14 +83,19 @@ export async function runLocal(cmd: string): Promise<void> {
 
 /** Run a command locally using an argument array (no shell interpretation). */
 export async function runLocalArgs(args: ReadonlyArray<string>): Promise<void> {
-  const proc = Bun.spawn(args, {
-    stdio: [
-      "inherit",
-      "inherit",
-      "inherit",
+  const proc = Bun.spawn(
+    [
+      ...args,
     ],
-    env: process.env,
-  });
+    {
+      stdio: [
+        "inherit",
+        "inherit",
+        "inherit",
+      ],
+      env: process.env,
+    },
+  );
   const exitCode = await proc.exited;
   if (exitCode !== 0) {
     throw new Error(`Command failed (exit ${exitCode}): ${args.join(" ")}`);


### PR DESCRIPTION
**Why:** `tsc --noEmit` reports 4 type errors in production code (non-test files). While these don't cause runtime failures today (Bun doesn't enforce types at runtime), they mask real type-safety gaps:

1. **`delete.ts:323`** — `SpawnRecordSchema` allows `id` to be optional (for backwards compat), but `SpawnRecord` interface requires it. Records without an `id` could silently slip into `SpawnRecord[]` arrays.
2. **`run.ts:1199,1202`** — `conn.server_id` / `conn.server_name` are `string | undefined` but passed to `validateServerIdentifier(string)` inside closures where TypeScript can't narrow.
3. **`local.ts:86`** — `ReadonlyArray<string>` not assignable to `string[]` expected by `Bun.spawn`.

**Fixes:**
- `delete.ts`: Filter for `result.output.id` before pushing, spread with explicit `id` field
- `run.ts`: Capture optional fields in local variables for proper narrowing
- `local.ts`: Spread `ReadonlyArray` into mutable array
- Version bump: 1.0.2 → 1.0.3

**Verification:** `tsc --noEmit` (0 production errors), `biome check` (0 errors), `bun test` (2043/2043 pass)

-- refactor/code-health