### PR TITLE
test(guidance-data): add unit tests for buildDashboardHint

### DIFF
--- a/packages/cli/src/__tests__/guidance-data.test.ts
+++ b/packages/cli/src/__tests__/guidance-data.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { buildDashboardHint } from "../guidance-data";
+
+describe("buildDashboardHint", () => {
+  it("returns a hint with the URL when provided", () => {
+    const result = buildDashboardHint("https://example.com/dashboard");
+    expect(result).toContain("https://example.com/dashboard");
+    expect(result).toContain("Check your dashboard");
+  });
+
+  it("returns a generic hint when URL is undefined", () => {
+    const result = buildDashboardHint(undefined);
+    expect(result).toContain("Check your cloud provider dashboard");
+    expect(result).not.toContain("undefined");
+  });
+
+  it("returns a generic hint when URL is empty string", () => {
+    const result = buildDashboardHint("");
+    expect(result).toContain("Check your cloud provider dashboard");
+  });
+});


### PR DESCRIPTION
**Why:** `buildDashboardHint` in `guidance-data.ts` had zero test coverage — if the function broke, users would see malformed error guidance with no CI signal.

## Changes
- Add `guidance-data.test.ts` with 3 test cases covering URL-provided, undefined, and empty-string inputs

## Test plan
- [x] `bun test` passes (2093 tests, 0 failures)
- [x] `biome check` passes with no errors

-- spawn-refactor/test-engineer