### PR TITLE
fix(docker): publish spawn-pi image so --beta sandbox works for pi

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        agent: [claude, codex, cursor, openclaw, opencode, kilocode, hermes, junie]
+        agent: [claude, codex, cursor, openclaw, opencode, kilocode, hermes, junie, pi]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/sh/docker/pi.Dockerfile
+++ b/sh/docker/pi.Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base packages
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      curl git ca-certificates build-essential unzip zsh && \
+    rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 via n
+RUN curl --proto '=https' -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s install 22
+
+# Pi (pi-coding-agent)
+RUN npm install -g @mariozechner/pi-coding-agent
+
+CMD ["/bin/sleep", "inf"]


### PR DESCRIPTION
## Summary

\`spawn pi local --beta sandbox\` fails because the sandbox flow tries to pull \`ghcr.io/openrouterteam/spawn-pi:latest\`, but the image was never published — \`pi\` was missing from the Docker build matrix in \`.github/workflows/docker.yml\`, and there was no \`sh/docker/pi.Dockerfile\`.

This PR:
- Adds \`sh/docker/pi.Dockerfile\` (Ubuntu 24.04 + Node 22 via \`n\` + \`npm install -g @mariozechner/pi-coding-agent\` — same shape as \`kilocode.Dockerfile\` and \`codex.Dockerfile\`).
- Adds \`pi\` to the matrix in \`.github/workflows/docker.yml\` so the daily/scheduled build (and any push touching \`sh/docker/**\`) publishes \`ghcr.io/openrouterteam/spawn-pi:latest\`.

## Test plan
- [ ] Merge → workflow runs (push trigger fires on \`sh/docker/**\` change) → \`spawn-pi:latest\` published to ghcr.io.
- [ ] After publish: \`spawn pi local --beta sandbox\` pulls successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)