### PR TITLE
fix(growth): replace BASH_SOURCE with git rev-parse (closes #3303)

### DIFF
--- a/.claude/skills/setup-agent-team/growth.sh
+++ b/.claude/skills/setup-agent-team/growth.sh
@@ -6,8 +6,11 @@ set -eo pipefail
 # Phase 2: Pass results to Claude for scoring/qualification (no tool use)
 # Phase 3: POST candidate to SPA for Slack notification
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+# Derive paths from git — works regardless of how the script is invoked
+# (direct execution, Bun.spawn, or process substitution). Avoids BASH_SOURCE
+# which breaks under bash <(curl ...) per .claude/rules/shell-scripts.md.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT_DIR="${REPO_ROOT}/.claude/skills/setup-agent-team"
 cd "${REPO_ROOT}"
 
 SPAWN_REASON="${SPAWN_REASON:-manual}"


### PR DESCRIPTION
## Summary

Closes #3303. Replaces `BASH_SOURCE[0]`-based path resolution in `growth.sh` with `git rev-parse --show-toplevel`, which works regardless of invocation method.

## Change

```diff
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT_DIR="${REPO_ROOT}/.claude/skills/setup-agent-team"
```

## Note

The same `BASH_SOURCE` pattern exists in `refactor.sh`, `security.sh`, and `discovery.sh`. Those are not touched here per the issue scope — they're also never curl-piped (always executed directly on the VM by `trigger-server.ts`), so the practical risk is zero, but the rule violation is technically real.

## Test plan

- [x] `bash -n growth.sh` — syntax clean