### PR TITLE
feat(cli): expand fast_provision experiment to images + docker + sandbox

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/feature-flags.test.ts
+++ b/packages/cli/src/__tests__/feature-flags.test.ts
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import {
   _awaitBackgroundRefreshForTest,
   _resetFeatureFlagsForTest,
+  expandFastProvisionVariant,
   getFeatureFlag,
   initFeatureFlags,
 } from "../shared/feature-flags.js";
@@ -223,6 +224,30 @@ describe("feature flags", () => {
       await initFeatureFlags();
       expect(getFeatureFlag("known", "default")).toBe("yes");
       expect(getFeatureFlag("unknown", "default")).toBe("default");
+    });
+  });
+
+  describe("expandFastProvisionVariant", () => {
+    // These tests pin the experiment bundle composition so that tweaking the
+    // list in feature-flags.ts forces an explicit test update — drifting the
+    // bundle silently is the failure mode we're guarding against.
+
+    it("returns the full provisioning-speed bundle for the test variant", () => {
+      expect(expandFastProvisionVariant("test")).toEqual([
+        "images",
+        "docker",
+        "sandbox",
+      ]);
+    });
+
+    it("returns an empty bundle for the control variant", () => {
+      expect(expandFastProvisionVariant("control")).toEqual([]);
+    });
+
+    it("returns an empty bundle for unknown variants (fail-closed)", () => {
+      expect(expandFastProvisionVariant("")).toEqual([]);
+      expect(expandFastProvisionVariant("rollout")).toEqual([]);
+      expect(expandFastProvisionVariant("totally-made-up")).toEqual([]);
     });
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -962,14 +962,9 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   }
-  // --fast: explicit user opt-in to the full provisioning-speed stack. Kept
-  // aligned with the `fast_provision` experiment's `test` variant (images,
-  // docker, sandbox) so the explicit flag and the silent A/B exercise the same
-  // surface — plus tarball + parallel, which are speed-ups outside the
-  // experiment scope. If you change either bundle, update the other or the
-  // alignment comment in expandFastProvisionVariant().
+  // --fast implies all beta features
   if (process.env.SPAWN_FAST === "1") {
-    betaFeatures.push("tarball", "images", "parallel", "docker", "sandbox");
+    betaFeatures.push("tarball", "images", "parallel", "docker");
   }
 
   // fast_provision experiment: if the user did NOT pass --beta or --fast,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -969,12 +969,15 @@ async function main(): Promise<void> {
 
   // fast_provision experiment: if the user did NOT pass --beta or --fast,
   // bucket them on the PostHog `fast_provision` flag. The `test` variant
-  // turns on images by default; control behaves as before.
+  // turns on images + docker + sandbox by default; control behaves as before.
+  // - images:  pre-built DO marketplace images (cloud-side faster boot)
+  // - docker:  Docker CE host image on Hetzner/GCP (cloud-side faster boot)
+  // - sandbox: local agents run in a Docker container (local-side faster boot)
   // Exposure is captured for both variants so PostHog can compute conversion.
   if (!userOptedIntoBeta) {
     const variant = getFeatureFlag("fast_provision", "control");
     if (variant === "test") {
-      betaFeatures.push("images");
+      betaFeatures.push("images", "docker", "sandbox");
     }
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,7 +40,7 @@ import {
 } from "./commands/index.js";
 import { expandEqualsFlags, findUnknownFlag } from "./flags.js";
 import { agentKeys, cloudKeys, getCacheAge, loadManifest } from "./manifest.js";
-import { getFeatureFlag, initFeatureFlags } from "./shared/feature-flags.js";
+import { expandFastProvisionVariant, getFeatureFlag, initFeatureFlags } from "./shared/feature-flags.js";
 import { getInstallRefPath } from "./shared/paths.js";
 import { asyncTryCatch, asyncTryCatchIf, isFileError, isNetworkError, tryCatch, tryCatchIf } from "./shared/result.js";
 import { captureError, initTelemetry, setTelemetryContext } from "./shared/telemetry.js";
@@ -962,9 +962,14 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   }
-  // --fast implies all beta features
+  // --fast: explicit user opt-in to the full provisioning-speed stack. Kept
+  // aligned with the `fast_provision` experiment's `test` variant (images,
+  // docker, sandbox) so the explicit flag and the silent A/B exercise the same
+  // surface — plus tarball + parallel, which are speed-ups outside the
+  // experiment scope. If you change either bundle, update the other or the
+  // alignment comment in expandFastProvisionVariant().
   if (process.env.SPAWN_FAST === "1") {
-    betaFeatures.push("tarball", "images", "parallel", "docker");
+    betaFeatures.push("tarball", "images", "parallel", "docker", "sandbox");
   }
 
   // fast_provision experiment: if the user did NOT pass --beta or --fast,
@@ -974,11 +979,11 @@ async function main(): Promise<void> {
   // - docker:  Docker CE host image on Hetzner/GCP (cloud-side faster boot)
   // - sandbox: local agents run in a Docker container (local-side faster boot)
   // Exposure is captured for both variants so PostHog can compute conversion.
+  // Bundle composition lives in expandFastProvisionVariant() for unit testing.
   if (!userOptedIntoBeta) {
     const variant = getFeatureFlag("fast_provision", "control");
-    if (variant === "test") {
-      betaFeatures.push("images", "docker", "sandbox");
-    }
+    const variantStr = isString(variant) ? variant : "control";
+    betaFeatures.push(...expandFastProvisionVariant(variantStr));
   }
 
   if (betaFeatures.length > 0) {

--- a/packages/cli/src/shared/feature-flags.ts
+++ b/packages/cli/src/shared/feature-flags.ts
@@ -207,10 +207,8 @@ export function getFeatureFlag<T extends string | boolean>(key: string, fallback
  * caller is responsible for de-duping against features the user already passed.
  *
  * Kept as a pure, named export so the bundle composition is testable in
- * isolation from `main()` arg parsing. Keep this in sync with the `--fast`
- * branch in `index.ts` — both opt the user into the same speed-ups; they only
- * differ on `tarball` + `parallel`, which `--fast` adds (these aren't part of
- * the experiment because they're already on by default in most paths).
+ * isolation from `main()` arg parsing. This is the experiment surface only —
+ * unrelated to `--fast`, which is its own user-facing flag and stays as-is.
  */
 export function expandFastProvisionVariant(variant: string): readonly string[] {
   if (variant === "test") {

--- a/packages/cli/src/shared/feature-flags.ts
+++ b/packages/cli/src/shared/feature-flags.ts
@@ -201,6 +201,28 @@ export function getFeatureFlag<T extends string | boolean>(key: string, fallback
   return value;
 }
 
+/**
+ * Beta features bundled by the `fast_provision` PostHog experiment for a given
+ * variant. Returns an empty array for `control` or any unknown variant — the
+ * caller is responsible for de-duping against features the user already passed.
+ *
+ * Kept as a pure, named export so the bundle composition is testable in
+ * isolation from `main()` arg parsing. Keep this in sync with the `--fast`
+ * branch in `index.ts` — both opt the user into the same speed-ups; they only
+ * differ on `tarball` + `parallel`, which `--fast` adds (these aren't part of
+ * the experiment because they're already on by default in most paths).
+ */
+export function expandFastProvisionVariant(variant: string): readonly string[] {
+  if (variant === "test") {
+    return [
+      "images",
+      "docker",
+      "sandbox",
+    ];
+  }
+  return [];
+}
+
 /** Test-only: reset module state between tests. */
 export function _resetFeatureFlagsForTest(): void {
   _flags = null;


### PR DESCRIPTION
## Summary

The PostHog \`fast_provision\` flag is already wired via \`shared/feature-flags.ts\` and currently bundles \`images\` for the \`test\` variant. This PR expands the test variant to the full provisioning-speed stack:

- **images** — pre-built DO marketplace images (cloud-side faster boot)
- **docker** — Docker CE host image on Hetzner/GCP (cloud-side faster boot)
- **sandbox** — local agents run in a Docker container (local-side faster boot)

Users who explicitly pass \`--beta\` or \`--fast\` still take precedence and skip the experiment bucket. \`\$feature_flag_called\` exposure events continue to capture for both variants so PostHog can compute conversion across the broader bundle.

## Heads-up: known sandbox gap

\`pullAndStartContainer\` in \`packages/cli/src/local/local.ts:533\` runs \`docker run\` with no volume mount. When the experiment routes a user into the test variant on \`local\` for a coding agent (claude/codex/cursor/etc.), the container cannot see their working directory — the primary use case breaks.

Two options before flipping the flag on at PostHog:
1. **Recommended** — add \`-v \"\$(pwd)\":/workspace -w /workspace\` to \`pullAndStartContainer\` for coding agents. One-liner, makes sandbox actually usable.
2. **Alternative** — exclude coding agents from the sandbox variant; keep it limited to openclaw/hermes where containerization without mount is fine.

Either way, this PR ships the bundle change cleanly; the volume-mount fix is small enough to land separately or as a follow-up commit on this branch — your call.

## Test plan

- [x] \`bun test src/__tests__/feature-flags.test.ts\` — 11/11 pass
- [x] \`bunx @biomejs/biome check src/\` — clean
- [ ] Smoke test: \`SPAWN_FEATURE_FLAGS_DISABLED=1 spawn claude local\` (control path) → behaves as today
- [ ] Smoke test: force test variant, verify \`SPAWN_BETA=images,docker,sandbox\`
- [ ] Decide on volume-mount before flipping flag at PostHog

🤖 Generated with [Claude Code](https://claude.com/claude-code)