### PR TITLE
fix(install): add SHA-256 verification for cli.js download

### DIFF
--- a/sh/cli/install.sh
+++ b/sh/cli/install.sh
@@ -288,10 +288,38 @@ build_and_install() {
     trap '[ -n "${tmpdir}" ] && [ -d "${tmpdir}" ] && rm -rf "${tmpdir}"' EXIT
 
     log_step "Downloading pre-built CLI binary..."
-    curl -fsSL --proto '=https' "https://github.com/${SPAWN_REPO}/releases/download/cli-latest/cli.js" -o "${tmpdir}/cli.js"
+    local _release_base="https://github.com/${SPAWN_REPO}/releases/download/cli-latest"
+    curl -fsSL --proto '=https' "${_release_base}/cli.js" -o "${tmpdir}/cli.js"
     if [ ! -s "${tmpdir}/cli.js" ]; then
         log_error "Failed to download pre-built binary"
         exit 1
+    fi
+
+    # Verify SHA-256 of cli.js if the checksum file is published alongside it.
+    # The checksum file contains just the hex digest (no filename).
+    local _expected_sha="" _actual_sha=""
+    if curl -fsSL --proto '=https' "${_release_base}/cli.js.sha256" -o "${tmpdir}/cli.js.sha256" 2>/dev/null \
+       && [ -s "${tmpdir}/cli.js.sha256" ]; then
+        _expected_sha="$(tr -d '[:space:]' < "${tmpdir}/cli.js.sha256")"
+        _actual_sha="$(sha256_file "${tmpdir}/cli.js" 2>/dev/null || true)"
+        if [ -z "$_actual_sha" ]; then
+            log_warn "Cannot verify cli.js (no sha256sum/shasum available), continuing unverified"
+        elif [ "$_actual_sha" != "$_expected_sha" ]; then
+            log_error "cli.js hash mismatch — possible supply chain attack"
+            log_error "Expected: ${_expected_sha}"
+            log_error "Got:      ${_actual_sha}"
+            echo ""
+            echo "The cli.js binary does not match the expected SHA-256 hash."
+            echo "This could indicate a compromised release artifact or CDN."
+            echo ""
+            echo "Please report this at:"
+            echo "  https://github.com/${SPAWN_REPO}/issues"
+            exit 1
+        else
+            log_info "SHA-256 verified"
+        fi
+    else
+        log_warn "No cli.js.sha256 checksum published yet — skipping verification"
     fi
 
     if [ -n "${SPAWN_INSTALL_DIR:-}" ]; then


### PR DESCRIPTION
Why: Prevents MITM/tampered binary downloads by verifying SHA-256 of cli.js before execution — closes the last unverified download in the install path (bun installer already has hash verification).

## Changes

- Downloads `cli.js.sha256` companion file from the same GitHub Release
- Verifies the hash using the existing portable `sha256_file()` helper (works on both macOS `shasum` and Linux `sha256sum`)
- On hash mismatch: aborts with a clear error (same UX as the bun installer hash check)
- On missing checksum file (not yet published by CI): warns and continues — zero breakage for existing installs
- On missing hash tools: warns and continues (same graceful degradation as bun check)

## Remaining work (separate PR, requires human review)

`.github/workflows/release.yml` must be updated to publish `cli.js.sha256` alongside `cli.js` in the `cli-latest` release. Workflow changes are off-limits for automated PRs per team rules. Once CI publishes the checksum file, this verification activates automatically.

Fixes #3327