### PR TITLE
fix(test): resolve 2 flaky tests caused by parallel fetch mock interference

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,37 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let doApiCalls = 0;
+    let oauthChecks = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthChecks++;
+        return Promise.reject(new Error("network unavailable"));
+      }
+      // DO API calls (api.digitalocean.com)
+      if (urlStr.includes("api.digitalocean.com")) {
+        doApiCalls++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
-      // (avoids starting a real Bun.serve OAuth server)
-      if (urlStr.includes("cloud.digitalocean.com")) {
-        return Promise.reject(new Error("network unavailable"));
-      }
+      // Ignore unrelated fetch calls from parallel tests
       return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
+        new Response("", {
+          status: 200,
         }),
       );
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted: 1 API call + 1 connectivity check = 2
-    expect(callCount).toBe(2);
+    // Verify recovery was attempted: 1 API call + 1 OAuth connectivity check
+    expect(doApiCalls).toBe(1);
+    expect(oauthChecks).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -585,11 +585,23 @@ describe("hetzner/createServer", () => {
         },
       },
     };
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
-        // Token validation
+    // Route by URL to avoid interference from parallel tests' global.fetch mocks
+    let hetznerCallCount = 0;
+    let serverPostCount = 0;
+    global.fetch = mock((url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = String(url);
+      const method = init?.method ?? "GET";
+      // Ignore non-Hetzner fetch calls from parallel tests
+      if (!urlStr.includes("api.hetzner.cloud")) {
+        return Promise.resolve(
+          new Response("", {
+            status: 200,
+          }),
+        );
+      }
+      hetznerCallCount++;
+      // GET /servers — token validation (ensureHcloudToken)
+      if (urlStr.includes("/servers") && method === "GET") {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -598,8 +610,8 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 2) {
-        // SSH keys
+      // GET /ssh_keys — key listing
+      if (urlStr.includes("/ssh_keys")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -608,24 +620,28 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 3) {
-        // First create attempt — resource_limit_exceeded (HTTP 403)
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              error: {
-                code: "resource_limit_exceeded",
-                message: "primary_ip_limit",
+      // POST /servers — create attempts
+      if (urlStr.includes("/servers") && method === "POST") {
+        serverPostCount++;
+        if (serverPostCount === 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                error: {
+                  code: "resource_limit_exceeded",
+                  message: "primary_ip_limit",
+                },
+              }),
+              {
+                status: 403,
               },
-            }),
-            {
-              status: 403,
-            },
-          ),
-        );
+            ),
+          );
+        }
+        return Promise.resolve(new Response(JSON.stringify(serverResp)));
       }
-      if (callCount <= 4) {
-        // List primary IPs for cleanup
+      // GET /primary_ips — list for cleanup
+      if (urlStr.includes("/primary_ips") && method === "GET") {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -645,23 +661,19 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 5) {
-        // Delete orphaned IP 100
-        return Promise.resolve(
-          new Response("", {
-            status: 204,
-          }),
-        );
-      }
-      // Retry create — success
-      return Promise.resolve(new Response(JSON.stringify(serverResp)));
+      // DELETE /primary_ips/:id — cleanup orphaned IP
+      return Promise.resolve(
+        new Response("", {
+          status: 204,
+        }),
+      );
     });
     const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
     await ensureHcloudToken();
     const conn = await createServer("test-retry", "cx23", "fsn1");
     expect(conn.ip).toBe("10.0.0.5");
-    // Should have called: token(1), ssh_keys(2), create-fail(3), list-ips(4), delete-ip(5), create-ok(6)
-    expect(callCount).toBeGreaterThanOrEqual(6);
+    // Should have called Hetzner API at least 6 times: token, ssh_keys, create-fail, list-ips, delete-ip, create-ok
+    expect(hetznerCallCount).toBeGreaterThanOrEqual(6);
   });
 
   it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {


### PR DESCRIPTION
**Why:** 2 tests (`hetzner-cov.test.ts` and `digitalocean-token.test.ts`) fail consistently in full-suite `bun test` but pass in isolation, masking real regressions and training developers to ignore test failures.

## Summary
- `hetzner-cov.test.ts` "cleans up orphaned primary IPs on resource_limit_exceeded and retries" and `digitalocean-token.test.ts` "attempts OAuth recovery on 401 before throwing" both used sequential `callCount` to determine mock responses
- When Bun runs the full suite in parallel, other test files also mock `global.fetch`, causing extra calls that shift the count and break the sequence
- Fix: route mock responses by URL pattern (`api.hetzner.cloud` / `api.digitalocean.com`) and HTTP method instead of raw call count, ignoring unrelated fetch calls from parallel tests

## Test plan
- [x] Full test suite passes: 2112 pass, 0 fail (confirmed on 3 consecutive runs)
- [x] Biome lint: 0 errors
- [x] Both previously-failing tests now pass reliably in full-suite context

-- spawn-refactor/code-health