### PR TITLE
fix(tests): use URL-based mock routing to fix flaky tests

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,33 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let doApiCalls = 0;
+    let oauthChecks = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthChecks++;
+        return Promise.reject(new Error("network unavailable"));
+      }
+      // DigitalOcean API call returning 401
+      if (urlStr.includes("api.digitalocean.com")) {
+        doApiCalls++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
-      // (avoids starting a real Bun.serve OAuth server)
-      if (urlStr.includes("cloud.digitalocean.com")) {
-        return Promise.reject(new Error("network unavailable"));
-      }
-      return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
-        }),
-      );
+      // Other fetches from concurrent tests — return harmless 200
+      return Promise.resolve(new Response("{}"));
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted: 1 API call + 1 connectivity check = 2
-    expect(callCount).toBe(2);
+    // Verify recovery was attempted: 1 DO API call + 1 connectivity check
+    expect(doApiCalls).toBe(1);
+    expect(oauthChecks).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -585,47 +585,40 @@ describe("hetzner/createServer", () => {
         },
       },
     };
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
-        // Token validation
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              servers: [],
-            }),
-          ),
-        );
-      }
-      if (callCount <= 2) {
-        // SSH keys
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              ssh_keys: [],
-            }),
-          ),
-        );
-      }
-      if (callCount <= 3) {
-        // First create attempt — resource_limit_exceeded (HTTP 403)
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              error: {
-                code: "resource_limit_exceeded",
-                message: "primary_ip_limit",
+    let serverPostCount = 0;
+    global.fetch = mock((url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = String(url);
+      const method = init?.method ?? "GET";
+      // POST /servers — first attempt returns 403 resource_limit_exceeded, retry succeeds
+      if (method === "POST" && urlStr.includes("/servers")) {
+        serverPostCount++;
+        if (serverPostCount <= 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                error: {
+                  code: "resource_limit_exceeded",
+                  message: "primary_ip_limit",
+                },
+              }),
+              {
+                status: 403,
               },
-            }),
-            {
-              status: 403,
-            },
-          ),
+            ),
+          );
+        }
+        return Promise.resolve(new Response(JSON.stringify(serverResp)));
+      }
+      // DELETE primary IP
+      if (method === "DELETE" && urlStr.includes("/primary_ips/")) {
+        return Promise.resolve(
+          new Response("", {
+            status: 204,
+          }),
         );
       }
-      if (callCount <= 4) {
-        // List primary IPs for cleanup
+      // GET /primary_ips — list for cleanup
+      if (urlStr.includes("/primary_ips")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -645,23 +638,34 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 5) {
-        // Delete orphaned IP 100
+      // GET /ssh_keys
+      if (urlStr.includes("/ssh_keys")) {
         return Promise.resolve(
-          new Response("", {
-            status: 204,
-          }),
+          new Response(
+            JSON.stringify({
+              ssh_keys: [],
+            }),
+          ),
         );
       }
-      // Retry create — success
-      return Promise.resolve(new Response(JSON.stringify(serverResp)));
+      // Token validation — GET /servers
+      if (urlStr.includes("/servers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              servers: [],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(new Response("{}"));
     });
     const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
     await ensureHcloudToken();
     const conn = await createServer("test-retry", "cx23", "fsn1");
     expect(conn.ip).toBe("10.0.0.5");
-    // Should have called: token(1), ssh_keys(2), create-fail(3), list-ips(4), delete-ip(5), create-ok(6)
-    expect(callCount).toBeGreaterThanOrEqual(6);
+    // Verify the retry happened: first POST failed, second succeeded
+    expect(serverPostCount).toBe(2);
   });
 
   it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {


### PR DESCRIPTION
## Why
Two tests (`digitalocean-token.test.ts` and `hetzner-cov.test.ts`) failed intermittently in the full suite but passed in isolation. Both relied on sequential `callCount` to route mock fetch responses, but Bun runs test files in the same process — concurrent tests sharing `global.fetch` caused the count to drift, producing wrong responses and assertion failures.

## What changed
- **digitalocean-token.test.ts**: Replaced count-based routing with URL-based routing (`api.digitalocean.com` vs `cloud.digitalocean.com`), returning harmless `{}` for unrelated concurrent fetches.
- **hetzner-cov.test.ts**: Replaced count-based routing with URL+method routing (`POST /servers` vs `GET /servers`, `GET /ssh_keys`, `GET /primary_ips`, `DELETE /primary_ips/:id`), using a `serverPostCount` to track only the relevant POST retries.

## Test results
Full suite: **2138 pass, 0 fail** (verified across multiple runs).