### PR TITLE
fix: always fetch manifest from GitHub, 3s timeout for bad wifi

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/manifest.test.ts
+++ b/packages/cli/src/__tests__/manifest.test.ts
@@ -136,7 +136,7 @@ describe("manifest", () => {
       );
     });
 
-    it("should use disk cache when fresh", async () => {
+    it("should always fetch from GitHub even when cache exists", async () => {
       mkdirSync(join(env.testDir, "spawn"), {
         recursive: true,
       });
@@ -149,7 +149,8 @@ describe("manifest", () => {
       expect(manifest).toHaveProperty("agents");
       expect(manifest).toHaveProperty("clouds");
       expect(manifest).toHaveProperty("matrix");
-      expect(global.fetch).not.toHaveBeenCalled();
+      // Always fetches fresh — cache is only an offline fallback
+      expect(global.fetch).toHaveBeenCalled();
     });
 
     it("should refresh cache when forceRefresh is true", async () => {

--- a/packages/cli/src/manifest.ts
+++ b/packages/cli/src/manifest.ts
@@ -117,8 +117,7 @@ const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/main` as const;
 const SPAWN_CDN = "https://openrouter.ai/labs/spawn" as const;
 /** Static URL for version checks — GitHub release artifact, never changes with repo structure */
 const VERSION_URL = `https://github.com/${REPO}/releases/download/cli-latest/version` as const;
-const CACHE_TTL = 3600; // 1 hour in seconds
-const FETCH_TIMEOUT = 10_000; // 10 seconds
+const FETCH_TIMEOUT = 3_000; // 3 seconds — fast fallback on bad wifi
 
 // ── Cache helpers ──────────────────────────────────────────────────────────────
 
@@ -236,13 +235,6 @@ async function fetchManifestFromGitHub(): Promise<Manifest | null> {
 let _cached: Manifest | null = null;
 let _staleCache = false;
 
-function tryLoadFromDiskCache(): Manifest | null {
-  if (cacheAge() >= CACHE_TTL) {
-    return null;
-  }
-  return readCache();
-}
-
 function updateCache(manifest: Manifest): Manifest {
   writeCache(manifest);
   _cached = manifest;
@@ -287,17 +279,7 @@ export async function loadManifest(forceRefresh = false): Promise<Manifest> {
     return local;
   }
 
-  // Check disk cache first if not forcing refresh
-  if (!forceRefresh) {
-    const cached = tryLoadFromDiskCache();
-    if (cached) {
-      _cached = cached;
-      _staleCache = false;
-      return cached;
-    }
-  }
-
-  // Fetch from GitHub
+  // Always fetch fresh from GitHub — disk cache is offline-only fallback.
   const fetched = await fetchManifestFromGitHub();
   if (fetched) {
     return updateCache(fetched);


### PR DESCRIPTION
## Summary
- Remove 1h cache-first path that caused stale manifests (user had 14-day-old cache missing new agents/clouds)
- Every run now fetches fresh from GitHub with a **3s timeout** (down from 10s)
- Disk cache is only used as an offline fallback when network is unreachable
- Supersedes #3271 which had 10s timeout — too slow on bad wifi

## What changed
- Removed `CACHE_TTL` (1h) and `tryLoadFromDiskCache()` — no more cache-first path
- Reduced `FETCH_TIMEOUT` from 10s to 3s — manifest.json is ~10KB, loads in <1s on any connection
- `cacheAge()` kept only for `spawn version` display info
- Cache still written on every successful fetch (offline fallback)

## Trade-off
Each `spawn` run makes a ~10KB fetch to GitHub. On good wifi this adds <500ms. On bad wifi (60% packet loss), the 3s timeout kicks in and falls back to cache — much better than the 10s timeout in #3271.

## Test plan
- [x] 2104 tests pass
- [x] Biome lint clean
- [x] Updated test that previously expected cache-first behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)