### PR TITLE
chore(deps): bump @clack/prompts, align valibot, unify CI bun version

### DIFF
--- a/.claude/scripts/package.json
+++ b/.claude/scripts/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "version": "0.0.1",
   "dependencies": {
-    "valibot": "^1.0.0"
+    "valibot": "1.2.0"
   }
 }

--- a/.github/workflows/agent-tarballs.yml
+++ b/.github/workflows/agent-tarballs.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
-          bun-version: "1.3.11"
+          bun-version: "1.3.9"
 
       - name: Install agent under /root
         env:

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       "name": "@spawn/hooks",
       "version": "0.0.1",
       "dependencies": {
-        "valibot": "^1.0.0",
+        "valibot": "1.2.0",
       },
     },
     ".claude/skills/setup-spa": {
@@ -29,12 +29,12 @@
     },
     "packages/cli": {
       "name": "@openrouter/spawn",
-      "version": "0.31.0",
+      "version": "1.1.2",
       "bin": {
         "spawn": "cli.js",
       },
       "dependencies": {
-        "@clack/prompts": "1.0.0",
+        "@clack/prompts": "1.5.0",
         "@daytonaio/sdk": "0.160.0",
         "@openrouter/spawn-shared": "workspace:*",
         "picocolors": "1.1.1",
@@ -158,9 +158,9 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.3", "", { "os": "win32", "cpu": "x64" }, "sha512-vSm/vOJe06pf14aGHfHl3Ar91Nlx4YYmohElDJ+17UbRwe99n987S/MhAlQOkONqf1utJor04ChkCPmKb8SWdw=="],
 
-    "@clack/core": ["@clack/core@1.0.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ=="],
+    "@clack/core": ["@clack/core@1.4.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw=="],
 
-    "@clack/prompts": ["@clack/prompts@1.0.0", "", { "dependencies": { "@clack/core": "1.0.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A=="],
+    "@clack/prompts": ["@clack/prompts@1.5.0", "", { "dependencies": { "@clack/core": "1.4.0", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-wKh+wTjmrUoUdkZg8KpJO5X+p9PWV+KE9mePseq9UYWkukgTKsGS47RRL2HstwVcvDQH+PenrPJWII8+MfiiyA=="],
 
     "@commitlint/cli": ["@commitlint/cli@20.4.3", "", { "dependencies": { "@commitlint/format": "^20.4.3", "@commitlint/lint": "^20.4.3", "@commitlint/load": "^20.4.3", "@commitlint/read": "^20.4.3", "@commitlint/types": "^20.4.3", "tinyexec": "^1.0.0", "yargs": "^17.0.0" }, "bin": { "commitlint": "./cli.js" } }, "sha512-Z37EMoDT7+Upg500vlr/vZrgRsb6Xc5JAA3Tv7BYbobnN/ZpqUeZnSLggBg2+1O+NptRDtyujr2DD1CPV2qwhA=="],
 
@@ -596,7 +596,13 @@
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openrouter/spawn",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "bin": {
     "spawn": "cli.js"
@@ -14,7 +14,7 @@
     "test:watch": "bun test --watch"
   },
   "dependencies": {
-    "@clack/prompts": "1.0.0",
+    "@clack/prompts": "1.5.0",
     "@daytonaio/sdk": "0.160.0",
     "@openrouter/spawn-shared": "workspace:*",
     "picocolors": "1.1.1",


### PR DESCRIPTION
**3 of 3** — stacked on #3446 (stale data). Merge last.

- `@clack/prompts` `1.0.0 → 1.5.0`.
- valibot in `.claude/scripts` `^1.0.0 → 1.2.0` (matches `packages/cli` + `packages/shared`).
- CI `bun-version` (`agent-tarballs.yml`) `1.3.11 → 1.3.9` to match the SHA-pinned `install.sh` + all 82 agent scripts (CI had drifted upward alone).

`@daytonaio/sdk` (0.160 → 0.183) intentionally **not** bumped — 0.183 has breaking API changes needing a tested migration (tracked in #3444).

`biome` clean (205 files); `bun test` 2202 pass (3 pre-existing flakes, identical on `main`). CLI version `1.1.1 → 1.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)