### PR TITLE
fix(growth): increase hard timeout from 600s to 1800s

### DIFF
--- a/.claude/skills/setup-agent-team/growth.sh
+++ b/.claude/skills/setup-agent-team/growth.sh
@@ -12,7 +12,7 @@ cd "${REPO_ROOT}"
 
 SPAWN_REASON="${SPAWN_REASON:-manual}"
 TEAM_NAME="spawn-growth"
-HARD_TIMEOUT=600   # 10 min (claude scoring can take 5+ min with large post sets)
+HARD_TIMEOUT=1800  # 30 min (claude scoring can take 10+ min with 500+ post sets)
 
 LOG_FILE="${REPO_ROOT}/.docs/${TEAM_NAME}.log"
 PROMPT_FILE=""


### PR DESCRIPTION
## Summary
- Bumps the growth agent's Claude scoring hard timeout from 600s (10 min) to 1800s (30 min)
- Today's run timed out at 600s while scoring 559 posts — Claude was killed mid-scoring with no candidate produced
- Yesterday's successful run took ~8 min for 577 posts, so 10 min is too tight a margin

## Files changed
- `.claude/skills/setup-agent-team/growth.sh` — single line: `HARD_TIMEOUT=600` → `HARD_TIMEOUT=1800`

## Test plan
- [ ] Verify `bash -n` passes (confirmed)
- [ ] Next daily run (tomorrow 14:37 UTC) should complete without timeout

_Filed from Slack by SPA_

🤖 Generated with [Claude Code](https://claude.com/claude-code)