### PR TITLE
fix(interactive): remove dead --beta sandbox injection code

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -81,30 +81,12 @@ function getAndValidateCloudChoices(
 }
 
 // Prompt user to select a cloud with arrow-key navigation.
-// When --beta sandbox is active and "local" is in the list, injects a
-// "Local Machine (Sandboxed)" option right after "Local Machine".
 async function selectCloud(
   manifest: Manifest,
   cloudList: string[],
   hintOverrides: Record<string, string>,
 ): Promise<string> {
-  const betaFeatures = (process.env.SPAWN_BETA ?? "").split(",");
-  const sandboxEnabled = betaFeatures.includes("sandbox");
-
   const options = mapToSelectOptions(cloudList, manifest.clouds, hintOverrides);
-
-  // Inject sandbox option next to "local" when --beta sandbox is set
-  if (sandboxEnabled && cloudList.includes("local")) {
-    const localIdx = options.findIndex((o) => o.value === "local");
-    if (localIdx !== -1) {
-      options[localIdx].hint = "No isolation — runs on your machine";
-      options.splice(localIdx + 1, 0, {
-        value: "local-sandbox",
-        label: "Local Machine (Sandboxed)",
-        hint: "Runs in a Docker container",
-      });
-    }
-  }
 
   // Add "Link Existing Server" option at the bottom for BYOS workflow
   options.push({
@@ -120,15 +102,6 @@ async function selectCloud(
   });
   if (p.isCancel(cloudChoice)) {
     handleCancel();
-  }
-
-  // Map synthetic "local-sandbox" back to "local" and ensure sandbox beta is set
-  if (cloudChoice === "local-sandbox") {
-    const existing = process.env.SPAWN_BETA ?? "";
-    if (!existing.split(",").includes("sandbox")) {
-      process.env.SPAWN_BETA = existing ? `${existing},sandbox` : "sandbox";
-    }
-    return "local";
   }
 
   return cloudChoice;


### PR DESCRIPTION
**Why:** Commit 18bbe3e9 promoted sandbox to a first-class cloud and removed it from the \`--beta\` gate, but left ~30 lines of dead code in \`selectCloud()\` that inject a synthetic \`local-sandbox\` option when \`SPAWN_BETA\` includes \`sandbox\`. Since nothing adds \`sandbox\` to \`SPAWN_BETA\` anymore, \`sandboxEnabled\` is always \`false\` — the entire inject/remap block was unreachable and misleads readers into thinking the old beta flow is still active.

## Changes

- \`packages/cli/src/commands/interactive.ts\` — remove dead \`sandboxEnabled\` check, injection block, and \`local-sandbox\` remap (~28 lines deleted)
- \`packages/cli/package.json\` — bump to 1.1.1

## Test plan

- [ ] \`bun test\` passes (28/28 interactive tests, 1 pre-existing hetzner flaky failure unrelated to this change — tracked in #3393 / PR #3406)
- [ ] \`bunx @biomejs/biome check src/\` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)