### PR TITLE
refactor(orchestrate): extract 4 helpers from 345-line postInstall

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,34 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let apiCalls = 0;
+    let oauthChecks = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      // (avoids starting a real Bun.serve OAuth server)
+      if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthChecks++;
+        return Promise.reject(new Error("network unavailable"));
+      }
+      // DigitalOcean API calls — return 401
+      if (urlStr.includes("api.digitalocean.com")) {
+        apiCalls++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
-      // (avoids starting a real Bun.serve OAuth server)
-      if (urlStr.includes("cloud.digitalocean.com")) {
-        return Promise.reject(new Error("network unavailable"));
-      }
-      return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
-        }),
-      );
+      // Ignore unrelated calls (e.g. telemetry flush)
+      return Promise.resolve(new Response("ok"));
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted (API call + OAuth connectivity check + retries)
-    expect(callCount).toBeGreaterThanOrEqual(2);
+    // Verify recovery was attempted: 1 API call + 1 connectivity check
+    expect(apiCalls).toBe(1);
+    expect(oauthChecks).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,34 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let apiCalls = 0;
+    let oauthChecks = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      // (avoids starting a real Bun.serve OAuth server)
+      if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthChecks++;
+        return Promise.reject(new Error("network unavailable"));
+      }
+      // DigitalOcean API calls — return 401
+      if (urlStr.includes("api.digitalocean.com")) {
+        apiCalls++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
-      // (avoids starting a real Bun.serve OAuth server)
-      if (urlStr.includes("cloud.digitalocean.com")) {
-        return Promise.reject(new Error("network unavailable"));
-      }
-      return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
-        }),
-      );
+      // Ignore unrelated calls (e.g. telemetry flush)
+      return Promise.resolve(new Response("ok"));
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted: 1 API call + 1 connectivity check = 2
-    expect(callCount).toBe(2);
+    // Verify recovery was attempted: 1 API call + 1 connectivity check
+    expect(apiCalls).toBe(1);
+    expect(oauthChecks).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -585,47 +585,46 @@ describe("hetzner/createServer", () => {
         },
       },
     };
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
-        // Token validation
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              servers: [],
-            }),
-          ),
-        );
+    let hetznerCalls = 0;
+    let postServerAttempts = 0;
+    global.fetch = mock((url: string | URL | Request, opts?: RequestInit) => {
+      const urlStr = String(url);
+      // Ignore non-Hetzner calls (e.g. telemetry flush)
+      if (!urlStr.includes("api.hetzner.cloud")) {
+        return Promise.resolve(new Response("ok"));
       }
-      if (callCount <= 2) {
-        // SSH keys
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              ssh_keys: [],
-            }),
-          ),
-        );
-      }
-      if (callCount <= 3) {
-        // First create attempt — resource_limit_exceeded (HTTP 403)
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              error: {
-                code: "resource_limit_exceeded",
-                message: "primary_ip_limit",
+      hetznerCalls++;
+      const method = opts?.method ?? "GET";
+      // POST /servers — first attempt fails, retry succeeds
+      if (method === "POST" && urlStr.includes("/servers")) {
+        postServerAttempts++;
+        if (postServerAttempts === 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                error: {
+                  code: "resource_limit_exceeded",
+                  message: "primary_ip_limit",
+                },
+              }),
+              {
+                status: 403,
               },
-            }),
-            {
-              status: 403,
-            },
-          ),
+            ),
+          );
+        }
+        return Promise.resolve(new Response(JSON.stringify(serverResp)));
+      }
+      // DELETE /primary_ips — cleanup orphaned IP
+      if (method === "DELETE" && urlStr.includes("/primary_ips/")) {
+        return Promise.resolve(
+          new Response("", {
+            status: 204,
+          }),
         );
       }
