### PR TITLE
fix(telemetry): emit setup_options_selected for preset steps

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -360,8 +360,15 @@ export async function cmdInteractive(): Promise<void> {
       ].join(",");
       captureEvent("setup_options_selected", {
         step_count: enabledSteps.size,
+        source: "interactive",
       });
     }
+  } else {
+    const presetSteps = process.env.SPAWN_ENABLED_STEPS.split(",").filter(Boolean);
+    captureEvent("setup_options_selected", {
+      step_count: presetSteps.length,
+      source: "preset",
+    });
   }
 
   // Skills picker (--beta skills)
@@ -463,8 +470,15 @@ export async function cmdAgentInteractive(agent: string, prompt?: string, dryRun
       ].join(",");
       captureEvent("setup_options_selected", {
         step_count: enabledSteps.size,
+        source: "interactive",
       });
     }
+  } else {
+    const presetSteps = process.env.SPAWN_ENABLED_STEPS.split(",").filter(Boolean);
+    captureEvent("setup_options_selected", {
+      step_count: presetSteps.length,
+      source: "preset",
+    });
   }
 
   captureEvent("name_prompt_shown");


### PR DESCRIPTION
## Summary

- When users pass `--steps` or `--config`, `SPAWN_ENABLED_STEPS` is pre-set so the setup options prompt is skipped — but `setup_options_selected` was also skipped
- This made the PostHog spawn funnel show a **68% ghost drop-off** at step 1→2 (`cloud_selected` → `setup_options_selected`), inflating real drop-off with users who actually continued successfully
- Now emits the event in both paths with a `source` field (`"interactive"` vs `"preset"`) so the funnel accurately reflects real user behavior
- Fixes both code paths: full interactive picker (`cmdInteractive`) and agent-preselected picker (`cmdAgentInteractive`)

## Test plan
- [x] `bunx @biomejs/biome check` — 0 errors
- [x] `bun test` — 2151 pass, 0 fail
- [ ] Verify in PostHog that `setup_options_selected` events now appear with `source: "preset"` for `--steps` users

🤖 Generated with [Claude Code](https://claude.com/claude-code)