### PR TITLE
refactor(cli): extract parseFlags helper from 302-line main()

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,34 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let apiCalls = 0;
+    let oauthChecks = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      // (avoids starting a real Bun.serve OAuth server)
+      if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthChecks++;
+        return Promise.reject(new Error("network unavailable"));
+      }
+      // DigitalOcean API calls — return 401
+      if (urlStr.includes("api.digitalocean.com")) {
+        apiCalls++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
-      // (avoids starting a real Bun.serve OAuth server)
-      if (urlStr.includes("cloud.digitalocean.com")) {
-        return Promise.reject(new Error("network unavailable"));
-      }
-      return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
-        }),
-      );
+      // Ignore unrelated calls (e.g. telemetry flush)
+      return Promise.resolve(new Response("ok"));
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted (API call + OAuth connectivity check + retries)
-    expect(callCount).toBeGreaterThanOrEqual(2);
+    // Verify recovery was attempted: 1 API call + 1 connectivity check
+    expect(apiCalls).toBe(1);
+    expect(oauthChecks).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,34 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let apiCalls = 0;
+    let oauthChecks = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      // (avoids starting a real Bun.serve OAuth server)
+      if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthChecks++;
+        return Promise.reject(new Error("network unavailable"));
+      }
+      // DigitalOcean API calls — return 401
+      if (urlStr.includes("api.digitalocean.com")) {
+        apiCalls++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
-      // (avoids starting a real Bun.serve OAuth server)
-      if (urlStr.includes("cloud.digitalocean.com")) {
-        return Promise.reject(new Error("network unavailable"));
-      }
-      return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
-        }),
-      );
+      // Ignore unrelated calls (e.g. telemetry flush)
+      return Promise.resolve(new Response("ok"));
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted: 1 API call + 1 connectivity check = 2
-    expect(callCount).toBe(2);
+    // Verify recovery was attempted: 1 API call + 1 connectivity check
+    expect(apiCalls).toBe(1);
+    expect(oauthChecks).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -585,47 +585,46 @@ describe("hetzner/createServer", () => {
         },
       },
     };
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
-        // Token validation
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              servers: [],
-            }),
-          ),
-        );
+    let hetznerCalls = 0;
+    let postServerAttempts = 0;
+    global.fetch = mock((url: string | URL | Request, opts?: RequestInit) => {
+      const urlStr = String(url);
+      // Ignore non-Hetzner calls (e.g. telemetry flush)
+      if (!urlStr.includes("api.hetzner.cloud")) {
+        return Promise.resolve(new Response("ok"));
       }
-      if (callCount <= 2) {
-        // SSH keys
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              ssh_keys: [],
-            }),
-          ),
-        );
-      }
-      if (callCount <= 3) {
-        // First create attempt — resource_limit_exceeded (HTTP 403)
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              error: {
-                code: "resource_limit_exceeded",
-                message: "primary_ip_limit",
+      hetznerCalls++;
+      const method = opts?.method ?? "GET";
+      // POST /servers — first attempt fails, retry succeeds
+      if (method === "POST" && urlStr.includes("/servers")) {
+        postServerAttempts++;
+        if (postServerAttempts === 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                error: {
+                  code: "resource_limit_exceeded",
+                  message: "primary_ip_limit",
+                },
+              }),
+              {
+                status: 403,
               },
-            }),
-            {
-              status: 403,
-            },
-          ),
+            ),
+          );
+        }
+        return Promise.resolve(new Response(JSON.stringify(serverResp)));
+      }
+      // DELETE /primary_ips — cleanup orphaned IP
+      if (method === "DELETE" && urlStr.includes("/primary_ips/")) {
+        return Promise.resolve(
+          new Response("", {
+            status: 204,
+          }),
         );
       }
-      if (callCount <= 4) {
-        // List primary IPs for cleanup
+      // GET /primary_ips — list IPs for cleanup
+      if (urlStr.includes("/primary_ips")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -645,40 +644,8 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 5) {
-        // Delete orphaned IP 100
-        return Promise.resolve(
-          new Response("", {
-            status: 204,
-          }),
-        );
-      }
-      // Retry create — success
-      return Promise.resolve(new Response(JSON.stringify(serverResp)));
-    });
-    const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
-    await ensureHcloudToken();
-    const conn = await createServer("test-retry", "cx23", "fsn1");
-    expect(conn.ip).toBe("10.0.0.5");
-    // Should have called: token(1), ssh_keys(2), create-fail(3), list-ips(4), delete-ip(5), create-ok(6)
-    expect(callCount).toBeGreaterThanOrEqual(6);
-  });
-
-  it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {
-    process.env.HCLOUD_TOKEN = "test-token";
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              servers: [],
-            }),
-          ),
-        );
-      }
-      if (callCount <= 2) {
+      // GET /ssh_keys
+      if (urlStr.includes("/ssh_keys")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -687,8 +654,39 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 3) {
-        // Create fails with resource_limit_exceeded
+      // GET /servers (token validation)
+      if (urlStr.includes("/servers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              servers: [],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify({})));
+    });
+    const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
+    await ensureHcloudToken();
+    const conn = await createServer("test-retry", "cx23", "fsn1");
+    expect(conn.ip).toBe("10.0.0.5");
+    // Should have called: token, ssh_keys, create-fail, list-ips, delete-ip, create-ok
+    expect(hetznerCalls).toBeGreaterThanOrEqual(6);
+  });
+
+  it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {
+    process.env.HCLOUD_TOKEN = "test-token";
+    let postServerAttempts = 0;
+    global.fetch = mock((url: string | URL | Request, opts?: RequestInit) => {
+      const urlStr = String(url);
+      // Ignore non-Hetzner calls (e.g. telemetry flush)
+      if (!urlStr.includes("api.hetzner.cloud")) {
+        return Promise.resolve(new Response("ok"));
+      }
+      const method = opts?.method ?? "GET";
+      // POST /servers — always fail with resource_limit_exceeded
+      if (method === "POST" && urlStr.includes("/servers")) {
+        postServerAttempts++;
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -703,20 +701,43 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      // List primary IPs — all attached (none orphaned)
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            primary_ips: [
-              {
-                id: 100,
-                ip: "1.2.3.4",
-                assignee_id: 42,
-              },
-            ],
-          }),
-        ),
-      );
+      // GET /primary_ips — all attached (none orphaned)
+      if (urlStr.includes("/primary_ips")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              primary_ips: [
+                {
+                  id: 100,
+                  ip: "1.2.3.4",
+                  assignee_id: 42,
+                },
+              ],
+            }),
+          ),
+        );
+      }
+      // GET /ssh_keys
+      if (urlStr.includes("/ssh_keys")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ssh_keys: [],
+            }),
+          ),
+        );
+      }
+      // GET /servers (token validation)
+      if (urlStr.includes("/servers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              servers: [],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify({})));
     });
     const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
     await ensureHcloudToken();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -751,6 +751,278 @@ async function dispatchSlashNotation(
   return false;
 }
 
