### PR TITLE
fix(tests): reset telemetry singleton to prevent cross-test fetch leakage

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "bin": {
     "spawn": "cli.js"

--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -125,7 +125,12 @@ describe("telemetry", () => {
     global.fetch = fetchMock;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Reset telemetry singleton state to prevent cross-test leakage.
+    // initTelemetry() sets _enabled=true which persists across test files,
+    // causing logWarn/logError in other tests to fire unexpected fetch calls.
+    const mod = await import("../shared/telemetry.js");
+    mod.resetTelemetry();
     global.fetch = originalFetch;
     if (originalTelemetry !== undefined) {
       process.env.SPAWN_TELEMETRY = originalTelemetry;

--- a/packages/cli/src/shared/telemetry.ts
+++ b/packages/cli/src/shared/telemetry.ts
@@ -238,6 +238,14 @@ export function captureError(type: string, err: unknown): void {
   });
 }
 
+/** Reset telemetry state. Used by tests to prevent cross-test leakage. */
+export function resetTelemetry(): void {
+  _enabled = false;
+  _userId = "";
+  _sessionId = "";
+  _context = {};
+}
+
 // ── Send ────────────────────────────────────────────────────────────────────
 
 /** Send a single event to PostHog immediately. Fire-and-forget. */


### PR DESCRIPTION
**Why:** Fixes 1 consistently failing test in the full suite (`hetzner/createServer > cleans up orphaned primary IPs on resource_limit_exceeded and retries`). The telemetry singleton's `_enabled` flag leaked across test files, causing `logWarn`/`logError` to fire unexpected `fetch()` calls that shifted mock counters.

## Changes
- `packages/cli/src/shared/telemetry.ts` — Added `resetTelemetry()` export that resets singleton state
- `packages/cli/src/__tests__/telemetry.test.ts` — Call `resetTelemetry()` in `afterEach` to clean up
- `packages/cli/package.json` — Version bump 1.1.0 → 1.1.1

## Test plan
- [x] `bun test` — 2205 pass, 0 fail (was 2204 pass, 1 fail)
- [x] `bun test telemetry.test.ts hetzner-cov.test.ts` — confirms the specific interaction is fixed
- [x] Biome lint — 0 errors

-- refactor/test-engineer