### PR TITLE
fix(link): add pi and cursor to agent auto-detection

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -71,14 +71,28 @@ const KNOWN_AGENTS = [
   "kilocode",
   "hermes",
   "junie",
+  "pi",
+  "cursor",
 ] as const;
 type KnownAgent = (typeof KNOWN_AGENTS)[number];
+
+/** Map manifest agent key → CLI binary name (only where they differ). */
+const AGENT_BINARY: Partial<Record<KnownAgent, string>> = {
+  cursor: "agent",
+};
+
+/** Get the CLI binary name for an agent (defaults to the agent key itself). */
+function agentBinary(agent: KnownAgent): string {
+  return AGENT_BINARY[agent] ?? agent;
+}
 
 /** Auto-detect which agent is installed/running on the remote host. */
 function detectAgent(host: string, user: string, keyOpts: string[], runCmd: SshCommandFn): string | null {
   // First: check running processes
+  // Note: cursor's binary is "agent" which is too generic for ps grep, so it's
+  // detected only via the installed-binary check below.
   const psCmd =
-    "ps aux 2>/dev/null | grep -oE 'claude(-code)?|openclaw|codex|opencode|kilocode|hermes|junie' | grep -v grep | head -1 || true";
+    "ps aux 2>/dev/null | grep -oE 'claude(-code)?|openclaw|codex|opencode|kilocode|hermes|junie|pi' | grep -v grep | head -1 || true";
   const psOut = runCmd(host, user, keyOpts, psCmd);
   if (psOut) {
     const match = KNOWN_AGENTS.find((b: KnownAgent) => psOut.includes(b));
@@ -89,7 +103,7 @@ function detectAgent(host: string, user: string, keyOpts: string[], runCmd: SshC
 
   // Second: check installed binaries — one SSH call per agent to avoid shell injection
   for (const agent of KNOWN_AGENTS) {
-    const whichOut = runCmd(host, user, keyOpts, `command -v ${agent}`);
+    const whichOut = runCmd(host, user, keyOpts, `command -v ${agentBinary(agent)}`);
     if (whichOut) {
       return agent;
     }


### PR DESCRIPTION
**Why:** `spawn link` cannot auto-detect Pi or Cursor CLI agents on remote servers — users must manually specify `--agent pi` or `--agent cursor`. This is because `KNOWN_AGENTS` in `link.ts` was never updated when these agents were added.

## Changes

- Add `"pi"` and `"cursor"` to `KNOWN_AGENTS` array
- Add `AGENT_BINARY` mapping for cursor (`agent` binary) so `command -v` checks the correct binary name
- Update `ps aux` grep pattern to include `pi` (cursor's `agent` binary is intentionally excluded from ps grep — too generic)
- Bump CLI version to 1.0.14

-- refactor/code-health