### PR TITLE
fix: always fetch manifest from GitHub, cache is offline-only

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.32.4",
+  "version": "0.32.5",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/manifest.test.ts
+++ b/packages/cli/src/__tests__/manifest.test.ts
@@ -136,7 +136,7 @@ describe("manifest", () => {
       );
     });
 
-    it("should use disk cache when fresh", async () => {
+    it("should always fetch from GitHub even when cache exists", async () => {
       mkdirSync(join(env.testDir, "spawn"), {
         recursive: true,
       });
@@ -149,7 +149,8 @@ describe("manifest", () => {
       expect(manifest).toHaveProperty("agents");
       expect(manifest).toHaveProperty("clouds");
       expect(manifest).toHaveProperty("matrix");
-      expect(global.fetch).not.toHaveBeenCalled();
+      // Always fetches fresh — cache is only an offline fallback
+      expect(global.fetch).toHaveBeenCalled();
     });
 
     it("should refresh cache when forceRefresh is true", async () => {

--- a/packages/cli/src/manifest.ts
+++ b/packages/cli/src/manifest.ts
@@ -76,7 +76,6 @@ const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/main` as const;
 const SPAWN_CDN = "https://openrouter.ai/labs/spawn" as const;
 /** Static URL for version checks — GitHub release artifact, never changes with repo structure */
 const VERSION_URL = `https://github.com/${REPO}/releases/download/cli-latest/version` as const;
-const CACHE_TTL = 3600; // 1 hour in seconds
 const FETCH_TIMEOUT = 10_000; // 10 seconds
 
 // ── Cache helpers ──────────────────────────────────────────────────────────────
@@ -195,13 +194,6 @@ async function fetchManifestFromGitHub(): Promise<Manifest | null> {
 let _cached: Manifest | null = null;
 let _staleCache = false;
 
-function tryLoadFromDiskCache(): Manifest | null {
-  if (cacheAge() >= CACHE_TTL) {
-    return null;
-  }
-  return readCache();
-}
-
 function updateCache(manifest: Manifest): Manifest {
   writeCache(manifest);
   _cached = manifest;
@@ -246,17 +238,8 @@ export async function loadManifest(forceRefresh = false): Promise<Manifest> {
     return local;
   }
 
-  // Check disk cache first if not forcing refresh
-  if (!forceRefresh) {
-    const cached = tryLoadFromDiskCache();
-    if (cached) {
-      _cached = cached;
-      _staleCache = false;
-      return cached;
-    }
-  }
-
-  // Fetch from GitHub
+  // Always fetch from GitHub first — ensures users always see latest agents/clouds.
+  // Disk cache is only used as an offline fallback.
   const fetched = await fetchManifestFromGitHub();
   if (fetched) {
     return updateCache(fetched);


### PR DESCRIPTION
## Summary
- Manifest is now always fetched fresh from GitHub on every run
- Disk cache is only used when the network is unreachable (offline fallback)
- Removed `CACHE_TTL` and `tryLoadFromDiskCache` — no more cache-first path

## Why
The 1h cache TTL could get stuck stale if GitHub fetches failed silently. Users would see a 14-day-old manifest missing new agents/clouds (like Daytona and Pi) with no way to fix it except manually deleting the cache file.

## Trade-off
Each `spawn` run now makes a ~10KB network request to GitHub. The 10s timeout ensures it doesn't block if GitHub is slow. For users who run spawn frequently, the in-memory cache still works within the same process.

## Test plan
- [x] 2043 tests pass (updated 1 test that expected cache-first behavior)
- [x] Biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)