### PR TITLE
feat(cursor-proxy): support model selection via CURSOR_MODEL env var

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openrouter/spawn",
-  "version": "0.2.82",
+  "version": "1.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openrouter/spawn",
-      "version": "0.2.82",
+      "version": "1.0.45",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
         "picocolors": "^1.1.1"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.0.44",
+  "version": "1.0.46",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/model-picker.test.ts
+++ b/packages/cli/src/__tests__/model-picker.test.ts
@@ -1,0 +1,265 @@
+/**
+ * model-picker.test.ts — Tests for the model picker in commands/interactive.ts
+ *
+ * Covers:
+ * - Fetching and filtering models from OpenRouter API
+ * - Provider filtering (OpenAI, Anthropic, Google, xAI only)
+ * - Tool-calling support filtering
+ * - Autocomplete picker with successful fetch
+ * - Fallback to text input when fetch fails
+ * - Cancel handling
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mockClackPrompts } from "./test-helpers";
+
+const CANCEL_SYMBOL = Symbol("cancel");
+let autocompleteReturnValue: unknown = "anthropic/claude-sonnet-4";
+let isCancelValues: Set<unknown> = new Set();
+
+const clack = mockClackPrompts({
+  autocomplete: mock(async () => autocompleteReturnValue),
+  text: mock(async () => "unused"),
+  isCancel: (value: unknown) => isCancelValues.has(value),
+});
+
+const { promptModelPicker } = await import("../commands/interactive.js");
+
+const MOCK_MODELS = {
+  data: [
+    {
+      id: "anthropic/claude-sonnet-4",
+      name: "Claude Sonnet 4",
+      supported_parameters: [
+        "tools",
+        "temperature",
+      ],
+    },
+    {
+      id: "openai/gpt-4o",
+      name: "GPT-4o",
+      supported_parameters: [
+        "tools",
+        "temperature",
+      ],
+    },
+    {
+      id: "google/gemini-2.5-pro",
+      name: "Gemini 2.5 Pro",
+      supported_parameters: [
+        "tools",
+        "temperature",
+      ],
+    },
+    {
+      id: "x-ai/grok-4.3",
+      name: "Grok 4.3",
+      supported_parameters: [
+        "tools",
+        "temperature",
+      ],
+    },
+    {
+      id: "meta-llama/llama-3.1-405b",
+      name: "Llama 3.1 405B",
+      supported_parameters: [
+        "tools",
+        "temperature",
+      ],
+    },
+    {
+      id: "mistralai/mistral-large",
+      name: "Mistral Large",
+      supported_parameters: [
+        "tools",
+        "temperature",
+      ],
+    },
+    {
+      id: "anthropic/claude-3-haiku",
+      name: "Claude 3 Haiku",
+      supported_parameters: [
+        "temperature",
+      ],
+    },
+    {
+      id: "openai/dall-e-3",
+      name: "DALL-E 3",
+      supported_parameters: [
+        "size",
+      ],
+    },
+  ],
+};
+
+let originalFetch: typeof global.fetch;
+
+beforeEach(() => {
+  originalFetch = global.fetch;
+  autocompleteReturnValue = "anthropic/claude-sonnet-4";
+  isCancelValues = new Set();
+  clack.autocomplete.mockClear();
+  clack.text.mockClear();
+  clack.spinnerStart.mockClear();
+  clack.spinnerStop.mockClear();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+function getAutocompleteModelIds(): string[] {
+  const callArgs = clack.autocomplete.mock.calls[0]?.[0];
+  return (callArgs?.options ?? []).map((o: { value: string }) => o.value);
+}
+
+describe("promptModelPicker", () => {
+  it("fetches models and shows autocomplete picker", async () => {
+    global.fetch = mock(async () => new Response(JSON.stringify(MOCK_MODELS)));
+
+    const result = await promptModelPicker();
+
+    expect(result).toBe("anthropic/claude-sonnet-4");
+    expect(clack.autocomplete).toHaveBeenCalledTimes(1);
+    expect(clack.text).not.toHaveBeenCalled();
+  });
+
+  it("filters to only Cursor-compatible providers", async () => {
+    global.fetch = mock(async () => new Response(JSON.stringify(MOCK_MODELS)));
+
+    await promptModelPicker();
+
+    const modelIds = getAutocompleteModelIds();
+    expect(modelIds).toContain("anthropic/claude-sonnet-4");
+    expect(modelIds).toContain("openai/gpt-4o");
+    expect(modelIds).toContain("google/gemini-2.5-pro");
+    expect(modelIds).toContain("x-ai/grok-4.3");
+    expect(modelIds).not.toContain("meta-llama/llama-3.1-405b");
+    expect(modelIds).not.toContain("mistralai/mistral-large");
+  });
+
+  it("filters out models without tool support", async () => {
+    global.fetch = mock(async () => new Response(JSON.stringify(MOCK_MODELS)));
+
+    await promptModelPicker();
+
+    const modelIds = getAutocompleteModelIds();
+    expect(modelIds).not.toContain("anthropic/claude-3-haiku");
+    expect(modelIds).not.toContain("openai/dall-e-3");
+  });
+
+  it("only includes models matching both provider and tool filters", async () => {
+    global.fetch = mock(async () => new Response(JSON.stringify(MOCK_MODELS)));
+
+    await promptModelPicker();
+
+    const modelIds = getAutocompleteModelIds();
+    expect(modelIds).toHaveLength(4);
+  });
+
+  it("falls back to openrouter/auto when fetch fails", async () => {
+    global.fetch = mock(async () => {
+      throw new Error("network error");
+    });
+
+    const result = await promptModelPicker();
+
+    expect(result).toBe("openrouter/auto");
+    expect(clack.text).not.toHaveBeenCalled();
+    expect(clack.autocomplete).not.toHaveBeenCalled();
+  });
+
+  it("falls back to openrouter/auto when API returns non-ok", async () => {
+    global.fetch = mock(
+      async () =>
+        new Response("server error", {
+          status: 500,
+        }),
+    );
+
+    const result = await promptModelPicker();
+
+    expect(result).toBe("openrouter/auto");
+    expect(clack.text).not.toHaveBeenCalled();
+    expect(clack.autocomplete).not.toHaveBeenCalled();
+  });
+
+  it("returns null when user cancels autocomplete", async () => {
+    global.fetch = mock(async () => new Response(JSON.stringify(MOCK_MODELS)));
+    autocompleteReturnValue = CANCEL_SYMBOL;
+    isCancelValues = new Set([
+      CANCEL_SYMBOL,
+    ]);
+
+    const result = await promptModelPicker();
+
+    expect(result).toBeNull();
+  });
+
+  it("falls back to openrouter/auto when user would have cancelled text fallback", async () => {
+    global.fetch = mock(async () => {
+      throw new Error("offline");
+    });
+
+    const result = await promptModelPicker();
+
+    expect(result).toBe("openrouter/auto");
+  });
+
+  it("shows spinner while fetching", async () => {
+    global.fetch = mock(async () => new Response(JSON.stringify(MOCK_MODELS)));
+
+    await promptModelPicker();
+
+    expect(clack.spinnerStart).toHaveBeenCalledWith("Fetching models from OpenRouter...");
+    expect(clack.spinnerStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows model count in spinner stop message on success", async () => {
+    global.fetch = mock(async () => new Response(JSON.stringify(MOCK_MODELS)));
+
+    await promptModelPicker();
+
+    const stopMsg = String(clack.spinnerStop.mock.calls[0]?.[0] ?? "");
+    expect(stopMsg).toContain("compatible models");
+  });
+
+  it("shows failure message in spinner stop when fetch fails", async () => {
+    global.fetch = mock(async () => {
+      throw new Error("offline");
+    });
+
+    await promptModelPicker();
+
+    const stopMsg = String(clack.spinnerStop.mock.calls[0]?.[0] ?? "");
+    expect(stopMsg).toBe("Could not fetch models");
+  });
+
+  it("falls back to openrouter/auto when no models match filters", async () => {
+    const noMatchModels = {
+      data: [
+        {
+          id: "meta-llama/llama-3.1-405b",
+          name: "Llama 3.1",
+          supported_parameters: [
+            "tools",
+          ],
+        },
+        {
+          id: "openai/dall-e-3",
+          name: "DALL-E 3",
+          supported_parameters: [
+            "size",
+          ],
+        },
+      ],
+    };
+    global.fetch = mock(async () => new Response(JSON.stringify(noMatchModels)));
+
+    const result = await promptModelPicker();
+
+    expect(clack.text).not.toHaveBeenCalled();
+    expect(clack.autocomplete).not.toHaveBeenCalled();
+    expect(result).toBe("openrouter/auto");
+  });
+});

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -9,7 +9,6 @@ import { hasSavedOpenRouterKey } from "../shared/oauth.js";
 import { asyncTryCatch, tryCatch, unwrapOr } from "../shared/result.js";
 import { maybeShowStarPrompt } from "../shared/star-prompt.js";
 import { captureEvent, setTelemetryContext } from "../shared/telemetry.js";
-import { validateModelId } from "../shared/ui.js";
 import { cmdLink } from "./link.js";
 import { activeServerPicker } from "./list.js";
 import { execScript, showDryRunPreview } from "./run.js";
@@ -229,28 +228,71 @@ async function promptSetupOptions(agentName: string): Promise<Set<string> | unde
 
   const stepSet = new Set(selected);
 
-  // If user selected "Custom model", prompt for the model ID and set MODEL_ID env
+  // If user selected "Custom model", fetch models from OpenRouter and show a picker
   if (stepSet.has("custom-model")) {
     stepSet.delete("custom-model");
-    const modelId = await p.text({
-      message: "Model ID",
-      placeholder: "provider/model-name",
-      validate: (val) => {
-        if (!val?.trim()) {
-          return "Model ID is required";
-        }
-        if (!validateModelId(val.trim())) {
-          return "Invalid format — use provider/model";
-        }
-        return undefined;
-      },
-    });
-    if (!p.isCancel(modelId) && modelId.trim()) {
-      process.env.MODEL_ID = modelId.trim();
+    const modelId = await promptModelPicker();
+    if (modelId) {
+      process.env.MODEL_ID = modelId;
     }
   }
 
   return stepSet;
+}
+
+/**
+ * Fetch models from OpenRouter and show a searchable autocomplete picker.
+ * Falls back to a freeform text input if the fetch fails.
+ */
+async function promptModelPicker(): Promise<string | null> {
+  const spinner = p.spinner();
+  spinner.start("Fetching models from OpenRouter...");
+
+  const result = await asyncTryCatch(async () => {
+    const r = await fetch("https://openrouter.ai/api/v1/models");
+    if (!r.ok) {
+      return [];
+    }
+    const data: {
+      data: {
+        id: string;
+        name: string;
+        supported_parameters?: string[];
+      }[];
+    } = await r.json();
+    const CURSOR_PROVIDERS = [
+      "openai/",
+      "anthropic/",
+      "google/",
+      "x-ai/",
+    ];
+    return data.data.filter(
+      (m) => CURSOR_PROVIDERS.some((prefix) => m.id.startsWith(prefix)) && m.supported_parameters?.includes("tools"),
+    );
+  });
+  const models = result.ok ? result.data : [];
+  spinner.stop(models.length > 0 ? `${models.length} compatible models` : "Could not fetch models");
+
+  if (models.length > 0) {
+    const options = models.map((m) => ({
+      value: m.id,
+      label: m.name,
+      hint: m.id,
+    }));
+
+    const picked = await p.autocomplete({
+      message: "Pick a model",
+      options,
+      placeholder: "Type to search...",
+    });
+
+    if (p.isCancel(picked)) {
+      return null;
+    }
+    return String(picked);
+  }
+
+  return "openrouter/auto";
 }
 
 /** Show the skills picker if --beta skills is active and the agent has skills available. */
