### PR TITLE
fix(agent-team): cut token spend — reduce cron + Sonnet team leads

### DIFF
--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -221,7 +221,9 @@ log "Hard timeout: ${HARD_TIMEOUT}s"
 
 # Run claude in background, output goes to log file.
 # The trigger server is fire-and-forget — VM keep-alive is handled by systemd.
-claude -p "$(cat "${PROMPT_FILE}")" >> "${LOG_FILE}" 2>&1 &
+# Team lead uses Sonnet — coordination (spawn, monitor, shutdown) doesn't need
+# Opus-level reasoning and Sonnet output tokens are 5x cheaper.
+claude -p "$(cat "${PROMPT_FILE}")" --model sonnet >> "${LOG_FILE}" 2>&1 &
 CLAUDE_PID=$!
 log "Claude started (pid=${CLAUDE_PID})"
 

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -320,8 +320,12 @@ HARD_TIMEOUT=$((CYCLE_TIMEOUT + 300))
 log "Hard timeout: ${HARD_TIMEOUT}s"
 
 # Run claude in background, output goes to log file.
-# Triage uses gemini-3-flash (lightweight safety check); other modes use default (Opus) for team lead.
-CLAUDE_MODEL_FLAG=""
+# Triage uses gemini-3-flash (lightweight safety check).
+# All other modes use Sonnet for the team lead — the lead's job is coordination
+# (spawn teammates, monitor, shut down), not deep reasoning. Opus is 5x more
+# expensive on output tokens and the quality difference for coordination is
+# negligible. Teammates (spawned by the lead) use their own model flags.
+CLAUDE_MODEL_FLAG="--model sonnet"
 if [[ "${RUN_MODE}" == "triage" ]]; then
     CLAUDE_MODEL_FLAG="--model google/gemini-3-flash-preview"
 fi

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -2,7 +2,7 @@ name: Trigger Refactor
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 */2 * * *'
   issues:
     types: [opened, reopened, labeled]
   workflow_dispatch:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, reopened, labeled]
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '0 */4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Phase 1 of the token-savings plan. Two changes that close most of the daily cost gap:

### 1. Reduce cron frequency

| Workflow | Before | After | Cycles/day |
|---|---|---|---|
| Security | `*/30 * * * *` (every 30 min) | `0 */4 * * *` (every 4 hours) | 48 → 6 |
| Refactor | `*/15 * * * *` (every 15 min) | `0 */2 * * *` (every 2 hours) | 96 → 12 |

Most cycles find nothing to do. Issue-triggered runs still fire instantly via the `issues` event type. The trigger-server returns 409 when already running, so high cron frequency was just idle-polling cost.

### 2. Downgrade team-lead model to Sonnet

The team lead's job is coordination — spawn teammates, monitor, shut down. Not reasoning. Sonnet handles it fine and output tokens are ~5x cheaper.

- `security.sh`: `--model sonnet` for review_all and scan modes (triage was already on gemini-3-flash)
- `refactor.sh`: `--model sonnet`

Teammates (spawned by the lead) are unaffected — they use their own model flags.

### Combined impact

~90% fewer cycles × ~80% cheaper per cycle on team lead = **estimated 95%+ cost reduction on team-lead tokens alone.**

### Follow-up (Phase 2+3, separate PR)

- Trim prompt sizes via shared rules file + teammate micro-prompts (319→100 lines for refactor-team, etc.)
- Consolidate security teammates from 4 → 2

## Test plan

- [x] `bash -n security.sh` — syntax clean
- [x] `bash -n refactor.sh` — syntax clean
- [x] `bunx biome check src/` — 0 errors on 187 files
- [x] `bun test` — 2068/2068 pass
- [ ] Manual: trigger one security review_all cycle after merge, confirm Sonnet team lead spawns and shuts down normally
- [ ] Manual: trigger one refactor cycle, same verification
- [ ] After 24h: check OpenRouter usage dashboard, confirm daily spend dropped