### PR TITLE
feat(telemetry): install referrer attribution for growth channels

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import type { Manifest } from "./manifest.js";
 
+import { readFileSync } from "node:fs";
 import { getErrorMessage, isString, toRecord } from "@openrouter/spawn-shared";
 import pc from "picocolors";
 import pkg from "../package.json" with { type: "json" };
@@ -38,6 +39,7 @@ import {
 } from "./commands/index.js";
 import { expandEqualsFlags, findUnknownFlag } from "./flags.js";
 import { agentKeys, cloudKeys, getCacheAge, loadManifest } from "./manifest.js";
+import { getInstallRefPath } from "./shared/paths.js";
 import { asyncTryCatch, asyncTryCatchIf, isFileError, isNetworkError, tryCatch, tryCatchIf } from "./shared/result.js";
 import { captureError, initTelemetry, setTelemetryContext } from "./shared/telemetry.js";
 import { checkForUpdates } from "./update-check.js";
@@ -47,6 +49,16 @@ const VERSION = pkg.version;
 // Initialize telemetry early — captures uncaught errors and exit flush.
 // Disabled with SPAWN_TELEMETRY=0.
 initTelemetry(VERSION);
+
+// Attribution: if the user installed via a tagged URL (SPAWN_REF=reddit|x|...),
+// the install script persisted the ref to ~/.config/spawn/.ref. Read it once
+// and attach to every telemetry event so PostHog can segment by acquisition channel.
+tryCatchIf(isFileError, () => {
+  const ref = readFileSync(getInstallRefPath(), "utf8").trim();
+  if (ref && /^[a-zA-Z0-9_-]+$/.test(ref)) {
+    setTelemetryContext("ref", ref);
+  }
+});
 
 function handleError(err: unknown): never {
   captureError("cli_error", err);

--- a/packages/cli/src/shared/paths.ts
+++ b/packages/cli/src/shared/paths.ts
@@ -58,6 +58,11 @@ export function getSpawnPreferencesPath(): string {
   return join(getUserHome(), ".config", "spawn", "preferences.json");
 }
 
+/** Return the path to the install referrer file: ~/.config/spawn/.ref */
+export function getInstallRefPath(): string {
+  return join(getUserHome(), ".config", "spawn", ".ref");
+}
+
 /** Return the cache directory for spawn, respecting XDG_CACHE_HOME. */
 export function getCacheDir(): string {
   return join(process.env.XDG_CACHE_HOME || join(getUserHome(), ".cache"), "spawn");

--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -374,3 +374,19 @@ ensure_min_bun_version
 
 log_step "Installing spawn via bun..."
 build_and_install
+
+# Persist install referrer (e.g. SPAWN_REF=reddit) so the CLI can report
+# attribution on first run. Only written once — never overwritten on updates.
+if [ -n "${SPAWN_REF:-}" ]; then
+    _ref_dir="${HOME}/.config/spawn"
+    _ref_file="${_ref_dir}/.ref"
+    if [ ! -f "${_ref_file}" ]; then
+        mkdir -p "${_ref_dir}"
+        # Sanitize: allow only alphanumeric, hyphens, underscores (no injection)
+        _clean_ref=$(printf '%s' "${SPAWN_REF}" | tr -cd 'a-zA-Z0-9_-' | head -c 32)
+        if [ -n "${_clean_ref}" ]; then
+            printf '%s' "${_clean_ref}" > "${_ref_file}"
+            log_info "Install referrer: ${_clean_ref}"
+        fi
+    fi
+fi


### PR DESCRIPTION
## Summary

Tracks whether installs came from Reddit, X, or organic. Answers: **"is the growth bot actually driving installs?"**

## How it works

Growth bot (or human) shares a tagged install command:

```bash
# Reddit
curl -fsSL https://openrouter.ai/labs/spawn/cli/install.sh | SPAWN_REF=reddit bash

# X / Twitter
curl -fsSL https://openrouter.ai/labs/spawn/cli/install.sh | SPAWN_REF=x bash
```

**`install.sh`** — if `SPAWN_REF` is set, sanitizes it (alphanumeric + hyphens only, max 32 chars) and writes to `~/.config/spawn/.ref`. Written once, never overwritten on updates.

**`index.ts`** — on startup, reads `.ref` and calls `setTelemetryContext("ref", ref)`. Every PostHog event from that install carries the ref tag forever.

## What you see in PostHog

Every event (funnel steps, spawn_connected, spawn_deleted, errors) now has a `ref` property for attributed installs:

- `ref=reddit` — came from the Reddit growth bot
- `ref=x` — came from X/Twitter
- no `ref` — organic install

**Sample queries:**
- Funnel filtered by `ref=reddit` → "12 Reddit users started, 8 picked an agent, 3 reached handoff"
- `spawn_launched` count grouped by `ref` → "reddit: 15, x: 3, organic: 200"
- Conversion rate by channel → "Reddit converts at 20% vs organic 73%"

## Changes

| File | Change |
|---|---|
| `sh/cli/install.sh` | Read `SPAWN_REF`, sanitize, write to `~/.config/spawn/.ref` |
| `packages/cli/src/index.ts` | Read `.ref` on startup, set as telemetry context |
| `packages/cli/src/shared/paths.ts` | New `getInstallRefPath()` helper |
| `packages/cli/package.json` | Bump 1.0.15 → 1.0.16 |

## Test plan

- [x] `bash -n install.sh` — syntax clean
- [x] `bunx biome check src/` — 0 errors
- [x] `bun test` — 2070/2070 pass
- [ ] Manual: `SPAWN_REF=test curl ... | bash`, verify `~/.config/spawn/.ref` contains `test`
- [ ] Manual: run `spawn`, check PostHog live events for `ref=test` property