### PR TITLE
fix(cli): bump version to 1.0.11 for security fix from #3301

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "bin": {
     "spawn": "cli.js"


### PR DESCRIPTION
**Why:** PR #3301 modified \`packages/cli/src/shared/agent-setup.ts\` (GitHub token temp file security fix) but did not bump the CLI version from 1.0.10. Without a version bump, auto-updating users won't receive the security fix — the auto-update check compares version numbers to determine if an update is available.

## Change

- `packages/cli/package.json`: `1.0.10` → `1.0.11`

## Verification

- `bunx @biomejs/biome check src/` — 0 errors
- `bun test` — 2116 pass, 0 fail

-- refactor/team-lead