### PR TITLE
ci(docker): build multi-arch images (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,3 +41,20 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/openrouterteam/spawn-${{ matrix.agent }}:latest
+
+      # Verify the pushed manifest actually contains both architectures.
+      # Catches regressions where setup-qemu/buildx gets dropped or the
+      # platforms flag gets lost in a future refactor.
+      - name: Verify multi-arch manifest
+        run: |
+          set -euo pipefail
+          image="ghcr.io/openrouterteam/spawn-${{ matrix.agent }}:latest"
+          echo "Inspecting $image"
+          manifest="$(docker buildx imagetools inspect "$image")"
+          echo "$manifest"
+          for arch in linux/amd64 linux/arm64; do
+            if ! grep -qF "$arch" <<< "$manifest"; then
+              echo "::error::$image is missing $arch in the published manifest"
+              exit 1
+            fi
+          done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
@@ -34,5 +38,6 @@ jobs:
         with:
           context: .
           file: sh/docker/${{ matrix.agent }}.Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/openrouterteam/spawn-${{ matrix.agent }}:latest


### PR DESCRIPTION
## Summary
- Adds `docker/setup-qemu-action` + `docker/setup-buildx-action` to `.github/workflows/docker.yml`, and sets `platforms: linux/amd64,linux/arm64` on the build-push step.
- Apple Silicon hosts running `--beta sandbox` will now pull a native arm64 image instead of falling back to Rosetta emulation of amd64.

## Why
`spawn <agent> local --beta sandbox` hangs at the GitHub auth step on M-series Macs. Inside the running container I caught the smoking gun:

```
root  39  [rosetta] /usr/bin/apt-get apt-get update -qq    # stuck in S state
_apt  43   \_ [rosetta] /usr/lib/apt/methods/http ...
_apt  45   \_ [rosetta] /usr/lib/apt/methods/https ...
```

`github-auth.sh` triggers `apt-get update` to install `gh`. Under Rosetta x86_64 emulation on arm64, the apt http methods sleep indefinitely.

Side-by-side reproduction (host: `arm64`, OrbStack):

| Image | apt-get update + install curl + ca-certs |
|---|---|
| `ubuntu:24.04 linux/arm64` (native) | **12s** |
| `ubuntu:24.04 linux/amd64` (Rosetta) | **>5 min, still hung** |

When the user passes `SPAWN_SKIP_GITHUB_AUTH=1` (or has no local gh token), no apt-get runs at runtime and the sandbox boots fine — confirming the hang is the apt path under emulation.

## Compatibility
All current Dockerfiles (`claude`, `codex`, `cursor`, `hermes`, `junie`, `kilocode`, `openclaw`, `opencode`, `pi`) install via `npm install -g`, `curl ... | bash`, or `uname -m`-aware download. None depend on amd64-only artifacts, so multi-arch builds should succeed unchanged.

QEMU-emulated arm64 builds add CI time (Node install, npm global, curl-based installers run under emulation on the amd64 GH runner). The schedule is daily, so the extra few minutes per agent is acceptable.

## Test plan
- [ ] Trigger the workflow manually (`workflow_dispatch`) and verify each `spawn-<agent>:latest` is published as a multi-arch manifest (`docker manifest inspect ghcr.io/openrouterteam/spawn-claude:latest` shows both `linux/amd64` and `linux/arm64`).
- [ ] On an Apple Silicon host: `spawn claude local --beta sandbox` no longer hangs at the GitHub auth step; `docker image inspect ghcr.io/openrouterteam/spawn-claude:latest --format '{{.Architecture}}'` reports `arm64`.
- [ ] On an x86_64 host: same flow continues to work (pulls `amd64` variant of the manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)