### PR TITLE
fix(security): use temp file for GitHub token to avoid process listing exposure

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -267,8 +267,11 @@ export async function offerGithubAuth(runner: CloudRunner, explicitlyRequested?:
 
   let ghCmd = "curl --proto '=https' -fsSL https://openrouter.ai/labs/spawn/shared/github-auth.sh | bash";
   if (githubToken) {
-    const tokenB64 = Buffer.from(githubToken).toString("base64");
-    ghCmd = `export GITHUB_TOKEN=$(printf '%s' ${shellQuote(tokenB64)} | base64 -d) && ${ghCmd}`;
+    const tmpFile = join(getTmpDir(), `spawn_gh_token_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+    writeFileSync(tmpFile, githubToken, {
+      mode: 0o600,
+    });
+    ghCmd = `export GITHUB_TOKEN=$(cat ${shellQuote(tmpFile)}) && rm -f ${shellQuote(tmpFile)} && ${ghCmd}`;
   }
 
   logStep("Installing and authenticating GitHub CLI on the remote server...");

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -267,11 +267,11 @@ export async function offerGithubAuth(runner: CloudRunner, explicitlyRequested?:
 
   let ghCmd = "curl --proto '=https' -fsSL https://openrouter.ai/labs/spawn/shared/github-auth.sh | bash";
   if (githubToken) {
-    const tmpFile = join(getTmpDir(), `spawn_gh_token_${Date.now()}_${Math.random().toString(36).slice(2)}`);
-    writeFileSync(tmpFile, githubToken, {
-      mode: 0o600,
-    });
-    ghCmd = `export GITHUB_TOKEN=$(cat ${shellQuote(tmpFile)}) && rm -f ${shellQuote(tmpFile)} && ${ghCmd}`;
+    // Pass token via heredoc to avoid exposing it in process listings (`ps auxe`).
+    // The heredoc is read by the shell's parser, not passed as a command argument,
+    // so it never appears in /proc/*/cmdline. A local temp file won't work here
+    // because the command executes on the REMOTE server via runner.runServer().
+    ghCmd = `export GITHUB_TOKEN=$(cat <<'SPAWN_TOKEN_EOF'\n${githubToken}\nSPAWN_TOKEN_EOF\n) && ${ghCmd}`;
   }
 
   logStep("Installing and authenticating GitHub CLI on the remote server...");

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -266,17 +266,33 @@ export async function offerGithubAuth(runner: CloudRunner, explicitlyRequested?:
   }
 
   let ghCmd = "curl --proto '=https' -fsSL https://openrouter.ai/labs/spawn/shared/github-auth.sh | bash";
+  // Upload the token to a remote temp file so it never appears in `ps auxe`
+  // process listings. We use runner.uploadFile() (SCP) — the same proven
+  // pattern as uploadConfigFile(). A heredoc won't work here because all
+  // cloud runners wrap commands in `bash -c ${shellQuote(cmd)}`, and
+  // heredocs are not valid inside single-quoted `bash -c '...'` strings.
+  let remoteTokenPath = "";
   if (githubToken) {
-    // Pass token via heredoc to avoid exposing it in process listings (`ps auxe`).
-    // The heredoc is read by the shell's parser, not passed as a command argument,
-    // so it never appears in /proc/*/cmdline. A local temp file won't work here
-    // because the command executes on the REMOTE server via runner.runServer().
-    ghCmd = `export GITHUB_TOKEN=$(cat <<'SPAWN_TOKEN_EOF'\n${githubToken}\nSPAWN_TOKEN_EOF\n) && ${ghCmd}`;
+    const localTmpFile = join(getTmpDir(), `spawn_gh_token_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+    remoteTokenPath = `/tmp/spawn_gh_token_${Date.now()}`;
+    writeFileSync(localTmpFile, githubToken, {
+      mode: 0o600,
+    });
+    const uploadResult = await asyncTryCatch(() => runner.uploadFile(localTmpFile, remoteTokenPath));
+    tryCatchIf(isOperationalError, () => unlinkSync(localTmpFile));
+    if (!uploadResult.ok) {
+      throw uploadResult.error;
+    }
+    ghCmd = `export GITHUB_TOKEN=$(cat ${shellQuote(remoteTokenPath)}) && rm -f ${shellQuote(remoteTokenPath)} && ${ghCmd}`;
   }
 
   logStep("Installing and authenticating GitHub CLI on the remote server...");
   const ghSetup = await asyncTryCatchIf(isOperationalError, () => runner.runServer(ghCmd));
   if (!ghSetup.ok) {
+    // Best-effort cleanup of remote token file if the command failed before rm ran
+    if (remoteTokenPath) {
+      await asyncTryCatchIf(isOperationalError, () => runner.runServer(`rm -f ${shellQuote(remoteTokenPath)}`));
+    }
     logWarn("GitHub CLI setup failed (non-fatal, continuing)");
   }
 


### PR DESCRIPTION
**Why:** GitHub token passed inline as env var in shell command is visible in `ps auxe` process listings during execution, exposing user credentials. Temp file approach (mode 0600, deleted immediately after read) keeps the secret off the process table.

Fixes #3300

## Changes
- `packages/cli/src/shared/agent-setup.ts`: Replace inline base64-encoded env var with temp file in `offerGithubAuth()`
- `packages/cli/package.json`: Patch version bump 1.0.9 → 1.0.10

-- refactor/security-auditor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openrouterteam/spawn/pull/3301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
