### PR TITLE
fix(sprite): update flag syntax for sprite CLI v0.0.1-rc43 breaking changes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.43",
+  "version": "1.1.0",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/cmd-connect-cov.test.ts
+++ b/packages/cli/src/__tests__/cmd-connect-cov.test.ts
@@ -233,7 +233,7 @@ describe("cmdEnterAgent", () => {
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("enters agent via sprite exec -tty", async () => {
+  it("enters agent via sprite exec --tty", async () => {
     const conn = makeConn({
       ip: "sprite-console",
       server_name: "my-sprite",
@@ -244,7 +244,7 @@ describe("cmdEnterAgent", () => {
     const args = spawnInteractiveSpy.mock.calls[0][0];
     expect(args[0]).toBe("sprite");
     expect(args).toContain("exec");
-    expect(args).toContain("-tty");
+    expect(args).toContain("--tty");
     expect(args).toContain("my-sprite");
   });
 

--- a/packages/cli/src/__tests__/sprite-keep-alive.test.ts
+++ b/packages/cli/src/__tests__/sprite-keep-alive.test.ts
@@ -193,7 +193,7 @@ describe("interactiveSession (keep-alive wrapper)", () => {
     expect(capturedSessionScript).toContain(expectedB64);
   });
 
-  it("uses -tty flag for interactive mode (SPAWN_PROMPT not set)", async () => {
+  it("uses --tty flag for interactive mode (SPAWN_PROMPT not set)", async () => {
     delete process.env.SPAWN_PROMPT;
 
     let capturedArgs: string[] = [];
@@ -204,10 +204,10 @@ describe("interactiveSession (keep-alive wrapper)", () => {
 
     await interactiveSession("agent-cmd", mockSpawnInteractive);
 
-    expect(capturedArgs).toContain("-tty");
+    expect(capturedArgs).toContain("--tty");
   });
 
-  it("omits -tty flag when SPAWN_PROMPT is set", async () => {
+  it("omits --tty flag when SPAWN_PROMPT is set", async () => {
     process.env.SPAWN_PROMPT = "non-interactive";
 
     let capturedArgs: string[] = [];
@@ -218,7 +218,7 @@ describe("interactiveSession (keep-alive wrapper)", () => {
 
     await interactiveSession("agent-cmd", mockSpawnInteractive);
 
-    expect(capturedArgs).not.toContain("-tty");
+    expect(capturedArgs).not.toContain("--tty");
   });
 
   it("returns the exit code from spawnInteractive", async () => {

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -265,14 +265,14 @@ export async function cmdEnterAgent(
         "exec",
         "-s",
         connection.server_name,
-        "-tty",
+        "--tty",
         "--",
         "bash",
         "-lc",
         remoteCmd,
       ],
       `Failed to enter ${agentName}`,
-      `sprite exec -s ${connection.server_name} -tty -- bash -lc '${remoteCmd}'`,
+      `sprite exec -s ${connection.server_name} --tty -- bash -lc '${remoteCmd}'`,
     );
   }
 

--- a/packages/cli/src/sprite/sprite.ts
+++ b/packages/cli/src/sprite/sprite.ts
@@ -145,7 +145,7 @@ export async function ensureSpriteCli(): Promise<void> {
     // Log version if available
     const { stdout } = spawnSync([
       cmd,
-      "version",
+      "--version",
     ]);
     const ver = stdout.match(/v?\d+\.\d+\.\d+(-rc\d+)?/)?.[0];
     if (ver) {
@@ -318,7 +318,7 @@ export async function createSprite(name: string): Promise<void> {
         cmd,
         ...orgFlags(),
         "create",
-        "-skip-console",
+        "--skip-console",
         name,
       ],
       {
@@ -426,7 +426,7 @@ export function startLocalKeepAlive(): void {
   const urlResult = spawnSync([
     cmd,
     ...orgFlags(),
-    "url",
+    "info",
     "-s",
     _state.name,
   ]);
@@ -602,7 +602,7 @@ export async function uploadFileSprite(localPath: string, remotePath: string): P
         "exec",
         "-s",
         _state.name,
-        "-file",
+        "--file",
         `${localPath}:${tempRemote}`,
         "--",
         "mkdir",
@@ -781,7 +781,7 @@ export async function interactiveSession(cmd: string, spawnFn?: (args: string[])
         "exec",
         "-s",
         _state.name,
-        "-tty",
+        "--tty",
         "--",
         "bash",
         "-c",


### PR DESCRIPTION
## Why

Sprite CLI v0.0.1-rc43 changed single-dash long flags to double-dash and renamed `sprite url` to `sprite info`, breaking ALL agents on sprite.dev. This fixes every agent on sprite (not just hermes).

## Changes

| File | Old (broken) | New |
|------|------|------|
| `sprite.ts:148` | `sprite version` | `sprite --version` |
| `sprite.ts:321` | `-skip-console` | `--skip-console` |
| `sprite.ts:429` | `sprite url` | `sprite info` |
| `sprite.ts:605` | `-file` | `--file` |
| `sprite.ts:784` | `-tty` | `--tty` |
| `connect.ts:268,275` | `-tty` | `--tty` |
| Tests | `-tty` assertions | `--tty` assertions |

Fixes #3408

-- refactor/code-health