### PR TITLE
fix(growth): emphasise brevity in tweet prompt (no numbers, no limits)

### DIFF
--- a/.claude/skills/setup-agent-team/tweet-prompt.md
+++ b/.claude/skills/setup-agent-team/tweet-prompt.md
@@ -21,8 +21,6 @@ Spawn lets anyone spin up an AI coding agent (Claude, Codex, etc.) on a cheap cl
   - "Spawn now works with any git URL, not just GitHub. clone from GitLab, Bitbucket, or anywhere else and your cloud AI coding session starts with your code already loaded."
   - "new: spawn export lets you capture your Claude coding session on a cloud VM and push it to GitHub. write code in the cloud, ship it to a repo."
 
-Do not treat the platform's 280 char limit as a goal. It's a ceiling. If your draft is pushing it, you're writing marketing copy, not a tweet.
-
 ## Past Tweet Decisions
 
 Learn from what was previously approved, edited, or skipped:
@@ -92,6 +90,6 @@ Or if nothing tweet-worthy:
 ## Rules
 
 - Pick exactly 1 tweet per cycle. No ties, no "here are 3 options."
-- Must fit in a tweet (under the platform limit). Shorter is better. Trim before you submit.
+- Shorter is better. Trim before you submit.
 - Do NOT use tools. Your only input is the git data above.
 - A "no tweet" result is perfectly fine, quality over quantity.

--- a/.claude/skills/setup-agent-team/tweet-prompt.md
+++ b/.claude/skills/setup-agent-team/tweet-prompt.md
@@ -1,10 +1,27 @@
 # Tweet Draft — Daily Spawn Update
 
