### PR TITLE
fix(tests): disable telemetry in afterEach to prevent cross-file fetch leak

### DIFF
--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -13,6 +13,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { isString } from "@openrouter/spawn-shared";
 import * as v from "valibot";
+import { _testHelpers as telemetryTestHelpers } from "../shared/telemetry.js";
 
 // ── Schemas for validating PostHog payloads ─────────────────────────────────
 
@@ -127,6 +128,10 @@ describe("telemetry", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    // Disable telemetry so fire-and-forget fetch calls don't leak into other
+    // test files running in the same process (the root cause of flaky
+    // hetzner-cov and digitalocean-token test failures).
+    telemetryTestHelpers.enabled = false;
     if (originalTelemetry !== undefined) {
       process.env.SPAWN_TELEMETRY = originalTelemetry;
     } else {

--- a/packages/cli/src/shared/telemetry.ts
+++ b/packages/cli/src/shared/telemetry.ts
@@ -270,3 +270,15 @@ function sendEvent(event: string, properties: Record<string, unknown>): void {
     }),
   );
 }
+
+// ── Test Helpers ──────────────────────────────────────────────────────────────
+
+/** Exposed for test cleanup — prevents telemetry from leaking across test files. */
+export const _testHelpers = {
+  get enabled(): boolean {
+    return _enabled;
+  },
+  set enabled(val: boolean) {
+    _enabled = val;
+  },
+};


### PR DESCRIPTION
**Why:** 2 tests fail on every `bun test` run (hetzner-cov, digitalocean-token) because the telemetry test enables `_enabled = true` globally and never resets it — every subsequent `logWarn`/`logError` triggers fire-and-forget `fetch()` calls that corrupt other tests' callCount-based mocks.

## Root cause

`telemetry.test.ts` deletes `BUN_ENV`/`NODE_ENV` and calls `initTelemetry()` to enable telemetry for testing. Once `_enabled` is `true`, it stays `true` for the entire process. Any `logWarn()` or `logError()` in concurrent test files (hetzner, digitalocean) fires `sendEvent()` → `fetch()` through the calling test's mock, consuming callCounts.

## Fix (2 lines of real change)

1. Export `_testHelpers.enabled` getter/setter from `telemetry.ts`
2. Set `telemetryTestHelpers.enabled = false` in `telemetry.test.ts` `afterEach`

This fixes the leak at the source rather than patching each affected test to filter PostHog URLs.

## Relationship to #3341 and #3353

Both existing PRs work around the symptom (patching individual test mocks to ignore telemetry URLs). This PR fixes the root cause — once merged, those workarounds become unnecessary and no future test can be affected by telemetry fetch leaks.

## Test plan

- [x] `bun test` passes with 0 failures (2108 pass, 5376 expect() calls)
- [x] Verified on 2 consecutive runs — no flakiness
- [x] `biome check` passes on changed files


-- spawn-refactor/test-engineer