### PR TITLE
fix(telemetry): init telemetry in cloud bundle entry points

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/aws/main.ts
+++ b/packages/cli/src/aws/main.ts
@@ -5,7 +5,9 @@
 import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import pkg from "../../package.json" with { type: "json" };
 import { runOrchestration } from "../shared/orchestrate.js";
+import { initTelemetry } from "../shared/telemetry.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
   authenticate,
@@ -72,6 +74,7 @@ async function main() {
   await runOrchestration(cloud, agent, agentName);
 }
 
+initTelemetry(pkg.version);
 main().catch((err) => {
   process.stderr.write(`\x1b[0;31mFatal: ${getErrorMessage(err)}\x1b[0m\n`);
   process.exit(1);

--- a/packages/cli/src/daytona/main.ts
+++ b/packages/cli/src/daytona/main.ts
@@ -5,7 +5,9 @@
 import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import pkg from "../../package.json" with { type: "json" };
 import { runOrchestration } from "../shared/orchestrate.js";
+import { initTelemetry } from "../shared/telemetry.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
   createServer,
@@ -66,6 +68,7 @@ async function main() {
   await runOrchestration(cloud, agent, agentName);
 }
 
+initTelemetry(pkg.version);
 main().catch((err) => {
   process.stderr.write(`\x1b[0;31mFatal: ${getErrorMessage(err)}\x1b[0m\n`);
   process.exit(1);

--- a/packages/cli/src/digitalocean/main.ts
+++ b/packages/cli/src/digitalocean/main.ts
@@ -5,7 +5,9 @@
 import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import pkg from "../../package.json" with { type: "json" };
 import { runOrchestration } from "../shared/orchestrate.js";
+import { initTelemetry } from "../shared/telemetry.js";
 import { logInfo } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
@@ -108,6 +110,7 @@ async function main() {
   await runOrchestration(cloud, agent, agentName);
 }
 
+initTelemetry(pkg.version);
 main().catch((err) => {
   process.stderr.write(`\x1b[0;31mFatal: ${getErrorMessage(err)}\x1b[0m\n`);
   process.exit(1);

--- a/packages/cli/src/gcp/main.ts
+++ b/packages/cli/src/gcp/main.ts
@@ -5,8 +5,10 @@
 import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import pkg from "../../package.json" with { type: "json" };
 import { shouldSkipCloudInit } from "../shared/cloud-init.js";
 import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY, makeDockerRunner, runOrchestration } from "../shared/orchestrate.js";
+import { initTelemetry } from "../shared/telemetry.js";
 import { logInfo, logStep, shellQuote } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
@@ -118,6 +120,7 @@ async function main() {
   await runOrchestration(cloud, agent, agentName);
 }
 
+initTelemetry(pkg.version);
 main().catch((err) => {
   process.stderr.write(`\x1b[0;31mFatal: ${getErrorMessage(err)}\x1b[0m\n`);
   process.exit(1);

--- a/packages/cli/src/hetzner/main.ts
+++ b/packages/cli/src/hetzner/main.ts
@@ -5,8 +5,10 @@
 import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import pkg from "../../package.json" with { type: "json" };
 import { shouldSkipCloudInit } from "../shared/cloud-init.js";
 import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY, makeDockerRunner, runOrchestration } from "../shared/orchestrate.js";
+import { initTelemetry } from "../shared/telemetry.js";
 import { logInfo, logStep, shellQuote } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
@@ -124,6 +126,7 @@ async function main() {
   await runOrchestration(cloud, agent, agentName);
 }
 
+initTelemetry(pkg.version);
 main().catch((err) => {
   process.stderr.write(`\x1b[0;31mFatal: ${getErrorMessage(err)}\x1b[0m\n`);
   process.exit(1);

--- a/packages/cli/src/local/main.ts
+++ b/packages/cli/src/local/main.ts
@@ -6,8 +6,10 @@ import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import * as p from "@clack/prompts";
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import pkg from "../../package.json" with { type: "json" };
 import { createCloudAgents } from "../shared/agent-setup.js";
 import { makeDockerRunner, runOrchestration } from "../shared/orchestrate.js";
+import { initTelemetry } from "../shared/telemetry.js";
 import { logWarn } from "../shared/ui.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
@@ -117,6 +119,7 @@ async function main() {
   await runOrchestration(cloud, agent, agentName);
 }
 
+initTelemetry(pkg.version);
 main().catch((err) => {
   process.stderr.write(`\x1b[0;31mFatal: ${getErrorMessage(err)}\x1b[0m\n`);
   process.exit(1);

--- a/packages/cli/src/sprite/main.ts
+++ b/packages/cli/src/sprite/main.ts
@@ -5,7 +5,9 @@
 import type { CloudOrchestrator } from "../shared/orchestrate.js";
 
 import { getErrorMessage } from "@openrouter/spawn-shared";
+import pkg from "../../package.json" with { type: "json" };
 import { runOrchestration } from "../shared/orchestrate.js";
+import { initTelemetry } from "../shared/telemetry.js";
 import { agents, resolveAgent } from "./agents.js";
 import {
   createSprite,
@@ -71,6 +73,7 @@ async function main() {
   await runOrchestration(cloud, agent, agentName);
 }
 
+initTelemetry(pkg.version);
 main().catch((err) => {
   process.stderr.write(`\x1b[0;31mFatal: ${getErrorMessage(err)}\x1b[0m\n`);
   process.exit(1);


### PR DESCRIPTION
## Summary
- Cloud bundles (`hetzner.js`, `digitalocean.js`, `gcp.js`, `aws.js`, `sprite.js`, `local.js`, `daytona.js`) never called `initTelemetry()`, so `_enabled` was `false` and every `captureEvent`/`trackFunnel` call in `orchestrate.ts` was a silent no-op
- All orchestration funnel events (`funnel_cloud_authed` through `funnel_handoff`) were permanently lost — zero real data in PostHog across all time
- Adds `initTelemetry(pkg.version)` to all 7 cloud entry points

## Test plan
- [x] Lint clean (biome check)
- [x] 2104 tests pass (4 pre-existing failures unrelated)
- [ ] After merge + release rebuild, verify `funnel_cloud_authed` events appear in PostHog

🤖 Generated with [Claude Code](https://claude.com/claude-code)