-You are writing a single tweet (max 280 characters) about the Spawn project (<https://github.com/OpenRouterTeam/spawn>) for a general audience — devs curious about AI but NOT infra/security nerds.
+You are writing a single tweet about the Spawn project (<https://github.com/OpenRouterTeam/spawn>) for a general audience — devs curious about AI but NOT infra/security nerds.
 
 Spawn lets anyone spin up an AI coding agent (Claude, Codex, etc.) on a cheap cloud server with one command. That's it. Think "AI coding assistant in the cloud, ready in 30 seconds."
 
 **Audience check**: a curious developer who doesn't know what `ps aux`, `OAuth`, `SigV4`, or `TLS` means, but does know what Claude / Codex / GitHub / cloud is.
+
+## BREVITY IS THE #1 RULE
+
+**Short tweets win. Long tweets get scrolled past.** Write like you're texting a friend, not writing a press release.
+
+- **Target: 80-140 characters total.** Including the link.
+- **Hard cap: 180 characters.** If your draft is over 180, cut it. No exceptions.
+- The 280 char platform limit is a ceiling, NOT a goal. Tweets that fill 280 chars read as spammy marketing copy.
+- If your draft is over 140 chars, delete words until it isn't. Cut adjectives. Cut setup phrases like "you can now" or "we just added". Cut the second sentence.
+- Prefer one clean sentence over two. Prefer a verb over a noun phrase. Prefer a concrete example over a description.
+- Good length examples:
+  - "spawn export now redacts API keys before pushing to github. https://openrouter.ai/spawn" (88 chars)
+  - "new: spawn export. ship your cloud session to a github repo in one command. https://openrouter.ai/spawn" (104 chars)
+  - "spawn now works with any git URL. gitlab, bitbucket, whatever. https://openrouter.ai/spawn" (90 chars)
+- Bad length examples (too long, cut these down):
+  - "Spawn now works with any git URL, not just GitHub. clone from GitLab, Bitbucket, or anywhere else and your cloud AI coding session starts with your code already loaded." (explains too much, cut the second half)
+  - "new: spawn export lets you capture your Claude coding session on a cloud VM and push it to GitHub. write code in the cloud, ship it to a repo." (two sentences saying the same thing, keep one)
 
 ## Past Tweet Decisions
 
@@ -24,7 +41,8 @@ GIT_DATA_PLACEHOLDER
    - Avoid: low-level security fixes, OAuth changes, type-safety refactors, CI tweaks, internal plumbing
    - If the only notable commits are internal/infra, output `found: false` — no tweet is better than a boring technical tweet
 
-2. **Draft exactly 1 tweet**, max 280 characters. Rules:
+2. **Draft exactly 1 tweet**. Rules:
+   - **Keep it under 140 characters. Hard cap 180.** Re-read and trim before submitting.
    - Casual, short, and plain-English. No jargon a beginner wouldn't get.
    - **BANNED terms in tweets**: `ps aux`, `OAuth`, `SigV4`, `TLS`, `CORS`, `RBAC`, `syscall`, `stdin`, `stdout`, `CLI args`, `process listing`, `temp file`, `env var`, `--flag names`, commit hashes, file paths. If you need any of these to explain the commit, pick a different commit or output found:false.
    - Allowed terms: Claude, Codex, Cursor, GitHub, cloud, agent, server, VM, one command, token, API.
@@ -34,7 +52,9 @@ GIT_DATA_PLACEHOLDER
    - At most 1 hashtag (only if it fits naturally)
    - OK to include `https://openrouter.ai/spawn`
 
-3. **If nothing is tweet-worthy** (no notable changes, or all recent commits are internal/infra that would need banned jargon to explain), output `found: false`.
+3. **Before you output, count chars and trim.** If over 140, cut. If over 180, cut harder. Two passes minimum.
+
+4. **If nothing is tweet-worthy** (no notable changes, or all recent commits are internal/infra that would need banned jargon to explain), output `found: false`.
 
 ## Output Format
 
@@ -44,7 +64,7 @@ First, a human-readable summary:
 === TWEET DRAFT ===
 Topic: {which commit/feature/fix this highlights}
 Category: {feature | fix | best-practice}
-Chars: {N}/280
+Chars: {N}/180 (target ≤140)
 
 Draft:
 {the tweet text}
@@ -57,11 +77,11 @@ Then a machine-readable block:
 {
   "found": true,
   "type": "tweet",
-  "tweetText": "{the tweet, max 280 chars}",
+  "tweetText": "{the tweet, ideally ≤140 chars, hard cap 180}",
   "topic": "{brief description of what the tweet is about}",
   "category": "feature",
   "sourceCommits": ["abc1234def"],
-  "charCount": 142
+  "charCount": 98
 }
 ```
 
@@ -74,6 +94,6 @@ Or if nothing tweet-worthy:
 ## Rules
 
 - Pick exactly 1 tweet per cycle. No ties, no "here are 3 options."
-- MUST be under 280 characters. Count carefully.
+- **Target ≤140 chars. Hard cap 180 chars.** Count carefully. Trim aggressively.
 - Do NOT use tools. Your only input is the git data above.
 - A "no tweet" result is perfectly fine — quality over quantity.

--- a/.claude/skills/setup-agent-team/tweet-prompt.md
+++ b/.claude/skills/setup-agent-team/tweet-prompt.md
@@ -6,22 +6,22 @@ Spawn lets anyone spin up an AI coding agent (Claude, Codex, etc.) on a cheap cl
 
 **Audience check**: a curious developer who doesn't know what `ps aux`, `OAuth`, `SigV4`, or `TLS` means, but does know what Claude / Codex / GitHub / cloud is.
 
-## BREVITY IS THE #1 RULE
+## Keep it short
 
 **Short tweets win. Long tweets get scrolled past.** Write like you're texting a friend, not writing a press release.
 
-- **Target: 80-140 characters total.** Including the link.
-- **Hard cap: 180 characters.** If your draft is over 180, cut it. No exceptions.
-- The 280 char platform limit is a ceiling, NOT a goal. Tweets that fill 280 chars read as spammy marketing copy.
-- If your draft is over 140 chars, delete words until it isn't. Cut adjectives. Cut setup phrases like "you can now" or "we just added". Cut the second sentence.
-- Prefer one clean sentence over two. Prefer a verb over a noun phrase. Prefer a concrete example over a description.
-- Good length examples:
-  - "spawn export now redacts API keys before pushing to github. https://openrouter.ai/spawn" (88 chars)
-  - "new: spawn export. ship your cloud session to a github repo in one command. https://openrouter.ai/spawn" (104 chars)
-  - "spawn now works with any git URL. gitlab, bitbucket, whatever. https://openrouter.ai/spawn" (90 chars)
-- Bad length examples (too long, cut these down):
-  - "Spawn now works with any git URL, not just GitHub. clone from GitLab, Bitbucket, or anywhere else and your cloud AI coding session starts with your code already loaded." (explains too much, cut the second half)
-  - "new: spawn export lets you capture your Claude coding session on a cloud VM and push it to GitHub. write code in the cloud, ship it to a repo." (two sentences saying the same thing, keep one)
+- Shorter is almost always better. The best tweets about Spawn are a single short sentence plus the link.
+- Do not pad. Do not explain twice. Do not add a second sentence that restates the first. Do not add setup phrases like "you can now", "we just added", "excited to share".
+- Prefer a verb over a noun phrase. Prefer a concrete example over a description. Say less.
+- These are the vibe:
+  - "spawn export now redacts API keys before pushing to github. https://openrouter.ai/spawn"
+  - "new: spawn export. ship your cloud session to github in one command. https://openrouter.ai/spawn"
+  - "spawn now works with any git URL. gitlab, bitbucket, whatever. https://openrouter.ai/spawn"
+- These are too long (they explain twice, or tack on a second sentence that adds nothing):
+  - "Spawn now works with any git URL, not just GitHub. clone from GitLab, Bitbucket, or anywhere else and your cloud AI coding session starts with your code already loaded."
+  - "new: spawn export lets you capture your Claude coding session on a cloud VM and push it to GitHub. write code in the cloud, ship it to a repo."
+
+Do not treat the platform's 280 char limit as a goal. It's a ceiling. If your draft is pushing it, you're writing marketing copy, not a tweet.
 
 ## Past Tweet Decisions
 
@@ -42,8 +42,8 @@ GIT_DATA_PLACEHOLDER
    - If the only notable commits are internal/infra, output `found: false` — no tweet is better than a boring technical tweet
 
 2. **Draft exactly 1 tweet**. Rules:
-   - **Keep it under 140 characters. Hard cap 180.** Re-read and trim before submitting.
-   - Casual, short, and plain-English. No jargon a beginner wouldn't get.
+   - Keep it short. One clean sentence is ideal. See the "Keep it short" section above.
+   - Casual, plain-English. No jargon a beginner wouldn't get.
    - **BANNED terms in tweets**: `ps aux`, `OAuth`, `SigV4`, `TLS`, `CORS`, `RBAC`, `syscall`, `stdin`, `stdout`, `CLI args`, `process listing`, `temp file`, `env var`, `--flag names`, commit hashes, file paths. If you need any of these to explain the commit, pick a different commit or output found:false.
    - Allowed terms: Claude, Codex, Cursor, GitHub, cloud, agent, server, VM, one command, token, API.
    - Write like you're texting a friend who likes tech. "just added X", "now you can Y", "spin up a whole AI coding setup in 30 seconds"
@@ -52,7 +52,7 @@ GIT_DATA_PLACEHOLDER
    - At most 1 hashtag (only if it fits naturally)
    - OK to include `https://openrouter.ai/spawn`
 
-3. **Before you output, count chars and trim.** If over 140, cut. If over 180, cut harder. Two passes minimum.
+3. **Before you output, re-read your draft and cut anything that isn't pulling weight.** If a clause could be deleted without changing the meaning, delete it. If a second sentence restates the first, delete it.
 
 4. **If nothing is tweet-worthy** (no notable changes, or all recent commits are internal/infra that would need banned jargon to explain), output `found: false`.
 
@@ -64,7 +64,6 @@ First, a human-readable summary:
 === TWEET DRAFT ===
 Topic: {which commit/feature/fix this highlights}
 Category: {feature | fix | best-practice}
-Chars: {N}/180 (target ≤140)
 
 Draft:
 {the tweet text}
@@ -77,11 +76,10 @@ Then a machine-readable block:
 {
   "found": true,
   "type": "tweet",
-  "tweetText": "{the tweet, ideally ≤140 chars, hard cap 180}",
+  "tweetText": "{the tweet}",
   "topic": "{brief description of what the tweet is about}",
   "category": "feature",
-  "sourceCommits": ["abc1234def"],
-  "charCount": 98
+  "sourceCommits": ["abc1234def"]
 }
 ```
 
@@ -94,6 +92,6 @@ Or if nothing tweet-worthy:
 ## Rules
 
 - Pick exactly 1 tweet per cycle. No ties, no "here are 3 options."
-- **Target ≤140 chars. Hard cap 180 chars.** Count carefully. Trim aggressively.
+- Must fit in a tweet (under the platform limit). Shorter is better. Trim before you submit.
 - Do NOT use tools. Your only input is the git data above.
-- A "no tweet" result is perfectly fine — quality over quantity.
+- A "no tweet" result is perfectly fine, quality over quantity.


### PR DESCRIPTION
## Summary

Recent tweets were running too long and reading as marketing copy. Push the tweet drafting prompt toward much shorter drafts with **no numbers, no targets, no limits** in the instructions at all. The model will anchor to whatever number we put in front of it. So don't put any.

Changes to `.claude/skills/setup-agent-team/tweet-prompt.md`:
- New **"Keep it short"** section at the top. Short tweets win. Long tweets get scrolled past.
- Rules are purely qualitative: don't pad, don't explain twice, don't add setup phrases ("you can now", "we just added", "excited to share"), don't tack on a second sentence that restates the first, prefer one clean sentence.
- Good/bad examples drawn from real prior drafts so the model pattern-matches on vibe, not a number.
- Dropped every length reference: no target range, no hard cap, no "280 char platform limit", no `Chars: N/280` in the output format, no `charCount` in the JSON schema. Nothing to anchor on, nothing to game.
- Final rule: re-read the draft and cut anything that isn't pulling weight.

The platform enforces its own character limit. The prompt doesn't need to.

## Test plan

- [ ] Next discovery cycle drafts a short tweet without any length counter in the output
- [ ] Quality bar (banned terms, no em dashes, casual tone) stays intact
- [ ] Past decisions log keeps tuning the voice over time