### PR TITLE
fix(ux): correct reconnect command suggestion from "spawn connect" to "spawn last"

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -917,7 +917,7 @@ async function postInstall(
   if (isConnectionDrop(exitCode)) {
     process.stderr.write("\n");
     logWarn("Could not reconnect. Server is still running.");
-    logInfo("Reconnect manually: spawn connect");
+    logInfo("Reconnect manually: spawn last");
   }
 
   if (tunnelHandle) {


### PR DESCRIPTION
**Why:** After exhausting SSH reconnect attempts, the CLI tells users "Reconnect manually: spawn connect" — but `spawn connect` is not a valid top-level command. Users following this guidance see "Unknown agent or cloud: connect", a confusing dead-end. `spawn last` is the correct command to reconnect to the most recent spawn.

## Changes
- `packages/cli/src/shared/orchestrate.ts`: Replace `spawn connect` with `spawn last` in reconnect failure message
- `packages/cli/package.json`: Bump version 1.0.14 → 1.0.15