### PR TITLE
feat(oss): collaborator gate — bots ignore external issues

### DIFF
--- a/.claude/scripts/collaborator-gate.sh
+++ b/.claude/scripts/collaborator-gate.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# collaborator-gate.sh — Filter GitHub issues/PRs to collaborator-authored only.
+#
+# OSS readiness: when the repo goes public, anyone can open issues/PRs.
+# The agent team must only engage with collaborators/members — external
+# submissions are invisible to the bots.
+#
+# Usage:
+#   source .claude/scripts/collaborator-gate.sh
+#   is_collaborator "username"  # returns 0 (true) or 1 (false)
+#   list_collaborator_issues    # gh issue list filtered to collaborators only
+#
+# Caches collaborator list for 10 minutes to avoid API rate limits.
+
+set -eo pipefail
+
+_COLLAB_CACHE_FILE="/tmp/spawn-collaborators-cache"
+_COLLAB_CACHE_TTL=600  # 10 minutes
+_COLLAB_REPO="OpenRouterTeam/spawn"
+
+# Refresh the collaborator cache if stale or missing
+_refresh_collaborator_cache() {
+    local now
+    now=$(date +%s)
+
+    if [ -f "$_COLLAB_CACHE_FILE" ]; then
+        local mtime
+        mtime=$(stat -c %Y "$_COLLAB_CACHE_FILE" 2>/dev/null || stat -f %m "$_COLLAB_CACHE_FILE" 2>/dev/null || echo 0)
+        local age=$(( now - mtime ))
+        if [ "$age" -lt "$_COLLAB_CACHE_TTL" ]; then
+            return 0
+        fi
+    fi
+
+    gh api "repos/${_COLLAB_REPO}/collaborators" --paginate --jq '.[].login' 2>/dev/null | sort -u > "$_COLLAB_CACHE_FILE" || true
+}
+
+# Check if a username is a collaborator
+is_collaborator() {
+    local username="${1:-}"
+    if [ -z "$username" ]; then
+        return 1
+    fi
+    _refresh_collaborator_cache
+    grep -qx "$username" "$_COLLAB_CACHE_FILE" 2>/dev/null
+}
+
+# List open issues filtered to collaborator authors only.
+# Passes through all arguments to gh issue list, then filters.
+list_collaborator_issues() {
+    local issues
+    issues=$(gh issue list --repo "$_COLLAB_REPO" --json number,title,labels,author "$@" 2>/dev/null) || return 1
+
+    _refresh_collaborator_cache
+
+    echo "$issues" | jq -c --slurpfile collabs <(jq -R . "$_COLLAB_CACHE_FILE" | jq -s .) \
+        '[.[] | select(.author.login as $a | $collabs[0] | index($a))]'
+}
+
+# List open PRs filtered to collaborator authors only.
+# Passes through all arguments to gh pr list, then filters.
+list_collaborator_prs() {
+    local prs
+    prs=$(gh pr list --repo "$_COLLAB_REPO" --json number,title,labels,author "$@" 2>/dev/null) || return 1
+
+    _refresh_collaborator_cache
+
+    echo "$prs" | jq -c --slurpfile collabs <(jq -R . "$_COLLAB_CACHE_FILE" | jq -s .) \
+        '[.[] | select(.author.login as $a | $collabs[0] | index($a))]'
+}
+
+# Check if a specific issue was authored by a collaborator
+is_issue_from_collaborator() {
+    local issue_num="${1:-}"
+    if [ -z "$issue_num" ]; then
+        return 1
+    fi
+    local author
+    author=$(gh issue view "$issue_num" --repo "$_COLLAB_REPO" --json author --jq '.author.login' 2>/dev/null) || return 1
+    is_collaborator "$author"
+}

