### PR TITLE
chore(ci): disable autonomous agent-team workflows (manual-only)

### DIFF
--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -1,22 +1,14 @@
 name: Trigger Discovery
 
+# Disabled: schedule + issue triggers removed to pause the autonomous agent
+# team. workflow_dispatch is kept so the cycle can still be run manually.
 on:
-  schedule:
-    - cron: '0 0 */3 * *'
-  issues:
-    types: [opened, reopened, labeled]
   workflow_dispatch:
 
 jobs:
   trigger:
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    # Only trigger on issues with safe-to-work AND (cloud-request or agent-request) labels, or schedule/manual
-    if: >-
-      github.event_name != 'issues' ||
-      (contains(github.event.issue.labels.*.name, 'safe-to-work') &&
-       (contains(github.event.issue.labels.*.name, 'cloud-request') ||
-        contains(github.event.issue.labels.*.name, 'agent-request')))
     steps:
       - name: Trigger discovery cycle
         env:

--- a/.github/workflows/growth.yml
+++ b/.github/workflows/growth.yml
@@ -1,8 +1,8 @@
 name: Trigger Growth
 
+# Disabled: schedule trigger removed to pause the autonomous agent team.
+# workflow_dispatch is kept so the cycle can still be run manually.
 on:
-  schedule:
-    - cron: '37 14 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,9 +1,7 @@
 name: QA
+# Disabled: schedule triggers removed to pause the autonomous agent team.
+# workflow_dispatch is kept so QA modes can still be run manually.
 on:
-  schedule:
-    - cron: '0 */4 * * *'   # Every 4 hours — quality sweep
-    - cron: '30 1 * * 1'    # Every Monday 1:30am UTC — Telegram soak test (offset from */4 to avoid dedup)
-    - cron: '0 6 * * *'     # Daily 6am UTC — Interactive E2E (1 agent, 1 cloud)
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -1,24 +1,14 @@
 name: Trigger Refactor
 
+# Disabled: schedule + issue triggers removed to pause the autonomous agent
+# team. workflow_dispatch is kept so the cycle can still be run manually.
 on:
-  schedule:
-    - cron: '0 */2 * * *'
-  issues:
-    types: [opened, reopened, labeled]
   workflow_dispatch:
 
 jobs:
   trigger:
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    # Only trigger on issues with safe-to-work AND (bug, cli, enhancement, or maintenance) labels, or schedule/manual
-    if: >-
-      github.event_name != 'issues' ||
-      (contains(github.event.issue.labels.*.name, 'safe-to-work') &&
-       (contains(github.event.issue.labels.*.name, 'bug') ||
-        contains(github.event.issue.labels.*.name, 'cli') ||
-        contains(github.event.issue.labels.*.name, 'enhancement') ||
-        contains(github.event.issue.labels.*.name, 'maintenance')))
     steps:
       - name: Trigger refactor cycle
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,22 +1,14 @@
 name: Security Review
 
+# Disabled: schedule + issue triggers removed to pause the autonomous agent
+# team. workflow_dispatch is kept so the review can still be run manually.
 on:
-  issues:
-    types: [opened, reopened, labeled]
-  schedule:
-    - cron: '0 */4 * * *'
   workflow_dispatch:
 
 jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Only trigger on issues with safe-to-work AND (team-building or security) labels, or schedule/manual
-    if: >-
-      github.event_name != 'issues' ||
-      (contains(github.event.issue.labels.*.name, 'safe-to-work') &&
-       (contains(github.event.issue.labels.*.name, 'team-building') ||
-        contains(github.event.issue.labels.*.name, 'security')))
     steps:
       - name: Trigger security review
         env:


### PR DESCRIPTION
## What

Disables the autonomous **agent team** by removing the automatic triggers from its five GitHub Actions workflows. Each workflow keeps `workflow_dispatch`, so it can still be launched by hand from the Actions tab.

| Workflow | Removed triggers | Kept |
|---|---|---|
| `discovery.yml` | `schedule` (every 3 days) + `issues` | `workflow_dispatch` |
| `refactor.yml` | `schedule` (every 2 hours) + `issues` | `workflow_dispatch` |
| `growth.yml` | `schedule` (daily 14:37 UTC) | `workflow_dispatch` |
| `qa.yml` | `schedule` (3 crons) | `workflow_dispatch` + inputs |
| `security.yml` | `schedule` (every 4 hours) + `issues` | `workflow_dispatch` |

## Why

Pauses the self-running discovery / refactor / growth / qa / security cycles so they no longer fire on a schedule or in response to issue activity.

## Notes

- **Reversible** — re-add the `on:` triggers to turn automation back on.
- The now-dead `if:` label gates (only relevant to issue-triggered runs) are removed too.
- The `setup-agent-team` skill, trigger servers, and Sprite VMs are untouched — this only stops GitHub from poking them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)