### PR TITLE
fix(ssh): use spawn-owned key + IdentitiesOnly to kill MaxAuthTries flood

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/ssh-keys-cov.test.ts
+++ b/packages/cli/src/__tests__/ssh-keys-cov.test.ts
@@ -1,8 +1,5 @@
 /**
- * ssh-keys-cov.test.ts — Additional coverage for shared/ssh-keys.ts
- *
- * Covers edge cases: generateSshKey failure + race recovery,
- * getSshFingerprint empty output, discoverSshKeys with UNKNOWN type
+ * ssh-keys-cov.test.ts — Additional edge-case coverage for shared/ssh-keys.ts.
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
@@ -16,10 +13,11 @@ mockClackPrompts({
   text: mock(() => Promise.resolve("")),
 });
 
-const { discoverSshKeys, generateSshKey, getSshFingerprint, _resetCache } = await import("../shared/ssh-keys.js");
+const { discoverLegacyKeys, getSpawnKey, getSshFingerprint, _resetCache } = await import("../shared/ssh-keys.js");
 
 let tmpDir: string;
 let origHome: string | undefined;
+let stderrSpy: ReturnType<typeof spyOn>;
 
 function makeSyncResult(text: string, exitCode = 0): Bun.SyncSubprocess<"pipe", "pipe"> {
   return {
@@ -74,41 +72,37 @@ afterEach(() => {
   );
 });
 
-// Suppress stderr — restored in afterEach to avoid contaminating other tests
-let stderrSpy: ReturnType<typeof spyOn>;
-
-describe("generateSshKey race recovery", () => {
-  it("recovers when ssh-keygen fails but key was created by another process", () => {
+describe("getSpawnKey race recovery", () => {
+  it("recovers when ssh-keygen fails but key files appeared", () => {
     const sshDir = join(tmpDir, ".ssh");
     mkdirSync(sshDir, {
       recursive: true,
       mode: 0o700,
     });
-    const privPath = join(sshDir, "id_ed25519");
+    const privPath = join(sshDir, "spawn_ed25519");
     const pubPath = `${privPath}.pub`;
 
     let callCount = 0;
     const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        // First call: ssh-keygen -t ed25519 fails, but files appear (race)
+        // ssh-keygen "fails" but files appear (race)
         writeFileSync(privPath, "fake-priv\n", {
           mode: 0o600,
         });
         writeFileSync(pubPath, "ssh-ed25519 AAAA fake\n");
-        return makeSyncResult("", 1); // non-zero exit
+        return makeSyncResult("", 1);
       }
-      // Second call: ssh-keygen -lf for getKeyType
       return makeSyncResult("256 SHA256:abc user@host (ED25519)");
     });
 
-    const pair = generateSshKey();
+    const pair = getSpawnKey();
     spawnSpy.mockRestore();
-    expect(pair.name).toBe("id_ed25519");
+    expect(pair.name).toBe("spawn_ed25519");
     expect(existsSync(pair.privPath)).toBe(true);
   });
 
-  it("throws when ssh-keygen fails and no files created", () => {
+  it("throws when ssh-keygen fails and no files were created", () => {
     const sshDir = join(tmpDir, ".ssh");
     mkdirSync(sshDir, {
       recursive: true,
@@ -117,59 +111,52 @@ describe("generateSshKey race recovery", () => {
 
     const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(makeSyncResult("", 1));
 
-    expect(() => generateSshKey()).toThrow("SSH key generation failed");
+    expect(() => getSpawnKey()).toThrow("Spawn SSH key generation failed");
     spawnSpy.mockRestore();
   });
 });
 
-describe("discoverSshKeys with unknown key type", () => {
-  it("labels key as UNKNOWN when ssh-keygen -lf fails (after verification passes)", () => {
+describe("discoverLegacyKeys edge cases", () => {
+  it("labels legacy key as UNKNOWN when ssh-keygen has no parenthesized type", () => {
     const sshDir = join(tmpDir, ".ssh");
     mkdirSync(sshDir, {
       recursive: true,
       mode: 0o700,
     });
-    writeFileSync(join(sshDir, "id_custom"), "fake-priv\n", {
+    writeFileSync(join(sshDir, "id_rsa"), "fake-priv\n", {
       mode: 0o600,
     });
-    writeFileSync(join(sshDir, "id_custom.pub"), "some-key AAAA fake\n");
+    writeFileSync(join(sshDir, "id_rsa.pub"), "ssh-rsa AAAA fake\n");
 
-    // verify (`-y`) succeeds with matching pub; getKeyType (`-lf`) throws
+    // verifyKeyPair → match (deriv reads pub), getKeyType → no type
     const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation((args: string[]) => {
       if (args[1] === "-y") {
-        return makeSyncResult("some-key AAAA fake\n");
+        return makeSyncResult("ssh-rsa AAAA fake\n");
       }
-      throw new Error("command not found");
+      return makeSyncResult("256 SHA256:abc user@host"); // no (TYPE) suffix
     });
 
-    const keys = discoverSshKeys();
+    const keys = discoverLegacyKeys();
     spawnSpy.mockRestore();
     expect(keys).toHaveLength(1);
     expect(keys[0].type).toBe("UNKNOWN");
   });
 
-  it("labels key as UNKNOWN when ssh-keygen -lf output has no parenthesized type", () => {
+  it("skips passphrase-protected legacy keys (verifyKeyPair → unverifiable)", () => {
     const sshDir = join(tmpDir, ".ssh");
     mkdirSync(sshDir, {
       recursive: true,
       mode: 0o700,
     });
-    writeFileSync(join(sshDir, "id_weird"), "fake-priv\n", {
+    writeFileSync(join(sshDir, "id_ed25519"), "fake-priv\n", {
       mode: 0o600,
     });
-    writeFileSync(join(sshDir, "id_weird.pub"), "weird-key AAAA fake\n");
+    writeFileSync(join(sshDir, "id_ed25519.pub"), "ssh-ed25519 AAAA fake\n");
 
-    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation((args: string[]) => {
-      if (args[1] === "-y") {
-        return makeSyncResult("weird-key AAAA fake\n");
-      }
-      return makeSyncResult("256 SHA256:abc user@host"); // no (TYPE) suffix
-    });
-
-    const keys = discoverSshKeys();
+    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(makeSyncResult("", 1));
+    const keys = discoverLegacyKeys();
     spawnSpy.mockRestore();
-    expect(keys).toHaveLength(1);
-    expect(keys[0].type).toBe("UNKNOWN");
+    expect(keys).toEqual([]);
   });
 });
 
@@ -190,56 +177,5 @@ describe("getSshFingerprint edge cases", () => {
     const fp = getSshFingerprint("/tmp/fake.pub");
     spawnSpy.mockRestore();
     expect(fp).toBe("");
-  });
-});
-
-describe("discoverSshKeys sorting", () => {
-  it("sorts ed25519 before rsa before unknown types", () => {
-    const sshDir = join(tmpDir, ".ssh");
-    mkdirSync(sshDir, {
-      recursive: true,
-      mode: 0o700,
-    });
-    // Create 3 key pairs
-    writeFileSync(join(sshDir, "id_rsa"), "fake\n", {
-      mode: 0o600,
-    });
-    writeFileSync(join(sshDir, "id_rsa.pub"), "ssh-rsa AAAA\n");
-    writeFileSync(join(sshDir, "id_ecdsa"), "fake\n", {
-      mode: 0o600,
-    });
-    writeFileSync(join(sshDir, "id_ecdsa.pub"), "ecdsa-sha2 AAAA\n");
-    writeFileSync(join(sshDir, "id_ed25519"), "fake\n", {
-      mode: 0o600,
-    });
-    writeFileSync(join(sshDir, "id_ed25519.pub"), "ssh-ed25519 AAAA\n");
-
-    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation((args: string[]) => {
-      const path = String(args[args.length - 1]);
-      if (args[1] === "-y") {
-        // verify (`-y`) call: return the matching pub file contents from disk
-        if (path.endsWith("id_ed25519")) {
-          return makeSyncResult("ssh-ed25519 AAAA\n");
-        }
-        if (path.endsWith("id_rsa")) {
-          return makeSyncResult("ssh-rsa AAAA\n");
-        }
-        return makeSyncResult("ecdsa-sha2 AAAA\n");
-      }
-      if (path.includes("ed25519")) {
-        return makeSyncResult("256 SHA256:x (ED25519)");
-      }
-      if (path.includes("rsa")) {
-        return makeSyncResult("2048 SHA256:x (RSA)");
-      }
-      return makeSyncResult("256 SHA256:x (ECDSA)");
-    });
-
-    const keys = discoverSshKeys();
-    spawnSpy.mockRestore();
-
-    expect(keys[0].type).toBe("ED25519");
-    expect(keys[1].type).toBe("RSA");
-    expect(keys[2].type).toBe("ECDSA");
   });
 });

--- a/packages/cli/src/__tests__/ssh-keys.test.ts
+++ b/packages/cli/src/__tests__/ssh-keys.test.ts
@@ -1,12 +1,12 @@
 /**
- * ssh-keys.test.ts — Tests for shared SSH key discovery, selection, and generation.
+ * ssh-keys.test.ts — Tests for the spawn-owned SSH key with legacy fallback.
  *
  * Uses real temp directories for filesystem tests and spyOn(Bun, "spawnSync")
  * to mock ssh-keygen invocations — no real subprocess calls.
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tryCatch } from "@openrouter/spawn-shared";
 import { mockClackPrompts } from "./test-helpers";
@@ -19,13 +19,14 @@ mockClackPrompts({
 // ── Import after @clack/prompts mock ────────────────────────────────────────
 
 const {
-  discoverSshKeys,
-  generateSshKey,
+  getSpawnKey,
+  discoverLegacyKeys,
   getSshFingerprint,
   ensureSshKeys,
   getSshKeyOpts,
   verifyKeyPair,
   repairPubFromPriv,
+  SPAWN_KEY_NAME,
   _resetCache,
 } = await import("../shared/ssh-keys");
 
@@ -53,12 +54,7 @@ function cleanupTmpHome() {
   );
 }
 
-/**
- * Create a fake SSH key pair in the temp ~/.ssh directory.
- * Writes placeholder key files — no subprocess calls.
- * The getKeyType function internally calls Bun.spawnSync(["ssh-keygen", "-lf", ...]);
- * tests that exercise key type detection must mock Bun.spawnSync separately.
- */
+/** Create a fake key pair on disk. Does not call subprocesses. */
 function createFakeKeyPair(name: string, keyType: "ed25519" | "rsa" = "ed25519") {
   const sshDir = join(tmpDir, ".ssh");
   mkdirSync(sshDir, {
@@ -116,65 +112,46 @@ function makeSyncResult(text: string, exitCode = 0): Bun.SyncSubprocess<"pipe", 
   };
 }
 
-/**
- * Build a mock spawnSync implementation that returns ssh-keygen -lf output
- * for a given key type ("ED25519" or "RSA").
- */
 function sshKeygenLfResult(keyType: string): Bun.SyncSubprocess<"pipe", "pipe"> {
   return makeSyncResult(`256 SHA256:fakehash user@host (${keyType})`);
 }
 
-/**
- * Build a mock spawnSync result that simulates ssh-keygen -lf -E md5 output.
- */
 function sshKeygenMd5Result(): Bun.SyncSubprocess<"pipe", "pipe"> {
   return makeSyncResult("256 MD5:aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99 user@host (ED25519)");
 }
 
 /**
- * Smart mock for Bun.spawnSync that handles all three ssh-keygen invocations
- * used by ssh-keys.ts:
- *   - `ssh-keygen -y -P "" -f <priv>` (verifyKeyPair) — returns the contents
- *     of the corresponding .pub file from disk so verification reports "match"
- *   - `ssh-keygen -lf <pub>` (getKeyType) — returns lf output for the given
- *     keyType (default ED25519, or RSA if pub path contains "rsa")
+ * Smart mock for Bun.spawnSync that handles all ssh-keygen invocations:
+ *   - `ssh-keygen -y -P "" -f <priv>` (verifyKeyPair) — returns the .pub contents
+ *   - `ssh-keygen -lf <pub>` (getKeyType) — returns lf output
  *   - `ssh-keygen -lf <pub> -E md5` (getSshFingerprint) — returns MD5 output
  *
- * Pass `mismatch: true` to make verifyKeyPair return "mismatch" instead.
+ * Pass `mismatch: true` to make verifyKeyPair return a mismatched derivation.
  */
 function smartSshKeygenMock(opts: { mismatch?: boolean } = {}): (args: string[]) => Bun.SyncSubprocess<"pipe", "pipe"> {
   return (args: string[]) => {
     if (args[1] === "-y") {
-      const privPath = args[args.length - 1];
+      const privPath = String(args[args.length - 1]);
       const pubPath = `${privPath}.pub`;
       if (opts.mismatch) {
         return makeSyncResult("ssh-ed25519 AAAADIFFERENT spawn\n");
       }
-      const pubText = unwrapOrEmpty(() => readFileSync(pubPath, "utf-8"));
-      return makeSyncResult(pubText);
+      const r = tryCatch(() => readFileSync(pubPath, "utf-8"));
+      return makeSyncResult(r.ok ? r.data : "");
     }
     if (args.includes("-E") && args[args.indexOf("-E") + 1] === "md5") {
       return sshKeygenMd5Result();
     }
     if (args[1] === "-lf") {
-      const pubPath = args[2];
+      const pubPath = String(args[2]);
       const type = pubPath.includes("rsa") ? "RSA" : "ED25519";
       return sshKeygenLfResult(type);
     }
-    // Default: empty success
     return makeSyncResult("");
   };
 }
 
-function unwrapOrEmpty<T>(fn: () => T): T | "" {
-  const r = tryCatch(fn);
-  return r.ok ? r.data : "";
-}
-
-/**
- * Build a mock spawnSync result that simulates successful ssh-keygen key generation.
- * Also writes the expected output files so existsSync checks pass.
- */
+/** Mock ssh-keygen generation: write the expected output files so existsSync passes. */
 function sshKeygenGenerateResult(privPath: string): Bun.SyncSubprocess<"pipe", "pipe"> {
   const pubPath = `${privPath}.pub`;
   writeFileSync(privPath, "fake-private-key\n", {
@@ -196,138 +173,198 @@ afterEach(() => {
   cleanupTmpHome();
 });
 
-// ─── discoverSshKeys ────────────────────────────────────────────────────────
+// ─── getSpawnKey ────────────────────────────────────────────────────────────
 
-describe("discoverSshKeys", () => {
-  it("returns empty array when ~/.ssh does not exist", () => {
-    const keys = discoverSshKeys();
-    expect(keys).toEqual([]);
-  });
-
-  it("returns empty array when no .pub files exist", () => {
+describe("getSpawnKey", () => {
+  it("generates the spawn key when it does not exist", () => {
     const sshDir = join(tmpDir, ".ssh");
-    mkdirSync(sshDir, {
-      recursive: true,
-    });
-    writeFileSync(join(sshDir, "config"), "Host *\n");
-    const keys = discoverSshKeys();
-    expect(keys).toEqual([]);
-  });
+    const privPath = join(sshDir, SPAWN_KEY_NAME);
 
-  it("skips .pub files without matching private key", () => {
-    const sshDir = join(tmpDir, ".ssh");
-    mkdirSync(sshDir, {
-      recursive: true,
-    });
-    writeFileSync(join(sshDir, "orphan_key.pub"), "ssh-ed25519 AAAA...\n");
-    // No private key
-    const keys = discoverSshKeys();
-    expect(keys).toEqual([]);
-  });
-
-  it("discovers a single key pair", () => {
-    createFakeKeyPair("id_ed25519", "ed25519");
-    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(smartSshKeygenMock());
-    const keys = discoverSshKeys();
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(() => sshKeygenGenerateResult(privPath));
+    const pair = getSpawnKey();
     spawnSpy.mockRestore();
-    expect(keys).toHaveLength(1);
-    expect(keys[0].name).toBe("id_ed25519");
-    expect(keys[0].type).toContain("ED25519");
-    expect(keys[0].privPath).toContain("id_ed25519");
-    expect(keys[0].pubPath).toContain("id_ed25519.pub");
+
+    expect(pair.name).toBe(SPAWN_KEY_NAME);
+    expect(pair.type).toBe("ED25519");
+    expect(pair.privPath).toBe(privPath);
+    expect(pair.pubPath).toBe(`${privPath}.pub`);
+    expect(existsSync(pair.privPath)).toBe(true);
+    expect(existsSync(pair.pubPath)).toBe(true);
   });
 
-  it("auto-repairs pairs whose .pub does not match the local private key", () => {
-    const { pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
-    const staleContents = readFileSync(pubPath, "utf-8");
-    const derivedContents = "ssh-ed25519 AAAADERIVED spawn\n";
+  it("reuses existing spawn key without regenerating", () => {
+    createFakeKeyPair(SPAWN_KEY_NAME, "ed25519");
 
+    let generateCalls = 0;
     const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation((args: string[]) => {
-      if (args[1] === "-y") {
-        // ssh-keygen -y derives the *correct* pub from the priv
-        return makeSyncResult(derivedContents);
-      }
-      if (args.includes("-E") && args[args.indexOf("-E") + 1] === "md5") {
-        return sshKeygenMd5Result();
+      if (args[0] === "ssh-keygen" && args[1] === "-t") {
+        generateCalls++;
       }
       return sshKeygenLfResult("ED25519");
     });
 
-    const keys = discoverSshKeys();
+    const pair = getSpawnKey();
     spawnSpy.mockRestore();
 
-    // Pair is returned, not skipped
-    expect(keys).toHaveLength(1);
-    expect(keys[0].name).toBe("id_ed25519");
-    expect(keys[0].pubPath).toBe(pubPath);
-
-    // .pub has been rewritten with the derived contents
-    expect(readFileSync(pubPath, "utf-8")).toBe(derivedContents);
-
-    // The stale contents are preserved in a backup file
-    const sshDir = join(tmpDir, ".ssh");
-    const files = readdirSync(sshDir);
-    const backup = files.find((f) => f.startsWith("id_ed25519.pub.spawn-backup-"));
-    expect(backup).toBeDefined();
-    if (backup) {
-      expect(readFileSync(join(sshDir, backup), "utf-8")).toBe(staleContents);
-    }
+    expect(generateCalls).toBe(0);
+    expect(pair.name).toBe(SPAWN_KEY_NAME);
   });
 
-  it("skips pairs that ssh-keygen cannot derive (e.g. passphrase-protected)", () => {
-    createFakeKeyPair("id_ed25519", "ed25519");
-    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation((args: string[]) => {
-      if (args[1] === "-y") {
-        // Simulate ssh-keygen -y failing (e.g. passphrase prompt rejected)
-        return makeSyncResult("", 1);
-      }
-      return sshKeygenLfResult("ED25519");
-    });
-    const keys = discoverSshKeys();
-    spawnSpy.mockRestore();
-    expect(keys).toEqual([]);
-  });
-});
-
-// ─── generateSshKey ─────────────────────────────────────────────────────────
-
-describe("generateSshKey", () => {
-  it("generates an ed25519 key and returns the pair", () => {
+  it("recovers when ssh-keygen exits non-zero but files appear (race)", () => {
     const sshDir = join(tmpDir, ".ssh");
     mkdirSync(sshDir, {
       recursive: true,
       mode: 0o700,
     });
-    const privPath = join(sshDir, "id_ed25519");
+    const privPath = join(sshDir, SPAWN_KEY_NAME);
+    const pubPath = `${privPath}.pub`;
 
-    // Use mockImplementation so key files are written when ssh-keygen is
-    // "called", not at mock setup time. generateSshKey() checks existsSync()
-    // first — if the files already exist it reuses them instead of generating.
-    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(() => sshKeygenGenerateResult(privPath));
+    let callCount = 0;
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // ssh-keygen "fails" but files appear (race with another process)
+        writeFileSync(privPath, "fake-priv\n", {
+          mode: 0o600,
+        });
+        writeFileSync(pubPath, "ssh-ed25519 AAAA fake\n");
+        return makeSyncResult("", 1);
+      }
+      return sshKeygenLfResult("ED25519");
+    });
 
-    const pair = generateSshKey();
+    const pair = getSpawnKey();
     spawnSpy.mockRestore();
-    expect(pair.name).toBe("id_ed25519");
-    expect(pair.type).toBe("ED25519");
-    expect(pair.privPath).toContain("id_ed25519");
-    expect(pair.pubPath).toContain("id_ed25519.pub");
+    expect(pair.name).toBe(SPAWN_KEY_NAME);
     expect(existsSync(pair.privPath)).toBe(true);
-    expect(existsSync(pair.pubPath)).toBe(true);
   });
 
-  it("reuses existing key instead of regenerating (race condition safety)", () => {
-    // Simulate another process having already generated the key
-    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
-
-    // Mock getKeyType to return ED25519 for the existing key
-    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(sshKeygenLfResult("ED25519"));
-
-    const pair = generateSshKey();
+  it("throws when ssh-keygen fails and no files were created", () => {
+    const sshDir = join(tmpDir, ".ssh");
+    mkdirSync(sshDir, {
+      recursive: true,
+      mode: 0o700,
+    });
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(makeSyncResult("", 1));
+    expect(() => getSpawnKey()).toThrow("Spawn SSH key generation failed");
     spawnSpy.mockRestore();
-    expect(pair.name).toBe("id_ed25519");
-    expect(pair.type).toBe("ED25519");
-    expect(pair.privPath).toBe(privPath);
-    expect(pair.pubPath).toBe(pubPath);
+    stderrSpy.mockRestore();
+  });
+});
+
+// ─── discoverLegacyKeys ─────────────────────────────────────────────────────
+
+describe("discoverLegacyKeys", () => {
+  it("returns empty array when ~/.ssh does not exist", () => {
+    expect(discoverLegacyKeys()).toEqual([]);
+  });
+
+  it("returns empty array when no default-named keys exist", () => {
+    const sshDir = join(tmpDir, ".ssh");
+    mkdirSync(sshDir, {
+      recursive: true,
+    });
+    writeFileSync(join(sshDir, "config"), "Host *\n");
+    expect(discoverLegacyKeys()).toEqual([]);
+  });
+
+  it("ignores custom-named keys (only finds default names)", () => {
+    createFakeKeyPair("work_key", "ed25519");
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(smartSshKeygenMock());
+    const keys = discoverLegacyKeys();
+    spawnSpy.mockRestore();
+    expect(keys).toEqual([]);
+  });
+
+  it("excludes the spawn key itself", () => {
+    createFakeKeyPair(SPAWN_KEY_NAME, "ed25519");
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(smartSshKeygenMock());
+    const keys = discoverLegacyKeys();
+    spawnSpy.mockRestore();
+    expect(keys).toEqual([]);
+  });
+
+  it("finds id_ed25519 and id_rsa when present and valid", () => {
+    createFakeKeyPair("id_ed25519", "ed25519");
+    createFakeKeyPair("id_rsa", "rsa");
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(smartSshKeygenMock());
+    const keys = discoverLegacyKeys();
+    spawnSpy.mockRestore();
+
+    const names = keys.map((k) => k.name);
+    expect(names).toContain("id_ed25519");
+    expect(names).toContain("id_rsa");
+  });
+
+  it("skips a key when private file is missing", () => {
+    const sshDir = join(tmpDir, ".ssh");
+    mkdirSync(sshDir, {
+      recursive: true,
+      mode: 0o700,
+    });
+    writeFileSync(join(sshDir, "id_ed25519.pub"), "ssh-ed25519 AAAA orphan\n");
+    // No matching private key
+    const keys = discoverLegacyKeys();
+    expect(keys).toEqual([]);
+  });
+});
+
+// ─── verifyKeyPair / repairPubFromPriv ──────────────────────────────────────
+
+describe("verifyKeyPair", () => {
+  it("returns 'match' when derived pub equals .pub", () => {
+    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(smartSshKeygenMock());
+    expect(verifyKeyPair(privPath, pubPath)).toBe("match");
+    spawnSpy.mockRestore();
+  });
+
+  it("returns 'mismatch' when derived pub differs from .pub", () => {
+    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(
+      smartSshKeygenMock({
+        mismatch: true,
+      }),
+    );
+    expect(verifyKeyPair(privPath, pubPath)).toBe("mismatch");
+    spawnSpy.mockRestore();
+  });
+
+  it("returns 'unverifiable' when ssh-keygen -y exits non-zero", () => {
+    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
+    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(makeSyncResult("", 1));
+    expect(verifyKeyPair(privPath, pubPath)).toBe("unverifiable");
+    spawnSpy.mockRestore();
+  });
+});
+
+describe("repairPubFromPriv", () => {
+  it("rewrites .pub from derived contents and backs up the original", () => {
+    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
+    const derived = "ssh-ed25519 AAAADERIVED comment\n";
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation((args: string[]) => {
+      if (args[1] === "-y") {
+        return makeSyncResult(derived);
+      }
+      return makeSyncResult("");
+    });
+
+    const backup = repairPubFromPriv(privPath, pubPath);
+    spawnSpy.mockRestore();
+    expect(typeof backup).toBe("string");
+    if (typeof backup !== "string") {
+      throw new Error("backup is not a string");
+    }
+    expect(existsSync(backup)).toBe(true);
+    expect(readFileSync(pubPath, "utf-8")).toBe(derived);
+  });
+
+  it("returns null when private key cannot be derived", () => {
+    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
+    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(makeSyncResult("", 1));
+    expect(repairPubFromPriv(privPath, pubPath)).toBeNull();
+    spawnSpy.mockRestore();
   });
 });
 
@@ -339,7 +376,6 @@ describe("getSshFingerprint", () => {
     const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(sshKeygenMd5Result());
     const fp = getSshFingerprint(pubPath);
     spawnSpy.mockRestore();
-    // Should be a colon-separated hex string
     expect(fp).toMatch(/^[a-f0-9:]+$/);
     expect(fp.split(":")).toHaveLength(16);
   });
@@ -355,50 +391,49 @@ describe("getSshFingerprint", () => {
 // ─── ensureSshKeys ──────────────────────────────────────────────────────────
 
 describe("ensureSshKeys", () => {
-  it("generates a key when no keys are found", async () => {
+  it("returns just the spawn key when no legacy keys exist", async () => {
     const sshDir = join(tmpDir, ".ssh");
-    mkdirSync(sshDir, {
-      recursive: true,
-      mode: 0o700,
-    });
-    const privPath = join(sshDir, "id_ed25519");
+    const privPath = join(sshDir, SPAWN_KEY_NAME);
 
-    // Use mockImplementation so key files are written when ssh-keygen is
-    // "called", not at mock setup time. This prevents the early-return path
-    // in generateSshKey() from triggering due to pre-existing files.
     const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(() => sshKeygenGenerateResult(privPath));
-
     const keys = await ensureSshKeys();
     spawnSpy.mockRestore();
+
     expect(keys).toHaveLength(1);
-    expect(keys[0].name).toBe("id_ed25519");
-    expect(existsSync(keys[0].privPath)).toBe(true);
+    expect(keys[0].name).toBe(SPAWN_KEY_NAME);
   });
 
-  it("uses single key silently when only one is found", async () => {
-    createFakeKeyPair("id_rsa", "rsa");
-    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(smartSshKeygenMock());
-    const keys = await ensureSshKeys();
-    spawnSpy.mockRestore();
-    expect(keys).toHaveLength(1);
-    expect(keys[0].name).toBe("id_rsa");
-  });
-
-  it("uses all discovered keys when multiple exist", async () => {
+  it("places spawn key first, then legacy keys", async () => {
+    createFakeKeyPair(SPAWN_KEY_NAME, "ed25519");
     createFakeKeyPair("id_ed25519", "ed25519");
     createFakeKeyPair("id_rsa", "rsa");
 
     const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(smartSshKeygenMock());
-
     const keys = await ensureSshKeys();
     spawnSpy.mockRestore();
-    expect(keys).toHaveLength(2);
-    expect(keys[0].name).toBe("id_ed25519");
-    expect(keys[1].name).toBe("id_rsa");
+
+    expect(keys[0].name).toBe(SPAWN_KEY_NAME);
+    const legacyNames = keys.slice(1).map((k) => k.name);
+    expect(legacyNames).toContain("id_ed25519");
+    expect(legacyNames).toContain("id_rsa");
+  });
+
+  it("caps total keys at 3 to stay under typical sshd MaxAuthTries", async () => {
+    createFakeKeyPair(SPAWN_KEY_NAME, "ed25519");
+    createFakeKeyPair("id_ed25519", "ed25519");
+    createFakeKeyPair("id_rsa", "rsa");
+    createFakeKeyPair("id_ecdsa", "ed25519");
+
+    const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(smartSshKeygenMock());
+    const keys = await ensureSshKeys();
+    spawnSpy.mockRestore();
+
+    expect(keys).toHaveLength(3);
+    expect(keys[0].name).toBe(SPAWN_KEY_NAME);
   });
 
   it("caches results across calls", async () => {
-    createFakeKeyPair("id_ed25519", "ed25519");
+    createFakeKeyPair(SPAWN_KEY_NAME, "ed25519");
     const spawnSpy = spyOn(Bun, "spawnSync").mockImplementation(smartSshKeygenMock());
 
     const keys1 = await ensureSshKeys();
@@ -408,93 +443,15 @@ describe("ensureSshKeys", () => {
   });
 });
 
-// ─── verifyKeyPair ──────────────────────────────────────────────────────────
-
-describe("verifyKeyPair", () => {
-  it("returns 'match' when the derived public key equals the .pub file (ignoring comment)", () => {
-    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
-    // Same key core as createFakeKeyPair writes, with a different comment field
-    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(
-      makeSyncResult("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFake different-comment\n"),
-    );
-    const result = verifyKeyPair(privPath, pubPath);
-    spawnSpy.mockRestore();
-    expect(result).toBe("match");
-  });
-
-  it("returns 'mismatch' when the derived public key differs from the .pub file", () => {
-    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
-    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(
-      makeSyncResult("ssh-ed25519 AAAACOMPLETELYDIFFERENT spawn\n"),
-    );
-    const result = verifyKeyPair(privPath, pubPath);
-    spawnSpy.mockRestore();
-    expect(result).toBe("mismatch");
-  });
-
-  it("returns 'unverifiable' when ssh-keygen exits non-zero (e.g. passphrase)", () => {
-    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
-    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(makeSyncResult("", 1));
-    const result = verifyKeyPair(privPath, pubPath);
-    spawnSpy.mockRestore();
-    expect(result).toBe("unverifiable");
-  });
-
-  it("returns 'unverifiable' when the .pub file is missing or empty", () => {
-    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
-    rmSync(pubPath);
-    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(
-      makeSyncResult("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFake spawn\n"),
-    );
-    const result = verifyKeyPair(privPath, pubPath);
-    spawnSpy.mockRestore();
-    expect(result).toBe("unverifiable");
-  });
-});
-
-// ─── repairPubFromPriv ──────────────────────────────────────────────────────
-
-describe("repairPubFromPriv", () => {
-  it("rewrites the .pub from the derived key and backs up the original", () => {
-    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
-    const stale = readFileSync(pubPath, "utf-8");
-    const derived = "ssh-ed25519 AAAADERIVEDCONTENT spawn\n";
-    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(makeSyncResult(derived));
-
-    const backupPath = repairPubFromPriv(privPath, pubPath);
-    spawnSpy.mockRestore();
-
-    expect(backupPath).not.toBeNull();
-    expect(backupPath).toContain(".spawn-backup-");
-    expect(readFileSync(pubPath, "utf-8")).toBe(derived);
-    if (backupPath) {
-      expect(readFileSync(backupPath, "utf-8")).toBe(stale);
-    }
-  });
-
-  it("returns null when the private key cannot be derived (e.g. passphrase)", () => {
-    const { privPath, pubPath } = createFakeKeyPair("id_ed25519", "ed25519");
-    const stale = readFileSync(pubPath, "utf-8");
-    const spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue(makeSyncResult("", 1));
-
-    const backupPath = repairPubFromPriv(privPath, pubPath);
-    spawnSpy.mockRestore();
-
-    expect(backupPath).toBeNull();
-    // .pub is untouched, no backup created
-    expect(readFileSync(pubPath, "utf-8")).toBe(stale);
-  });
-});
-
 // ─── getSshKeyOpts ──────────────────────────────────────────────────────────
 
 describe("getSshKeyOpts", () => {
   it("builds -i flags for each key", () => {
     const keys = [
       {
-        privPath: "/home/user/.ssh/id_ed25519",
-        pubPath: "/home/user/.ssh/id_ed25519.pub",
-        name: "id_ed25519",
+        privPath: "/home/user/.ssh/spawn_ed25519",
+        pubPath: "/home/user/.ssh/spawn_ed25519.pub",
+        name: "spawn_ed25519",
         type: "ED25519",
       },
       {
@@ -507,7 +464,7 @@ describe("getSshKeyOpts", () => {
     const opts = getSshKeyOpts(keys);
     expect(opts).toEqual([
       "-i",
-      "/home/user/.ssh/id_ed25519",
+      "/home/user/.ssh/spawn_ed25519",
       "-i",
       "/home/user/.ssh/id_rsa",
     ]);

--- a/packages/cli/src/aws/aws.ts
+++ b/packages/cli/src/aws/aws.ts
@@ -22,7 +22,7 @@ import {
   spawnInteractive,
   validateRemotePath,
 } from "../shared/ssh.js";
-import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys.js";
+import { ensureSshKeys, getSpawnKey, getSshKeyOpts, SPAWN_KEY_NAME } from "../shared/ssh-keys.js";
 import {
   getServerNameFromEnv,
   jsonEscape,
@@ -857,9 +857,9 @@ async function lightsailGetInstance(instanceName: string): Promise<{
 // ─── SSH Key Management ─────────────────────────────────────────────────────
 
 export async function ensureSshKey(): Promise<void> {
-  const selectedKeys = await ensureSshKeys();
-  // Lightsail associates one key pair per instance — use the first selected key
-  const key = selectedKeys[0];
+  // Lightsail associates one key pair per instance — always use the
+  // spawn-managed key. User's personal keys stay off the AWS account.
+  const key = getSpawnKey();
 
   const pubPath = key.pubPath;
   if (!existsSync(pubPath)) {
@@ -1236,7 +1236,7 @@ export async function interactiveSession(cmd: string): Promise<number> {
   logInfo("  spawn delete");
   logInfo("To reconnect:");
   logInfo("  spawn last");
-  logInfo(`  or: ssh ${SSH_USER}@${_state.instanceIp}`);
+  logInfo(`  or: ssh -i ~/.ssh/${SPAWN_KEY_NAME} ${SSH_USER}@${_state.instanceIp}`);
 
   return exitCode;
 }

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -32,7 +32,7 @@ import {
   validateRemotePath,
   waitForSshSnapshotBoot,
 } from "../shared/ssh.js";
-import { ensureSshKeys, getSshFingerprint, getSshKeyOpts } from "../shared/ssh-keys.js";
+import { ensureSshKeys, getSpawnKey, getSshFingerprint, getSshKeyOpts, SPAWN_KEY_NAME } from "../shared/ssh-keys.js";
 import {
   defaultSpawnName,
   getServerNameFromEnv,
@@ -365,27 +365,18 @@ export async function fetchDoAccountSnapshot(): Promise<DoAccountSnapshot | null
 }
 
 /**
- * True if at least one local SSH key fingerprint is registered on the DO account.
+ * True if the spawn-managed key is registered on the DO account.
  */
 export async function areSshKeysRegisteredOnDigitalOcean(): Promise<boolean> {
   if (!_state.token) {
     return false;
   }
-  const selectedKeys = await ensureSshKeys();
-  if (selectedKeys.length === 0) {
+  const fingerprint = getSshFingerprint(getSpawnKey().pubPath);
+  if (!fingerprint) {
     return false;
   }
   const keys = await doGetAll("/account/keys", "ssh_keys");
-  for (const key of selectedKeys) {
-    const fingerprint = getSshFingerprint(key.pubPath);
-    if (!fingerprint) {
-      continue;
-    }
-    if (keys.some((k: Record<string, unknown>) => (k.fingerprint || "") === fingerprint)) {
-      return true;
-    }
-  }
-  return false;
+  return keys.some((k) => k.fingerprint === fingerprint);
 }
 
 /** Ensure attribution tag exists (ignore if already present or insufficient scope). */
@@ -966,55 +957,45 @@ export async function ensureDoToken(): Promise<boolean> {
 
 // ─── SSH Key Management ──────────────────────────────────────────────────────
 
+/** Register the spawn-managed key with DigitalOcean if not already present.
+ * Only the spawn key is uploaded — the user's personal keys stay private. */
 export async function ensureSshKey(): Promise<void> {
-  const selectedKeys = await ensureSshKeys();
-
-  // Fetch all registered keys (paginated) once before the loop to avoid N+1 API calls
-  const keys = await doGetAll("/account/keys", "ssh_keys");
-
-  for (const key of selectedKeys) {
-    const fingerprint = getSshFingerprint(key.pubPath);
-    if (!fingerprint) {
-      logWarn(`Could not determine fingerprint for SSH key '${key.name}'`);
-      continue;
-    }
-
-    const found = keys.some((k: Record<string, unknown>) => {
-      const fp = k.fingerprint || "";
-      return fp === fingerprint;
-    });
-
-    if (found) {
-      logInfo(`SSH key '${key.name}' already registered with DigitalOcean`);
-      continue;
-    }
-
-    // Register key
-    logStep(`Registering SSH key '${key.name}' with DigitalOcean...`);
-    const pubKey = readFileSync(key.pubPath, "utf-8").trim();
-    const body = JSON.stringify({
-      name: `spawn-${key.name}`,
-      public_key: pubKey,
-    });
-    const regResult = await asyncTryCatch(() => doApi("POST", "/account/keys", body));
-    if (!regResult.ok) {
-      const msg = getErrorMessage(regResult.error);
-      // Key may already exist under a different name — non-fatal
-      if (msg.includes("already been taken") || msg.includes("already in use")) {
-        logInfo(`SSH key '${key.name}' already registered (under a different name)`);
-        continue;
-      }
-      logWarn(`SSH key '${key.name}' registration may have failed, continuing...`);
-      continue;
-    }
-    const regData = parseJsonObj(regResult.data);
-    if (regData?.ssh_key) {
-      logInfo(`SSH key '${key.name}' registered with DigitalOcean`);
-      continue;
-    }
-
-    logWarn(`SSH key '${key.name}' registration may have failed, continuing...`);
+  const spawnKey = getSpawnKey();
+  const fingerprint = getSshFingerprint(spawnKey.pubPath);
+  if (!fingerprint) {
+    logWarn(`Could not determine fingerprint for SSH key '${spawnKey.name}'`);
+    return;
   }
+
+  const keys = await doGetAll("/account/keys", "ssh_keys");
+  const found = keys.some((k) => k.fingerprint === fingerprint);
+  if (found) {
+    logInfo(`SSH key '${spawnKey.name}' already registered with DigitalOcean`);
+    return;
+  }
+
+  logStep(`Registering SSH key '${spawnKey.name}' with DigitalOcean...`);
+  const pubKey = readFileSync(spawnKey.pubPath, "utf-8").trim();
+  const body = JSON.stringify({
+    name: `spawn-${spawnKey.name}`,
+    public_key: pubKey,
+  });
+  const regResult = await asyncTryCatch(() => doApi("POST", "/account/keys", body));
+  if (!regResult.ok) {
+    const msg = getErrorMessage(regResult.error);
+    if (msg.includes("already been taken") || msg.includes("already in use")) {
+      logInfo(`SSH key '${spawnKey.name}' already registered (under a different name)`);
+      return;
+    }
+    logWarn(`SSH key '${spawnKey.name}' registration may have failed, continuing...`);
+    return;
+  }
+  const regData = parseJsonObj(regResult.data);
+  if (regData?.ssh_key) {
+    logInfo(`SSH key '${spawnKey.name}' registered with DigitalOcean`);
+    return;
+  }
+  logWarn(`SSH key '${spawnKey.name}' registration may have failed, continuing...`);
 }
 
 // ─── Droplet Size Options ────────────────────────────────────────────────────
@@ -1214,16 +1195,21 @@ export async function createServer(
     `Creating DigitalOcean droplet '${name}' (size: ${size}, region: ${effectiveRegion}, image: ${imageLabel})...`,
   );
 
-  // Get all SSH key IDs (paginated to avoid missing keys beyond page 1)
-  const allKeys = await doGetAll("/account/keys", "ssh_keys");
-  const sshKeyIds: number[] = allKeys.map((k) => (isNumber(k.id) ? k.id : 0)).filter((n) => n > 0);
+  // Attach only the spawn-managed key — user's other registered keys stay off
+  // the droplet (privacy + avoids sshd MaxAuthTries flood on the client side).
+  const spawnFingerprint = getSshFingerprint(getSpawnKey().pubPath);
+  const sshKeys: string[] = spawnFingerprint
+    ? [
+        spawnFingerprint,
+      ]
+    : [];
 
   const dropletConfig: Record<string, unknown> = {
     name,
     region: effectiveRegion,
     size,
     image,
-    ssh_keys: sshKeyIds,
+    ssh_keys: sshKeys,
     backups: false,
     monitoring: false,
   };
@@ -1668,7 +1654,7 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   logInfo("  spawn delete");
   logInfo("To reconnect:");
   logInfo("  spawn last");
-  logInfo(`  or: ssh root@${serverIp}`);
+  logInfo(`  or: ssh -i ~/.ssh/${SPAWN_KEY_NAME} root@${serverIp}`);
 
   return exitCode;
 }

--- a/packages/cli/src/gcp/gcp.ts
+++ b/packages/cli/src/gcp/gcp.ts
@@ -19,7 +19,7 @@ import {
   spawnInteractive,
   validateRemotePath,
 } from "../shared/ssh.js";
-import { ensureSshKeys, getSshKeyOpts } from "../shared/ssh-keys.js";
+import { ensureSshKeys, getSpawnKey, getSshKeyOpts } from "../shared/ssh-keys.js";
 import {
   getServerNameFromEnv,
   logError,
@@ -642,15 +642,12 @@ export async function promptZone(): Promise<string> {
 // ─── SSH Key ────────────────────────────────────────────────────────────────
 
 async function ensureSshKey(): Promise<string> {
-  const selectedKeys = await ensureSshKeys();
-  // GCP accepts multiple ssh-keys in metadata, one per line
-  const pubKeys: string[] = [];
-  for (const key of selectedKeys) {
-    const pubKey = readFileSync(key.pubPath, "utf-8").trim();
-    pubKeys.push(pubKey);
-  }
-  logInfo(`${selectedKeys.length} SSH key(s) ready`);
-  return pubKeys.join("\n");
+  // Inject only the spawn-managed key into instance metadata. User's other
+  // local keys stay off the instance (privacy + avoids client-side auth flood).
+  const spawnKey = getSpawnKey();
+  const pubKey = readFileSync(spawnKey.pubPath, "utf-8").trim();
+  logInfo(`SSH key '${spawnKey.name}' ready`);
+  return pubKey;
 }
 
 // ─── Username ───────────────────────────────────────────────────────────────

--- a/packages/cli/src/hetzner/hetzner.ts
+++ b/packages/cli/src/hetzner/hetzner.ts
@@ -21,7 +21,7 @@ import {
   validateRemotePath,
   waitForSshSnapshotBoot,
 } from "../shared/ssh.js";
-import { ensureSshKeys, getSshFingerprint, getSshKeyOpts } from "../shared/ssh-keys.js";
+import { ensureSshKeys, getSpawnKey, getSshFingerprint, getSshKeyOpts, SPAWN_KEY_NAME } from "../shared/ssh-keys.js";
 import {
   getServerNameFromEnv,
   jsonEscape,
@@ -243,61 +243,51 @@ export async function ensureHcloudToken(): Promise<void> {
 
 // ─── SSH Key Management ──────────────────────────────────────────────────────
 
+/** Register the spawn-managed key with Hetzner if not already present.
+ * Only the spawn key is uploaded — the user's personal keys stay private. */
 export async function ensureSshKey(): Promise<void> {
-  const selectedKeys = await ensureSshKeys();
-
-  // Fetch all registered keys (paginated) once before the loop to avoid N+1 API calls
-  const sshKeys = await hetznerGetAll("/ssh_keys", "ssh_keys");
-
-  for (const key of selectedKeys) {
-    const fingerprint = getSshFingerprint(key.pubPath);
-    if (!fingerprint) {
-      logWarn(`Could not determine fingerprint for SSH key '${key.name}'`);
-      continue;
-    }
-    const pubKey = readFileSync(key.pubPath, "utf-8").trim();
-
-    const alreadyRegistered = sshKeys.some((k) => k.fingerprint === fingerprint);
-
-    if (alreadyRegistered) {
-      logInfo(`SSH key '${key.name}' already registered with Hetzner`);
-      continue;
-    }
-
-    // Register key
-    logStep(`Registering SSH key '${key.name}' with Hetzner...`);
-    const keyName = `spawn-${key.name}-${Date.now()}`;
-    const body = JSON.stringify({
-      name: keyName,
-      public_key: pubKey,
-    });
-    const regResult = await asyncTryCatch(() => hetznerApi("POST", "/ssh_keys", body));
-    if (!regResult.ok) {
-      // HTTP 409 "uniqueness_error" means the key already exists under a different
-      // name. Hetzner's error message says "SSH key not unique" which the API layer
-      // throws as an Error before we can parse the response body.
-      const errMsg = getErrorMessage(regResult.error);
-      if (/uniqueness_error|not unique|already/.test(errMsg)) {
-        logInfo(`SSH key '${key.name}' already registered (different name)`);
-        continue;
-      }
-      throw regResult.error;
-    }
-    const regResp = regResult.data;
-    const regData = parseJsonObj(regResp);
-    const regError = toRecord(regData?.error);
-    const regErrMsg = isString(regError?.message) ? regError.message : "";
-    if (regErrMsg) {
-      // Key may already exist under a different name — non-fatal
-      if (/already|uniqueness|not unique/.test(regErrMsg)) {
-        logInfo(`SSH key '${key.name}' already registered (different name)`);
-        continue;
-      }
-      logError(`Failed to register SSH key '${key.name}': ${regErrMsg}`);
-      throw new Error("SSH key registration failed");
-    }
-    logInfo(`SSH key '${key.name}' registered with Hetzner`);
+  const spawnKey = getSpawnKey();
+  const fingerprint = getSshFingerprint(spawnKey.pubPath);
+  if (!fingerprint) {
+    logWarn(`Could not determine fingerprint for SSH key '${spawnKey.name}'`);
+    return;
   }
+  const pubKey = readFileSync(spawnKey.pubPath, "utf-8").trim();
+
+  const sshKeys = await hetznerGetAll("/ssh_keys", "ssh_keys");
+  const alreadyRegistered = sshKeys.some((k) => k.fingerprint === fingerprint);
+  if (alreadyRegistered) {
+    logInfo(`SSH key '${spawnKey.name}' already registered with Hetzner`);
+    return;
+  }
+
+  logStep(`Registering SSH key '${spawnKey.name}' with Hetzner...`);
+  const keyName = `spawn-${spawnKey.name}-${Date.now()}`;
+  const body = JSON.stringify({
+    name: keyName,
+    public_key: pubKey,
+  });
+  const regResult = await asyncTryCatch(() => hetznerApi("POST", "/ssh_keys", body));
+  if (!regResult.ok) {
+    const errMsg = getErrorMessage(regResult.error);
+    if (/uniqueness_error|not unique|already/.test(errMsg)) {
+      logInfo(`SSH key '${spawnKey.name}' already registered (different name)`);
+      return;
+    }
+    throw regResult.error;
+  }
+  const regData = parseJsonObj(regResult.data);
+  const regError = toRecord(regData?.error);
+  const regErrMsg = isString(regError?.message) ? regError.message : "";
+  if (regErrMsg) {
+    if (/already|uniqueness|not unique/.test(regErrMsg)) {
+      logInfo(`SSH key '${spawnKey.name}' already registered (different name)`);
+      return;
+    }
+    logError(`Failed to register SSH key '${spawnKey.name}': ${regErrMsg}`);
+    throw new Error("SSH key registration failed");
+  }
+  logInfo(`SSH key '${spawnKey.name}' registered with Hetzner`);
 }
 
 // ─── Cloud Init Userdata ────────────────────────────────────────────────────
@@ -549,9 +539,14 @@ export async function createServer(
     throw new Error("Invalid location");
   }
 
-  // Get all SSH key IDs once (paginated to avoid missing keys beyond page 1)
+  // Attach only the spawn-managed key (look it up by fingerprint among the
+  // account's keys). User's other registered keys stay off the server.
+  const spawnFingerprint = getSshFingerprint(getSpawnKey().pubPath);
   const allKeys = await hetznerGetAll("/ssh_keys", "ssh_keys");
-  const sshKeyIds: number[] = allKeys.map((k) => (isNumber(k.id) ? k.id : 0)).filter(Boolean);
+  const sshKeyIds: number[] = allKeys
+    .filter((k) => k.fingerprint === spawnFingerprint)
+    .map((k) => (isNumber(k.id) ? k.id : 0))
+    .filter(Boolean);
   const userdata = getCloudInitUserdata(tier);
 
   // Track locations that failed so the user isn't offered them again
@@ -939,7 +934,7 @@ export async function interactiveSession(cmd: string, ip?: string): Promise<numb
   logInfo("  spawn delete");
   logInfo("To reconnect:");
   logInfo("  spawn last");
-  logInfo(`  or: ssh root@${serverIp}`);
+  logInfo(`  or: ssh -i ~/.ssh/${SPAWN_KEY_NAME} root@${serverIp}`);
 
   return exitCode;
 }

--- a/packages/cli/src/shared/ssh-keys.ts
+++ b/packages/cli/src/shared/ssh-keys.ts
@@ -1,112 +1,49 @@
-// shared/ssh-keys.ts — SSH key discovery, selection, and generation
+// shared/ssh-keys.ts — Spawn-owned SSH key with legacy fallback for back-compat
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { getSshDir } from "./paths.js";
 import { isFileError, tryCatch, tryCatchIf, unwrapOr } from "./result.js";
-import { logInfo, logStep, logWarn } from "./ui.js";
+import { logInfo, logStep } from "./ui.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface SshKeyPair {
   privPath: string;
   pubPath: string;
-  /** Base name, e.g. "id_ed25519" or "work_key" */
+  /** Base name, e.g. "spawn_ed25519" or "id_rsa" */
   name: string;
   /** Key algorithm, e.g. "ED25519", "RSA" */
   type: string;
 }
 
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Filename of the spawn-managed key under ~/.ssh/. */
+export const SPAWN_KEY_NAME = "spawn_ed25519";
+
+/** Default key filenames OpenSSH auto-tries; used as legacy -i fallbacks
+ * so droplets provisioned by older Spawn versions stay reachable. */
+const LEGACY_KEY_NAMES = [
+  "id_ed25519",
+  "id_rsa",
+  "id_ecdsa",
+];
+
+/** Cap the total number of -i flags to stay under a typical sshd MaxAuthTries. */
+const MAX_KEYS = 3;
+
 // ─── Module-level cache ─────────────────────────────────────────────────────
 
+let cachedSpawnKey: SshKeyPair | null = null;
 let cachedKeys: SshKeyPair[] | null = null;
 
 /** Reset the module-level cache (for testing). */
 export function _resetCache(): void {
+  cachedSpawnKey = null;
   cachedKeys = null;
 }
 
-// ─── Key Discovery ──────────────────────────────────────────────────────────
-
-/** Scan ~/.ssh/ for valid key pairs and extract key types. */
-export function discoverSshKeys(): SshKeyPair[] {
-  const sshDir = getSshDir();
-  if (!existsSync(sshDir)) {
-    return [];
-  }
-
-  const dirResult = tryCatchIf(isFileError, () => readdirSync(sshDir));
-  if (!dirResult.ok) {
-    return [];
-  }
-  const entries = dirResult.data;
-
-  const pubFiles = entries.filter((f) => f.endsWith(".pub"));
-  const pairs: SshKeyPair[] = [];
-
-  for (const pubFile of pubFiles) {
-    const baseName = pubFile.slice(0, -4); // strip ".pub"
-    const pubPath = `${sshDir}/${pubFile}`;
-    const privPath = `${sshDir}/${baseName}`;
-
-    if (!existsSync(privPath)) {
-      continue;
-    }
-
-    // Auto-repair pairs whose public key doesn't pair with the private key.
-    // Without this, the stale .pub gets registered with the cloud provider and
-    // SSH fails with "Permission denied (publickey)" because the local .priv
-    // can't prove ownership of that .pub. The .priv is authoritative — any .pub
-    // that doesn't derive from it is wrong by definition, so we back up the
-    // stale file and rewrite .pub from the derived key.
-    //
-    // Passphrase-protected and otherwise unverifiable keys are skipped silently
-    // — BatchMode SSH can't use them without an active ssh-agent anyway.
-    const verification = verifyKeyPair(privPath, pubPath);
-    if (verification === "mismatch") {
-      const repaired = repairPubFromPriv(privPath, pubPath);
-      if (!repaired) {
-        logWarn(
-          `SSH key '${baseName}' skipped: ${pubPath} does not pair with the local private key and could not be repaired automatically.`,
-        );
-        continue;
-      }
-      logInfo(`Repaired ${pubPath} (stale public key replaced; original saved as ${repaired}).`);
-      // fall through — pair is now valid
-    } else if (verification === "unverifiable") {
-      continue;
-    }
-
-    // Extract key type via ssh-keygen
-    const keyType = getKeyType(pubPath);
-    pairs.push({
-      privPath,
-      pubPath,
-      name: baseName,
-      type: keyType,
-    });
-  }
-
-  // Sort: ed25519 first, then rsa, then others; alphabetical within each group
-  pairs.sort((a, b) => {
-    const order = (t: string) => {
-      const upper = t.toUpperCase();
-      if (upper.includes("ED25519")) {
-        return 0;
-      }
-      if (upper.includes("RSA")) {
-        return 1;
-      }
-      return 2;
-    };
-    const diff = order(a.type) - order(b.type);
-    if (diff !== 0) {
-      return diff;
-    }
-    return a.name.localeCompare(b.name);
-  });
-
-  return pairs;
-}
+// ─── Pubkey helpers ─────────────────────────────────────────────────────────
 
 /**
  * Read the first two whitespace-separated fields ("type base64") from an OpenSSH
@@ -164,11 +101,9 @@ function derivePubFromPriv(privPath: string): string {
  * derive the public key from the private key and compare to the `.pub`.
  *
  * Returns:
- *   - "match"       — derived public matches `.pub`
- *   - "mismatch"    — files exist but do NOT pair (silent-failure source)
+ *   - "match"        — derived public matches `.pub`
+ *   - "mismatch"     — files exist but do NOT pair (silent-failure source)
  *   - "unverifiable" — passphrase-protected, corrupt, or otherwise can't derive
- *                     (skip silently — spawn's BatchMode SSH can't use these
- *                     anyway unless the user has them in ssh-agent)
  */
 export function verifyKeyPair(privPath: string, pubPath: string): "match" | "mismatch" | "unverifiable" {
   const derivedCore = pubKeyCore(derivePubFromPriv(privPath));
@@ -193,11 +128,7 @@ export function verifyKeyPair(privPath: string, pubPath: string): "match" | "mis
  *
  * The original `.pub` is preserved as `<pubPath>.spawn-backup-<timestamp>` so
  * the user can inspect what was replaced. Returns the backup path on success,
- * or null if the private key couldn't be read (passphrase-protected, etc.) or
- * the filesystem write failed.
- *
- * Safe because the `.priv` is authoritative: any `.pub` that doesn't derive
- * from it is wrong by definition.
+ * or null if the private key couldn't be read or the filesystem write failed.
  */
 export function repairPubFromPriv(privPath: string, pubPath: string): string | null {
   const derived = derivePubFromPriv(privPath);
@@ -245,81 +176,6 @@ function getKeyType(pubPath: string): string {
   );
 }
 
-// ─── Key Generation ─────────────────────────────────────────────────────────
-
-/** Generate a new ed25519 key at ~/.ssh/id_ed25519. Returns the pair. */
-export function generateSshKey(): SshKeyPair {
-  const sshDir = getSshDir();
-  const privPath = `${sshDir}/id_ed25519`;
-  const pubPath = `${privPath}.pub`;
-
-  mkdirSync(sshDir, {
-    recursive: true,
-    mode: 0o700,
-  });
-
-  // If the key already exists (e.g. another concurrent process generated it),
-  // reuse it instead of failing. ssh-keygen prompts for overwrite on stdin,
-  // which fails when stdin is "ignore".
-  if (existsSync(privPath) && existsSync(pubPath)) {
-    logInfo("SSH key already exists, reusing");
-    const keyType = getKeyType(pubPath);
-    return {
-      privPath,
-      pubPath,
-      name: "id_ed25519",
-      type: keyType,
-    };
-  }
-
-  logStep("Generating SSH key...");
-  const result = Bun.spawnSync(
-    [
-      "ssh-keygen",
-      "-t",
-      "ed25519",
-      "-f",
-      privPath,
-      "-N",
-      "",
-      "-C",
-      "spawn",
-    ],
-    {
-      stdio: [
-        "ignore",
-        "pipe",
-        "pipe",
-      ],
-    },
-  );
-  if (result.exitCode !== 0) {
-    // Another process may have created the key between our check and ssh-keygen.
-    // Re-check before throwing.
-    if (existsSync(privPath) && existsSync(pubPath)) {
-      logInfo("SSH key created by another process, reusing");
-      const keyType = getKeyType(pubPath);
-      return {
-        privPath,
-        pubPath,
-        name: "id_ed25519",
-        type: keyType,
-      };
-    }
-    throw new Error("SSH key generation failed");
-  }
-  logInfo("SSH key generated");
-
-  return {
-    privPath,
-    pubPath,
-    name: "id_ed25519",
-    type: "ED25519",
-  };
-}
-
-// ─── Fingerprint ────────────────────────────────────────────────────────────
-
 /** Get the MD5 fingerprint of a public key (for cloud provider matching). */
 export function getSshFingerprint(pubPath: string): string {
   return unwrapOr(
@@ -349,33 +205,155 @@ export function getSshFingerprint(pubPath: string): string {
   );
 }
 
+// ─── Spawn Key Management ───────────────────────────────────────────────────
+
+/**
+ * Ensure the spawn-managed ed25519 key exists at ~/.ssh/spawn_ed25519 and
+ * return it. Generated on first use, then cached. The custom filename avoids
+ * clobbering the user's personal `id_ed25519` and keeps Spawn's key isolated
+ * from the rest of their SSH setup.
+ */
+export function getSpawnKey(): SshKeyPair {
+  if (cachedSpawnKey) {
+    return cachedSpawnKey;
+  }
+
+  const sshDir = getSshDir();
+  const privPath = `${sshDir}/${SPAWN_KEY_NAME}`;
+  const pubPath = `${privPath}.pub`;
+
+  mkdirSync(sshDir, {
+    recursive: true,
+    mode: 0o700,
+  });
+
+  if (existsSync(privPath) && existsSync(pubPath)) {
+    cachedSpawnKey = {
+      privPath,
+      pubPath,
+      name: SPAWN_KEY_NAME,
+      type: getKeyType(pubPath),
+    };
+    return cachedSpawnKey;
+  }
+
+  logStep("Generating Spawn SSH key...");
+  const result = Bun.spawnSync(
+    [
+      "ssh-keygen",
+      "-t",
+      "ed25519",
+      "-f",
+      privPath,
+      "-N",
+      "",
+      "-C",
+      "spawn",
+    ],
+    {
+      stdio: [
+        "ignore",
+        "pipe",
+        "pipe",
+      ],
+    },
+  );
+  if (result.exitCode !== 0) {
+    // Race: another process may have created the key between our check and ssh-keygen.
+    if (existsSync(privPath) && existsSync(pubPath)) {
+      cachedSpawnKey = {
+        privPath,
+        pubPath,
+        name: SPAWN_KEY_NAME,
+        type: getKeyType(pubPath),
+      };
+      return cachedSpawnKey;
+    }
+    throw new Error("Spawn SSH key generation failed");
+  }
+  logInfo(`Spawn SSH key generated at ~/.ssh/${SPAWN_KEY_NAME}`);
+
+  cachedSpawnKey = {
+    privPath,
+    pubPath,
+    name: SPAWN_KEY_NAME,
+    type: "ED25519",
+  };
+  return cachedSpawnKey;
+}
+
+/**
+ * Discover pre-existing default-named keys (id_ed25519, id_rsa, id_ecdsa) in
+ * ~/.ssh/, excluding the spawn-managed key. Used as -i fallbacks so droplets
+ * provisioned by older Spawn versions (which registered the user's personal
+ * keys with the cloud account) remain SSH-reachable.
+ *
+ * Stale .pub files are auto-repaired against their .priv (the .priv is
+ * authoritative; a non-derivable .pub is wrong by definition). Passphrase-
+ * protected and unverifiable pairs are skipped silently — BatchMode SSH can't
+ * use those without an active ssh-agent anyway.
+ */
+export function discoverLegacyKeys(): SshKeyPair[] {
+  const sshDir = getSshDir();
+  if (!existsSync(sshDir)) {
+    return [];
+  }
+
+  const pairs: SshKeyPair[] = [];
+  for (const baseName of LEGACY_KEY_NAMES) {
+    if (baseName === SPAWN_KEY_NAME) {
+      continue;
+    }
+    const privPath = `${sshDir}/${baseName}`;
+    const pubPath = `${privPath}.pub`;
+    if (!existsSync(privPath) || !existsSync(pubPath)) {
+      continue;
+    }
+
+    const verification = verifyKeyPair(privPath, pubPath);
+    if (verification === "mismatch") {
+      const repaired = repairPubFromPriv(privPath, pubPath);
+      if (!repaired) {
+        continue;
+      }
+    } else if (verification === "unverifiable") {
+      continue;
+    }
+
+    pairs.push({
+      privPath,
+      pubPath,
+      name: baseName,
+      type: getKeyType(pubPath),
+    });
+  }
+  return pairs;
+}
+
 // ─── Main Entry Point ───────────────────────────────────────────────────────
 
 /**
- * Discover, generate, or use all SSH keys automatically.
+ * Return the keys to offer when SSHing to a Spawn-managed VM.
  *
- * - 0 keys found → generate one, return [generatedKey]
- * - 1+ keys found → use all silently (ed25519 preferred, sorted first)
+ * - First entry is always the spawn-managed key (generated if missing) — this
+ *   is what new VMs are provisioned with.
+ * - Followed by any pre-existing default-named keys as legacy -i fallbacks
+ *   so VMs provisioned by older Spawn versions remain reachable.
+ * - Capped at MAX_KEYS so we stay under a typical sshd MaxAuthTries (6).
  *
- * Results are cached at module level so subsequent calls return instantly.
+ * Cached at module level so subsequent calls return instantly.
  */
 export async function ensureSshKeys(): Promise<SshKeyPair[]> {
   if (cachedKeys) {
     return cachedKeys;
   }
 
-  const discovered = discoverSshKeys();
-
-  if (discovered.length === 0) {
-    const generated = generateSshKey();
-    cachedKeys = [
-      generated,
-    ];
-    return cachedKeys;
-  }
-
-  logInfo(`Using ${discovered.length} SSH key(s)`);
-  cachedKeys = discovered;
+  const spawnKey = getSpawnKey();
+  const legacy = discoverLegacyKeys();
+  cachedKeys = [
+    spawnKey,
+    ...legacy,
+  ].slice(0, MAX_KEYS);
   return cachedKeys;
 }
 

--- a/packages/cli/src/shared/ssh.ts
+++ b/packages/cli/src/shared/ssh.ts
@@ -8,7 +8,12 @@ import { logError, logInfo, logStep, logStepDone, logStepInline } from "./ui.js"
 
 // ─── Shared SSH Options ──────────────────────────────────────────────────────
 
-/** Base SSH options shared across all clouds (array form for Bun.spawn). */
+/** Base SSH options shared across all clouds (array form for Bun.spawn).
+ *
+ * IdentitiesOnly=yes forces ssh to use only the keys passed via -i and ignore
+ * agent-loaded identities. Without it, a user with several keys in ssh-agent
+ * can hit the server's MaxAuthTries (default 6) before our -i key is offered,
+ * producing a misleading "Permission denied (publickey)". */
 export const SSH_BASE_OPTS: string[] = [
   "-o",
   "StrictHostKeyChecking=accept-new",
@@ -28,6 +33,8 @@ export const SSH_BASE_OPTS: string[] = [
   "TCPKeepAlive=no",
   "-o",
   "BatchMode=yes",
+  "-o",
+  "IdentitiesOnly=yes",
 ];
 
 /**
@@ -67,6 +74,8 @@ export const SSH_INTERACTIVE_OPTS: string[] = [
   "EscapeChar=none",
   "-o",
   "AddressFamily=inet",
+  "-o",
+  "IdentitiesOnly=yes",
   "-t",
 ];
 


### PR DESCRIPTION
## Summary

Fixes the SSH handshake failure Chris hit on hermes/digitalocean (\"Permission denied (publickey)\" despite the key being registered in the DO dashboard). Root cause: when a user has several keys in \`ssh-agent\`, OpenSSH offers them all before our \`-i\` keys. sshd's default \`MaxAuthTries=6\` boots the connection before the right key is tried.

Two changes:

1. **\`IdentitiesOnly=yes\`** added to \`SSH_BASE_OPTS\` + \`SSH_INTERACTIVE_OPTS\` so ssh ignores agent identities and only uses the \`-i\` keys we pass.
2. **Spawn-owned key** at \`~/.ssh/spawn_ed25519\`. New VMs across all 4 clouds (DO/Hetzner/AWS/GCP) are provisioned with **only** this key. The user's personal keys (\`id_ed25519\`, \`id_rsa\`) stay off cloud accounts — privacy win, also fixes the scenario where Alex's dad's personal keys were silently uploaded to a fresh DO account on first run.

## Backwards compatibility

\`ensureSshKeys()\` still returns \`[spawnKey, ...legacyKeys]\` capped at 3, so droplets provisioned by older Spawn versions (which registered the user's old \`id_ed25519\`) remain SSH-reachable through the legacy \`-i\` fallback.

Reconnect hints across all clouds now print \`ssh -i ~/.ssh/spawn_ed25519 root@<ip>\` since the custom filename isn't auto-tried by bare \`ssh root@<ip>\`.

## Test plan

- [ ] Tests pass locally (\`bun test\`) — only 4 pre-existing failures remain, identical to upstream/main on this commit
- [ ] Biome clean (\`bunx @biomejs/biome check src/\`)
- [ ] Manually spawn a fresh DO droplet and confirm SSH handshake succeeds
- [ ] Repeat with multiple keys loaded in ssh-agent — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)