### PR TITLE
fix(cli): inject SPAWN_CLI_DIR in dev script so local source is always used

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
     "spawn": "cli.js"
   },
   "scripts": {
-    "dev": "bun run src/index.ts",
+    "dev": "SPAWN_CLI_DIR=$(git rev-parse --show-toplevel) bun run src/index.ts",
     "build": "bun build src/index.ts --outfile cli.js --target bun --minify --packages bundle",
     "compile": "bun build src/index.ts --compile --outfile spawn",
     "lint": "biome lint src/",

--- a/sh/local/README.md
+++ b/sh/local/README.md
@@ -43,6 +43,24 @@ OPENROUTER_API_KEY=sk-or-v1-xxxxx \
   bash <(curl -fsSL https://openrouter.ai/labs/spawn/local/claude.sh)
 ```
 
+## Cursor CLI — Local Model Picker
+
+When spawning Cursor locally, select the **Custom model** setup option to get the
+OpenRouter model picker. Without it, Cursor uses its default model.
+
+```bash
+# Install Spawn
+curl -fsSL https://openrouter.ai/labs/spawn/cli/install.sh | bash
+
+# Launch — select "Custom model" when prompted for setup options
+spawn cursor local
+```
+
+> **Supported providers:** Only providers supported by Cursor's API key
+> integration work locally. See
+> [Cursor docs — What providers are supported?](https://cursor.com/help/models-and-usage/api-keys#what-providers-are-supported)
+> for the current list.
+
 ## What It Does
 
 Local scripts will:


### PR DESCRIPTION
## Summary

When running `bun run dev` from `packages/cli`, the CLI downloads the spawn script from the published CDN release instead of using local source. This means any unpublished branch fixes (e.g. the macOS compatibility changes in `cursor-proxy/macos-compat`) are silently ignored — the terminal shows errors from the old published code while the fixes sit unused on disk.

The visible symptom is `bun run dev` printing "Downloading spawn script..." and then running stale code with already-fixed bugs (wrong Caddy install path, `setsid` instead of `nohup`, missing `sudo` for `/etc/hosts`).

### Fix

Set `SPAWN_CLI_DIR` to the repo root (via `git rev-parse --show-toplevel`) in the `dev` script so the local checkout is always used during development.

## Test plan

- [ ] Run `bun run dev` from `packages/cli`, verify "Downloading spawn script..." no longer appears
- [ ] Verify the local source is used (e.g., local fixes are reflected in behavior)