### PR TITLE
fix(docker): add missing t3code.Dockerfile

### DIFF
--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,16 +88,12 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let doCallCount = 0;
+    let callCount = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
+      callCount++;
       const urlStr = String(url);
-      // Ignore telemetry (PostHog) fire-and-forget calls triggered by logWarn
-      if (urlStr.includes("posthog") || urlStr.includes("i.posthog")) {
-        return Promise.resolve(new Response("ok"));
-      }
-      doCallCount++;
       // First call: the actual API call returning 401
-      if (doCallCount === 1) {
+      if (callCount === 1) {
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,

--- a/packages/cli/src/__tests__/digitalocean-token.test.ts
+++ b/packages/cli/src/__tests__/digitalocean-token.test.ts
@@ -88,12 +88,16 @@ describe("doApi 401 OAuth recovery", () => {
 
   it("attempts OAuth recovery on 401 before throwing", async () => {
     state.token = "expired-token";
-    let callCount = 0;
+    let doCallCount = 0;
     globalThis.fetch = mock((url: string | URL | Request) => {
-      callCount++;
       const urlStr = String(url);
+      // Ignore telemetry (PostHog) fire-and-forget calls triggered by logWarn
+      if (urlStr.includes("posthog") || urlStr.includes("i.posthog")) {
+        return Promise.resolve(new Response("ok"));
+      }
+      doCallCount++;
       // First call: the actual API call returning 401
-      if (callCount === 1) {
+      if (doCallCount === 1) {
         return Promise.resolve(
           new Response("Unauthorized", {
             status: 401,

--- a/sh/docker/t3code.Dockerfile
+++ b/sh/docker/t3code.Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base packages
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      curl git ca-certificates build-essential unzip zsh && \
+    rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 via n
+RUN curl --proto '=https' -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s install 22
+
+# T3 Code (web GUI wrapping Claude Code and Codex via browser interface)
+RUN npm install -g t3
+
+CMD ["/bin/sleep", "inf"]


### PR DESCRIPTION
**Why:** Users running \`spawn t3code <cloud> --beta docker\`, \`--beta sandbox\`, or in the \`fast_provision\` experiment group hit a runtime failure — \`ghcr.io/openrouterteam/spawn-t3code:latest\` doesn't exist because the Dockerfile was never added when t3code was introduced.

## What

Adds \`sh/docker/t3code.Dockerfile\` following the exact same pattern as \`pi.Dockerfile\`:
- Base: \`ubuntu:24.04\`
- Runtime: Node.js 22 via n
- Install: \`npm install -g t3\`

All 9 other agents already have their Dockerfiles. This is the only one missing.

## What's not included

The \`.github/workflows/docker.yml\` matrix update (adding \`t3code\` to the build matrix) is tracked in #3418 and requires human review — workflow files are off-limits for automated agents.

## Checklist
- [x] Dockerfile follows same structure as all other agent Dockerfiles
- [x] install command matches \`manifest.json\` agents[\`t3code\`].install (\`npm install -g t3\`)

-- refactor/code-health