### PR TITLE
feat(sandbox): implement sandbox/t3code

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -519,7 +519,7 @@
     "sandbox/junie": "implemented",
     "sandbox/pi": "implemented",
     "sandbox/cursor": "implemented",
-    "sandbox/t3code": "missing",
+    "sandbox/t3code": "implemented",
     "hetzner/claude": "implemented",
     "hetzner/openclaw": "implemented",
     "hetzner/codex": "implemented",

--- a/sh/docker/t3code.Dockerfile
+++ b/sh/docker/t3code.Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base packages
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      curl git ca-certificates build-essential unzip zsh && \
+    rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 via n
+RUN curl --proto '=https' -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s install 22
+
+# T3 Code
+RUN npm install -g t3
+
+CMD ["/bin/sleep", "inf"]

--- a/sh/sandbox/README.md
+++ b/sh/sandbox/README.md
@@ -20,6 +20,7 @@ spawn hermes sandbox
 spawn junie sandbox
 spawn cursor sandbox
 spawn pi sandbox
+spawn t3code sandbox
 ```
 
 Or run directly without the CLI:
@@ -34,6 +35,7 @@ bash <(curl -fsSL https://openrouter.ai/labs/spawn/sandbox/hermes.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/sandbox/junie.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/sandbox/cursor.sh)
 bash <(curl -fsSL https://openrouter.ai/labs/spawn/sandbox/pi.sh)
+bash <(curl -fsSL https://openrouter.ai/labs/spawn/sandbox/t3code.sh)
 ```
 
 ## Requirements
@@ -53,5 +55,5 @@ The `sandbox` cloud reuses the `local` orchestrator with a Docker-wrapped runner
 
 ## Notes
 
-- Agents that need a Docker image: `claude`, `codex`, `cursor`, `hermes`, `junie`, `kilocode`, `openclaw`, `opencode`, `pi`. The container images are built from `sh/docker/<agent>.Dockerfile`.
+- Agents that need a Docker image: `claude`, `codex`, `cursor`, `hermes`, `junie`, `kilocode`, `openclaw`, `opencode`, `pi`, `t3code`. The container images are built from `sh/docker/<agent>.Dockerfile`.
 - For host-native execution (no container), use the [`local`](../local/README.md) cloud instead.

--- a/sh/sandbox/t3code.sh
+++ b/sh/sandbox/t3code.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eo pipefail
+
+# Thin shim for the `sandbox` cloud: runs the agent inside a throwaway Docker
+# container on this machine. Ensures bun is available, then runs bundled
+# sandbox.js (local source or from the GitHub release).
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sandbox/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sandbox/main.ts" t3code "$@"
+fi
+
+# Remote — download bundled sandbox.js from GitHub release
+SANDBOX_JS=$(mktemp)
+trap 'rm -f "$SANDBOX_JS"' EXIT
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/sandbox-latest/sandbox.js" -o "$SANDBOX_JS" \
+    || { printf '\033[0;31mFailed to download sandbox.js\033[0m\n' >&2; exit 1; }
+
+exec bun run "$SANDBOX_JS" t3code "$@"


### PR DESCRIPTION
## Why

`sandbox/t3code` was the last `"missing"` entry in the manifest matrix. All 7 other clouds (`local`, `hetzner`, `aws`, `digitalocean`, `gcp`, `daytona`, `sprite`) already had t3code implemented. The sandbox lacked the thin-shim script and Docker image required to run it in a throwaway container.

## Changes

- `sh/sandbox/t3code.sh` — thin shim (mirrors `sandbox/pi.sh`, passes `t3code` to `sandbox.js`)
- `sh/docker/t3code.Dockerfile` — Ubuntu 24.04 + Node.js 22 (via n) + `npm install -g t3`
- `manifest.json` — `sandbox/t3code`: `"missing"` → `"implemented"`
- `sh/sandbox/README.md` — added t3code to quick-start commands and Docker image list

## Verification

- `bash -n sh/sandbox/t3code.sh` — syntax OK
- `bunx @biomejs/biome check src/` — 0 errors
- `bun test` — 2204 pass, 1 pre-existing flaky failure (`hetzner/createServer > cleans up orphaned primary IPs`) unrelated to this change

Agent: code-health
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>