### PR TITLE
refactor(link): extract 5 helpers from 270-line cmdLink()

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,34 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let apiCalls = 0;
+    let oauthChecks = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      // (avoids starting a real Bun.serve OAuth server)
+      if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthChecks++;
+        return Promise.reject(new Error("network unavailable"));
+      }
+      // DigitalOcean API calls — return 401
+      if (urlStr.includes("api.digitalocean.com")) {
+        apiCalls++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
-      // (avoids starting a real Bun.serve OAuth server)
-      if (urlStr.includes("cloud.digitalocean.com")) {
-        return Promise.reject(new Error("network unavailable"));
-      }
-      return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
-        }),
-      );
+      // Ignore unrelated calls (e.g. telemetry flush)
+      return Promise.resolve(new Response("ok"));
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted (API call + OAuth connectivity check + retries)
-    expect(callCount).toBeGreaterThanOrEqual(2);
+    // Verify recovery was attempted: 1 API call + 1 connectivity check
+    expect(apiCalls).toBe(1);
+    expect(oauthChecks).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,34 +88,34 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let apiCalls = 0;
+    let oauthChecks = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
-      // First call: the actual API call returning 401
-      if (callCount === 1) {
+      // OAuth connectivity check — fail it so tryDoOAuth returns null quickly
+      // (avoids starting a real Bun.serve OAuth server)
+      if (urlStr.includes("cloud.digitalocean.com")) {
+        oauthChecks++;
+        return Promise.reject(new Error("network unavailable"));
+      }
+      // DigitalOcean API calls — return 401
+      if (urlStr.includes("api.digitalocean.com")) {
+        apiCalls++;
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,
           }),
         );
       }
-      // Second call: OAuth connectivity check — fail it so tryDoOAuth returns null quickly
-      // (avoids starting a real Bun.serve OAuth server)
-      if (urlStr.includes("cloud.digitalocean.com")) {
-        return Promise.reject(new Error("network unavailable"));
-      }
-      return Promise.resolve(
-        new Response("Unauthorized", {
-          status: 401,
-        }),
-      );
+      // Ignore unrelated calls (e.g. telemetry flush)
+      return Promise.resolve(new Response("ok"));
     });
 
     // OAuth recovery fails (connectivity check fails), so doApi throws the 401
     await expect(doApi("GET", "/account", undefined, 1)).rejects.toThrow("DigitalOcean API error 401");
-    // Verify recovery was attempted: 1 API call + 1 connectivity check = 2
-    expect(callCount).toBe(2);
+    // Verify recovery was attempted: 1 API call + 1 connectivity check
+    expect(apiCalls).toBe(1);
+    expect(oauthChecks).toBe(1);
   });
 
   it("succeeds after OAuth recovery provides a new token", async () => {

--- a/packages/cli/src/__tests__/hetzner-cov.test.ts
+++ b/packages/cli/src/__tests__/hetzner-cov.test.ts
@@ -585,47 +585,46 @@ describe("hetzner/createServer", () => {
         },
       },
     };
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
-        // Token validation
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              servers: [],
-            }),
-          ),
-        );
+    let hetznerCalls = 0;
+    let postServerAttempts = 0;
+    global.fetch = mock((url: string | URL | Request, opts?: RequestInit) => {
+      const urlStr = String(url);
+      // Ignore non-Hetzner calls (e.g. telemetry flush)
+      if (!urlStr.includes("api.hetzner.cloud")) {
+        return Promise.resolve(new Response("ok"));
       }
-      if (callCount <= 2) {
-        // SSH keys
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              ssh_keys: [],
-            }),
-          ),
-        );
-      }
-      if (callCount <= 3) {
-        // First create attempt — resource_limit_exceeded (HTTP 403)
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              error: {
-                code: "resource_limit_exceeded",
-                message: "primary_ip_limit",
+      hetznerCalls++;
+      const method = opts?.method ?? "GET";
+      // POST /servers — first attempt fails, retry succeeds
+      if (method === "POST" && urlStr.includes("/servers")) {
+        postServerAttempts++;
+        if (postServerAttempts === 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                error: {
+                  code: "resource_limit_exceeded",
+                  message: "primary_ip_limit",
+                },
+              }),
+              {
+                status: 403,
               },
-            }),
-            {
-              status: 403,
-            },
-          ),
+            ),
+          );
+        }
+        return Promise.resolve(new Response(JSON.stringify(serverResp)));
+      }
+      // DELETE /primary_ips — cleanup orphaned IP
+      if (method === "DELETE" && urlStr.includes("/primary_ips/")) {
+        return Promise.resolve(
+          new Response("", {
+            status: 204,
+          }),
         );
       }
