### PR TITLE
fix(test): use URL-based fetch mocking to prevent cross-test interference

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,34 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let doApiCalls = 0;
+    let oauthChecks = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      // DO API calls
+      if (urlStr.includes("api.digitalocean.com")) {
+        doApiCalls++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
       // (avoids starting a real Bun.serve OAuth server)
       if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthChecks++;
         return Promise.reject(new Error("network unavailable"));
       }
-      return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
-        }),
-      );
+      // Ignore non-DO requests (e.g. telemetry) to avoid cross-test interference
+      return Promise.resolve(new Response("ok"));
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted: 1 API call + 1 connectivity check = 2
-    expect(callCount).toBe(2);
+    // Verify recovery was attempted: 1 API call + 1 connectivity check
+    expect(doApiCalls).toBe(1);
+    expect(oauthChecks).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -585,10 +585,15 @@ describe("hetzner/createServer", () => {
         },
       },
     };
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
+    let createAttempts = 0;
+    let deletedIps = 0;
+    global.fetch = mock((url: string | URL | Request) => {
+      const urlStr = String(url);
+      // Ignore non-Hetzner requests (e.g. telemetry) to avoid cross-test interference
+      if (!urlStr.includes("api.hetzner.cloud")) {
+        return Promise.resolve(new Response("ok"));
+      }
+      if (urlStr.includes("/servers") && urlStr.includes("per_page=1")) {
         // Token validation
         return Promise.resolve(
           new Response(
@@ -598,8 +603,7 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 2) {
-        // SSH keys
+      if (urlStr.includes("/ssh_keys")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -608,23 +612,16 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 3) {
-        // First create attempt — resource_limit_exceeded (HTTP 403)
+      if (urlStr.includes("/primary_ips/")) {
+        // Delete orphaned IP
+        deletedIps++;
         return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              error: {
-                code: "resource_limit_exceeded",
-                message: "primary_ip_limit",
-              },
-            }),
-            {
-              status: 403,
-            },
-          ),
+          new Response("", {
+            status: 204,
+          }),
         );
       }
-      if (callCount <= 4) {
+      if (urlStr.includes("/primary_ips")) {
         // List primary IPs for cleanup
         return Promise.resolve(
           new Response(
@@ -645,23 +642,36 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 5) {
-        // Delete orphaned IP 100
-        return Promise.resolve(
-          new Response("", {
-            status: 204,
-          }),
-        );
+      if (urlStr.includes("/servers")) {
+        createAttempts++;
+        if (createAttempts <= 1) {
+          // First create attempt — resource_limit_exceeded (HTTP 403)
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                error: {
+                  code: "resource_limit_exceeded",
+                  message: "primary_ip_limit",
+                },
+              }),
+              {
+                status: 403,
+              },
+            ),
+          );
+        }
+        // Retry create — success
+        return Promise.resolve(new Response(JSON.stringify(serverResp)));
       }
-      // Retry create — success
-      return Promise.resolve(new Response(JSON.stringify(serverResp)));
+      return Promise.resolve(new Response("ok"));
     });
     const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
     await ensureHcloudToken();
     const conn = await createServer("test-retry", "cx23", "fsn1");
     expect(conn.ip).toBe("10.0.0.5");
-    // Should have called: token(1), ssh_keys(2), create-fail(3), list-ips(4), delete-ip(5), create-ok(6)
-    expect(callCount).toBeGreaterThanOrEqual(6);
+    // Should have attempted create twice and deleted 1 orphaned IP
+    expect(createAttempts).toBe(2);
+    expect(deletedIps).toBe(1);
   });
 
   it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {


### PR DESCRIPTION
**Why:** Two tests fail deterministically in the full suite (0 failures in isolation) because concurrent telemetry test flushes increment their sequential `callCount` mock counters.

## Changes

- `hetzner-cov.test.ts`: Rewrote the `resource_limit_exceeded` retry test to route mock responses by URL pattern (`/servers`, `/ssh_keys`, `/primary_ips`) instead of sequential `callCount`. Non-Hetzner requests (telemetry flushes) return a harmless `200 ok`.

- `digitalocean-token.test.ts`: Rewrote the `401 OAuth recovery` test to count DO API calls and OAuth checks separately by URL pattern. Non-DO requests return a harmless `200 ok`.

## Root cause

Bun runs test files concurrently. The telemetry test calls `process.emit("beforeExit")` to flush events, which triggers `global.fetch` calls. When these land during the hetzner/DO test's async operations, they increment `callCount` and shift the mock response sequence, causing the wrong response to be returned.

## Test plan

- [x] `bun test` full suite: 2138 pass, 0 fail (run twice for stability)
- [x] `biome check` on modified files: clean

-- refactor/test-engineer