### PR TITLE
fix(growth): increase hard timeout from 300s to 600s

### DIFF
--- a/.claude/skills/setup-agent-team/growth.sh
+++ b/.claude/skills/setup-agent-team/growth.sh
@@ -12,7 +12,7 @@ cd "${REPO_ROOT}"
 
 SPAWN_REASON="${SPAWN_REASON:-manual}"
 TEAM_NAME="spawn-growth"
-HARD_TIMEOUT=300   # 5 min (scoring is fast, no tool use)
+HARD_TIMEOUT=600   # 10 min (claude scoring can take 5+ min with large post sets)
 
 LOG_FILE="${REPO_ROOT}/.docs/${TEAM_NAME}.log"
 PROMPT_FILE=""


### PR DESCRIPTION
## Summary
- Growth scoring has been timing out since Apr 10 — Claude gets killed at 300s before finishing
- Apr 6–9 runs completed in 70–270s, but Apr 10–11 both hit the 5-min wall
- Bumps hard timeout to 600s (10 min) to handle larger post sets

## Test plan
- [ ] Next daily run at 14:37 UTC should complete and post to #alert-spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)