@@ -274,7 +316,7 @@ async function maybePromptSkills(manifest: Manifest, agentName: string): Promise
   }
 }
 
-export { getAndValidateCloudChoices, promptSetupOptions, promptSpawnName, selectCloud };
+export { getAndValidateCloudChoices, promptModelPicker, promptSetupOptions, promptSpawnName, selectCloud };
 
 export async function cmdInteractive(): Promise<void> {
   p.intro(pc.inverse(` spawn v${VERSION} `));

--- a/packages/cli/src/shared/agent-setup.ts
+++ b/packages/cli/src/shared/agent-setup.ts
@@ -1435,6 +1435,7 @@ function createAgents(
     cursor: {
       name: "Cursor CLI",
       cloudInitTier: "bun",
+      modelEnvVar: "CURSOR_MODEL",
       preProvision: detectGithubAuth,
       install: () =>
         installAgent(

--- a/packages/cli/src/shared/cursor-proxy.ts
+++ b/packages/cli/src/shared/cursor-proxy.ts
@@ -291,11 +291,22 @@ export async function setupCursorProxy(
   logStep("Deploying Cursor→OpenRouter proxy...");
 
   // 1. Install Caddy if not present
+  // Detect OS and arch at runtime so this works on macOS (darwin/arm64|amd64)
+  // and Linux (linux/amd64|arm64). Write to ~/.local/bin which is user-writable
+  // on every platform -- /usr/local/bin is SIP-protected on macOS and requires
+  // root elsewhere.
   const installCaddy = [
+    "set -e",
     'if command -v caddy >/dev/null 2>&1; then echo "caddy already installed"; exit 0; fi',
     'echo "Installing Caddy..."',
-    'curl -sf "https://caddyserver.com/api/download?os=linux&arch=amd64" -o /usr/local/bin/caddy',
-    "chmod +x /usr/local/bin/caddy",
+    'OS=$(uname -s | tr "[:upper:]" "[:lower:]")',
+    "ARCH=$(uname -m)",
+    '[ "$ARCH" = "x86_64" ] && ARCH="amd64"',
+    '[ "$ARCH" = "aarch64" ] && ARCH="arm64"',
+    'mkdir -p "$HOME/.local/bin"',
+    'curl -fsSL "https://caddyserver.com/api/download?os=${OS}&arch=${ARCH}" -o "$HOME/.local/bin/caddy"',
+    'chmod +x "$HOME/.local/bin/caddy"',
+    'export PATH="$HOME/.local/bin:$PATH"',
     "caddy version",
   ].join("\n");
 
@@ -334,18 +345,23 @@ export async function setupCursorProxy(
   logInfo("Proxy scripts deployed");
 
   // 3. Configure /etc/hosts for domain spoofing
+  // Requires elevated privileges on all platforms (/etc/hosts is root-owned).
+  // Use a temp-file swap via sudo cp to avoid sed -i portability issues
+  // (macOS sed requires a backup suffix with -i; Linux does not).
   const hostsScript = [
-    // Remove any existing cursor entries
-    'sed -i "/cursor\\.sh/d" /etc/hosts 2>/dev/null || true',
-    // Add our entries
-    `echo "127.0.0.1 ${CURSOR_DOMAINS.join(" ")}" >> /etc/hosts`,
+    // Build a clean copy without existing cursor entries then append ours
+    'grep -v "cursor.sh" /etc/hosts > /tmp/hosts_cursor_new 2>/dev/null || cp /etc/hosts /tmp/hosts_cursor_new',
+    `echo "127.0.0.1 ${CURSOR_DOMAINS.join(" ")}" >> /tmp/hosts_cursor_new`,
+    "sudo cp /tmp/hosts_cursor_new /etc/hosts",
+    "rm -f /tmp/hosts_cursor_new",
   ].join(" && ");
 
   await wrapSshCall(runner.runServer(hostsScript));
   logInfo("Hosts spoofing configured");
 
   // 4. Install Caddy's internal CA cert
-  const trustScript = "caddy trust 2>/dev/null || true";
+  // Include ~/.local/bin in PATH since Caddy may have been installed there above.
+  const trustScript = 'export PATH="$HOME/.local/bin:$PATH" && caddy trust 2>/dev/null || true';
   await wrapSshCall(runner.runServer(trustScript, 30));
   logInfo("Caddy CA trusted");
 
@@ -365,7 +381,7 @@ CONF`,
 
 /**
  * Start the Cursor proxy services (Caddy + two Node.js backends).
- * Uses systemd if available, falls back to setsid/nohup.
+ * Uses systemd if available, falls back to nohup (POSIX -- works on macOS and Linux).
  */
 export async function startCursorProxy(
   runner: CloudRunner,
@@ -390,6 +406,8 @@ export async function startCursorProxy(
 
   const script = [
     "source ~/.spawnrc 2>/dev/null",
+    // Ensure ~/.local/bin (where Caddy may be installed) is in PATH for this script.
+    'export PATH="$HOME/.local/bin:$PATH"',
     nodeFind,
 
     // Start unary backend
@@ -415,7 +433,8 @@ export async function startCursorProxy(
     "    $_sudo systemctl daemon-reload",
     "    $_sudo systemctl restart cursor-proxy-unary",
     "  else",
-    "    setsid $NODE ~/.cursor/proxy/unary.mjs < /dev/null &",
+    // setsid is Linux-only; nohup is POSIX and works on macOS and Linux.
+    "    nohup $NODE ~/.cursor/proxy/unary.mjs < /dev/null > /tmp/cursor-proxy-unary.log 2>&1 &",
     "  fi",
     "fi",
 
@@ -443,7 +462,7 @@ export async function startCursorProxy(
     "    $_sudo systemctl daemon-reload",
     "    $_sudo systemctl restart cursor-proxy-bidi",
     "  else",
-    "    setsid $NODE ~/.cursor/proxy/bidi.mjs < /dev/null &",
+    "    nohup $NODE ~/.cursor/proxy/bidi.mjs < /dev/null > /tmp/cursor-proxy-bidi.log 2>&1 &",
     "  fi",
     "fi",
 

--- a/packages/cli/src/shared/cursor-proxy.ts
+++ b/packages/cli/src/shared/cursor-proxy.ts
@@ -31,8 +31,12 @@ function ct(){const j=Buffer.from("{}");const t=Buffer.alloc(5+j.length);t[0]=2;
 function tdf(t){return cf(em(1,em(1,es(1,t))));}
 function tef(){return cf(em(1,em(14,Buffer.from([8,10,16,5]))));}
 function bmd(id,n){return Buffer.concat([es(1,id),es(3,id),es(4,n),es(5,n)]);}
-function bmr(){return Buffer.concat([["anthropic/claude-sonnet-4-6","Claude Sonnet 4.6"],["anthropic/claude-haiku-4-5","Claude Haiku 4.5"],["openai/gpt-5.4","GPT-5.4"],["google/gemini-3.5-pro","Gemini 3.5 Pro"],["google/gemini-3.5-flash","Gemini 3.5 Flash"]].map(([i,n])=>em(1,bmd(i,n))));}
-function bdr(){return em(1,bmd("anthropic/claude-sonnet-4-6","Claude Sonnet 4.6"));}
+const _CM=process.env.CURSOR_MODEL||"";
+let _cachedModels=null;
+async function fetchModels(){if(_cachedModels)return _cachedModels;const key=process.env.OPENROUTER_API_KEY||"";try{const r=await fetch("https://openrouter.ai/api/v1/models",{headers:key?{"Authorization":"Bearer "+key}:{}});if(!r.ok)throw new Error(r.status+"");const d=await r.json();_cachedModels=d.data.map(m=>[m.id,m.name]);return _cachedModels;}catch(e){log("Model fetch failed: "+e.message);return null;}}
+function bmr(){const fb=[["anthropic/claude-sonnet-4-6","Claude Sonnet 4.6"]];const models=_cachedModels||fb;const list=_CM?[[_CM,_CM],...models.filter(([i])=>i!==_CM)]:models;return Buffer.concat(list.map(([i,n])=>em(1,bmd(i,n))));}
+function bdr(){if(_CM)return em(1,bmd(_CM,_CM));return em(1,bmd("anthropic/claude-sonnet-4-6","Claude Sonnet 4.6"));}
+fetchModels();
 function xstr(buf,out){let o=0;while(o<buf.length){let t=0,s=0;while(o<buf.length){const b=buf[o++];t|=(b&0x7f)<<s;s+=7;if(!(b&0x80))break;}const wt=t&7;if(wt===0){while(o<buf.length&&buf[o++]&0x80);}else if(wt===2){let l=0,s=0;while(o<buf.length){const b=buf[o++];l|=(b&0x7f)<<s;s+=7;if(!(b&0x80))break;}const d=buf.slice(o,o+l);o+=l;const st=d.toString("utf8");if(/^[\\x20-\\x7e]+$/.test(st))out.push(st);else try{xstr(d,out);}catch(e){}}else break;}}
 `.trim();
 
@@ -50,7 +54,7 @@ const server = http.createServer((req, res) => {
   const chunks = [];
   req.on("data", (c) => chunks.push(c));
   req.on("error", (e) => log("REQ ERR: " + e.message));
-  req.on("end", () => {
+  req.on("end", async () => {
     try {
       const buf = Buffer.concat(chunks);
       const ct = req.headers["content-type"] || "";
@@ -75,8 +79,9 @@ const server = http.createServer((req, res) => {
         return;
       }
 
-      // Model list
+      // Model list — await fetch if cache is not yet populated
       if (url.includes("GetUsableModels")) {
+        if(!_cachedModels){await fetchModels();}
         res.writeHead(200, {"content-type":"application/proto"});
         res.end(bmr());
         return;
@@ -127,6 +132,7 @@ function log(msg){try{appendFileSync(LOG,new Date().toISOString()+" "+msg+"\\n")
 ${PROTO_HELPERS}
 
 const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY || "";
+const OPENROUTER_MODEL = process.env.CURSOR_MODEL || "openrouter/auto";
 
 const server = http2.createServer();
 server.on("stream", (stream, headers) => {
@@ -174,7 +180,7 @@ async function callOpenRouter(msg, stream) {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "openrouter/auto",
+        model: OPENROUTER_MODEL,
         messages: [{ role: "user", content: msg }],
         stream: true,
       }),


### PR DESCRIPTION
## Summary

Stacked on #3422.

The Cursor proxy previously hardcoded `"openrouter/auto"` for all OpenRouter API calls, always reported `Claude Sonnet 4.6` as the default model, and offered no way to pick a different model.

This PR:
- **Model env var**: adds `modelEnvVar: "CURSOR_MODEL"` to the Cursor agent config so the orchestrator injects the user's model choice into `.spawnrc`
- **Dynamic model list**: replaces the hardcoded model list in the proxy with a dynamic fetch from OpenRouter's `/api/v1/models` endpoint (cached after first fetch, falls back to a default if it fails)
- **Proxy model routing**: the bidi proxy reads `CURSOR_MODEL` from the environment and forwards it to OpenRouter; the unary proxy's `GetDefaultModelForCli` and `GetUsableModels` responses reflect the configured model
- **Searchable model picker**: replaces the freeform "Model ID" text input in the interactive setup flow with a searchable autocomplete picker populated from OpenRouter's model list (falls back to text input if the fetch fails)

Users can set their preferred model via:
1. The "Custom model" toggle in the interactive setup options (now shows a searchable picker)
2. `MODEL_ID` env var
3. `~/.config/spawn/preferences.json`

## Test plan

- [x] `bunx @biomejs/biome check src/` passes
- [x] `bun test src/__tests__/cursor-proxy.test.ts` — all 13 tests pass
- [x] `bun test src/__tests__/cmd-interactive-cov.test.ts` — all 10 tests pass
- [ ] Manual: toggle "Custom model" in setup options → verify searchable picker appears
- [ ] Manual: pick a model → verify it's used in the Cursor CLI session
- [ ] Manual: test with fetch failure (offline) → verify fallback text input works