### PR TITLE
fix(ux): add 'spawn last' to reconnect hints in cloud modules

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -1235,7 +1235,8 @@ export async function interactiveSession(cmd: string): Promise<number> {
   logInfo("To delete from CLI:");
   logInfo("  spawn delete");
   logInfo("To reconnect:");
-  logInfo(`  ssh ${SSH_USER}@${_state.instanceIp}`);
+  logInfo("  spawn last");
+  logInfo(`  or: ssh ${SSH_USER}@${_state.instanceIp}`);
 
   return exitCode;
 }

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1516,7 +1516,8 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   logInfo("To delete from CLI:");
   logInfo("  spawn delete");
   logInfo("To reconnect:");
-  logInfo(`  ssh root@${serverIp}`);
+  logInfo("  spawn last");
+  logInfo(`  or: ssh root@${serverIp}`);
 
   return exitCode;
 }

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -1136,7 +1136,8 @@ export async function interactiveSession(cmd: string): Promise<number> {
   logInfo("To delete from CLI:");
   logInfo("  spawn delete");
   logInfo("To reconnect:");
-  logInfo(`  gcloud compute ssh ${_state.instanceName} --zone=${_state.zone} --project=${_state.project}`);
+  logInfo("  spawn last");
+  logInfo(`  or: gcloud compute ssh ${_state.instanceName} --zone=${_state.zone} --project=${_state.project}`);
 
   return exitCode;
 }

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -938,7 +938,8 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   logInfo("To delete from CLI:");
   logInfo("  spawn delete");
   logInfo("To reconnect:");
-  logInfo(`  ssh root@${serverIp}`);
+  logInfo("  spawn last");
+  logInfo(`  or: ssh root@${serverIp}`);
 
   return exitCode;
 }

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -789,7 +789,8 @@ export async function interactiveSession(cmd: string, spawnFn?: (args: string[])
   logInfo("To destroy:");
   logInfo(`  sprite destroy ${_state.name}`);
   logInfo("To reconnect:");
-  logInfo(`  sprite console -s ${_state.name}`);
+  logInfo("  spawn last");
+  logInfo(`  or: sprite console -s ${_state.name}`);
 
   return exitCode;
 }


### PR DESCRIPTION
**Why:** Reconnect hints shown after provisioning in all 5 cloud providers only showed raw SSH/CLI commands (`ssh root@IP`, `gcloud compute ssh ...`, `sprite console -s ...`). Users following these hints got a bare shell without re-entering the agent, missing spawn's SSH key management, tunnel setup, and IP refresh. This is the same class of issue fixed by #3311 and #3312 but in different files that were missed.

## Changes

- `packages/cli/src/hetzner/hetzner.ts` — add `spawn last` as primary reconnect hint
- `packages/cli/src/aws/aws.ts` — add `spawn last` as primary reconnect hint
- `packages/cli/src/digitalocean/digitalocean.ts` — add `spawn last` as primary reconnect hint
- `packages/cli/src/gcp/gcp.ts` — add `spawn last` as primary reconnect hint
- `packages/cli/src/sprite/sprite.ts` — add `spawn last` as primary reconnect hint
- `packages/cli/package.json` — version bump 1.0.18 → 1.0.19

## Test plan

- [x] `bunx @biomejs/biome check` passes on all changed files
- [x] `bun test` — 2154 tests pass, 0 failures

-- spawn-refactor/ux-engineer