-      if (callCount <= 4) {
-        // List primary IPs for cleanup
+      // GET /primary_ips — list IPs for cleanup
+      if (urlStr.includes("/primary_ips")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -645,40 +644,8 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 5) {
-        // Delete orphaned IP 100
-        return Promise.resolve(
-          new Response("", {
-            status: 204,
-          }),
-        );
-      }
-      // Retry create — success
-      return Promise.resolve(new Response(JSON.stringify(serverResp)));
-    });
-    const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
-    await ensureHcloudToken();
-    const conn = await createServer("test-retry", "cx23", "fsn1");
-    expect(conn.ip).toBe("10.0.0.5");
-    // Should have called: token(1), ssh_keys(2), create-fail(3), list-ips(4), delete-ip(5), create-ok(6)
-    expect(callCount).toBeGreaterThanOrEqual(6);
-  });
-
-  it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {
-    process.env.HCLOUD_TOKEN = "test-token";
-    let callCount = 0;
-    global.fetch = mock(() => {
-      callCount++;
-      if (callCount <= 1) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              servers: [],
-            }),
-          ),
-        );
-      }
-      if (callCount <= 2) {
+      // GET /ssh_keys
+      if (urlStr.includes("/ssh_keys")) {
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -687,8 +654,39 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      if (callCount <= 3) {
-        // Create fails with resource_limit_exceeded
+      // GET /servers (token validation)
+      if (urlStr.includes("/servers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              servers: [],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify({})));
+    });
+    const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
+    await ensureHcloudToken();
+    const conn = await createServer("test-retry", "cx23", "fsn1");
+    expect(conn.ip).toBe("10.0.0.5");
+    // Should have called: token, ssh_keys, create-fail, list-ips, delete-ip, create-ok
+    expect(hetznerCalls).toBeGreaterThanOrEqual(6);
+  });
+
+  it("throws with guidance when resource limit hit and no orphaned IPs to clean", async () => {
+    process.env.HCLOUD_TOKEN = "test-token";
+    let postServerAttempts = 0;
+    global.fetch = mock((url: string | URL | Request, opts?: RequestInit) => {
+      const urlStr = String(url);
+      // Ignore non-Hetzner calls (e.g. telemetry flush)
+      if (!urlStr.includes("api.hetzner.cloud")) {
+        return Promise.resolve(new Response("ok"));
+      }
+      const method = opts?.method ?? "GET";
+      // POST /servers — always fail with resource_limit_exceeded
+      if (method === "POST" && urlStr.includes("/servers")) {
+        postServerAttempts++;
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -703,20 +701,43 @@ describe("hetzner/createServer", () => {
           ),
         );
       }
-      // List primary IPs — all attached (none orphaned)
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            primary_ips: [
-              {
-                id: 100,
-                ip: "1.2.3.4",
-                assignee_id: 42,
-              },
-            ],
-          }),
-        ),
-      );
+      // GET /primary_ips — all attached (none orphaned)
+      if (urlStr.includes("/primary_ips")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              primary_ips: [
+                {
+                  id: 100,
+                  ip: "1.2.3.4",
+                  assignee_id: 42,
+                },
+              ],
+            }),
+          ),
+        );
+      }
+      // GET /ssh_keys
+      if (urlStr.includes("/ssh_keys")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ssh_keys: [],
+            }),
+          ),
+        );
+      }
+      // GET /servers (token validation)
+      if (urlStr.includes("/servers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              servers: [],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify({})));
     });
     const { ensureHcloudToken, createServer } = await import("../hetzner/hetzner");
     await ensureHcloudToken();

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -3,6 +3,8 @@
 // Lets users re-register a running remote VM by IP address, so that
 // spawn list/delete/fix all work seamlessly on the re-connected server.
 
