### PR TITLE
feat: runtime apt detection + add docker to fast_provision experiment

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -959,12 +959,12 @@ async function main(): Promise<void> {
 
   // fast_provision experiment: if the user did NOT pass --beta or --fast,
   // bucket them on the PostHog `fast_provision` flag. The `test` variant
-  // turns on images by default; control behaves as before.
+  // turns on images + docker by default; control behaves as before.
   // Exposure is captured for both variants so PostHog can compute conversion.
   if (!userOptedIntoBeta) {
     const variant = getFeatureFlag("fast_provision", "control");
     if (variant === "test") {
-      betaFeatures.push("images");
+      betaFeatures.push("images", "docker");
     }
   }
 

--- a/packages/cli/src/local/local.ts
+++ b/packages/cli/src/local/local.ts
@@ -460,7 +460,7 @@ export async function ensureDocker(): Promise<void> {
       process.exit(1);
     }
   } else {
-    logStep("Docker not found — installing docker.io...");
+    logStep("Docker not found — installing via get.docker.com...");
     const hasSudo =
       Bun.spawnSync(
         [
@@ -475,12 +475,12 @@ export async function ensureDocker(): Promise<void> {
           ],
         },
       ).exitCode === 0;
-    const prefix = hasSudo ? "sudo " : "";
+    const shellCmd = hasSudo ? "sudo sh" : "sh";
     const result = Bun.spawnSync(
       [
         "bash",
         "-c",
-        `${prefix}apt-get update -qq && ${prefix}apt-get install -y -qq docker.io`,
+        `curl -fsSL https://get.docker.com | ${shellCmd}`,
       ],
       {
         stdio: [
@@ -491,7 +491,7 @@ export async function ensureDocker(): Promise<void> {
       },
     );
     if (result.exitCode !== 0) {
-      logInfo("Auto-install failed. Install Docker manually: sudo apt-get install docker.io");
+      logInfo("Auto-install failed. Install Docker manually: https://docs.docker.com/engine/install/");
       process.exit(1);
     }
   }

--- a/packages/cli/src/local/local.ts
+++ b/packages/cli/src/local/local.ts
@@ -4,6 +4,7 @@ import { copyFileSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs"
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { tryCatch } from "@openrouter/spawn-shared";
+import { getFeatureFlag } from "../shared/feature-flags.js";
 import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY } from "../shared/orchestrate.js";
 import { getUserHome } from "../shared/paths.js";
 import { getLocalShell } from "../shared/shell.js";
@@ -460,7 +461,6 @@ export async function ensureDocker(): Promise<void> {
       process.exit(1);
     }
   } else {
-    logStep("Docker not found — installing via get.docker.com...");
     const hasSudo =
       Bun.spawnSync(
         [
@@ -475,12 +475,19 @@ export async function ensureDocker(): Promise<void> {
           ],
         },
       ).exitCode === 0;
-    const shellCmd = hasSudo ? "sudo sh" : "sh";
+    // PostHog experiment: "test" variant uses Docker's official convenience
+    // script (distro-agnostic — covers Fedora/Arch/Alpine, not just apt).
+    const useConvenienceScript = getFeatureFlag("linux_docker_install", "control") === "test";
+    const installLabel = useConvenienceScript ? "via get.docker.com" : "docker.io";
+    logStep(`Docker not found — installing ${installLabel}...`);
+    const installCmd = useConvenienceScript
+      ? `curl -fsSL https://get.docker.com | ${hasSudo ? "sudo sh" : "sh"}`
+      : `${hasSudo ? "sudo " : ""}apt-get update -qq && ${hasSudo ? "sudo " : ""}apt-get install -y -qq docker.io`;
     const result = Bun.spawnSync(
       [
         "bash",
         "-c",
-        `curl -fsSL https://get.docker.com | ${shellCmd}`,
+        installCmd,
       ],
       {
         stdio: [
@@ -491,7 +498,10 @@ export async function ensureDocker(): Promise<void> {
       },
     );
     if (result.exitCode !== 0) {
-      logInfo("Auto-install failed. Install Docker manually: https://docs.docker.com/engine/install/");
+      const manualHint = useConvenienceScript
+        ? "https://docs.docker.com/engine/install/"
+        : "sudo apt-get install docker.io";
+      logInfo(`Auto-install failed. Install Docker manually: ${manualHint}`);
       process.exit(1);
     }
   }

--- a/packages/cli/src/local/local.ts
+++ b/packages/cli/src/local/local.ts
@@ -4,7 +4,6 @@ import { copyFileSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs"
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { tryCatch } from "@openrouter/spawn-shared";
-import { getFeatureFlag } from "../shared/feature-flags.js";
 import { DOCKER_CONTAINER_NAME, DOCKER_REGISTRY } from "../shared/orchestrate.js";
 import { getUserHome } from "../shared/paths.js";
 import { getLocalShell } from "../shared/shell.js";
@@ -475,14 +474,27 @@ export async function ensureDocker(): Promise<void> {
           ],
         },
       ).exitCode === 0;
-    // PostHog experiment: "test" variant uses Docker's official convenience
-    // script (distro-agnostic — covers Fedora/Arch/Alpine, not just apt).
-    const useConvenienceScript = getFeatureFlag("linux_docker_install", "control") === "test";
-    const installLabel = useConvenienceScript ? "via get.docker.com" : "docker.io";
+    const hasApt =
+      Bun.spawnSync(
+        [
+          "which",
+          "apt-get",
+        ],
+        {
+          stdio: [
+            "ignore",
+            "ignore",
+            "ignore",
+          ],
+        },
+      ).exitCode === 0;
+    // Prefer apt-get on Debian/Ubuntu (small, fast, distro-trusted).
+    // Fall back to Docker's convenience script for Fedora/Arch/Alpine/etc.
+    const installLabel = hasApt ? "docker.io" : "via get.docker.com";
     logStep(`Docker not found — installing ${installLabel}...`);
-    const installCmd = useConvenienceScript
-      ? `curl -fsSL https://get.docker.com | ${hasSudo ? "sudo sh" : "sh"}`
-      : `${hasSudo ? "sudo " : ""}apt-get update -qq && ${hasSudo ? "sudo " : ""}apt-get install -y -qq docker.io`;
+    const installCmd = hasApt
+      ? `${hasSudo ? "sudo " : ""}apt-get update -qq && ${hasSudo ? "sudo " : ""}apt-get install -y -qq docker.io`
+      : `curl -fsSL https://get.docker.com | ${hasSudo ? "sudo sh" : "sh"}`;
     const result = Bun.spawnSync(
       [
         "bash",
@@ -498,9 +510,7 @@ export async function ensureDocker(): Promise<void> {
       },
     );
     if (result.exitCode !== 0) {
-      const manualHint = useConvenienceScript
-        ? "https://docs.docker.com/engine/install/"
-        : "sudo apt-get install docker.io";
+      const manualHint = hasApt ? "sudo apt-get install docker.io" : "https://docs.docker.com/engine/install/";
       logInfo(`Auto-install failed. Install Docker manually: ${manualHint}`);
       process.exit(1);
     }


### PR DESCRIPTION
## Summary

**\`local.ts\` — runtime apt detection (no PostHog flag).** \`ensureDocker()\` now prefers \`apt-get install docker.io\` when \`which apt-get\` succeeds, and falls back to Docker's official convenience script (\`curl -fsSL https://get.docker.com | sh\`) otherwise. This unblocks Fedora/Arch/Alpine/openSUSE users without changing behavior on Debian/Ubuntu.

**\`index.ts\` — extend the \`fast_provision\` experiment.** The test variant previously pushed only \`images\`. It now pushes \`images\` + \`docker\`, so the experiment measures the full provisioning-speed bundle (marketplace image + Docker-preinstalled image). Control behaves as before.

Bumps CLI \`1.0.27\` → \`1.0.28\`.

## Test plan
- [x] \`bunx @biomejs/biome check src/\` — clean
- [x] \`bun test\` — 2134 pass / 4 pre-existing failures (DO OAuth, hetzner createServer, cmdRun pipeline) — all unrelated
- [ ] Verify the \`fast_provision=test\` cohort sees \`SPAWN_BETA=images,docker\` in PostHog event payloads
- [ ] Manual: smoke-test \`spawn claude local\` on a non-apt distro (e.g., Fedora Docker container) and confirm get.docker.com path runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)