### PR TITLE
fix(tarball): rewrite absolute /root symlinks after non-root extract

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/shared/agent-tarball.ts
+++ b/packages/cli/src/shared/agent-tarball.ts
@@ -101,12 +101,29 @@ export async function tryTarballInstall(
   // - Non-root user: use tar --transform to remap /root/ to $HOME/ during extraction.
   //   This avoids needing sudo entirely (Sprite VMs don't have it).
   //   Falls back to sudo-based extraction for clouds with passwordless sudo (AWS, GCP).
+  //
+  // After non-root extraction we also have to rewrite SYMLINK TARGETS — tar's
+  // --transform only rewrites file names, not the absolute paths stored inside
+  // symlinks. Without this, the agent's binary symlinks (e.g.
+  // ~/.local/bin/claude -> /root/.claude/local/claude) extract as dangling
+  // links and `claude` shows up as "command not found" on PATH.
+  const fixSymlinks = [
+    'find "$HOME" -type l 2>/dev/null | while IFS= read -r _l; do',
+    '  _t=$(readlink "$_l" 2>/dev/null) || continue',
+    '  case "$_t" in',
+    '    /root/*) ln -snf "$HOME${_t#/root}" "$_l" 2>/dev/null ;;',
+    "  esac",
+    "done",
+    "true",
+  ].join(" ");
+
   const extractCmd = [
     'if [ "$(id -u)" = "0" ]; then',
     "  tar xz -C /",
     "else",
-    // Try transform first (no sudo needed) — remap /root/ paths to $HOME/
-    '  tar xz --transform "s|^root/|${HOME#/}/|" -C / 2>/dev/null ||',
+    // Try transform first (no sudo needed) — remap /root/ paths to $HOME/,
+    // then walk $HOME and rewrite any leftover absolute /root/ symlinks.
+    `  { tar xz --transform "s|^root/|\${HOME#/}/|" -C / 2>/dev/null && { ${fixSymlinks}; }; } ||`,
     // Fallback: sudo extract + mirror (for clouds with passwordless sudo)
     "  sudo tar xz -C / 2>/dev/null",
     "fi",


### PR DESCRIPTION
## Root cause

Tarballs are built on a CI VM running as **root**, so file layouts contain absolute symlinks like:

\`\`\`
/root/.local/bin/claude -> /root/.claude/local/claude
\`\`\`

When extracted on a **non-root** user (Sprite, scp-style installs without passwordless sudo), tar's \`--transform "s|^root/|\${HOME#/}/|"\` rewrites file PATHS — so the file lands at \`\$HOME/.local/bin/claude\` — but **does not rewrite symlink TARGETS**. The symlink still points to \`/root/.claude/local/claude\`, which doesn't exist.

User experience: \`tryTarballInstall\` returns \`true\` (the marker file extracts fine), the orchestrator logs "Agent installed from pre-built tarball" and proceeds to launch. Then:

\`\`\`
/tmp/spawn_T6Gu8f.sh: line 4: claude: command not found
\`\`\`

10 retries, exit 127, give up. Repro from a real session today on \`spawn claude sprite\` (no flags — fast_provision experiment had bucketed the user to test).

## Fix

Post-extract, walk \`\$HOME\` and rewrite any \`/root/*\` symlink targets to point under \`\$HOME\`:

\`\`\`bash
find "\$HOME" -type l 2>/dev/null | while IFS= read -r _l; do
  _t=\$(readlink "\$_l" 2>/dev/null) || continue
  case "\$_t" in
    /root/*) ln -snf "\$HOME\${_t#/root}" "\$_l" 2>/dev/null ;;
  esac
done
\`\`\`

Wired into the non-root branch of \`extractCmd\` in \`shared/agent-tarball.ts\`. Only runs when the transform extract succeeds; the sudo fallback (which extracts as root and doesn't need rewriting) is unchanged.

## Why this is the right fix vs. alternatives

- **GNU tar \`--transform "flags=rsh;..."\`** would rewrite symlink targets too, but only handles \`^root/\` (relative form) and would need a second rule for absolute \`/root/\`. Also relies on a relatively obscure GNU tar feature; the find walk is more portable.
- **Build tarballs as a non-root user** would require duplicating the install pipeline. Out of scope.
- **Switch to relative symlinks at capture time** would require knowing the layout each agent's installer produces. Brittle per-agent.

## Test plan

- [x] \`bunx @biomejs/biome check src/\` — 0 errors
- [x] \`bunx tsc --noEmit -p .\` — 0 production errors
- [x] \`bun test orchestrate.test.ts\` — 41 pass
- [x] Smoke test: simulate post-transform extract layout in a temp dir with a dangling \`/root/.claude/local/claude\` symlink, run the fix loop, verify symlink resolves to \`\$HOME/.claude/local/claude\` and \`test -e\` passes
- [ ] End-to-end: \`spawn claude sprite --beta tarball\` + \`which claude\` returns a working path
- [ ] End-to-end: \`spawn openclaw sprite --beta tarball\` + \`openclaw --version\` (separately, openclaw also has a config-validation issue surfacing in \`Unrecognized key: "main"\` — that's a different bug, not this PR)

Bumps CLI to 1.0.24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)