--- a/.claude/skills/setup-agent-team/discovery-team-prompt.md
+++ b/.claude/skills/setup-agent-team/discovery-team-prompt.md
@@ -39,7 +39,12 @@ Research new cloud/sandbox providers. Criteria: prestige or unbeatable pricing (
 Search for trending AI coding agents meeting ALL of: 1000+ GitHub stars, single-command install, works with OpenRouter. Search HN, GitHub trending, Reddit. Create issue with label `agent-proposal,discovery-team`.
 
 ### Issue Responder (spawn 1)
-Fetch open issues. SKIP `discovery-team` labeled issues. DEDUP: if `-- discovery/` exists, skip. If someone requests a cloud/agent, point to existing proposal or create one. Leave bugs for refactor team.
+Fetch open issues. **Collaborator gate**: for each issue, check if the author is a repo collaborator before engaging:
+```bash
+gh api repos/OpenRouterTeam/spawn/collaborators/AUTHOR --silent 2>/dev/null
+```
+If the check fails (404 = not a collaborator), SKIP that issue entirely — do not comment, do not respond, do not acknowledge. Only engage with issues from collaborators.
+SKIP `discovery-team` labeled issues. DEDUP: if `-- discovery/` exists, skip. If someone requests a cloud/agent, point to existing proposal or create one. Leave bugs for refactor team.
 
 ### Skills Scout (spawn 1)
 Research best skills, MCP servers, and configs per agent in manifest.json. For each agent: check for skill standards, community skills, useful MCP servers, agent-specific configs, prerequisites. Verify packages exist on npm + start successfully. Update manifest.json skills section. Max 5 skills per PR.

--- a/.claude/skills/setup-agent-team/qa.sh
+++ b/.claude/skills/setup-agent-team/qa.sh
@@ -30,6 +30,21 @@ if [[ -n "${SPAWN_ISSUE}" ]]; then
     fi
 fi
 
+# --- Collaborator gate (OSS readiness) ---
+GATE_SCRIPT="${SCRIPT_DIR}/../../../.claude/scripts/collaborator-gate.sh"
+if [[ -f "${GATE_SCRIPT}" ]]; then
+    source "${GATE_SCRIPT}"
+fi
+
+if [[ -n "${SPAWN_ISSUE}" ]]; then
+    if command -v is_issue_from_collaborator &>/dev/null; then
+        if ! is_issue_from_collaborator "${SPAWN_ISSUE}"; then
+            echo "[qa] Skipping issue #${SPAWN_ISSUE} — author is not a collaborator" >&2
+            exit 0
+        fi
+    fi
+fi
+
 if [[ "${SPAWN_REASON}" == "soak" ]]; then
     RUN_MODE="soak"
     WORKTREE_BASE="/tmp/spawn-worktrees/qa-soak"

--- a/.claude/skills/setup-agent-team/refactor.sh
+++ b/.claude/skills/setup-agent-team/refactor.sh
@@ -28,7 +28,21 @@ if [[ -n "${SPAWN_ISSUE}" ]]; then
     fi
 fi
 
+# --- Collaborator gate (OSS readiness) ---
+# Source the collaborator check so bots never see external issues.
+GATE_SCRIPT="${SCRIPT_DIR}/../../../.claude/scripts/collaborator-gate.sh"
+if [[ -f "${GATE_SCRIPT}" ]]; then
+    source "${GATE_SCRIPT}"
+fi
+
 if [[ -n "${SPAWN_ISSUE}" ]]; then
+    # Check if issue author is a collaborator — skip silently if not
+    if command -v is_issue_from_collaborator &>/dev/null; then
+        if ! is_issue_from_collaborator "${SPAWN_ISSUE}"; then
+            echo "[refactor] Skipping issue #${SPAWN_ISSUE} — author is not a collaborator" >&2
+            exit 0
+        fi
+    fi
     RUN_MODE="issue"
     WORKTREE_BASE="/tmp/spawn-worktrees/issue-${SPAWN_ISSUE}"
     TEAM_NAME="spawn-issue-${SPAWN_ISSUE}"

--- a/.claude/skills/setup-agent-team/security.sh
+++ b/.claude/skills/setup-agent-team/security.sh
@@ -41,6 +41,21 @@ if [[ -n "${SLACK_WEBHOOK}" ]]; then
     fi
 fi
 
+# --- Collaborator gate (OSS readiness) ---
+GATE_SCRIPT="${SCRIPT_DIR}/../../../.claude/scripts/collaborator-gate.sh"
+if [[ -f "${GATE_SCRIPT}" ]]; then
+    source "${GATE_SCRIPT}"
+fi
+
+if [[ -n "${SPAWN_ISSUE}" ]]; then
+    if command -v is_issue_from_collaborator &>/dev/null; then
+        if ! is_issue_from_collaborator "${SPAWN_ISSUE}"; then
+            echo "[security] Skipping issue #${SPAWN_ISSUE} — author is not a collaborator" >&2
+            exit 0
+        fi
+    fi
+fi
+
 if [[ "${SPAWN_REASON}" == "issues" ]] && [[ -n "${SPAWN_ISSUE}" ]]; then
     # Workflow passed raw event_name — detect mode from issue labels
     if gh issue view "${SPAWN_ISSUE}" --repo OpenRouterTeam/spawn --json labels --jq '.labels[].name' 2>/dev/null | grep -q '^team-building$'; then

--- a/.claude/skills/setup-agent-team/teammates/refactor-community-coordinator.md
+++ b/.claude/skills/setup-agent-team/teammates/refactor-community-coordinator.md
@@ -1,10 +1,16 @@
 # community-coordinator (Sonnet)
 
-Manage open issues. Fetch: `gh issue list --repo OpenRouterTeam/spawn --state open --json number,title,body,labels,createdAt`
+Manage open issues. Fetch: `gh issue list --repo OpenRouterTeam/spawn --state open --json number,title,body,labels,createdAt,author`
+
+**Collaborator gate**: For each issue, check if the author is a repo collaborator before engaging:
+```bash
+gh api repos/OpenRouterTeam/spawn/collaborators/AUTHOR_LOGIN --silent 2>/dev/null
+```
+If the check fails (exit code != 0), SKIP that issue entirely — do not comment, do not respond.
 
 **IGNORE** issues labeled `discovery-team`, `cloud-proposal`, or `agent-proposal` — those are the discovery team's domain.
 
-For each remaining issue, fetch full context (comments + linked PRs).
+For each remaining issue (from collaborators only), fetch full context (comments + linked PRs).
 
 - **Label progression**: `pending-review` → `under-review` → `in-progress`
 - **Strict dedup**: if `-- refactor/community-coordinator` exists in any comment, only comment again for NEW PR links or concrete resolutions

--- a/.claude/skills/setup-agent-team/teammates/security-issue-checker.md
+++ b/.claude/skills/setup-agent-team/teammates/security-issue-checker.md
@@ -2,9 +2,15 @@
 
 Re-triage open issues for label consistency and staleness.
 
-`gh issue list --repo OpenRouterTeam/spawn --state open --json number,title,labels,updatedAt,comments`
+`gh issue list --repo OpenRouterTeam/spawn --state open --json number,title,labels,updatedAt,comments,author`
 
-For each issue, fetch full context: `gh issue view NUMBER --comments`
+**Collaborator gate**: For each issue, check if the author is a repo collaborator:
+```bash
+gh api repos/OpenRouterTeam/spawn/collaborators/AUTHOR_LOGIN --silent 2>/dev/null
+```
+If the check fails (exit code != 0), SKIP that issue entirely.
+
+For each collaborator-authored issue, fetch full context: `gh issue view NUMBER --comments`
 
 - **Strict dedup**: if `-- security/issue-checker` or `-- security/triage` exists in ANY comment → SKIP unless new human comments posted after the last security sign-off
 - **NEVER** post status updates, re-triages, or acknowledgment-only follow-ups. ONE triage comment per issue, EVER.


### PR DESCRIPTION
## Summary
OSS readiness: when the repo goes public, the agent team bots only engage with collaborator-authored issues. External submissions are invisible.

## How it works

**Shell scripts** (refactor.sh, security.sh, qa.sh):
- Source `.claude/scripts/collaborator-gate.sh` 
- If `SPAWN_ISSUE` is set, check author via `gh api repos/.../collaborators/AUTHOR`
- Non-collaborator → `exit 0` silently. Bot never sees the issue.

**Prompts** (discovery, refactor community-coordinator, security issue-checker):
- Added collaborator check instructions before issue engagement
- `gh api repos/OpenRouterTeam/spawn/collaborators/AUTHOR --silent` → skip if 404

**Caching:**
- Collaborator list cached at `/tmp/spawn-collaborators-cache` for 10 minutes
- Avoids API rate limits when processing multiple issues

## Files changed
| File | Change |
|------|--------|
| `.claude/scripts/collaborator-gate.sh` | **New** — shared helper (is_collaborator, list_collaborator_issues, etc.) |
| `refactor.sh` | Gate before issue dispatch |
| `security.sh` | Gate before issue dispatch |
| `qa.sh` | Gate before issue dispatch |
| `discovery-team-prompt.md` | Issue responder checks collaborator status |
| `teammates/refactor-community-coordinator.md` | Check before engaging |
| `teammates/security-issue-checker.md` | Check before engaging |

## Test plan
- [x] `bash -n` passes on all 4 scripts
- [x] 2090 tests pass
- [ ] Manual: open issue from non-collaborator account, verify bots don't respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)