### PR TITLE
chore(x-engage): drop disclosure line from X replies

### DIFF
--- a/.claude/skills/setup-agent-team/x-engage-prompt.md
+++ b/.claude/skills/setup-agent-team/x-engage-prompt.md
@@ -36,7 +36,7 @@ X_DATA_PLACEHOLDER
    - NO bulleted lists, NO multi-sentence explanations, NO feature dumps
    - Include the link `https://openrouter.ai/spawn` ONLY if it naturally closes the reply
    - **NEVER use em dashes (—) or en dashes (–).** Use periods, commas, or rephrase.
-   - Add "(disclosure: i help build this)" ONLY if it fits — if the reply is too short, skip disclosure entirely
+   - **NO disclosure line.** Do not add "(disclosure: i help build this)" or any similar attribution. Post the reply as-is.
 
 4. **If no good engagement opportunity** (all scores < 7), output `found: false`.
 


### PR DESCRIPTION
## Summary
- Removes the "(disclosure: i help build this)" instruction from the X engagement prompt (`x-engage-prompt.md`)
- X/Twitter replies now post as-is without any attribution footer
- Reddit growth prompt (`growth-prompt.md`) still keeps its disclosure requirement — only X was changed per request

## Test plan
- [ ] Next X engagement cycle drafts a reply without the disclosure line