### PR TITLE
fix(hermes): gate dashboard launch behind capability probe

### DIFF
--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -713,15 +713,30 @@ export async function startGateway(runner: CloudRunner): Promise<void> {
 export async function startHermesDashboard(runner: CloudRunner): Promise<void> {
   logStep("Starting Hermes web dashboard...");
 
+  // `hermes` lives inside the install venv; mirror launchCmd's PATH exactly.
+  const hermesPath = 'export PATH="$HOME/.local/bin:$HOME/.hermes/hermes-agent/venv/bin:$PATH"';
+
+  // Probe whether this hermes build supports the `dashboard` subcommand.
+  // Older versions lack it entirely, which causes confusing argparse errors.
+  const probeScript = [
+    "source ~/.spawnrc 2>/dev/null",
+    hermesPath,
+    "_hermes_bin=$(command -v hermes) || exit 1",
+    '"$_hermes_bin" dashboard --help >/dev/null 2>&1',
+  ].join("\n");
+
+  const probeResult = await asyncTryCatch(() => runner.runServer(probeScript));
+  if (!probeResult.ok) {
+    logWarn("Hermes version does not support 'dashboard' subcommand — skipping dashboard launch");
+    return;
+  }
+
   // Port check — same pattern as startGateway. Debian/Ubuntu bash is compiled
   // without /dev/tcp, so we chain ss → /dev/tcp → nc.
   const portCheck =
     'ss -tln 2>/dev/null | grep -q ":9119 " || ' +
     "(echo >/dev/tcp/127.0.0.1/9119) 2>/dev/null || " +
     "nc -z 127.0.0.1 9119 2>/dev/null";
-
-  // `hermes` lives inside the install venv; mirror launchCmd's PATH exactly.
-  const hermesPath = 'export PATH="$HOME/.local/bin:$HOME/.hermes/hermes-agent/venv/bin:$PATH"';
 
   const script = [
     "source ~/.spawnrc 2>/dev/null",


### PR DESCRIPTION
## Why

Prevents `hermes dashboard: not a command` error on DigitalOcean and other clouds where an older hermes version is installed, by probing capability before launch instead of swallowing the argparse error.

## What

Adds a `hermes dashboard --help` probe before attempting to start the dashboard. If the probe fails (exit non-zero), logs a warning and returns early instead of launching and hitting an argparse error.

Fixes #3407

-- refactor/code-health