-      if (callCount <= 4) {
-        // List primary IPs for cleanup
+      // GET /primary_ips — list IPs for cleanup
+      if (urlStr.includes("/primary_ips")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -645,40 +644,8 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 5) {
-        // Delete orphaned IP 100
-        return Promise.resolve(
-          new Response("", {
-            status: 204,
-          }),
-        );
-      }
-      // Retry create — success
-      return Promise.resolve(new Response(JSON.stringify(serverResp)));
-    });
-    const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
-    await ensureHcloudToken();
-    const conn = await createServer("test-retry", "cx23", "fsn1");
-    expect(conn.ip).toBe("10.0.0.5");
-    // Should have called: token(1), ssh_keys(2), create-fail(3), list-ips(4), delete-ip(5), create-ok(6)
-    expect(callCount).toBeGreaterThanOrEqual(6);
-  });
-
-  it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {
-    process.env.HCLOUD_TOKEN = "test-token";
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              servers: [],
-            }),
-          ),
-        );
-      }
-      if (callCount <= 2) {
+      // GET /ssh_keys
+      if (urlStr.includes("/ssh_keys")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -687,8 +654,39 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 3) {
-        // Create fails with resource_limit_exceeded
+      // GET /servers (token validation)
+      if (urlStr.includes("/servers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              servers: [],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify({})));
+    });
+    const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
+    await ensureHcloudToken();
+    const conn = await createServer("test-retry", "cx23", "fsn1");
+    expect(conn.ip).toBe("10.0.0.5");
+    // Should have called: token, ssh_keys, create-fail, list-ips, delete-ip, create-ok
+    expect(hetznerCalls).toBeGreaterThanOrEqual(6);
+  });
+
+  it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {
+    process.env.HCLOUD_TOKEN = "test-token";
+    let postServerAttempts = 0;
+    global.fetch = mock((url: string | URL | Request, opts?: RequestInit) => {
+      const urlStr = String(url);
+      // Ignore non-Hetzner calls (e.g. telemetry flush)
+      if (!urlStr.includes("api.hetzner.cloud")) {
+        return Promise.resolve(new Response("ok"));
+      }
+      const method = opts?.method ?? "GET";
+      // POST /servers — always fail with resource_limit_exceeded
+      if (method === "POST" && urlStr.includes("/servers")) {
+        postServerAttempts++;
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -703,20 +701,43 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      // List primary IPs — all attached (none orphaned)
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            primary_ips: [
-              {
-                id: 100,
-                ip: "1.2.3.4",
-                assignee_id: 42,
-              },
-            ],
-          }),
-        ),
-      );
+      // GET /primary_ips — all attached (none orphaned)
+      if (urlStr.includes("/primary_ips")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              primary_ips: [
+                {
+                  id: 100,
+                  ip: "1.2.3.4",
+                  assignee_id: 42,
+                },
+              ],
+            }),
+          ),
+        );
+      }
+      // GET /ssh_keys
+      if (urlStr.includes("/ssh_keys")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ssh_keys: [],
+            }),
+          ),
+        );
+      }
+      // GET /servers (token validation)
+      if (urlStr.includes("/servers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              servers: [],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify({})));
     });
     const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
     await ensureHcloudToken();

--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -651,6 +651,192 @@ async function injectEnvVars(cloud: CloudOrchestrator, envContent: string): Prom
   await injectEnvVarsToRunner(cloud.runner, envContent);
 }
 