+import type { Manifest } from "../manifest.js";
+
 import { spawnSync } from "node:child_process";
 import { connect } from "node:net";
 import * as p from "@clack/prompts";
@@ -178,19 +180,18 @@ export interface LinkOptions {
   sshCommand?: SshCommandFn;
 }
 
-// ─── Main command ─────────────────────────────────────────────────────────────
+// ─── Parsed flags ───────────────────────────────────────────────────────────
 
-/**
- * spawn link <ip> [--agent <agent>] [--cloud <cloud>] [--user <user>] [--name <name>]
- *
- * Re-registers an existing cloud deployment in spawn's local state so that
- * spawn list, spawn delete, spawn fix, etc. all work on it.
- */
-export async function cmdLink(args: string[], options?: LinkOptions): Promise<void> {
-  const tcpCheckFn = options?.tcpCheck ?? defaultTcpCheck;
-  const sshCommandFn = options?.sshCommand ?? defaultSshCommand;
+interface LinkFlags {
+  cloudFlag: string | undefined;
+  agentFlag: string | undefined;
+  userFlag: string | undefined;
+  nameFlag: string | undefined;
+  ip: string;
+}
 
-  // ── Parse flags ────────────────────────────────────────────────────────────
+/** Parse and validate CLI flags + positional IP from args. Exits on invalid input. */
+function parseLinkFlags(args: string[]): LinkFlags {
   let remaining = [
     ...args.slice(1),
   ]; // remove "link" command itself
@@ -214,7 +215,6 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
   ]);
   remaining = r4;
 
-  // ── Get IP from positional arg ─────────────────────────────────────────────
   const ip = parseIpArg(remaining);
 
   if (!ip) {
@@ -224,7 +224,6 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
     process.exit(1);
   }
 
-  // ── Validate IP ────────────────────────────────────────────────────────────
   const ipValidation = tryCatch(() => validateConnectionIP(ip));
   if (!ipValidation.ok) {
     console.error(pc.red(`Invalid IP address: ${pc.bold(ip)}`));
@@ -232,9 +231,17 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
     process.exit(1);
   }
 
-  p.intro(`${pc.bold("spawn link")} — reconnect an existing deployment`);
+  return {
+    cloudFlag,
+    agentFlag,
+    userFlag,
+    nameFlag,
+    ip,
+  };
+}
 
-  // ── Determine SSH user ─────────────────────────────────────────────────────
+/** Prompt for (or default) the SSH user and validate it. Exits on invalid input. */
+async function resolveSshUser(ip: string, userFlag: string | undefined): Promise<string> {
   let sshUser = userFlag ?? "root";
 
   if (!userFlag && isInteractiveTTY()) {
@@ -249,7 +256,6 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
     sshUser = userInput || "root";
   }
 
-  // Validate SSH user
   const userValidation = tryCatch(() => validateUsername(sshUser));
   if (!userValidation.ok) {
     p.log.error(`Invalid SSH user: ${sshUser}`);
@@ -257,7 +263,11 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
     process.exit(1);
   }
 
-  // ── Check connectivity ─────────────────────────────────────────────────────
+  return sshUser;
+}
+
+/** Verify SSH port 22 is reachable. Exits if unreachable. */
+async function checkSshConnectivity(ip: string, tcpCheckFn: TcpCheckFn): Promise<void> {
   const connectSpinner = p.spinner({
     output: process.stderr,
   });
@@ -273,125 +283,111 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
   }
 
   connectSpinner.stop(`${ip} is reachable`);
+}
 
