### PR TITLE
chore(data): fix stale agent/cloud counts, add missing pi/t3code

### DIFF
--- a/.claude/rules/agent-default-models.md
+++ b/.claude/rules/agent-default-models.md
@@ -3,7 +3,7 @@
 **Source of truth for the default LLM each agent uses via OpenRouter.**
 When updating an agent's default model, update BOTH the code and this file. This prevents regressions from stale model IDs.
 
-Last verified: 2026-03-13
+Last verified: 2026-06-02
 
 | Agent | Default Model | How It's Set |
 |---|---|---|
@@ -16,6 +16,7 @@ Last verified: 2026-03-13
 | Junie | _(provider default)_ | `JUNIE_OPENROUTER_API_KEY` — model selection handled by Junie natively |
 | Cursor CLI | _(provider default)_ | `--endpoint https://openrouter.ai/api/v1` + `CURSOR_API_KEY` — model selection via `--model` flag or `/model` in-session |
 | Pi | _(provider default)_ | `OPENROUTER_API_KEY` — model selection via `/model` in-session |
+| T3 Code | _(inherited by child agents)_ | Wraps Claude Code + Codex as subprocesses; OpenRouter via inherited `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` env vars on the children |
 
 ## When to update
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Launch any AI agent on any cloud with a single command. Coding agents, research agents, self-hosted AI tools — Spawn deploys them all. All models powered by [OpenRouter](https://openrouter.ai). (ALPHA software, use at your own risk!)
 
-**9 agents. 7 clouds. 63 working combinations. Zero config.**
+**10 agents. 8 clouds. 79 working combinations. Zero config.**
 
 ## Install
 
@@ -336,17 +336,18 @@ If an agent fails to install or launch on a cloud:
 
 ## Matrix
 
-| | [Local Machine](sh/local/) | [Hetzner Cloud](sh/hetzner/) | [AWS Lightsail](sh/aws/) | [DigitalOcean](sh/digitalocean/) | [GCP Compute Engine](sh/gcp/) | [Daytona](sh/daytona/) | [Sprite](sh/sprite/) |
-|---|---|---|---|---|---|---|---|
-| [**Claude Code**](https://claude.ai) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [**OpenClaw**](https://github.com/openclaw/openclaw) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [**Codex CLI**](https://github.com/openai/codex) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [**OpenCode**](https://github.com/anomalyco/opencode) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [**Kilo Code**](https://github.com/Kilo-Org/kilocode) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [**Hermes Agent**](https://github.com/NousResearch/hermes-agent) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [**Junie**](https://www.jetbrains.com/junie/) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [**Cursor CLI**](https://cursor.com/cli) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [**Pi**](https://pi.dev) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| | [Local Machine](sh/local/) | [Local Sandbox](sh/sandbox/) | [Hetzner Cloud](sh/hetzner/) | [AWS Lightsail](sh/aws/) | [DigitalOcean](sh/digitalocean/) | [GCP Compute Engine](sh/gcp/) | [Daytona](sh/daytona/) | [Sprite](sh/sprite/) |
+|---|---|---|---|---|---|---|---|---|
+| [**Claude Code**](https://claude.ai) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**OpenClaw**](https://github.com/openclaw/openclaw) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**Codex CLI**](https://github.com/openai/codex) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**OpenCode**](https://github.com/anomalyco/opencode) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**Kilo Code**](https://github.com/Kilo-Org/kilocode) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**Hermes Agent**](https://github.com/NousResearch/hermes-agent) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**Junie**](https://www.jetbrains.com/junie/) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**Cursor CLI**](https://cursor.com/cli) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**Pi**](https://pi.dev) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [**T3 Code**](https://github.com/pingdotgg/t3code) | ✓ | — | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ### How it works
 

--- a/packer/agents.json
+++ b/packer/agents.json
@@ -47,5 +47,17 @@
     "install": [
       "curl -fsSL https://cursor.com/install | bash || [ -f /root/.local/bin/cursor ]"
     ]
+  },
+  "pi": {
+    "tier": "node",
+    "install": [
+      "mkdir -p ~/.npm-global/bin && npm install -g --prefix ~/.npm-global @mariozechner/pi-coding-agent"
+    ]
+  },
+  "t3code": {
+    "tier": "node",
+    "install": [
+      "mkdir -p ~/.npm-global/bin && npm install -g --prefix ~/.npm-global t3"
+    ]
   }
 }


### PR DESCRIPTION
**2 of 3** — stacked on #3445 (repo rename). Merge after it.

`manifest.json` has 10 agents / 8 clouds (79/80 implemented) but docs & packer never caught up.

- **README**: headline `9/7/63 → 10/8/79`; add **Local Sandbox** column and **T3 Code** row to the matrix (t3code is `missing` on sandbox per manifest → marked `—`).
- **packer/agents.json**: add missing `pi` and `t3code` (node tier).
- **agent-default-models.md**: add T3 Code row; refresh "Last verified" date.

Docs/config only — no CLI code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)