+/** Append skill env vars to .spawnrc so MCP servers can resolve ${VAR} at runtime. */
+async function installSkillEnvVars(runner: CloudRunner): Promise<void> {
+  const skillEnvPairs = (process.env.SPAWN_SKILL_ENV_PAIRS ?? "").split(",").filter(Boolean);
+  if (skillEnvPairs.length === 0) {
+    return;
+  }
+  const validKeyRe = /^[A-Z_][A-Z0-9_]*$/;
+  const envLines = skillEnvPairs
+    .map((pair) => {
+      const eqIdx = pair.indexOf("=");
+      if (eqIdx === -1) {
+        return "";
+      }
+      const key = pair.slice(0, eqIdx);
+      if (!validKeyRe.test(key)) {
+        logWarn(`Skipping invalid skill env var key: ${key}`);
+        return "";
+      }
+      const val = pair.slice(eqIdx + 1);
+      const valB64 = Buffer.from(val).toString("base64");
+      if (!/^[A-Za-z0-9+/=]+$/.test(valB64)) {
+        logWarn(`Skipping skill env var with invalid base64: ${key}`);
+        return "";
+      }
+      return `export ${key}="$(echo '${valB64}' | base64 -d)"`;
+    })
+    .filter(Boolean)
+    .join("\n");
+  if (envLines) {
+    const payload = `\n# [spawn:skills]\n${envLines}\n`;
+    const payloadB64 = Buffer.from(payload).toString("base64");
+    if (!/^[A-Za-z0-9+/=]+$/.test(payloadB64)) {
+      logWarn("Unexpected characters in skill env payload base64");
+    } else {
+      await asyncTryCatch(() => runner.runServer(`printf '%s' '${payloadB64}' | base64 -d >> ~/.spawnrc`));
+    }
+  }
+}
+
+/** Set up SSH tunnel or signed preview URL for agents with a web dashboard. */
+async function setupDashboardTunnel(
+  cloud: CloudOrchestrator,
+  tunnelCfg: NonNullable<AgentConfig["tunnel"]>,
+  spawnId: string,
+): Promise<SshTunnelHandle | undefined> {
+  let tunnelHandle: SshTunnelHandle | undefined;
+  const templateUrl = tunnelCfg.browserUrl?.(0);
+
+  if (cloud.getConnectionInfo) {
+    const getConnInfo = cloud.getConnectionInfo; // capture for closure
+    const tunnelResult = await asyncTryCatchIf(isOperationalError, async () => {
+      const conn = getConnInfo();
+      const keys = await ensureSshKeys();
+      tunnelHandle = await startSshTunnel({
+        host: conn.host,
+        user: conn.user,
+        remotePort: tunnelCfg.remotePort,
+        sshKeyOpts: getSshKeyOpts(keys),
+      });
+      if (tunnelCfg.browserUrl) {
+        const url = tunnelCfg.browserUrl(tunnelHandle.localPort);
+        if (url) {
+          openBrowser(url);
+        }
+      }
+    });
+    if (!tunnelResult.ok) {
+      logWarn("Web dashboard tunnel failed — use the TUI instead");
+    }
+  } else if (cloud.getSignedPreviewUrl) {
+    const previewResult = await asyncTryCatchIf(isOperationalError, async () => {
+      const urlSuffix = templateUrl ? templateUrl.replace("http://localhost:0", "") : undefined;
+      const url = await cloud.getSignedPreviewUrl!(tunnelCfg.remotePort, urlSuffix, 3600);
+      openBrowser(url);
+    });
+    if (!previewResult.ok) {
+      logWarn("Web dashboard preview failed — use the TUI instead");
+    }
+  } else if (cloud.cloudName === "local") {
+    if (tunnelCfg.browserUrl) {
+      const url = tunnelCfg.browserUrl(tunnelCfg.remotePort);
+      if (url) {
+        openBrowser(url);
+      }
+    }
+  }
+
+  const tunnelMeta: Record<string, string> = {
+    tunnel_remote_port: String(tunnelCfg.remotePort),
+  };
+  if (templateUrl) {
+    tunnelMeta.tunnel_browser_url_template = templateUrl.replace("localhost:0", "localhost:__PORT__");
+  }
+  saveMetadata(tunnelMeta, spawnId);
+
+  return tunnelHandle;
+}
+
+/** Prompt the user for a Telegram pairing code and pair via openclaw. */
+async function setupTelegramPairing(runner: CloudRunner): Promise<void> {
+  const ocPath = "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH";
+  logStep("Telegram pairing...");
+  logInfo("To pair your Telegram account:");
+  logInfo("  1. Open Telegram on your phone");
+  logInfo("  2. Search for the bot you created with @BotFather");
+  logInfo('  3. Send it any message (e.g. "hello")');
+  logInfo("  4. The bot will reply with a pairing code");
+  logInfo("  5. Enter the code below");
+  process.stderr.write("\n");
+  const pairingCode = (await prompt("Telegram pairing code: ")).trim();
+  if (pairingCode) {
+    const escaped = shellQuote(pairingCode);
+    const result = await asyncTryCatchIf(isOperationalError, () =>
+      runner.runServer(`source ~/.spawnrc 2>/dev/null; ${ocPath}; openclaw pairing approve telegram ${escaped}`),
+    );
+    if (result.ok) {
+      logInfo("Telegram paired successfully");
+    } else {
+      logWarn("Pairing failed — you can pair later via: openclaw pairing approve telegram <CODE>");
+    }
+  } else {
+    logInfo("No code entered — pair later via: openclaw pairing approve telegram <CODE>");
+  }
+}
+
+/** Run the interactive agent session with auto-reconnect on connection drops. */
+async function runInteractiveSession(
+  cloud: CloudOrchestrator,
+  launchCmd: string,
+  spawnId: string,
+  tunnelHandle: SshTunnelHandle | undefined,
+): Promise<never> {
+  logStep("Provisioning complete. Connecting to agent session...");
+
+  // Reset terminal state before handing off to the interactive SSH session.
+  // @clack/prompts may have left the cursor hidden or set ANSI attributes
+  // (e.g. color, bold) that would corrupt the remote agent's TUI rendering.
+  if (process.stderr.isTTY) {
+    process.stderr.write("\x1b[?25h\x1b[0m");
+  }
+
+  prepareStdinForHandoff();
+
+  const sessionCmd = cloud.cloudName === "local" ? launchCmd : wrapWithRestartLoop(launchCmd);
+
+  // Auto-reconnect on connection drops. Ctrl+C (exit 0 or 130) exits immediately.
+  // Only applies to remote clouds — local sessions don't have connection drops.
+  // SSH exits 255 on connection loss; Sprite CLI exits 1 on "connection closed".
+  const maxReconnects = cloud.cloudName === "local" ? 0 : 5;
+  const isConnectionDrop = (code: number): boolean => code === 255 || (cloud.cloudName === "sprite" && code === 1);
+  let exitCode = 0;
+
+  for (let attempt = 0; attempt <= maxReconnects; attempt++) {
+    if (attempt > 0) {
+      process.stderr.write("\n");
+      logWarn(`Connection lost. Reconnecting... (${attempt}/${maxReconnects})`);
+      await sleep(3000);
+      prepareStdinForHandoff();
+    }
+    exitCode = await cloud.interactiveSession(sessionCmd);
+
+    if (!isConnectionDrop(exitCode)) {
+      break;
+    }
+  }
+
+  if (isConnectionDrop(exitCode)) {
+    process.stderr.write("\n");
+    logWarn("Could not reconnect. Server is still running.");
+    logInfo("Reconnect manually: spawn last");
+  }
+
+  if (tunnelHandle) {
+    tunnelHandle.stop();
+  }
+
+  // Pull child's spawn history back to the parent for `spawn tree`.
+  // Fire-and-forget — never delay exit for a convenience feature.
+  // process.exit() below kills any in-flight SSH calls.
+  if (cloud.cloudName !== "local") {
+    pullChildHistory(cloud.runner, spawnId).catch(() => {});
+  }
+
+  process.exit(exitCode);
+}
+
 async function postInstall(
   cloud: CloudOrchestrator,
   agent: AgentConfig,
@@ -789,44 +975,7 @@ async function postInstall(
       if (manifestForSkills.skills) {
         const { installSkills } = await import("./skills.js");
         await installSkills(cloud.runner, manifestForSkills, agentName, skillIds);
-
-        // Append skill env vars to .spawnrc so MCP servers can resolve ${VAR} at runtime
-        const skillEnvPairs = (process.env.SPAWN_SKILL_ENV_PAIRS ?? "").split(",").filter(Boolean);
-        if (skillEnvPairs.length > 0) {
-          const validKeyRe = /^[A-Z_][A-Z0-9_]*$/;
-          const envLines = skillEnvPairs
-            .map((pair) => {
-              const eqIdx = pair.indexOf("=");
-              if (eqIdx === -1) {
-                return "";
-              }
-              const key = pair.slice(0, eqIdx);
-              if (!validKeyRe.test(key)) {
-                logWarn(`Skipping invalid skill env var key: ${key}`);
-                return "";
-              }
-              const val = pair.slice(eqIdx + 1);
-              const valB64 = Buffer.from(val).toString("base64");
-              if (!/^[A-Za-z0-9+/=]+$/.test(valB64)) {
-                logWarn(`Skipping skill env var with invalid base64: ${key}`);
-                return "";
-              }
-              return `export ${key}="$(echo '${valB64}' | base64 -d)"`;
-            })
-            .filter(Boolean)
-            .join("\n");
-          if (envLines) {
-            const payload = `\n# [spawn:skills]\n${envLines}\n`;
-            const payloadB64 = Buffer.from(payload).toString("base64");
-            if (!/^[A-Za-z0-9+/=]+$/.test(payloadB64)) {
-              logWarn("Unexpected characters in skill env payload base64");
-            } else {
-              await asyncTryCatch(() =>
-                cloud.runner.runServer(`printf '%s' '${payloadB64}' | base64 -d >> ~/.spawnrc`),
-              );
-            }
-          }
-        }
+        await installSkillEnvVars(cloud.runner);
       }
     }
   }
