### PR TITLE
fix(packer): repair cursor tarball + hermes interactive install

### DIFF
--- a/packer/agents.json
+++ b/packer/agents.json
@@ -33,7 +33,7 @@
   "hermes": {
     "tier": "minimal",
     "install": [
-      "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash || [ -f ~/.local/bin/hermes ]"
+      "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup || [ -f ~/.local/bin/hermes ]"
     ]
   },
   "junie": {

--- a/packer/scripts/capture-agent.sh
+++ b/packer/scripts/capture-agent.sh
@@ -13,9 +13,9 @@ fi
 
 # Validate agent name against allowed list to prevent injection
 case "${AGENT_NAME}" in
-  openclaw|codex|kilocode|claude|opencode|hermes|junie) ;;
+  openclaw|codex|kilocode|claude|opencode|hermes|junie|cursor) ;;
   *)
-    printf 'Error: Invalid agent name: %s\nAllowed: openclaw, codex, kilocode, claude, opencode, hermes, junie\n' "${AGENT_NAME}" >&2
+    printf 'Error: Invalid agent name: %s\nAllowed: openclaw, codex, kilocode, claude, opencode, hermes, junie, cursor\n' "${AGENT_NAME}" >&2
     exit 1
     ;;
 esac
@@ -50,6 +50,12 @@ case "${AGENT_NAME}" in
     # The hermes installer (uv tool) creates the actual binary + venv under ~/.hermes/.
     # Without this, the ~/.local/bin/hermes symlink is dangling after tarball extraction.
     echo "/root/.hermes/" >> "${PATHS_FILE}"
+    ;;
+  cursor)
+    # Cursor installs to ~/.local/bin/agent (since 2026-03-25) with the
+    # extracted package under ~/.local/share/cursor-agent/.
+    echo "/root/.local/bin/" >> "${PATHS_FILE}"
+    echo "/root/.local/share/cursor-agent/" >> "${PATHS_FILE}"
     ;;
   *)
     echo "Unknown agent: ${AGENT_NAME}" >&2


### PR DESCRIPTION
## Summary

\`agent-tarballs.yml\` has been failing nightly since **2026-03-27** (~30 days) and \`packer-snapshots.yml\` since **2026-04-25** (2 days). Two distinct breakages, both unblocked by this PR.

### cursor

\`capture-agent.sh\`'s allowlist was missing \`cursor\`, so the install step succeeded but the capture step rejected the agent name with \`Error: Invalid agent name: cursor\`. Adds \`cursor\` to the allowlist plus its capture paths (\`~/.local/bin/\` for the \`agent\` symlink, \`~/.local/share/cursor-agent/\` for the extracted package — matches what \`sh/e2e/lib/verify.sh\` and \`packages/cli/src/shared/cursor-proxy.ts\` already expect).

### hermes

The upstream installer launches an interactive setup wizard after install, which fails in CI with:

\`\`\`
main: line 1347: /dev/tty: No such device or address
\`\`\`

Production code already passes \`--skip-setup\` (\`packages/cli/src/shared/agent-setup.ts:1336\`); \`packer/agents.json\` was the lone exception. Adds the same flag.

## Why this matters now

The \`fast_provision\` PostHog experiment (#3366, just merged) flips users to use these tarballs/images by default in the \`test\` variant. Without this fix:

- All test-variant cursor users would silently fall back to fresh install (since no tarball exists from the last 30 days)
- All test-variant hermes-on-DO users would hit a stale 2-day-old image, AND any rebuild would keep failing

The experiment results would be confounded by stale or missing artifacts.

## Test plan

- [x] \`bun -e 'JSON.parse(...packer/agents.json)'\` parses
- [x] \`bash -n packer/scripts/capture-agent.sh\` clean
- [x] cursor passes the new allowlist case statement
- [ ] CI: trigger \`agent-tarballs\` workflow on this branch — both \`cursor\` and \`hermes\` matrix jobs succeed
- [ ] CI: trigger \`packer-snapshots\` workflow — \`digitalocean/hermes\` succeeds

Both pipelines read install commands from \`packer/agents.json\`, so the single hermes edit unblocks both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)