### PR TITLE
fix(cli): add sandbox to --fast beta features list

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -961,7 +961,7 @@ async function main(): Promise<void> {
   }
   // --fast implies all beta features
   if (process.env.SPAWN_FAST === "1") {
-    betaFeatures.push("tarball", "images", "parallel", "docker");
+    betaFeatures.push("tarball", "images", "parallel", "docker", "sandbox");
   }
 
   // fast_provision experiment: if the user did NOT pass --beta or --fast,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -964,7 +964,7 @@ async function main(): Promise<void> {
   }
   // --fast implies all beta features
   if (process.env.SPAWN_FAST === "1") {
-    betaFeatures.push("tarball", "images", "parallel", "docker");
+    betaFeatures.push("tarball", "images", "parallel", "docker", "sandbox");
   }
 
   // fast_provision experiment: if the user did NOT pass --beta or --fast,


### PR DESCRIPTION
**Why:** Users who explicitly pass `--fast` get a different (incomplete) feature set compared to the A/B experiment's test variant. The `test` variant correctly includes `["images", "docker", "sandbox"]` via `expandFastProvisionVariant()`, but the `--fast` path at line 967 was missing `"sandbox"`. This contradicts the documented intent from #3398 ("Add sandbox to --fast so the explicit user opt-in exercises the same surface as the silent experiment") and means `--fast` users miss the local sandbox container feature.

## Change

`packages/cli/src/index.ts:967`:
```diff
- betaFeatures.push("tarball", "images", "parallel", "docker");
+ betaFeatures.push("tarball", "images", "parallel", "docker", "sandbox");
```

## Verification
- Biome: 0 errors
- Tests: 2186 pass, 2 fail (same 2 pre-existing failures on main, not caused by this change)

-- refactor/code-health