### PR TITLE
fix(test): use URL-based mock routing to eliminate flaky fetch tests

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,37 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let apiCallCount = 0;
+    let oauthCheckCount = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
-      const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      const urlStr = String(url instanceof Request ? url.url : url);
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthCheckCount++;
+        return Promise.reject(new Error("network unavailable"));
+      }
+      // DO API call — return 401
+      if (urlStr.includes("api.digitalocean.com")) {
+        apiCallCount++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
-      // (avoids starting a real Bun.serve OAuth server)
-      if (urlStr.includes("cloud.digitalocean.com")) {
-        return Promise.reject(new Error("network unavailable"));
-      }
+      // Fallback for any phantom fetches (e.g. telemetry from other test files)
       return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
+        new Response("", {
+          status: 200,
         }),
       );
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted: 1 API call + 1 connectivity check = 2
-    expect(callCount).toBe(2);
+    // Verify recovery was attempted: 1 API call + 1 connectivity check
+    expect(apiCallCount).toBe(1);
+    expect(oauthCheckCount).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -585,10 +585,13 @@ describe("hetzner/createServer", () => {
         },
       },
     };
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
+    let serverPostCount = 0;
+    global.fetch = mock((url: string | URL | Request, opts?: RequestInit) => {
+      const urlStr = String(url instanceof Request ? url.url : url);
+      const method = (opts?.method ?? "GET").toUpperCase();
+
+      // Route by URL+method to avoid callCount sensitivity to phantom fetches
+      if (method === "GET" && urlStr.includes("/servers")) {
         // Token validation
         return Promise.resolve(
           new Response(
@@ -598,8 +601,7 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 2) {
-        // SSH keys
+      if (method === "GET" && urlStr.includes("/ssh_keys")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -608,24 +610,28 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 3) {
-        // First create attempt — resource_limit_exceeded (HTTP 403)
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              error: {
-                code: "resource_limit_exceeded",
-                message: "primary_ip_limit",
+      if (method === "POST" && urlStr.includes("/servers")) {
+        serverPostCount++;
+        if (serverPostCount === 1) {
+          // First create attempt — resource_limit_exceeded (HTTP 403)
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                error: {
+                  code: "resource_limit_exceeded",
+                  message: "primary_ip_limit",
+                },
+              }),
+              {
+                status: 403,
               },
-            }),
-            {
-              status: 403,
-            },
-          ),
-        );
+            ),
+          );
+        }
+        // Retry create — success
+        return Promise.resolve(new Response(JSON.stringify(serverResp)));
       }
-      if (callCount <= 4) {
-        // List primary IPs for cleanup
+      if (method === "GET" && urlStr.includes("/primary_ips")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -645,23 +651,25 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 5) {
-        // Delete orphaned IP 100
+      if (method === "DELETE" && urlStr.includes("/primary_ips/")) {
         return Promise.resolve(
           new Response("", {
             status: 204,
           }),
         );
       }
-      // Retry create — success
-      return Promise.resolve(new Response(JSON.stringify(serverResp)));
+      // Fallback for any unexpected/phantom fetches (e.g. telemetry)
+      return Promise.resolve(
+        new Response("", {
+          status: 200,
+        }),
+      );
     });
     const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
     await ensureHcloudToken();
     const conn = await createServer("test-retry", "cx23", "fsn1");
     expect(conn.ip).toBe("10.0.0.5");
-    // Should have called: token(1), ssh_keys(2), create-fail(3), list-ips(4), delete-ip(5), create-ok(6)
-    expect(callCount).toBeGreaterThanOrEqual(6);
+    expect(serverPostCount).toBe(2);
   });
 
   it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {


### PR DESCRIPTION
**Why:** Two tests (hetzner orphaned-IP cleanup, DO OAuth recovery) fail consistently in the full suite but pass in isolation, blocking CI reliability. The root cause is Bun's single-process test execution where `global.fetch` mocks are susceptible to phantom fetch calls from concurrent test files.

## Summary
- Replace sequential `callCount`-based fetch mocking with URL+method routing
- hetzner-cov: route by URL path (`/servers`, `/ssh_keys`, `/primary_ips`) with state counter only for the POST `/servers` retry
- digitalocean-token: route by hostname (`api.digitalocean.com` vs `cloud.digitalocean.com`)
- Both mocks include a fallback response for unexpected/phantom fetches

## Test plan
- [x] `bun test` passes with 0 failures (verified 3 consecutive runs)
- [x] Both previously-flaky tests now pass reliably in the full suite
- [x] Biome lint/format passes

Fixes #3393