### PR TITLE
fix(tests): filter telemetry fetch calls in DO/Hetzner mocks

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -90,8 +90,16 @@ describe("doApi 401 OAuth recovery", () => {
     state.token = "expired-token";
     let callCount = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
+      // Ignore unrelated fetch calls (e.g. telemetry) that may fire in parallel
+      if (!urlStr.includes("digitalocean")) {
+        return Promise.resolve(
+          new Response("", {
+            status: 200,
+          }),
+        );
+      }
+      callCount++;
       // First call: the actual API call returning 401
       if (callCount === 1) {
         return Promise.resolve(

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -586,7 +586,16 @@ describe("hetzner/createServer", () => {
       },
     };
     let callCount = 0;
-    global.fetch = mock(() => {
+    global.fetch = mock((url: string | URL | Request) => {
+      const urlStr = String(url);
+      // Ignore unrelated fetch calls (e.g. telemetry) that may fire in parallel
+      if (!urlStr.includes("hetzner")) {
+        return Promise.resolve(
+          new Response("", {
+            status: 200,
+          }),
+        );
+      }
       callCount++;
       if (callCount <= 1) {
         // Token validation


### PR DESCRIPTION
## Summary
- Fixes 2 consistently flaky tests that failed in the full parallel suite but passed in isolation
- Root cause: PostHog telemetry `fetch()` calls fired during async test execution, polluting `callCount` in mocks that captured all `globalThis.fetch` traffic
- Fix: URL-filter mocks to only count calls to the relevant API domain (`digitalocean`/`hetzner`)

## Tests fixed
- `doApi 401 OAuth recovery > attempts OAuth recovery on 401 before throwing`
- `hetzner/createServer > cleans up orphaned primary IPs on resource_limit_exceeded and retries`

## Test plan
- [x] Full test suite passes: 2177 pass, 0 fail (verified 3 consecutive runs)
- [x] Lint passes

-- refactor/test-engineer