### PR TITLE
fix(telemetry): share session ID across picker and orchestration

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/telemetry.ts
+++ b/packages/cli/src/shared/telemetry.ts
@@ -154,11 +154,16 @@ export function initTelemetry(version: string): void {
     return;
   }
 
-  _sessionId = crypto.randomUUID();
+  // Inherit session ID from parent process (picker → orchestration continuity)
+  // or generate a new one. Export it so child processes can inherit it too.
+  _sessionId = process.env.SPAWN_TELEMETRY_SESSION || crypto.randomUUID();
+  process.env.SPAWN_TELEMETRY_SESSION = _sessionId;
+
   _context = {
     spawn_version: version,
     os: process.platform,
     arch: process.arch,
+    source: "cli",
   };
 
   // Capture uncaught errors


### PR DESCRIPTION
## Summary
- Picker events (steps 1-5) and orchestration events (steps 6-11) now share the same PostHog session
- Adds `source: "cli"` to all events to separate CLI from website data

## Problem
The CLI runs the cloud script via `spawnSync` — a child process. Both parent (picker) and child (orchestration) called `initTelemetry` independently, generating different `$session_id` and `distinct_id`. PostHog couldn't connect them, showing 0% conversion from `name_entered` to `funnel_credentials_ready`.

## Fix
Parent process sets `SPAWN_TELEMETRY_SESSION` env var with its session ID. Child process inherits it via `{ ...process.env }` (already the pattern for both bash and bundle execution). `initTelemetry` checks for the env var before generating a new UUID.

## Also
Added `source: "cli"` to the telemetry context. Filter by `source = cli` in PostHog to exclude website events from the same project.

## Test plan
- [x] 2108 tests pass
- [x] Biome lint clean
- [ ] Manual: run `spawn claude hetzner`, verify all 11 funnel steps share same distinct_id in PostHog Activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)