### PR TITLE
fix(cli): eliminate extra Ctrl+C needed to exit local spawn session

### DIFF
--- a/packages/cli/src/shared/orchestrate.ts
+++ b/packages/cli/src/shared/orchestrate.ts
@@ -1012,6 +1012,13 @@ async function postInstall(
     }
     exitCode = await cloud.interactiveSession(sessionCmd);
 
+    // SIGINT — exit immediately. The user is mashing Ctrl+C to get out;
+    // any post-session work (reconnect logic, history pull, tunnel teardown)
+    // just adds delay that forces yet another Ctrl+C.
+    if (exitCode === 130) {
+      process.exit(130);
+    }
+
     if (!isConnectionDrop(exitCode)) {
       break;
     }

--- a/packages/cli/src/shared/ssh.ts
+++ b/packages/cli/src/shared/ssh.ts
@@ -146,6 +146,15 @@ export function spawnInteractive(args: string[], env?: Record<string, string | u
     env: env ?? process.env,
   });
 
+  const exitCode = result.status ?? 1;
+
+  // On SIGINT (Ctrl+C), skip terminal cleanup and return immediately.
+  // The user is trying to exit — spawning stty sane here blocks just long
+  // enough that they have to press Ctrl+C a third time to get out.
+  if (exitCode === 130 || result.signal === "SIGINT") {
+    return exitCode;
+  }
+
   // Reset terminal state after the interactive session ends.
   // The remote agent's TUI (e.g. Claude Code) may leave the terminal in
   // raw mode or with altered attributes, causing garbled post-session output.
@@ -168,7 +177,7 @@ export function spawnInteractive(args: string[], env?: Record<string, string | u
     ),
   );
 
-  return result.status ?? 1;
+  return exitCode;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Exiting a local spawn session with Ctrl+C requires pressing it three times instead of two. After the agent process exits on the second Ctrl+C, the parent process hangs briefly — long enough that the user presses Ctrl+C again.

### Root cause

Two things add delay between the agent exiting and the process actually terminating:

1. **`spawnInteractive` runs `stty sane`** — a synchronous `nodeSpawnSync` call that blocks right after the agent exits, during the exact moment the user expects the process to be dying.

2. **`runOrchestration` continues post-session cleanup** — reconnect logic, tunnel teardown, and history pull all run before `process.exit()`, even on SIGINT where the user just wants out.

### Fix

- **`ssh.ts`**: On exit code 130 or `SIGINT` signal, skip terminal reset (`stty sane`, ANSI escape writes) and return immediately.
- **`orchestrate.ts`**: On exit code 130, call `process.exit(130)` immediately after the interactive session returns, skipping all post-session cleanup.

## Test plan

- [x] `bunx @biomejs/biome check src/shared/ssh.ts src/shared/orchestrate.ts` — zero errors
- [x] Full test suite — 2201 pass, 3 pre-existing flaky failures unrelated to this change
- [ ] Run `spawn cursor local`, press Ctrl+C twice — should exit cleanly without needing a third press