### PR TITLE
fix(security): pipe install script via temp file instead of bash -c

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/update-check.test.ts
+++ b/packages/cli/src/__tests__/update-check.test.ts
@@ -313,9 +313,9 @@ describe("update-check", () => {
       expect(execFileSyncCalls[0].file).toBe("curl");
       expect(execFileSyncCalls[0].args).toContain("-fsSL");
       expect(execFileSyncCalls[0].args.some((a: string) => a.includes("install.sh"))).toBe(true);
-      // 2. bash to execute fetched script
+      // 2. bash to execute fetched script via temp file (not -c)
       expect(execFileSyncCalls[1].file).toBe("bash");
-      expect(execFileSyncCalls[1].args[0]).toBe("-c");
+      expect(execFileSyncCalls[1].args[0]).toMatch(/spawn-install-.*\.sh$/);
       // 3. which spawn for binary lookup
       expect(execFileSyncCalls[2].file).toBe("which");
       expect(execFileSyncCalls[2].args).toEqual([

--- a/packages/cli/src/update-check.ts
+++ b/packages/cli/src/update-check.ts
@@ -320,17 +320,28 @@ function performAutoUpdate(latestVersion: string, jsonOutput = false): void {
         throw psResult.error;
       }
     } else {
-      // macOS/Linux: execute via bash -c
-      executor.execFileSync(
-        "bash",
-        [
-          "-c",
-          scriptContent,
-        ],
-        {
-          stdio: installStdio,
-        },
+      // macOS/Linux: write to temp file and execute via bash to avoid
+      // command injection and ARG_MAX limits (consistent with Windows path)
+      const tmpFile = path.join(tmpdir(), `spawn-install-${Date.now()}.sh`);
+      fs.writeFileSync(tmpFile, scriptContent, {
+        mode: 0o700,
+      });
+      const bashResult = tryCatch(() =>
+        executor.execFileSync(
+          "bash",
+          [
+            tmpFile,
+          ],
+          {
+            stdio: installStdio,
+          },
+        ),
       );
+      // Best-effort cleanup of temp file
+      tryCatchIf(isFileError, () => fs.unlinkSync(tmpFile));
+      if (!bashResult.ok) {
+        throw bashResult.error;
+      }
     }
   });
 


### PR DESCRIPTION
**Why:** `bash -c "scriptContent"` passes fetched script content as a shell argument, which is vulnerable to command injection if the script content contains shell metacharacters, and fails for large scripts due to `ARG_MAX` limits. Writing to a temp file and executing with `bash /tmp/script.sh` is safer and consistent with the existing Windows codepath.

**Changes:**
- `packages/cli/src/update-check.ts`: Replace `bash -c scriptContent` with write-to-temp-file + `bash tmpFile` pattern (matching the existing Windows PowerShell approach)
- `packages/cli/src/__tests__/update-check.test.ts`: Update test assertion to expect temp file path instead of `-c` flag
- `packages/cli/package.json`: Bump version 1.0.5 -> 1.0.6

Fixes #3291

-- refactor/security-auditor