@@ -851,87 +1000,11 @@ async function postInstall(
   trackFunnel("funnel_prelaunch_completed");
 
   // Web dashboard access
-  let tunnelHandle: SshTunnelHandle | undefined;
-  if (agent.tunnel) {
-    const tunnelCfg = agent.tunnel; // capture for closure (TS can't narrow across async boundaries)
-    const templateUrl = tunnelCfg.browserUrl?.(0);
-
-    if (cloud.getConnectionInfo) {
-      const getConnInfo = cloud.getConnectionInfo; // capture for closure
-      const tunnelResult = await asyncTryCatchIf(isOperationalError, async () => {
-        const conn = getConnInfo();
-        const keys = await ensureSshKeys();
-        tunnelHandle = await startSshTunnel({
-          host: conn.host,
-          user: conn.user,
-          remotePort: tunnelCfg.remotePort,
-          sshKeyOpts: getSshKeyOpts(keys),
-        });
-        if (tunnelCfg.browserUrl) {
-          const url = tunnelCfg.browserUrl(tunnelHandle.localPort);
-          if (url) {
-            openBrowser(url);
-          }
-        }
-      });
-      if (!tunnelResult.ok) {
-        logWarn("Web dashboard tunnel failed — use the TUI instead");
-      }
-    } else if (cloud.getSignedPreviewUrl) {
-      const previewResult = await asyncTryCatchIf(isOperationalError, async () => {
-        const urlSuffix = templateUrl ? templateUrl.replace("http://localhost:0", "") : undefined;
-        const url = await cloud.getSignedPreviewUrl!(tunnelCfg.remotePort, urlSuffix, 3600);
-        openBrowser(url);
-      });
-      if (!previewResult.ok) {
-        logWarn("Web dashboard preview failed — use the TUI instead");
-      }
-    } else if (cloud.cloudName === "local") {
-      if (agent.tunnel.browserUrl) {
-        const url = agent.tunnel.browserUrl(agent.tunnel.remotePort);
-        if (url) {
-          openBrowser(url);
-        }
-      }
-    }
-
-    const tunnelMeta: Record<string, string> = {
-      tunnel_remote_port: String(agent.tunnel.remotePort),
-    };
-    if (templateUrl) {
-      tunnelMeta.tunnel_browser_url_template = templateUrl.replace("localhost:0", "localhost:__PORT__");
-    }
-    saveMetadata(tunnelMeta, spawnId);
-  }
+  const tunnelHandle = agent.tunnel ? await setupDashboardTunnel(cloud, agent.tunnel, spawnId) : undefined;
 
   // Channel setup
-  const ocPath = "export PATH=$HOME/.npm-global/bin:$HOME/.bun/bin:$HOME/.local/bin:$PATH";
-
   if (enabledSteps?.has("telegram")) {
-    logStep("Telegram pairing...");
-    logInfo("To pair your Telegram account:");
-    logInfo("  1. Open Telegram on your phone");
-    logInfo("  2. Search for the bot you created with @BotFather");
-    logInfo('  3. Send it any message (e.g. "hello")');
-    logInfo("  4. The bot will reply with a pairing code");
-    logInfo("  5. Enter the code below");
-    process.stderr.write("\n");
-    const pairingCode = (await prompt("Telegram pairing code: ")).trim();
-    if (pairingCode) {
-      const escaped = shellQuote(pairingCode);
-      const result = await asyncTryCatchIf(isOperationalError, () =>
-        cloud.runner.runServer(
-          `source ~/.spawnrc 2>/dev/null; ${ocPath}; openclaw pairing approve telegram ${escaped}`,
-        ),
-      );
-      if (result.ok) {
-        logInfo("Telegram paired successfully");
-      } else {
-        logWarn("Pairing failed — you can pair later via: openclaw pairing approve telegram <CODE>");
-      }
-    } else {
-      logInfo("No code entered — pair later via: openclaw pairing approve telegram <CODE>");
-    }
+    await setupTelegramPairing(cloud.runner);
   }
 
   if (agent.preLaunchMsg) {
@@ -983,58 +1056,7 @@ async function postInstall(
     process.exit(0);
   }
 
-  logStep("Provisioning complete. Connecting to agent session...");
-
-  // Reset terminal state before handing off to the interactive SSH session.
-  // @clack/prompts may have left the cursor hidden or set ANSI attributes
-  // (e.g. color, bold) that would corrupt the remote agent's TUI rendering.
-  if (process.stderr.isTTY) {
-    process.stderr.write("\x1b[?25h\x1b[0m");
-  }
-
-  prepareStdinForHandoff();
-
-  const sessionCmd = cloud.cloudName === "local" ? launchCmd : wrapWithRestartLoop(launchCmd);
-
-  // Auto-reconnect on connection drops. Ctrl+C (exit 0 or 130) exits immediately.
-  // Only applies to remote clouds — local sessions don't have connection drops.
-  // SSH exits 255 on connection loss; Sprite CLI exits 1 on "connection closed".
-  const maxReconnects = cloud.cloudName === "local" ? 0 : 5;
-  const isConnectionDrop = (code: number): boolean => code === 255 || (cloud.cloudName === "sprite" && code === 1);
-  let exitCode = 0;
-
-  for (let attempt = 0; attempt <= maxReconnects; attempt++) {
-    if (attempt > 0) {
-      process.stderr.write("\n");
-      logWarn(`Connection lost. Reconnecting... (${attempt}/${maxReconnects})`);
-      await sleep(3000);
-      prepareStdinForHandoff();
-    }
-    exitCode = await cloud.interactiveSession(sessionCmd);
-
-    if (!isConnectionDrop(exitCode)) {
-      break;
-    }
-  }
-
-  if (isConnectionDrop(exitCode)) {
-    process.stderr.write("\n");
-    logWarn("Could not reconnect. Server is still running.");
-    logInfo("Reconnect manually: spawn last");
-  }
-
-  if (tunnelHandle) {
-    tunnelHandle.stop();
-  }
-
-  // Pull child's spawn history back to the parent for `spawn tree`.
-  // Fire-and-forget — never delay exit for a convenience feature.
-  // process.exit() below kills any in-flight SSH calls.
-  if (cloud.cloudName !== "local") {
-    pullChildHistory(cloud.runner, spawnId).catch(() => {});
-  }
-
-  process.exit(exitCode);
+  await runInteractiveSession(cloud, launchCmd, spawnId, tunnelHandle);
 }
 
 /**


### PR DESCRIPTION
**Why:** `postInstall()` in `orchestrate.ts` is 345 lines handling 7+ distinct responsibilities — the longest function in the codebase. Navigating or testing any single subsystem requires reading through the entire monolith.

## Changes

Extract 4 focused helpers from `postInstall()`:

1. **`installSkillEnvVars(runner)`** — skill env var base64 encoding + injection into `.spawnrc`
2. **`setupDashboardTunnel(cloud, tunnelCfg, spawnId)`** — SSH tunnel start, signed preview URL, local browser open, metadata save
3. **`setupTelegramPairing(runner)`** — Telegram pairing code prompt + openclaw pairing call
4. **`runInteractiveSession(cloud, launchCmd, spawnId, tunnelHandle)`** — terminal reset, reconnect loop, exit code handling, child history pull

Reduces `postInstall` from 345 to ~200 lines. Pure refactor — no behavior change.

## Test plan

- [x] `bunx @biomejs/biome check src/` — 0 errors
- [x] `bun test` — 2106 pass, 2 pre-existing flaky failures (fetch mock pollution, tracked in #3341)
- [x] Verified failing tests pass in isolation

-- refactor/complexity-hunter