+interface ParsedFlags {
+  filteredArgs: string[];
+  prompt: string | undefined;
+  dryRun: boolean;
+  debug: boolean;
+  headless: boolean;
+  custom: boolean;
+  outputFormat: string | undefined;
+  betaFeatures: string[];
+}
+
+/** Extract a boolean flag from args, mutating in place. Returns true if found. */
+function extractBooleanFlag(args: string[], flags: string[]): boolean {
+  const idx = args.findIndex((a) => flags.includes(a));
+  if (idx === -1) {
+    return false;
+  }
+  args.splice(idx, 1);
+  return true;
+}
+
+/** Extract and apply an env-var-setting boolean flag. Returns true if found. */
+function extractEnvFlag(args: string[], flag: string, envVar: string): boolean {
+  const idx = args.indexOf(flag);
+  if (idx === -1) {
+    return false;
+  }
+  args.splice(idx, 1);
+  process.env[envVar] = "1";
+  return true;
+}
+
+/** Extract a value flag and set it as an env var if present. Returns the value. */
+function extractValueToEnv(args: string[], flags: string[], usageHint: string, envVar: string): string | undefined {
+  const [value, remaining] = extractFlagValue(args, flags, usageHint);
+  args.splice(0, args.length, ...remaining);
+  if (value) {
+    process.env[envVar] = value;
+  }
+  return value;
+}
+
+/** Extract a value flag without setting an env var. Returns the value. */
+function extractValue(args: string[], flags: string[], usageHint: string): string | undefined {
+  const [value, remaining] = extractFlagValue(args, flags, usageHint);
+  args.splice(0, args.length, ...remaining);
+  return value;
+}
+
+const VALID_BETA_FEATURES = new Set([
+  "tarball",
+  "images",
+  "parallel",
+  "docker",
+  "recursive",
+  "sandbox",
+  "skills",
+]);
+
+/** Validate beta feature flags and exit with usage info if any are unknown. */
+function validateBetaFeatures(features: string[]): void {
+  for (const flag of features) {
+    if (!VALID_BETA_FEATURES.has(flag)) {
+      console.error(pc.red(`Unknown beta feature: ${pc.bold(flag)}`));
+      console.error("\nAvailable beta features:");
+      console.error(`  ${pc.cyan("tarball")}     Use pre-built tarball for agent installation`);
+      console.error(`  ${pc.cyan("images")}      Use pre-built DO marketplace images (faster boot)`);
+      console.error(`  ${pc.cyan("parallel")}    Parallelize server boot with setup prompts`);
+      console.error(`  ${pc.cyan("docker")}      Use Docker CE app image on Hetzner/GCP (faster boot)`);
+      console.error(`  ${pc.cyan("sandbox")}     Run local agents in a Docker container (sandboxed)`);
+      console.error(`  ${pc.cyan("skills")}      Pre-install MCP servers and tools on the VM`);
+      console.error(`  ${pc.cyan("recursive")}   Install spawn CLI on VM for recursive spawning`);
+      process.exit(1);
+    }
+  }
+}
+
+/** Parse all global flags from args, returning structured flags and the remaining args. */
+async function parseFlags(rawArgs: string[]): Promise<ParsedFlags> {
+  const args = expandEqualsFlags(rawArgs);
+
+  // Pre-scan for --output json before checkForUpdates() so install script
+  // stdout can be redirected to stderr, preventing JSON output pollution.
+  const preOutputIdx = args.indexOf("--output");
+  const isJsonOutput = preOutputIdx !== -1 && args[preOutputIdx + 1] === "json";
+
+  await checkForUpdates(isJsonOutput);
+
+  const [prompt, filteredArgs] = await resolvePrompt(args);
+
+  // Boolean flags
+  const dryRun = extractBooleanFlag(filteredArgs, [
+    "--dry-run",
+    "-n",
+  ]);
+  const debug = extractBooleanFlag(filteredArgs, [
+    "--debug",
+  ]);
+  const headless = extractBooleanFlag(filteredArgs, [
+    "--headless",
+  ]);
+  const custom = extractBooleanFlag(filteredArgs, [
+    "--custom",
+  ]);
+  if (custom) {
+    process.env.SPAWN_CUSTOM = "1";
+  }
+  extractEnvFlag(filteredArgs, "--reauth", "SPAWN_REAUTH");
+  const fast = extractEnvFlag(filteredArgs, "--fast", "SPAWN_FAST");
+
+  // Beta features (repeatable)
+  const betaFeatures = extractAllFlagValues(filteredArgs, "--beta", "spawn <agent> <cloud> --beta parallel");
+  const userOptedIntoBeta = betaFeatures.length > 0 || process.env.SPAWN_FAST === "1";
+  validateBetaFeatures(betaFeatures);
+  if (fast) {
+    betaFeatures.push("tarball", "images", "parallel", "docker");
+  }
+
+  // fast_provision experiment: if the user did NOT pass --beta or --fast,
+  // bucket them on the PostHog `fast_provision` flag. The `test` variant
+  // turns on images + docker + sandbox by default; control behaves as before.
+  // - images:  pre-built DO marketplace images (cloud-side faster boot)
+  // - docker:  Docker CE host image on Hetzner/GCP (cloud-side faster boot)
+  // - sandbox: local agents run in a Docker container (local-side faster boot)
+  // Exposure is captured for both variants so PostHog can compute conversion.
+  // Bundle composition lives in expandFastProvisionVariant() for unit testing.
+  if (!userOptedIntoBeta) {
+    const variant = getFeatureFlag("fast_provision", "control");
+    const variantStr = isString(variant) ? variant : "control";
+    betaFeatures.push(...expandFastProvisionVariant(variantStr));
+  }
+
+  if (betaFeatures.length > 0) {
+    process.env.SPAWN_BETA = [
+      ...new Set(betaFeatures),
+    ].join(",");
+  }
+
+  // Value flags
+  extractValueToEnv(
+    filteredArgs,
+    [
+      "--model",
+      "-m",
+    ],
+    'spawn <agent> <cloud> --model "openai/gpt-5.3-codex"',
+    "MODEL_ID",
+  );
+
+  // --config loads a config file and applies values as defaults
+  const configPath = extractValue(
+    filteredArgs,
+    [
+      "--config",
+    ],
+    "spawn <agent> <cloud> --config setup.json",
+  );
+  if (configPath) {
+    const { loadSpawnConfig } = await import("./shared/spawn-config.js");
+    const configResult = tryCatch(() => loadSpawnConfig(configPath));
+    if (!configResult.ok) {
+      console.error(pc.red(`Error loading config file: ${getErrorMessage(configResult.error)}`));
+      process.exit(1);
+    }
+    const config = configResult.data;
+    if (config) {
+      if (config.model && !process.env.MODEL_ID) {
+        process.env.MODEL_ID = config.model;
+      }
+      if (config.steps && !process.env.SPAWN_ENABLED_STEPS) {
+        process.env.SPAWN_ENABLED_STEPS = config.steps.join(",");
+      }
+      if (config.name && !process.env.SPAWN_NAME) {
+        process.env.SPAWN_NAME = config.name;
+      }
+      if (config.setup?.telegram_bot_token && !process.env.TELEGRAM_BOT_TOKEN) {
+        process.env.TELEGRAM_BOT_TOKEN = config.setup.telegram_bot_token;
+      }
+      if (config.setup?.github_token && !process.env.GITHUB_TOKEN) {
+        process.env.GITHUB_TOKEN = config.setup.github_token;
+      }
+    }
+  }
+
+  // --steps
+  const stepsFlag = extractValue(
+    filteredArgs,
+    [
+      "--steps",
+    ],
+    "spawn <agent> <cloud> --steps github,browser,telegram",
+  );
+  if (stepsFlag !== undefined) {
+    process.env.SPAWN_ENABLED_STEPS = stepsFlag;
+  }
+
+  // --output
+  const outputFormat = extractValue(
+    filteredArgs,
+    [
+      "--output",
+    ],
+    "spawn <agent> <cloud> --headless --output json",
+  );
+  if (outputFormat && outputFormat !== "json") {
+    console.error(pc.red(`Error: --output only supports "json" (got "${outputFormat}")`));
+    console.error(`\nUsage: ${pc.cyan("spawn <agent> <cloud> --headless --output json")}`);
+    process.exit(1);
+  }
+
+  // --repo <user/repo> — clone a template repo and apply spawn.md
+  extractValueToEnv(
+    filteredArgs,
+    [
+      "--repo",
+    ],
+    'spawn <agent> <cloud> --repo "user/my-template"',
+    "SPAWN_REPO",
+  );
+
+  // --name, --zone/--region, --size/--machine-type
+  extractValueToEnv(
+    filteredArgs,
+    [
+      "--name",
+    ],
+    'spawn <agent> <cloud> --name "my-dev-box"',
+    "SPAWN_NAME",
+  );
+
+  const zoneFlag = extractValue(
+    filteredArgs,
+    [
+      "--zone",
+      "--region",
+    ],
+    "spawn <agent> gcp --zone us-east1-b",
+  );
+  if (zoneFlag) {
+    process.env.GCP_ZONE = zoneFlag;
+    process.env.DO_REGION = zoneFlag;
+    process.env.HETZNER_LOCATION = zoneFlag;
+    process.env.AWS_DEFAULT_REGION = zoneFlag;
+  }
+
+  const sizeFlag = extractValue(
+    filteredArgs,
+    [
+      "--machine-type",
+      "--size",
+    ],
+    "spawn <agent> gcp --machine-type e2-standard-4",
+  );
+  if (sizeFlag) {
+    process.env.GCP_MACHINE_TYPE = sizeFlag;
+    process.env.DO_DROPLET_SIZE = sizeFlag;
+    process.env.HETZNER_SERVER_TYPE = sizeFlag;
+    process.env.LIGHTSAIL_BUNDLE = sizeFlag;
+  }
+
+  return {
+    filteredArgs,
+    prompt,
+    dryRun,
+    debug,
+    headless,
+    custom,
+    outputFormat,
+    betaFeatures,
+  };
+}
+
 /** Dispatch a named command or fall through to agent/cloud handling */
 async function dispatchCommand(
   cmd: string,
@@ -881,251 +1153,7 @@ async function main(): Promise<void> {
   // those fast paths never pay the flag-fetch cost.
   await initFeatureFlags();
 
-  const args = expandEqualsFlags(rawArgs);
-
-  // Pre-scan for --output json before checkForUpdates() so install script
-  // stdout can be redirected to stderr, preventing JSON output pollution.
-  const preOutputIdx = args.indexOf("--output");
-  const isJsonOutput = preOutputIdx !== -1 && args[preOutputIdx + 1] === "json";
-
-  await checkForUpdates(isJsonOutput);
-
-  const [prompt, filteredArgs] = await resolvePrompt(args);
-
-  // Extract --dry-run / -n boolean flag
-  const dryRunIdx = filteredArgs.findIndex((a) => a === "--dry-run" || a === "-n");
-  const dryRun = dryRunIdx !== -1;
-  if (dryRun) {
-    filteredArgs.splice(dryRunIdx, 1);
-  }
-
-  // Extract --debug boolean flag
-  const debugIdx = filteredArgs.indexOf("--debug");
-  const debug = debugIdx !== -1;
-  if (debug) {
-    filteredArgs.splice(debugIdx, 1);
-  }
-
-  // Extract --headless boolean flag
-  const headlessIdx = filteredArgs.indexOf("--headless");
-  const headless = headlessIdx !== -1;
-  if (headless) {
-    filteredArgs.splice(headlessIdx, 1);
-  }
-
-  // Extract --custom boolean flag
-  const customIdx = filteredArgs.indexOf("--custom");
-  const custom = customIdx !== -1;
-  if (custom) {
-    filteredArgs.splice(customIdx, 1);
-    process.env.SPAWN_CUSTOM = "1";
-  }
-
-  // Extract --reauth boolean flag
-  const reauthIdx = filteredArgs.indexOf("--reauth");
-  if (reauthIdx !== -1) {
-    filteredArgs.splice(reauthIdx, 1);
-    process.env.SPAWN_REAUTH = "1";
-  }
-
-  // Extract --fast boolean flag — enables images + tarballs + parallel setup
-  const fastIdx = filteredArgs.indexOf("--fast");
-  if (fastIdx !== -1) {
-    filteredArgs.splice(fastIdx, 1);
-    process.env.SPAWN_FAST = "1";
-  }
-
-  // Extract all --beta <feature> flags (repeatable, opt-in to experimental features)
-  const VALID_BETA_FEATURES = new Set([
-    "tarball",
-    "images",
-    "parallel",
-    "docker",
-    "recursive",
-    "skills",
-  ]);
-  const betaFeatures = extractAllFlagValues(filteredArgs, "--beta", "spawn <agent> <cloud> --beta parallel");
-  const userOptedIntoBeta = betaFeatures.length > 0 || process.env.SPAWN_FAST === "1";
-  for (const flag of betaFeatures) {
-    if (!VALID_BETA_FEATURES.has(flag)) {
-      console.error(pc.red(`Unknown beta feature: ${pc.bold(flag)}`));
-      console.error("\nAvailable beta features:");
-      console.error(`  ${pc.cyan("tarball")}     Use pre-built tarball for agent installation`);
-      console.error(`  ${pc.cyan("images")}      Use pre-built DO marketplace images (faster boot)`);
-      console.error(`  ${pc.cyan("parallel")}    Parallelize server boot with setup prompts`);
-      console.error(`  ${pc.cyan("docker")}      Use Docker CE app image on Hetzner/GCP (faster boot)`);
-      console.error(`  ${pc.cyan("skills")}      Pre-install MCP servers and tools on the VM`);
-      console.error(`  ${pc.cyan("recursive")}   Install spawn CLI on VM for recursive spawning`);
-      process.exit(1);
-    }
-  }
-  // --fast implies all beta features
-  if (process.env.SPAWN_FAST === "1") {
-    betaFeatures.push("tarball", "images", "parallel", "docker");
-  }
-
-  // fast_provision experiment: if the user did NOT pass --beta or --fast,
-  // bucket them on the PostHog `fast_provision` flag. The `test` variant
-  // turns on images + docker by default; control behaves as before.
-  // - images:  pre-built DO marketplace images (cloud-side faster boot)
-  // - docker:  Docker CE host image on Hetzner/GCP (cloud-side faster boot)
-  // Exposure is captured for both variants so PostHog can compute conversion.
-  // Bundle composition lives in expandFastProvisionVariant() for unit testing.
-  if (!userOptedIntoBeta) {
-    const variant = getFeatureFlag("fast_provision", "control");
-    const variantStr = isString(variant) ? variant : "control";
-    betaFeatures.push(...expandFastProvisionVariant(variantStr));
-  }
-
-  if (betaFeatures.length > 0) {
-    process.env.SPAWN_BETA = [
-      ...new Set(betaFeatures),
-    ].join(",");
-  }
-
-  // Extract --model / -m <value> flag → MODEL_ID env var (must be before --config so it takes priority)
-  const [modelFlag, modelFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--model",
-      "-m",
-    ],
-    'spawn <agent> <cloud> --model "openai/gpt-5.3-codex"',
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...modelFilteredArgs);
-  if (modelFlag) {
-    process.env.MODEL_ID = modelFlag;
-  }
-
-  // Extract --config <path> flag — load config file and apply as defaults
-  const [configPath, configFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--config",
-    ],
-    "spawn <agent> <cloud> --config setup.json",
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...configFilteredArgs);
-
-  if (configPath) {
-    const { loadSpawnConfig } = await import("./shared/spawn-config.js");
-    const configResult = tryCatch(() => loadSpawnConfig(configPath));
-    if (!configResult.ok) {
-      console.error(pc.red(`Error loading config file: ${getErrorMessage(configResult.error)}`));
-      process.exit(1);
-    }
-    const config = configResult.data;
-    if (config) {
-      // Apply config values as defaults (explicit flags take priority)
-      if (config.model && !process.env.MODEL_ID) {
-        process.env.MODEL_ID = config.model;
-      }
-      if (config.steps && !process.env.SPAWN_ENABLED_STEPS) {
-        process.env.SPAWN_ENABLED_STEPS = config.steps.join(",");
-      }
-      if (config.name && !process.env.SPAWN_NAME) {
-        process.env.SPAWN_NAME = config.name;
-      }
-      if (config.setup?.telegram_bot_token && !process.env.TELEGRAM_BOT_TOKEN) {
-        process.env.TELEGRAM_BOT_TOKEN = config.setup.telegram_bot_token;
-      }
-      if (config.setup?.github_token && !process.env.GITHUB_TOKEN) {
-        process.env.GITHUB_TOKEN = config.setup.github_token;
-      }
-    }
-  }
-
-  // Extract --steps <value> flag — comma-separated list of setup steps
-  const [stepsFlag, stepsFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--steps",
-    ],
-    "spawn <agent> <cloud> --steps github,browser,telegram",
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...stepsFilteredArgs);
-  if (stepsFlag !== undefined) {
-    // --steps "" means disable all optional steps
-    process.env.SPAWN_ENABLED_STEPS = stepsFlag;
-  }
-
-  // Extract --output <format> flag
-  const [outputFormat, outputFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--output",
-    ],
-    "spawn <agent> <cloud> --headless --output json",
-  );
-  // Replace filteredArgs contents in-place (splice + push to maintain reference)
-  filteredArgs.splice(0, filteredArgs.length, ...outputFilteredArgs);
-
-  // Validate --output value
-  if (outputFormat && outputFormat !== "json") {
-    console.error(pc.red(`Error: --output only supports "json" (got "${outputFormat}")`));
-    console.error(`\nUsage: ${pc.cyan("spawn <agent> <cloud> --headless --output json")}`);
-    process.exit(1);
-  }
-
-  // Extract --name <value> flag
-  const [nameFlag, nameFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--name",
-    ],
-    'spawn <agent> <cloud> --name "my-dev-box"',
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...nameFilteredArgs);
-  if (nameFlag) {
-    process.env.SPAWN_NAME = nameFlag;
-  }
-
-  // Extract --repo <user/repo> flag — clone a template repo and apply spawn.md
-  const [repoFlag, repoFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--repo",
-    ],
-    'spawn <agent> <cloud> --repo "user/my-template"',
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...repoFilteredArgs);
-  if (repoFlag) {
-    process.env.SPAWN_REPO = repoFlag;
-  }
-
-  // Extract --zone / --region <value> flag (maps to cloud-specific env vars)
-  const [zoneFlag, zoneFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--zone",
-      "--region",
-    ],
-    "spawn <agent> gcp --zone us-east1-b",
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...zoneFilteredArgs);
-  if (zoneFlag) {
-    process.env.GCP_ZONE = zoneFlag;
-    process.env.DO_REGION = zoneFlag;
-    process.env.HETZNER_LOCATION = zoneFlag;
-    process.env.AWS_DEFAULT_REGION = zoneFlag;
-  }
-
-  // Extract --machine-type / --size <value> flag (maps to cloud-specific env vars)
-  const [sizeFlag, sizeFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--machine-type",
-      "--size",
-    ],
-    "spawn <agent> gcp --machine-type e2-standard-4",
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...sizeFilteredArgs);
-  if (sizeFlag) {
-    process.env.GCP_MACHINE_TYPE = sizeFlag;
-    process.env.DO_DROPLET_SIZE = sizeFlag;
-    process.env.HETZNER_SERVER_TYPE = sizeFlag;
-    process.env.LIGHTSAIL_BUNDLE = sizeFlag;
-  }
+  const { filteredArgs, prompt, dryRun, debug, headless, custom, outputFormat } = await parseFlags(rawArgs);
 
   // --output implies --headless
   const effectiveHeadless = headless || !!outputFormat;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -752,6 +752,278 @@ async function dispatchSlashNotation(
   return false;
 }
 