-  // ── Get SSH keys ───────────────────────────────────────────────────────────
-  const keysResult = await asyncTryCatch(() => ensureSshKeys());
-  const keyOpts = keysResult.ok ? getSshKeyOpts(keysResult.data) : [];
-
-  // ── Auto-detect agent and cloud ────────────────────────────────────────────
-  let detectedAgent: string | null = agentFlag ?? null;
-  let detectedCloud: string | null = cloudFlag ?? null;
-
-  const needsDetection = !detectedAgent || !detectedCloud;
-
-  if (needsDetection) {
-    const detectSpinner = p.spinner({
-      output: process.stderr,
-    });
-    detectSpinner.start("Auto-detecting agent and cloud provider...");
-
-    if (!detectedAgent) {
-      detectedAgent = detectAgent(ip, sshUser, keyOpts, sshCommandFn);
-    }
-    if (!detectedCloud) {
-      detectedCloud = detectCloud(ip, sshUser, keyOpts, sshCommandFn);
-    }
-
-    const agentStatus = detectedAgent ?? "unknown";
-    const cloudStatus = detectedCloud ?? "unknown";
-    detectSpinner.stop(`Detected: agent=${agentStatus}, cloud=${cloudStatus}`);
+/** Auto-detect or interactively prompt for the agent. Exits in non-TTY if unresolvable. */
+async function resolveAgent(detected: string | null, ip: string, manifest: Manifest | null): Promise<string> {
+  if (detected) {
+    return detected;
   }
 
-  // ── Load manifest for validation and picker ────────────────────────────────
-  const manifestResult = await asyncTryCatch(() => loadManifest());
-  const manifest = manifestResult.ok ? manifestResult.data : null;
-
-  // ── Prompt for agent if not detected ──────────────────────────────────────
-  if (!detectedAgent) {
-    if (!isInteractiveTTY()) {
-      p.log.error("Could not auto-detect agent. Use --agent <agent> to specify it.");
-      p.log.info(`Example: ${pc.cyan(`spawn link ${ip} --agent claude`)}`);
-      if (manifest) {
-        const agents = agentKeys(manifest);
-        p.log.info(`Available agents: ${agents.join(", ")}`);
-      }
-      process.exit(1);
+  if (!isInteractiveTTY()) {
+    p.log.error("Could not auto-detect agent. Use --agent <agent> to specify it.");
+    p.log.info(`Example: ${pc.cyan(`spawn link ${ip} --agent claude`)}`);
+    if (manifest) {
+      const agents = agentKeys(manifest);
+      p.log.info(`Available agents: ${agents.join(", ")}`);
     }
+    process.exit(1);
+  }
 
-    const agentPickOptions =
-      manifest && Object.keys(manifest.agents).length > 0
-        ? agentKeys(manifest).map((key) => ({
+  const agentPickOptions =
+    manifest && Object.keys(manifest.agents).length > 0
+      ? agentKeys(manifest).map((key) => ({
+          value: key,
+          label: manifest.agents[key]?.name ?? key,
+          hint: key,
+        }))
+      : [
+          {
+            value: "claude",
+            label: "Claude Code",
+            hint: "claude",
+          },
+        ];
+
+  const agentPick = await p.select({
+    message: "Which agent is running on this server?",
+    options: agentPickOptions,
+  });
+
+  if (p.isCancel(agentPick)) {
+    handleCancel();
+  }
+
+  return agentPick;
+}
+
+/** Auto-detect or interactively prompt for the cloud provider. Exits in non-TTY if unresolvable. */
+async function resolveCloud(detected: string | null, ip: string, manifest: Manifest | null): Promise<string> {
+  if (detected) {
+    return detected;
+  }
+
+  if (!isInteractiveTTY()) {
+    p.log.error("Could not auto-detect cloud provider. Use --cloud <cloud> to specify it.");
+    p.log.info(`Example: ${pc.cyan(`spawn link ${ip} --cloud hetzner`)}`);
+    if (manifest) {
+      const clouds = cloudKeys(manifest).filter((c) => c !== "local");
+      p.log.info(`Available clouds: ${clouds.join(", ")}`);
+    }
+    process.exit(1);
+  }
+
+  const cloudPickOptions =
+    manifest && Object.keys(manifest.clouds).length > 0
+      ? cloudKeys(manifest)
+          .filter((key) => key !== "local")
+          .map((key) => ({
             value: key,
-            label: manifest.agents[key]?.name ?? key,
+            label: manifest.clouds[key]?.name ?? key,
             hint: key,
           }))
-        : [
-            {
-              value: "claude",
-              label: "Claude Code",
-              hint: "claude",
-            },
-          ];
+      : [];
+  cloudPickOptions.push({
+    value: "other",
+    label: "Other / Unknown",
+    hint: "other",
+  });
 
-    const agentPick = await p.select({
-      message: "Which agent is running on this server?",
-      options: agentPickOptions,
-    });
+  const cloudPick = await p.select({
+    message: "Which cloud provider is this server on?",
+    options: cloudPickOptions,
+  });
 
-    if (p.isCancel(agentPick)) {
-      handleCancel();
-    }
-
-    detectedAgent = agentPick;
+  if (p.isCancel(cloudPick)) {
+    handleCancel();
   }
 
-  // ── Prompt for cloud if not detected ──────────────────────────────────────
-  if (!detectedCloud) {
-    if (!isInteractiveTTY()) {
-      p.log.error("Could not auto-detect cloud provider. Use --cloud <cloud> to specify it.");
-      p.log.info(`Example: ${pc.cyan(`spawn link ${ip} --cloud hetzner`)}`);
-      if (manifest) {
-        const clouds = cloudKeys(manifest).filter((c) => c !== "local");
-        p.log.info(`Available clouds: ${clouds.join(", ")}`);
-      }
-      process.exit(1);
-    }
+  return cloudPick;
+}
 
-    const cloudPickOptions =
-      manifest && Object.keys(manifest.clouds).length > 0
-        ? cloudKeys(manifest)
-            .filter((key) => key !== "local")
-            .map((key) => ({
-              value: key,
-              label: manifest.clouds[key]?.name ?? key,
-              hint: key,
-            }))
-        : [];
-    cloudPickOptions.push({
-      value: "other",
-      label: "Other / Unknown",
-      hint: "other",
-    });
-
-    const cloudPick = await p.select({
-      message: "Which cloud provider is this server on?",
-      options: cloudPickOptions,
-    });
-
-    if (p.isCancel(cloudPick)) {
-      handleCancel();
-    }
-
-    detectedCloud = cloudPick;
-  }
-
-  // ── Confirm details ────────────────────────────────────────────────────────
+/** Confirm link details, save the record, and optionally connect via SSH. */
+async function confirmAndSave(
+  ip: string,
+  sshUser: string,
+  agent: string,
+  cloud: string,
+  nameFlag: string | undefined,
+  manifest: Manifest | null,
+  keyOpts: string[],
+): Promise<void> {
   const safeIpSegment = ip.replace(/\./g, "-");
-  const spawnName = nameFlag ?? `${detectedAgent}-${safeIpSegment}`;
+  const spawnName = nameFlag ?? `${agent}-${safeIpSegment}`;
 
   if (isInteractiveTTY()) {
-    const agentLabel = manifest?.agents[detectedAgent]?.name ?? detectedAgent;
-    const cloudLabel = manifest?.clouds[detectedCloud]?.name ?? detectedCloud;
+    const agentLabel = manifest?.agents[agent]?.name ?? agent;
+    const cloudLabel = manifest?.clouds[cloud]?.name ?? cloud;
 
     p.log.info(`  IP:    ${ip}`);
     p.log.info(`  User:  ${sshUser}`);
@@ -410,17 +406,16 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
     }
   }
 
-  // ── Save to history ────────────────────────────────────────────────────────
   const record = {
     id: generateSpawnId(),
-    agent: detectedAgent,
-    cloud: detectedCloud,
+    agent,
+    cloud,
     timestamp: new Date().toISOString(),
     name: spawnName,
     connection: {
       ip,
       user: sshUser,
-      cloud: detectedCloud,
+      cloud,
     },
   };
 
@@ -432,7 +427,6 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
 
   p.log.success(`Deployment linked! Run ${pc.cyan("spawn list")} to see it.`);
 
-  // ── Offer to connect immediately ───────────────────────────────────────────
   if (isInteractiveTTY()) {
     const connectNow = await p.confirm({
       message: "Connect now?",
@@ -456,4 +450,57 @@ export async function cmdLink(args: string[], options?: LinkOptions): Promise<vo
   }
 
   p.outro(`Linked as ${spawnName}. Run ${pc.cyan("spawn list")} to manage it.`);
+}
+
+// ─── Main command ─────────────────────────────────────────────────────────────
+
+/**
+ * spawn link <ip> [--agent <agent>] [--cloud <cloud>] [--user <user>] [--name <name>]
+ *
+ * Re-registers an existing cloud deployment in spawn's local state so that
+ * spawn list, spawn delete, spawn fix, etc. all work on it.
+ */
+export async function cmdLink(args: string[], options?: LinkOptions): Promise<void> {
+  const tcpCheckFn = options?.tcpCheck ?? defaultTcpCheck;
+  const sshCommandFn = options?.sshCommand ?? defaultSshCommand;
+
+  const { cloudFlag, agentFlag, userFlag, nameFlag, ip } = parseLinkFlags(args);
+
+  p.intro(`${pc.bold("spawn link")} — reconnect an existing deployment`);
+
+  const sshUser = await resolveSshUser(ip, userFlag);
+  await checkSshConnectivity(ip, tcpCheckFn);
+
+  // Get SSH keys for detection and later connection
+  const keysResult = await asyncTryCatch(() => ensureSshKeys());
+  const keyOpts = keysResult.ok ? getSshKeyOpts(keysResult.data) : [];
+
+  // Auto-detect agent and cloud via SSH if not provided as flags
+  let detectedAgent: string | null = agentFlag ?? null;
+  let detectedCloud: string | null = cloudFlag ?? null;
+
+  if (!detectedAgent || !detectedCloud) {
+    const detectSpinner = p.spinner({
+      output: process.stderr,
+    });
+    detectSpinner.start("Auto-detecting agent and cloud provider...");
+
+    if (!detectedAgent) {
+      detectedAgent = detectAgent(ip, sshUser, keyOpts, sshCommandFn);
+    }
+    if (!detectedCloud) {
+      detectedCloud = detectCloud(ip, sshUser, keyOpts, sshCommandFn);
+    }
+
+    detectSpinner.stop(`Detected: agent=${detectedAgent ?? "unknown"}, cloud=${detectedCloud ?? "unknown"}`);
+  }
+
+  // Load manifest for picker options and display labels
+  const manifestResult = await asyncTryCatch(() => loadManifest());
+  const manifest = manifestResult.ok ? manifestResult.data : null;
+
+  const agent = await resolveAgent(detectedAgent, ip, manifest);
+  const cloud = await resolveCloud(detectedCloud, ip, manifest);
+
+  await confirmAndSave(ip, sshUser, agent, cloud, nameFlag, manifest, keyOpts);
 }


### PR DESCRIPTION
**Why:** `cmdLink()` in `commands/link.ts` was 270 lines — the largest uncovered function outside existing refactor PRs. Extracting helpers improves readability and testability of each phase independently.

## Changes

Extracted 5 helpers from `cmdLink()`, reducing it from 270 lines to ~35 lines of orchestration:

- `parseLinkFlags(args)` — CLI flag parsing + IP validation
- `resolveSshUser(ip, userFlag)` — SSH user prompt + validation
- `checkSshConnectivity(ip, tcpCheckFn)` — TCP port 22 reachability check
- `resolveAgent(detected, ip, manifest)` — auto-detect or prompt for agent
- `resolveCloud(detected, ip, manifest)` — auto-detect or prompt for cloud
- `confirmAndSave(...)` — confirm details, save record, offer SSH connect

No behavioral changes. All 16 existing link tests pass. Bump CLI version to 1.0.44.

-- spawn-refactor/complexity-hunter