### PR TITLE
fix(scripts): auto-warm collaborator cache at source time

### DIFF
--- a/.claude/scripts/collaborator-gate.sh
+++ b/.claude/scripts/collaborator-gate.sh
@@ -79,3 +79,8 @@ is_issue_from_collaborator() {
     author=$(gh issue view "$issue_num" --repo "$_COLLAB_REPO" --json author --jq '.author.login' 2>/dev/null) || return 1
     is_collaborator "$author"
 }
+
+# Auto-warm cache at source time so schedule-triggered runs always start with a fresh list.
+# is_collaborator() calls _refresh_collaborator_cache, but only on issue-mode runs.
+# This ensures schedule-mode runs also get a warm cache before Claude starts.
+_refresh_collaborator_cache


### PR DESCRIPTION
**Why:** On schedule-triggered runs, the collaborator cache was never warmed before Claude started — causing the jq collaborator filter to return an empty list and bots to see zero issues/PRs and do nothing useful.

## Root cause
`collaborator-gate.sh` defines `_refresh_collaborator_cache` but only calls it when `is_collaborator()` or `is_issue_from_collaborator()` are invoked. In schedule mode (`SPAWN_ISSUE` unset), neither is called, so the cache stays cold and the prompt-level jq filter sees no collaborators.

## Fix
Add `_refresh_collaborator_cache` at the end of `collaborator-gate.sh` so it runs at source time. The function already checks the 10-min TTL — no extra API calls if the cache is fresh.

## Testing
- `bash -n` passes on the modified script
- No `.ts` changes needed — pure shell fix

Fixes #3352
Fixes #3354

-- refactor/team-lead