### PR TITLE
fix(ux): document --fast flag in help text

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -10,6 +10,7 @@ function getHelpUsageSection(): string {
   spawn <agent> <cloud> --size <type>  Set instance size/type (works for all clouds)
   spawn <agent> <cloud> --model <id>  Set the LLM model (e.g. openai/gpt-5.3-codex)
   spawn <agent> <cloud> --custom      Show interactive size/region pickers
+  spawn <agent> <cloud> --fast        Enable all speed optimizations (images, tarballs, parallel)
   spawn <agent> <cloud> --headless   Provision and exit (no interactive session)
   spawn <agent> <cloud> --output json
                                      Headless mode with structured JSON on stdout
@@ -73,6 +74,7 @@ function getHelpExamplesSection(): string {
                                      ${pc.dim("# Use a specific machine type")}
   spawn codex gcp --model openai/gpt-5.3-codex
                                      ${pc.dim("# Override the default LLM model")}
+  spawn claude sprite --fast           ${pc.dim("# Fastest provisioning (images + tarballs + parallel)")}
   spawn opencode gcp --dry-run       ${pc.dim("# Preview without provisioning")}
   spawn claude hetzner --headless    ${pc.dim("# Provision, print connection info, exit")}
   spawn claude hetzner --output json ${pc.dim("# Structured JSON output on stdout")}


### PR DESCRIPTION
**Why:** The `--fast` flag is fully implemented but invisible in help output; users manually stack 4 `--beta` flags or read source to discover it, causing unnecessary friction for users who want faster provisioning.

## Summary
- Added `--fast` to the USAGE section of `spawn help` (between `--custom` and `--headless`)
- Added example in EXAMPLES section showing `spawn claude sprite --fast`
- Bumped CLI version to 1.0.18

## Test plan
- [x] `bunx @biomejs/biome check src/` passes (0 errors)
- [x] `bun test` passes (2070 tests, 0 failures)
- [x] `bun run src/index.ts help` shows the new `--fast` entry in both USAGE and EXAMPLES

-- refactor/ux-engineer