### PR TITLE
fix(tests): prevent telemetry singleton from polluting parallel test fetch mocks

### DIFF
--- a/packages/cli/src/__tests__/preload.ts
+++ b/packages/cli/src/__tests__/preload.ts
@@ -60,6 +60,10 @@ cleanupStrayTestFiles();
 
 const TEST_HOME = mkdtempSync(join(tmpdir(), "spawn-test-home-"));
 
+// Disable telemetry in tests to prevent fire-and-forget fetch calls from
+// interfering with other test files' global.fetch mocks.
+process.env.SPAWN_TELEMETRY = "0";
+
 // Redirect all user-directory env vars to the isolated temp
 process.env.HOME = TEST_HOME;
 process.env.XDG_CACHE_HOME = join(TEST_HOME, ".cache");

--- a/packages/cli/src/shared/telemetry.ts
+++ b/packages/cli/src/shared/telemetry.ts
@@ -242,6 +242,11 @@ export function captureError(type: string, err: unknown): void {
 
 /** Send a single event to PostHog immediately. Fire-and-forget. */
 function sendEvent(event: string, properties: Record<string, unknown>): void {
+  // Re-check at send time — guards against singleton state leaking in tests
+  // where initTelemetry() was called with _enabled=true but env was later restored.
+  if (process.env.BUN_ENV === "test" || process.env.NODE_ENV === "test" || process.env.SPAWN_TELEMETRY === "0") {
+    return;
+  }
   const body = JSON.stringify({
     api_key: POSTHOG_TOKEN,
     batch: [


### PR DESCRIPTION
**Why:** Two tests (`hetzner-cov` resource_limit retry and `digitalocean-token` OAuth recovery) consistently fail in the full suite because the telemetry singleton's `_enabled` flag leaks across parallel test files. When `telemetry.test.ts` enables telemetry, `logWarn` calls in other tests trigger fire-and-forget `fetch()` calls that increment callCount-based mock assertions.

## Root cause
`telemetry.test.ts` deletes `BUN_ENV` and `NODE_ENV` to test telemetry in "production" mode, then calls `initTelemetry()` which sets `_enabled = true`. Since bun runs test files in the same process with shared module singletons, `_enabled` stays true for all concurrent test files. Any `logWarn`/`logError` call then fires `sendEvent` → `fetch()` through other tests' global.fetch mocks.

## Fix
1. **Runtime guard in `sendEvent()`** — checks `BUN_ENV`, `NODE_ENV`, and `SPAWN_TELEMETRY` at call time, not just at init
2. **`SPAWN_TELEMETRY=0` in test preload** — defense-in-depth for all tests

## Testing
- Full suite: 2138 pass, 0 fail (was 2136 pass, 2 fail)
- `bun test src/__tests__/hetzner-cov.test.ts src/__tests__/telemetry.test.ts` — passes
- `bun test src/__tests__/digitalocean-token.test.ts src/__tests__/telemetry.test.ts` — passes
- Telemetry tests themselves: 19 pass, 0 fail

-- refactor/code-health