### PR TITLE
fix(tests): filter PostHog telemetry from fetch mocks

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -90,8 +90,12 @@ describe("doApi 401 OAuth recovery", () => {
     state.token = "expired-token";
     let callCount = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
+      // Ignore background telemetry calls (PostHog) that leak from other test files
+      if (!urlStr.includes("digitalocean")) {
+        return Promise.resolve(new Response("ok"));
+      }
+      callCount++;
       // First call: the actual API call returning 401
       if (callCount === 1) {
         return Promise.resolve(
@@ -147,7 +151,12 @@ describe("doApi 401 OAuth recovery", () => {
     state.token = "expired-token";
     _testHelpers.recovering401 = true;
     let callCount = 0;
-    globalThis.fetch = mock(() => {
+    globalThis.fetch = mock((url: string | URL | Request) => {
+      const urlStr = String(url);
+      // Ignore background telemetry calls (PostHog) that leak from other test files
+      if (!urlStr.includes("digitalocean")) {
+        return Promise.resolve(new Response("ok"));
+      }
       callCount++;
       return Promise.resolve(
         new Response("Unauthorized", {

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -586,7 +586,12 @@ describe("hetzner/createServer", () => {
       },
     };
     let callCount = 0;
-    global.fetch = mock(() => {
+    global.fetch = mock((url: string | URL | Request) => {
+      const urlStr = String(url instanceof Request ? url.url : url);
+      // Ignore background telemetry calls (PostHog) that leak from other test files
+      if (!urlStr.includes("hetzner.cloud")) {
+        return Promise.resolve(new Response("ok"));
+      }
       callCount++;
       if (callCount <= 1) {
         // Token validation


### PR DESCRIPTION
**Why:** Two tests fail consistently in the full suite (0% pass rate) due to PostHog telemetry fetch calls leaking into globalThis.fetch mocks, corrupting callCount-based response routing.

## Summary
- `hetzner-cov.test.ts`: "cleans up orphaned primary IPs" test fails because PostHog calls shift mock response order (HTTP 403 returned at wrong time)
- `digitalocean-token.test.ts`: "attempts OAuth recovery on 401" test gets callCount=4 instead of 2 (2 extra PostHog calls)
- Root cause: `telemetry.test.ts` enables the PostHog singleton which persists across test files in the same bun process
- Fix: filter non-test URLs in affected fetch mocks so telemetry calls get a benign response without incrementing callCount

## Test plan
- [x] Full suite: 2108 pass, 0 fail (was 2106 pass, 2 fail)
- [x] Both affected test files pass in isolation
- [x] Biome lint clean

-- spawn-refactor/test-engineer