+interface ParsedFlags {
+  filteredArgs: string[];
+  prompt: string | undefined;
+  dryRun: boolean;
+  debug: boolean;
+  headless: boolean;
+  custom: boolean;
+  outputFormat: string | undefined;
+  betaFeatures: string[];
+}
+
+/** Extract a boolean flag from args, mutating in place. Returns true if found. */
+function extractBooleanFlag(args: string[], flags: string[]): boolean {
+  const idx = args.findIndex((a) => flags.includes(a));
+  if (idx === -1) {
+    return false;
+  }
+  args.splice(idx, 1);
+  return true;
+}
+
+/** Extract and apply an env-var-setting boolean flag. Returns true if found. */
+function extractEnvFlag(args: string[], flag: string, envVar: string): boolean {
+  const idx = args.indexOf(flag);
+  if (idx === -1) {
+    return false;
+  }
+  args.splice(idx, 1);
+  process.env[envVar] = "1";
+  return true;
+}
+
+/** Extract a value flag and set it as an env var if present. Returns the value. */
+function extractValueToEnv(args: string[], flags: string[], usageHint: string, envVar: string): string | undefined {
+  const [value, remaining] = extractFlagValue(args, flags, usageHint);
+  args.splice(0, args.length, ...remaining);
+  if (value) {
+    process.env[envVar] = value;
+  }
+  return value;
+}
+
+/** Extract a value flag without setting an env var. Returns the value. */
+function extractValue(args: string[], flags: string[], usageHint: string): string | undefined {
+  const [value, remaining] = extractFlagValue(args, flags, usageHint);
+  args.splice(0, args.length, ...remaining);
+  return value;
+}
+
+const VALID_BETA_FEATURES = new Set([
+  "tarball",
+  "images",
+  "parallel",
+  "docker",
+  "recursive",
+  "sandbox",
+  "skills",
+]);
+
+/** Validate beta feature flags and exit with usage info if any are unknown. */
+function validateBetaFeatures(features: string[]): void {
+  for (const flag of features) {
+    if (!VALID_BETA_FEATURES.has(flag)) {
+      console.error(pc.red(`Unknown beta feature: ${pc.bold(flag)}`));
+      console.error("\nAvailable beta features:");
+      console.error(`  ${pc.cyan("tarball")}     Use pre-built tarball for agent installation`);
+      console.error(`  ${pc.cyan("images")}      Use pre-built DO marketplace images (faster boot)`);
+      console.error(`  ${pc.cyan("parallel")}    Parallelize server boot with setup prompts`);
+      console.error(`  ${pc.cyan("docker")}      Use Docker CE app image on Hetzner/GCP (faster boot)`);
+      console.error(`  ${pc.cyan("sandbox")}     Run local agents in a Docker container (sandboxed)`);
+      console.error(`  ${pc.cyan("skills")}      Pre-install MCP servers and tools on the VM`);
+      console.error(`  ${pc.cyan("recursive")}   Install spawn CLI on VM for recursive spawning`);
+      process.exit(1);
+    }
+  }
+}
+
+/** Parse all global flags from args, returning structured flags and the remaining args. */
+async function parseFlags(rawArgs: string[]): Promise<ParsedFlags> {
+  const args = expandEqualsFlags(rawArgs);
+
+  // Pre-scan for --output json before checkForUpdates() so install script
+  // stdout can be redirected to stderr, preventing JSON output pollution.
+  const preOutputIdx = args.indexOf("--output");
+  const isJsonOutput = preOutputIdx !== -1 && args[preOutputIdx + 1] === "json";
+
+  await checkForUpdates(isJsonOutput);
+
+  const [prompt, filteredArgs] = await resolvePrompt(args);
+
+  // Boolean flags
+  const dryRun = extractBooleanFlag(filteredArgs, [
+    "--dry-run",
+    "-n",
+  ]);
+  const debug = extractBooleanFlag(filteredArgs, [
+    "--debug",
+  ]);
+  const headless = extractBooleanFlag(filteredArgs, [
+    "--headless",
+  ]);
+  const custom = extractBooleanFlag(filteredArgs, [
+    "--custom",
+  ]);
+  if (custom) {
+    process.env.SPAWN_CUSTOM = "1";
+  }
+  extractEnvFlag(filteredArgs, "--reauth", "SPAWN_REAUTH");
+  const fast = extractEnvFlag(filteredArgs, "--fast", "SPAWN_FAST");
+
+  // Beta features (repeatable)
+  const betaFeatures = extractAllFlagValues(filteredArgs, "--beta", "spawn <agent> <cloud> --beta parallel");
+  const userOptedIntoBeta = betaFeatures.length > 0 || process.env.SPAWN_FAST === "1";
+  validateBetaFeatures(betaFeatures);
+  if (fast) {
+    betaFeatures.push("tarball", "images", "parallel", "docker");
+  }
+
+  // fast_provision experiment: if the user did NOT pass --beta or --fast,
+  // bucket them on the PostHog `fast_provision` flag. The `test` variant
+  // turns on images + docker + sandbox by default; control behaves as before.
+  // - images:  pre-built DO marketplace images (cloud-side faster boot)
+  // - docker:  Docker CE host image on Hetzner/GCP (cloud-side faster boot)
+  // - sandbox: local agents run in a Docker container (local-side faster boot)
+  // Exposure is captured for both variants so PostHog can compute conversion.
+  // Bundle composition lives in expandFastProvisionVariant() for unit testing.
+  if (!userOptedIntoBeta) {
+    const variant = getFeatureFlag("fast_provision", "control");
+    const variantStr = isString(variant) ? variant : "control";
+    betaFeatures.push(...expandFastProvisionVariant(variantStr));
+  }
+
+  if (betaFeatures.length > 0) {
+    process.env.SPAWN_BETA = [
+      ...new Set(betaFeatures),
+    ].join(",");
+  }
+
+  // Value flags
+  extractValueToEnv(
+    filteredArgs,
+    [
+      "--model",
+      "-m",
+    ],
+    'spawn <agent> <cloud> --model "openai/gpt-5.3-codex"',
+    "MODEL_ID",
+  );
+
+  // --config loads a config file and applies values as defaults
+  const configPath = extractValue(
+    filteredArgs,
+    [
+      "--config",
+    ],
+    "spawn <agent> <cloud> --config setup.json",
+  );
+  if (configPath) {
+    const { loadSpawnConfig } = await import("./shared/spawn-config.js");
+    const configResult = tryCatch(() => loadSpawnConfig(configPath));
+    if (!configResult.ok) {
+      console.error(pc.red(`Error loading config file: ${getErrorMessage(configResult.error)}`));
+      process.exit(1);
+    }
+    const config = configResult.data;
+    if (config) {
+      if (config.model && !process.env.MODEL_ID) {
+        process.env.MODEL_ID = config.model;
+      }
+      if (config.steps && !process.env.SPAWN_ENABLED_STEPS) {
+        process.env.SPAWN_ENABLED_STEPS = config.steps.join(",");
+      }
+      if (config.name && !process.env.SPAWN_NAME) {
+        process.env.SPAWN_NAME = config.name;
+      }
+      if (config.setup?.telegram_bot_token && !process.env.TELEGRAM_BOT_TOKEN) {
+        process.env.TELEGRAM_BOT_TOKEN = config.setup.telegram_bot_token;
+      }
+      if (config.setup?.github_token && !process.env.GITHUB_TOKEN) {
+        process.env.GITHUB_TOKEN = config.setup.github_token;
+      }
+    }
+  }
+
+  // --steps
+  const stepsFlag = extractValue(
+    filteredArgs,
+    [
+      "--steps",
+    ],
+    "spawn <agent> <cloud> --steps github,browser,telegram",
+  );
+  if (stepsFlag !== undefined) {
+    process.env.SPAWN_ENABLED_STEPS = stepsFlag;
+  }
+
+  // --output
+  const outputFormat = extractValue(
+    filteredArgs,
+    [
+      "--output",
+    ],
+    "spawn <agent> <cloud> --headless --output json",
+  );
+  if (outputFormat && outputFormat !== "json") {
+    console.error(pc.red(`Error: --output only supports "json" (got "${outputFormat}")`));
+    console.error(`\nUsage: ${pc.cyan("spawn <agent> <cloud> --headless --output json")}`);
+    process.exit(1);
+  }
+
+  // --repo <user/repo> — clone a template repo and apply spawn.md
+  extractValueToEnv(
+    filteredArgs,
+    [
+      "--repo",
+    ],
+    'spawn <agent> <cloud> --repo "user/my-template"',
+    "SPAWN_REPO",
+  );
+
+  // --name, --zone/--region, --size/--machine-type
+  extractValueToEnv(
+    filteredArgs,
+    [
+      "--name",
+    ],
+    'spawn <agent> <cloud> --name "my-dev-box"',
+    "SPAWN_NAME",
+  );
+
+  const zoneFlag = extractValue(
+    filteredArgs,
+    [
+      "--zone",
+      "--region",
+    ],
+    "spawn <agent> gcp --zone us-east1-b",
+  );
+  if (zoneFlag) {
+    process.env.GCP_ZONE = zoneFlag;
+    process.env.DO_REGION = zoneFlag;
+    process.env.HETZNER_LOCATION = zoneFlag;
+    process.env.AWS_DEFAULT_REGION = zoneFlag;
+  }
+
+  const sizeFlag = extractValue(
+    filteredArgs,
+    [
+      "--machine-type",
+      "--size",
+    ],
+    "spawn <agent> gcp --machine-type e2-standard-4",
+  );
+  if (sizeFlag) {
+    process.env.GCP_MACHINE_TYPE = sizeFlag;
+    process.env.DO_DROPLET_SIZE = sizeFlag;
+    process.env.HETZNER_SERVER_TYPE = sizeFlag;
+    process.env.LIGHTSAIL_BUNDLE = sizeFlag;
+  }
+
+  return {
+    filteredArgs,
+    prompt,
+    dryRun,
+    debug,
+    headless,
+    custom,
+    outputFormat,
+    betaFeatures,
+  };
+}
+
 /** Dispatch a named command or fall through to agent/cloud handling */
 async function dispatchCommand(
   cmd: string,
@@ -882,254 +1154,7 @@ async function main(): Promise<void> {
   // those fast paths never pay the flag-fetch cost.
   await initFeatureFlags();
 
-  const args = expandEqualsFlags(rawArgs);
-
-  // Pre-scan for --output json before checkForUpdates() so install script
-  // stdout can be redirected to stderr, preventing JSON output pollution.
-  const preOutputIdx = args.indexOf("--output");
-  const isJsonOutput = preOutputIdx !== -1 && args[preOutputIdx + 1] === "json";
-
-  await checkForUpdates(isJsonOutput);
-
-  const [prompt, filteredArgs] = await resolvePrompt(args);
-
-  // Extract --dry-run / -n boolean flag
-  const dryRunIdx = filteredArgs.findIndex((a) => a === "--dry-run" || a === "-n");
-  const dryRun = dryRunIdx !== -1;
-  if (dryRun) {
-    filteredArgs.splice(dryRunIdx, 1);
-  }
-
-  // Extract --debug boolean flag
-  const debugIdx = filteredArgs.indexOf("--debug");
-  const debug = debugIdx !== -1;
-  if (debug) {
-    filteredArgs.splice(debugIdx, 1);
-  }
-
-  // Extract --headless boolean flag
-  const headlessIdx = filteredArgs.indexOf("--headless");
-  const headless = headlessIdx !== -1;
-  if (headless) {
-    filteredArgs.splice(headlessIdx, 1);
-  }
-
-  // Extract --custom boolean flag
-  const customIdx = filteredArgs.indexOf("--custom");
-  const custom = customIdx !== -1;
-  if (custom) {
-    filteredArgs.splice(customIdx, 1);
-    process.env.SPAWN_CUSTOM = "1";
-  }
-
-  // Extract --reauth boolean flag
-  const reauthIdx = filteredArgs.indexOf("--reauth");
-  if (reauthIdx !== -1) {
-    filteredArgs.splice(reauthIdx, 1);
-    process.env.SPAWN_REAUTH = "1";
-  }
-
-  // Extract --fast boolean flag — enables images + tarballs + parallel setup
-  const fastIdx = filteredArgs.indexOf("--fast");
-  if (fastIdx !== -1) {
-    filteredArgs.splice(fastIdx, 1);
-    process.env.SPAWN_FAST = "1";
-  }
-
-  // Extract all --beta <feature> flags (repeatable, opt-in to experimental features)
-  const VALID_BETA_FEATURES = new Set([
-    "tarball",
-    "images",
-    "parallel",
-    "docker",
-    "recursive",
-    "sandbox",
-    "skills",
-  ]);
-  const betaFeatures = extractAllFlagValues(filteredArgs, "--beta", "spawn <agent> <cloud> --beta parallel");
-  const userOptedIntoBeta = betaFeatures.length > 0 || process.env.SPAWN_FAST === "1";
-  for (const flag of betaFeatures) {
-    if (!VALID_BETA_FEATURES.has(flag)) {
-      console.error(pc.red(`Unknown beta feature: ${pc.bold(flag)}`));
-      console.error("\nAvailable beta features:");
-      console.error(`  ${pc.cyan("tarball")}     Use pre-built tarball for agent installation`);
-      console.error(`  ${pc.cyan("images")}      Use pre-built DO marketplace images (faster boot)`);
-      console.error(`  ${pc.cyan("parallel")}    Parallelize server boot with setup prompts`);
-      console.error(`  ${pc.cyan("docker")}      Use Docker CE app image on Hetzner/GCP (faster boot)`);
-      console.error(`  ${pc.cyan("sandbox")}     Run local agents in a Docker container (sandboxed)`);
-      console.error(`  ${pc.cyan("skills")}      Pre-install MCP servers and tools on the VM`);
-      console.error(`  ${pc.cyan("recursive")}   Install spawn CLI on VM for recursive spawning`);
-      process.exit(1);
-    }
-  }
-  // --fast implies all beta features
-  if (process.env.SPAWN_FAST === "1") {
-    betaFeatures.push("tarball", "images", "parallel", "docker");
-  }
-
-  // fast_provision experiment: if the user did NOT pass --beta or --fast,
-  // bucket them on the PostHog `fast_provision` flag. The `test` variant
-  // turns on images + docker + sandbox by default; control behaves as before.
-  // - images:  pre-built DO marketplace images (cloud-side faster boot)
-  // - docker:  Docker CE host image on Hetzner/GCP (cloud-side faster boot)
-  // - sandbox: local agents run in a Docker container (local-side faster boot)
-  // Exposure is captured for both variants so PostHog can compute conversion.
-  // Bundle composition lives in expandFastProvisionVariant() for unit testing.
-  if (!userOptedIntoBeta) {
-    const variant = getFeatureFlag("fast_provision", "control");
-    const variantStr = isString(variant) ? variant : "control";
-    betaFeatures.push(...expandFastProvisionVariant(variantStr));
-  }
-
-  if (betaFeatures.length > 0) {
-    process.env.SPAWN_BETA = [
-      ...new Set(betaFeatures),
-    ].join(",");
-  }
-
-  // Extract --model / -m <value> flag → MODEL_ID env var (must be before --config so it takes priority)
-  const [modelFlag, modelFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--model",
-      "-m",
-    ],
-    'spawn <agent> <cloud> --model "openai/gpt-5.3-codex"',
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...modelFilteredArgs);
-  if (modelFlag) {
-    process.env.MODEL_ID = modelFlag;
-  }
-
-  // Extract --config <path> flag — load config file and apply as defaults
-  const [configPath, configFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--config",
-    ],
-    "spawn <agent> <cloud> --config setup.json",
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...configFilteredArgs);
-
-  if (configPath) {
-    const { loadSpawnConfig } = await import("./shared/spawn-config.js");
-    const configResult = tryCatch(() => loadSpawnConfig(configPath));
-    if (!configResult.ok) {
-      console.error(pc.red(`Error loading config file: ${getErrorMessage(configResult.error)}`));
-      process.exit(1);
-    }
-    const config = configResult.data;
-    if (config) {
-      // Apply config values as defaults (explicit flags take priority)
-      if (config.model && !process.env.MODEL_ID) {
-        process.env.MODEL_ID = config.model;
-      }
-      if (config.steps && !process.env.SPAWN_ENABLED_STEPS) {
-        process.env.SPAWN_ENABLED_STEPS = config.steps.join(",");
-      }
-      if (config.name && !process.env.SPAWN_NAME) {
-        process.env.SPAWN_NAME = config.name;
-      }
-      if (config.setup?.telegram_bot_token && !process.env.TELEGRAM_BOT_TOKEN) {
-        process.env.TELEGRAM_BOT_TOKEN = config.setup.telegram_bot_token;
-      }
-      if (config.setup?.github_token && !process.env.GITHUB_TOKEN) {
-        process.env.GITHUB_TOKEN = config.setup.github_token;
-      }
-    }
-  }
-
-  // Extract --steps <value> flag — comma-separated list of setup steps
-  const [stepsFlag, stepsFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--steps",
-    ],
-    "spawn <agent> <cloud> --steps github,browser,telegram",
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...stepsFilteredArgs);
-  if (stepsFlag !== undefined) {
-    // --steps "" means disable all optional steps
-    process.env.SPAWN_ENABLED_STEPS = stepsFlag;
-  }
-
-  // Extract --output <format> flag
-  const [outputFormat, outputFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--output",
-    ],
-    "spawn <agent> <cloud> --headless --output json",
-  );
-  // Replace filteredArgs contents in-place (splice + push to maintain reference)
-  filteredArgs.splice(0, filteredArgs.length, ...outputFilteredArgs);
-
-  // Validate --output value
-  if (outputFormat && outputFormat !== "json") {
-    console.error(pc.red(`Error: --output only supports "json" (got "${outputFormat}")`));
-    console.error(`\nUsage: ${pc.cyan("spawn <agent> <cloud> --headless --output json")}`);
-    process.exit(1);
-  }
-
-  // Extract --name <value> flag
-  const [nameFlag, nameFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--name",
-    ],
-    'spawn <agent> <cloud> --name "my-dev-box"',
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...nameFilteredArgs);
-  if (nameFlag) {
-    process.env.SPAWN_NAME = nameFlag;
-  }
-
-  // Extract --repo <user/repo> flag — clone a template repo and apply spawn.md
-  const [repoFlag, repoFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--repo",
-    ],
-    'spawn <agent> <cloud> --repo "user/my-template"',
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...repoFilteredArgs);
-  if (repoFlag) {
-    process.env.SPAWN_REPO = repoFlag;
-  }
-
-  // Extract --zone / --region <value> flag (maps to cloud-specific env vars)
-  const [zoneFlag, zoneFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--zone",
-      "--region",
-    ],
-    "spawn <agent> gcp --zone us-east1-b",
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...zoneFilteredArgs);
-  if (zoneFlag) {
-    process.env.GCP_ZONE = zoneFlag;
-    process.env.DO_REGION = zoneFlag;
-    process.env.HETZNER_LOCATION = zoneFlag;
-    process.env.AWS_DEFAULT_REGION = zoneFlag;
-  }
-
-  // Extract --machine-type / --size <value> flag (maps to cloud-specific env vars)
-  const [sizeFlag, sizeFilteredArgs] = extractFlagValue(
-    filteredArgs,
-    [
-      "--machine-type",
-      "--size",
-    ],
-    "spawn <agent> gcp --machine-type e2-standard-4",
-  );
-  filteredArgs.splice(0, filteredArgs.length, ...sizeFilteredArgs);
-  if (sizeFlag) {
-    process.env.GCP_MACHINE_TYPE = sizeFlag;
-    process.env.DO_DROPLET_SIZE = sizeFlag;
-    process.env.HETZNER_SERVER_TYPE = sizeFlag;
-    process.env.LIGHTSAIL_BUNDLE = sizeFlag;
-  }
+  const { filteredArgs, prompt, dryRun, debug, headless, custom, outputFormat } = await parseFlags(rawArgs);
 
   // --output implies --headless
   const effectiveHeadless = headless || !!outputFormat;


### PR DESCRIPTION
**Why:** `main()` at 302 lines is the largest uncovered function; flag-parsing extraction reduces it by ~220 lines and isolates all argument handling.

## Summary
- Extract `parseFlags()` async function that handles all global flag parsing and returns a typed `ParsedFlags` object
- Extract reusable helpers: `extractBooleanFlag`, `extractEnvFlag`, `extractValueToEnv`, `extractValue`, `validateBetaFeatures`
- `main()` reduced from 302 lines to 84 lines (72% reduction)
- Zero behavioral changes — all flag parsing, env var setting, config loading, and validation preserved exactly

## Test plan
- [x] `bunx @biomejs/biome check src/` passes with zero errors
- [x] `bun test` passes (2106/2108, 2 pre-existing flaky failures in `digitalocean-token.test.ts` unrelated to this change)
- [x] Verified `main()` line count: 302 → 84

-- spawn-refactor/complexity-hunter